### PR TITLE
fix: apply CodeRabbit cleanup and harden normalization

### DIFF
--- a/olive-mcp-server/olive_mcp_server/mcp_server.py
+++ b/olive-mcp-server/olive_mcp_server/mcp_server.py
@@ -25,18 +25,23 @@ from olive_mcp_server.tools.troubleshooting import troubleshoot_olive_error
 
 mcp = FastMCP("olive-mcp-server")
 
-mcp.tool()(get_olive_passes)
-mcp.tool()(get_pass_config_template)
-mcp.tool()(get_quantization_strategy)
-mcp.tool()(get_hardware_optimization_guide)
-mcp.tool()(get_pass_chain)
-mcp.tool()(troubleshoot_olive_error)
-mcp.tool()(get_model_compatibility)
-mcp.tool()(get_cli_command)
-mcp.tool()(get_data_config_template)
-mcp.tool()(search_olive_documentation)
-mcp.tool()(get_pass_parameters)
-mcp.tool()(evaluate_optimization_tradeoff)
+TOOLS = [
+    get_olive_passes,
+    get_pass_config_template,
+    get_quantization_strategy,
+    get_hardware_optimization_guide,
+    get_pass_chain,
+    troubleshoot_olive_error,
+    get_model_compatibility,
+    get_cli_command,
+    get_data_config_template,
+    search_olive_documentation,
+    get_pass_parameters,
+    evaluate_optimization_tradeoff,
+]
+
+for tool in TOOLS:
+    mcp.tool()(tool)
 
 
 def main() -> None:

--- a/olive-mcp-server/olive_mcp_server/tools/__init__.py
+++ b/olive-mcp-server/olive_mcp_server/tools/__init__.py
@@ -1,38 +1,33 @@
 """Shared helpers for Olive MCP tools."""
 
 import json
-import os
 from pathlib import Path
 from typing import Any
 
-_KB_DIR = Path(__file__).parent.parent / "knowledge_base"
+KB_DIR = Path(__file__).parent.parent / "knowledge_base"
 
 
-def _load_json(name: str) -> dict[str, Any]:
-    path = _KB_DIR / name
+def load_json(name: str) -> dict[str, Any]:
+    path = KB_DIR / name
     with open(path, "r", encoding="utf-8") as f:
         return json.load(f)
 
 
 def load_passes() -> list[dict[str, Any]]:
-    return _load_json("passes.json").get("passes", [])
+    return load_json("passes.json").get("passes", [])
 
 
 def load_hardware_profiles() -> list[dict[str, Any]]:
-    return _load_json("hardware_profiles.json").get("profiles", [])
+    return load_json("hardware_profiles.json").get("profiles", [])
 
 
 def load_quirks() -> dict[str, Any]:
-    return _load_json("quirks.json").get("categories", {})
-
-
-def load_json(name: str) -> dict[str, Any]:
-    return _load_json(name)
+    return load_json("quirks.json").get("categories", {})
 
 
 def load_troubleshooting() -> list[dict[str, Any]]:
-    return _load_json("troubleshooting.json").get("entries", [])
+    return load_json("troubleshooting.json").get("entries", [])
 
 
 def load_compatibility_matrix() -> list[dict[str, Any]]:
-    return _load_json("compatibility_matrix.json").get("models", [])
+    return load_json("compatibility_matrix.json").get("models", [])

--- a/olive-mcp-server/olive_mcp_server/tools/config_generator.py
+++ b/olive-mcp-server/olive_mcp_server/tools/config_generator.py
@@ -85,6 +85,11 @@ def get_pass_config_template(
     # Apply target-specific defaults (target values take precedence)
     params = _apply_target_defaults(defaults, target)
 
+    # Fill in placeholders for any required params not already covered.
+    for req in meta.get("required_params", []):
+        if req not in params:
+            params[req] = f"<REQUIRED: set {req}>"
+
     # Framework-specific input model type.
     framework_map = {
         "torch": "PyTorchModel",
@@ -126,11 +131,6 @@ def get_pass_config_template(
             "output_dir": "./models/optimized",
         },
     }
-
-    # Adjust required_params.
-    for req in meta.get("required_params", []):
-        if req not in params:
-            params[req] = f"<REQUIRED: set {req}>"
 
     return {
         "pass_name": pass_name,

--- a/olive-mcp-server/olive_mcp_server/tools/docs_search.py
+++ b/olive-mcp-server/olive_mcp_server/tools/docs_search.py
@@ -1,10 +1,9 @@
 """Tool: search_olive_documentation."""
 
 import json
-from pathlib import Path
 from typing import Any
 
-_KB_DIR = Path(__file__).parent.parent / "knowledge_base"
+from . import KB_DIR
 
 
 def _flatten(obj: Any, prefix: str = "") -> list[tuple[str, str]]:
@@ -23,7 +22,7 @@ def _flatten(obj: Any, prefix: str = "") -> list[tuple[str, str]]:
 
 def _load_kb_text() -> list[tuple[str, str]]:
     all_text: list[tuple[str, str]] = []
-    for file in _KB_DIR.glob("*.json"):
+    for file in KB_DIR.glob("*.json"):
         try:
             with open(file, "r", encoding="utf-8") as f:
                 data = json.load(f)

--- a/olive-mcp-server/olive_mcp_server/tools/normalization.py
+++ b/olive-mcp-server/olive_mcp_server/tools/normalization.py
@@ -9,8 +9,8 @@ from . import load_hardware_profiles
 _FRAMEWORK_ALIASES = {
     "torch": "PyTorch",
     "pytorch": "PyTorch",
-    "hf": "HuggingFace",
-    "huggingface": "HuggingFace",
+    "hf": "PyTorch",
+    "huggingface": "PyTorch",
     "onnx": "ONNX",
     "tf": "TensorFlow",
     "tensorflow": "TensorFlow",
@@ -24,9 +24,29 @@ _MODEL_ALIASES = {
     "whisper": "Whisper",
 }
 
+_hardware_profiles_cache: list[dict] | None = None
+
+
+def _get_hardware_profiles() -> list[dict]:
+    """Return cached hardware profiles, loading them once."""
+    global _hardware_profiles_cache
+    if _hardware_profiles_cache is None:
+        _hardware_profiles_cache = load_hardware_profiles()
+    return _hardware_profiles_cache
+
+
+def _is_word_boundary(text: str, index: int, length: int) -> bool:
+    """Return True when text[index:index+length] is bounded by non-alphanumeric chars or string edges."""
+    if index > 0 and text[index - 1].isalnum():
+        return False
+    end = index + length
+    if end < len(text) and text[end].isalnum():
+        return False
+    return True
+
 
 def normalize_framework(framework: str) -> str:
-    """Canonicalize a framework name, e.g. "torch" -> "PyTorch"."""
+    """Canonicalize a framework name, e.g. 'torch' -> 'PyTorch'."""
     name = framework.strip()
     return _FRAMEWORK_ALIASES.get(name.lower(), name)
 
@@ -39,20 +59,45 @@ def normalize_model(model_name: str) -> str:
     """
     name = model_name.strip()
     lower = name.lower()
-    for alias, canonical in _MODEL_ALIASES.items():
-        if alias in lower:
-            return canonical
+    # Longer aliases first so overlapping names resolve to the most specific match.
+    for alias in sorted(_MODEL_ALIASES, key=len, reverse=True):
+        start = 0
+        while True:
+            idx = lower.find(alias, start)
+            if idx == -1:
+                break
+            if _is_word_boundary(lower, idx, len(alias)):
+                return _MODEL_ALIASES[alias]
+            start = idx + 1
     return name
 
 
 def normalize_hardware(target_hardware: str) -> str:
-    """Case-insensitively match a hardware target to its canonical profile name.
+    """Match a hardware target to its canonical profile name.
 
     Falls back to the stripped input if no known hardware profile matches.
     """
     name = target_hardware.strip()
     lower = name.lower()
-    for profile in load_hardware_profiles():
+    profiles = _get_hardware_profiles()
+
+    # Exact match
+    for profile in profiles:
         if profile["target"].lower() == lower:
             return profile["target"]
+
+    # Forward substring: profile target is contained in the input
+    # (e.g. "NVIDIA RTX 4090" in "NVIDIA RTX 4090 Super").
+    forward = [p for p in profiles if p["target"].lower() in lower]
+    if forward:
+        forward.sort(key=lambda p: len(p["target"]), reverse=True)
+        return forward[0]["target"]
+
+    # Reverse substring: input is contained in a profile target
+    # (e.g. "RTX 4090" in "NVIDIA RTX 4090").
+    reverse = [p for p in profiles if lower in p["target"].lower()]
+    if reverse:
+        reverse.sort(key=lambda p: len(p["target"]))
+        return reverse[0]["target"]
+
     return name

--- a/olive-mcp-server/olive_mcp_server/tools/normalization.py
+++ b/olive-mcp-server/olive_mcp_server/tools/normalization.py
@@ -1,0 +1,58 @@
+"""Shared normalization helpers for MCP tool inputs.
+
+These map user-supplied strings (which vary in casing and phrasing) to the
+canonical values used as keys in the knowledge base JSON files.
+"""
+
+from . import load_hardware_profiles
+
+_FRAMEWORK_ALIASES = {
+    "torch": "PyTorch",
+    "pytorch": "PyTorch",
+    "hf": "HuggingFace",
+    "huggingface": "HuggingFace",
+    "onnx": "ONNX",
+    "tf": "TensorFlow",
+    "tensorflow": "TensorFlow",
+}
+
+_MODEL_ALIASES = {
+    "mistral": "Mistral 7B",
+    "phi-3": "Phi-3-mini",
+    "phi3": "Phi-3-mini",
+    "resnet": "ResNet-50",
+    "whisper": "Whisper",
+}
+
+
+def normalize_framework(framework: str) -> str:
+    """Canonicalize a framework name, e.g. "torch" -> "PyTorch"."""
+    name = framework.strip()
+    return _FRAMEWORK_ALIASES.get(name.lower(), name)
+
+
+def normalize_model(model_name: str) -> str:
+    """Map a model name or HuggingFace ID to its compatibility-matrix key.
+
+    Falls back to the stripped input if no known alias matches, so callers
+    can still detect "not found in the local matrix" cases.
+    """
+    name = model_name.strip()
+    lower = name.lower()
+    for alias, canonical in _MODEL_ALIASES.items():
+        if alias in lower:
+            return canonical
+    return name
+
+
+def normalize_hardware(target_hardware: str) -> str:
+    """Case-insensitively match a hardware target to its canonical profile name.
+
+    Falls back to the stripped input if no known hardware profile matches.
+    """
+    name = target_hardware.strip()
+    lower = name.lower()
+    for profile in load_hardware_profiles():
+        if profile["target"].lower() == lower:
+            return profile["target"]
+    return name

--- a/olive-mcp-server/olive_mcp_server/tools/pass_chain.py
+++ b/olive-mcp-server/olive_mcp_server/tools/pass_chain.py
@@ -3,6 +3,7 @@
 from typing import Any
 
 from . import load_passes
+from .normalization import normalize_framework
 
 
 # Canonical ordering constraints: each pass type should appear after its
@@ -64,11 +65,11 @@ def get_pass_chain(pass_names: list[str], source_format: str = "") -> dict[str, 
         if ptype == "quantization" and "onnx" in meta.get("input_formats", []):
             if "OnnxConversion" not in seen_pass_names:
                 # Check if source is already ONNX
-                normalized_source = source_format.lower()
+                normalized_source = normalize_framework(source_format).lower()
                 if normalized_source == "onnx":
                     # Source is already ONNX, no conversion needed
                     pass
-                elif normalized_source in ("torch", "pytorch", "hf", "huggingface"):
+                elif normalized_source in ("torch", "pytorch", "tf", "tensorflow"):
                     # Explicitly non-ONNX source, require conversion
                     errors.append(
                         f"Pass '{name}' requires an ONNX input but no OnnxConversion precedes it in the chain."

--- a/olive-mcp-server/olive_mcp_server/tools/strategy_advisor.py
+++ b/olive-mcp-server/olive_mcp_server/tools/strategy_advisor.py
@@ -202,18 +202,9 @@ def get_quantization_strategy(
             # Skip override if parsing fails
             pass
 
-    # Assemble quirks defensively
-    relevant_quirks = []
-    quantization_quirks = quirks.get("quantization", [])
-    if len(quantization_quirks) > 0:
-        relevant_quirks.append(quantization_quirks[0].get("title", ""))
-    if len(quantization_quirks) > 1:
-        relevant_quirks.append(quantization_quirks[1].get("title", ""))
-    pass_ordering_quirks = quirks.get("pass_ordering", [])
-    if len(pass_ordering_quirks) > 0:
-        relevant_quirks.append(pass_ordering_quirks[0].get("title", ""))
-    # Filter out empty strings
-    relevant_quirks = [q for q in relevant_quirks if q]
+    # Pull the top quirks from the most relevant categories.
+    candidates = quirks.get("quantization", [])[:2] + quirks.get("pass_ordering", [])[:1]
+    relevant_quirks = [title for q in candidates if (title := q.get("title", ""))]
 
     return {
         "model_type": mt,

--- a/olive-mcp-server/olive_mcp_server/tools/troubleshooting.py
+++ b/olive-mcp-server/olive_mcp_server/tools/troubleshooting.py
@@ -2,7 +2,7 @@
 
 from typing import Any
 
-from . import load_json, load_quirks
+from . import load_quirks, load_troubleshooting
 
 
 def _score(entry: dict[str, Any], error_message: str, pass_name: str, config_context: str) -> int:
@@ -25,8 +25,7 @@ def troubleshoot_olive_error(
     Returns:
         Root cause, workaround, and updated config snippet.
     """
-    data = load_json("troubleshooting.json")
-    entries = data.get("entries", [])
+    entries = load_troubleshooting()
 
     scored = [(entry, _score(entry, error_message, pass_name, config_context)) for entry in entries]
     scored.sort(key=lambda x: x[1], reverse=True)
@@ -49,5 +48,5 @@ def troubleshoot_olive_error(
         "root_cause": best.get("root_cause", ""),
         "workaround": best.get("solution", ""),
         "updated_config": best.get("updated_config", {}),
-        "relevant_quirks": [q["title"] for q in load_quirks().get("calibration", [])[:2]],
+        "relevant_quirks": [q["title"] for q in load_quirks().get("quantization", [])[:2]],
     }

--- a/olive-mcp-server/tests/test_normalization.py
+++ b/olive-mcp-server/tests/test_normalization.py
@@ -1,0 +1,65 @@
+"""Tests for normalization helpers."""
+
+import pytest
+
+from olive_mcp_server.tools.normalization import (
+    normalize_framework,
+    normalize_hardware,
+    normalize_model,
+)
+
+
+@pytest.mark.parametrize(
+    ("input", "expected"),
+    [
+        ("torch", "PyTorch"),
+        ("PyTorch", "PyTorch"),
+        ("hf", "PyTorch"),
+        ("HuggingFace", "PyTorch"),
+        ("onnx", "ONNX"),
+        ("tf", "TensorFlow"),
+        ("TensorFlow", "TensorFlow"),
+        ("tflite", "tflite"),
+    ],
+)
+def test_normalize_framework(input: str, expected: str) -> None:
+    assert normalize_framework(input) == expected
+
+
+@pytest.mark.parametrize(
+    ("input", "expected"),
+    [
+        ("mistralai/Mistral-7B-v0.1", "Mistral 7B"),
+        ("Mistral-7B-Instruct", "Mistral 7B"),
+        ("microsoft/phi-3-mini", "Phi-3-mini"),
+        ("phi3-mini", "Phi-3-mini"),
+        ("resnet-101", "ResNet-50"),
+        ("openai/whisper-base", "Whisper"),
+        ("unrelated-model", "unrelated-model"),
+    ],
+)
+def test_normalize_model(input: str, expected: str) -> None:
+    assert normalize_model(input) == expected
+
+
+def test_normalize_model_no_false_substring_match() -> None:
+    """A name that merely contains an alias as part of a larger token should not match."""
+    assert normalize_model("mymistralmodel") == "mymistralmodel"
+
+
+@pytest.mark.parametrize(
+    ("input", "expected"),
+    [
+        ("NVIDIA RTX 4090", "NVIDIA RTX 4090"),
+        ("nvidia rtx 4090", "NVIDIA RTX 4090"),
+        ("RTX 4090", "NVIDIA RTX 4090"),
+        ("NVIDIA RTX 4090 Super", "NVIDIA RTX 4090"),
+        ("T4", "NVIDIA T4"),
+    ],
+)
+def test_normalize_hardware(input: str, expected: str) -> None:
+    assert normalize_hardware(input) == expected
+
+
+def test_normalize_hardware_unknown() -> None:
+    assert normalize_hardware("MadeUpChip 9000") == "MadeUpChip 9000"


### PR DESCRIPTION
Merges the CodeRabbit simplification branch with the registration/KB cleanup and fixes normalization.py before merging.

- Replaces imprecise substring model matching with token-boundary matching and longest-alias-first ordering.
- Caches hardware-profile loading in normalize_hardware and supports forward/reverse substring matching against the knowledge base.
- Wires normalize_framework into pass_chain so TensorFlow and HuggingFace aliases are handled consistently.
- Adds tests/test_normalization.py covering framework, model, and hardware normalization.

All 44 Olive MCP tests pass.

Generated with [Devin](https://devin.ai)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened normalization for frameworks, models, and hardware to produce accurate, consistent matches and avoid false positives. Cleaned up MCP tool registration and shared KB access; added tests for normalization.

- **Bug Fixes**
  - Model normalization now uses word boundaries and longest-alias-first to prevent false substring matches.
  - Hardware normalization caches profiles and supports exact, forward, and reverse substring matching.
  - Framework normalization treats HF/HuggingFace as PyTorch and is enforced in pass-chain ONNX checks.

- **Refactors**
  - Centralized KB path/loaders (`KB_DIR`) and updated docs search to use them.
  - Registered MCP tools via a single `TOOLS` list.
  - Ensured required param placeholders are populated in config templates.

<sup>Written for commit 7eb8fbaa7135b5fb6961c8508347d91752f25c3e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tonythethompson/Olive-Studio/pull/12?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

