### PR TITLE
chore(release): MIT + 0.2.0 alignment and production CI smoke

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,28 @@ jobs:
       - name: Recipe builder smoke test
         run: pnpm validate:recipe
 
+      - name: Build
+        run: pnpm build
+
+      - name: Assert production artifacts
+        run: |
+          test -f dist/server.cjs
+          test -f bin/cli.js
+
+      - name: Production start smoke
+        run: |
+          pnpm start &
+          SERVER_PID=$!
+          trap 'kill $SERVER_PID 2>/dev/null || true' EXIT
+          for i in 1 2 3 4 5 6 7 8 9 10; do
+            if curl -fsS http://localhost:3000 >/dev/null; then
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "Server did not respond on port 3000"
+          exit 1
+
   security:
     runs-on: ubuntu-latest
     permissions:

--- a/ABOUT.md
+++ b/ABOUT.md
@@ -36,7 +36,7 @@ Olive recipes are JSON documents with strict pass ordering, execution-provider c
 
 ## License & attribution
 
-Olive Studio is **AGPL-3.0-or-later** — see [LICENSE](LICENSE).  
+Olive Studio is **MIT** — see [LICENSE](LICENSE).  
 Microsoft Olive and related trademarks belong to Microsoft Corporation. This project is independent community tooling, not an official Microsoft product.
 
 ## Maintainer

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Thank you for your interest in Olive Studio. This project is a community front e
 
 - Read [README.md](README.md) for setup and architecture overview.
 - Read [ABOUT.md](ABOUT.md) for project scope — Olive Studio is a local runner and UI, not a fork of Olive itself.
-- Olive Studio is licensed under [AGPL-3.0-or-later](LICENSE). By contributing, you agree that your contributions are licensed under the same terms.
+- Olive Studio is licensed under the [MIT License](LICENSE). By contributing, you agree that your contributions are licensed under the same terms.
 
 ## Development setup
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Olive Studio
 
-[![License: AGPL v3](https://img.shields.io/badge/License-AGPL%20v3-blue.svg)](LICENSE)
-[![Node](https://img.shields.io/badge/node-%3E%3D18-brightgreen)](package.json)
-[![pnpm](https://img.shields.io/badge/package%20manager-pnpm%2010.8.0-f69203)](https://pnpm.io)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+[![Node](https://img.shields.io/badge/node-%3E%3D22-brightgreen)](package.json)
+[![pnpm](https://img.shields.io/badge/package%20manager-pnpm%2011.17.0-f69203)](https://pnpm.io)
 [![CI](https://github.com/tonythethompson/Olive-Studio/actions/workflows/ci.yml/badge.svg)](https://github.com/tonythethompson/Olive-Studio/actions/workflows/ci.yml)
 
 **A visual recipe builder and local runner for [Microsoft Olive](https://github.com/microsoft/Olive).**  
@@ -99,13 +99,13 @@ On the first **Execute Live** or batch run, the server creates `.venv/` in the p
 ```bash
 pnpm build
 pnpm start
+# equivalent after build:
+# node bin/cli.js
 ```
 
-Or use the CLI entrypoint after build:
+Open **<http://localhost:3000>**.
 
-```bash
-npx olive-studio
-```
+> **Not published to npm.** Olive Studio is distributed via this GitHub repository and [GitHub Releases](https://github.com/tonythethompson/Olive-Studio/releases). It creates local Python virtualenvs and may install CUDA / TensorRT packages for GPU recipes — clone and run from source rather than expecting a public `npx` package.
 
 ---
 
@@ -265,6 +265,6 @@ Issues and pull requests are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for
 
 Copyright © 2026 Anthony Thompson.
 
-Olive Studio is licensed under the [GNU Affero General Public License v3.0](LICENSE) (AGPL-3.0-or-later). Network use of a modified version must make corresponding source available under the same license.
+Olive Studio is licensed under the [MIT License](LICENSE).
 
 Microsoft Olive and related names are trademarks of Microsoft Corporation. This project is community tooling and is not affiliated with or endorsed by Microsoft.

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -10,7 +10,7 @@ const serverPath = path.join(pkgDir, "dist", "server.cjs");
 
 if (!fs.existsSync(serverPath)) {
   console.error(
-    "olive-studio: dist/ not found. Run `pnpm build` first, or reinstall via npx."
+    "olive-studio: dist/ not found. Run `pnpm build` first (from a clone of this repo)."
   );
   process.exit(1);
 }

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "olive-studio",
   "private": true,
-  "version": "0.1.0",
-  "license": "AGPL-3.0-or-later",
+  "version": "0.2.0",
+  "license": "MIT",
   "description": "GUI for Microsoft Olive model optimization — runs locally, no cloud required",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary
Implements steps 1, 3, and 4 of the Olive Studio 0.2.0 release handoff.

- Align all license/version surfaces to **MIT** and **0.2.0** (package.json, README badges/docs, ABOUT, CONTRIBUTING, CLI messaging). LICENSE and UI LicenseNotice were already MIT.
- Document honest **GitHub-first** distribution: clone + `pnpm install/build/start`; remove `npx olive-studio` claims; state not published to npm.
- Add CI gates: `pnpm build`, assert `dist/server.cjs` + `bin/cli.js`, production start smoke against `http://localhost:3000`.

## Out of scope (handoff later steps)
- Manual CPU/GPU validation matrix on clean machines
- Annotated tag + GitHub Release `v0.2.0`
- Architectural PR #14 merge decision (CI green path on main)

## Test plan
- [x] Local `pnpm lint` (warnings only)
- [x] Local `pnpm build`
- [x] Local production start returned HTTP 200 on :3000
- [ ] CI validate job with new build + smoke steps
- [ ] Confirm no AGPL hits outside CHANGELOG historical notes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns Olive Studio to MIT and version 0.2.0, and adds a production CI smoke test to guard releases. Updates docs to reflect GitHub-first distribution (clone + `pnpm build/start`) and removes `npx` references.

- **New Features**
  - CI now builds with `pnpm build`, asserts `dist/server.cjs` and `bin/cli.js`, then smokes `http://localhost:3000`.

- **Migration**
  - Distributed via GitHub, not npm: clone repo, run `pnpm build` then `pnpm start` (or `node bin/cli.js`).
  - CLI message now directs users to build from a clone if `dist/` is missing.

<sup>Written for commit 17630c3d5533fef51a1f3d9d497dc05773e85c8d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tonythethompson/Olive-Studio/pull/15?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

