### PR TITLE
fix(ci): unblock pnpm install on main and PRs

### DIFF
--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -7,6 +7,8 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  checks: read
+  actions: read
 
 jobs:
   auto-merge:
@@ -25,9 +27,40 @@ jobs:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Enable auto-merge (squash) — patch only
+      # Without branch protection, `gh pr merge --auto` merges immediately and
+      # can land lockfile bumps that fail pnpm's minimumReleaseAge check.
+      # Wait for the CI `validate` job, then squash-merge patch updates only.
+      - name: Wait for validate, then squash-merge patch PRs
         if: steps.metadata.outputs.update-type == 'version-update:semver-patch'
-        run: gh pr merge --auto --squash "$PR_URL"
+        run: |
+          set -euo pipefail
+          echo "Waiting for CI validate on $PR_URL"
+          for _ in $(seq 1 80); do
+            conclusion="$(gh pr view "$PR_URL" --json statusCheckRollup --jq '
+              [.statusCheckRollup[]
+                | select(.name == "validate" and (.workflowName == "CI" or .workflowName == null))
+              ]
+              | if length == 0 then "PENDING"
+                else (.[0].conclusion // .[0].state // "PENDING")
+                end
+            ')"
+            echo "validate=$conclusion"
+            case "$conclusion" in
+              SUCCESS|success)
+                gh pr merge --squash "$PR_URL"
+                exit 0
+                ;;
+              FAILURE|failure|CANCELLED|cancelled|ERROR|error|TIMED_OUT|timed_out|startup_failure)
+                echo "Refusing to merge: validate concluded $conclusion"
+                exit 1
+                ;;
+              *)
+                sleep 15
+                ;;
+            esac
+          done
+          echo "Timed out waiting for validate"
+          exit 1
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -44,4 +77,3 @@ jobs:
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "clsx": "^2.1.1",
     "dotenv": "^17.4.2",
     "express": "^5.2.1",
-    "express-rate-limit": "^8.6.1",
+    "express-rate-limit": "^8.6.0",
     "jszip": "^3.10.1",
     "lucide-react": "^1.27.0",
     "motion": "^12.40.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,8 +62,8 @@ importers:
         specifier: ^5.2.1
         version: 5.2.1(supports-color@7.2.0)
       express-rate-limit:
-        specifier: ^8.6.1
-        version: 8.6.1(express@5.2.1(supports-color@7.2.0))(supports-color@7.2.0)
+        specifier: ^8.6.0
+        version: 8.6.0(express@5.2.1(supports-color@7.2.0))(supports-color@7.2.0)
       jszip:
         specifier: ^3.10.1
         version: 3.10.1
@@ -3143,8 +3143,8 @@ packages:
     resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
     engines: {node: '>=12.0.0'}
 
-  express-rate-limit@8.6.1:
-    resolution: {integrity: sha512-0D493aP61w0TJ2A0wy27riRsO7FMQ7FK+KUHOKCSfPvYo0R55aiC6emCVgFUeShH0fq0ICPVzNcgoS+BsbXQCA==}
+  express-rate-limit@8.6.0:
+    resolution: {integrity: sha512-XKJXDsASUOo0LLtFwW5hCcQGH0N4WQc/Rn8/Pvoia+TJFOkkFPvrtW9lZOeeNcxQJspvOIERMwiRLsVFlhHEkA==}
     engines: {node: '>= 16'}
     peerDependencies:
       express: '>= 4.11'
@@ -7981,7 +7981,7 @@ snapshots:
 
   expect-type@1.4.0: {}
 
-  express-rate-limit@8.6.1(express@5.2.1(supports-color@7.2.0))(supports-color@7.2.0):
+  express-rate-limit@8.6.0(express@5.2.1(supports-color@7.2.0))(supports-color@7.2.0):
     dependencies:
       debug: 4.4.3(supports-color@7.2.0)
       express: 5.2.1(supports-color@7.2.0)

--- a/src/lib/__tests__/hooks.test.ts
+++ b/src/lib/__tests__/hooks.test.ts
@@ -205,9 +205,7 @@ describe("useMcpDiagnosticKeyed", () => {
 
     // Verify fetch was called (the hook slices to last 20 internally)
     expect(globalThis.fetch).toHaveBeenCalledOnce();
-    const callBody = JSON.parse(
-      (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0][1]?.body as string,
-    );
+    const callBody = JSON.parse(vi.mocked(globalThis.fetch).mock.calls[0][1]?.body as string);
     expect(callBody.args.error_message).toContain("[INFO] Line 30");
     expect(callBody.args.error_message).toContain("[INFO] Line 49");
     // Should NOT contain line 0 (outside the last 20)


### PR DESCRIPTION
## Summary
- Roll `express-rate-limit` back to `8.6.0` so `pnpm install --frozen-lockfile` passes pnpm 11's 24h `minimumReleaseAge` check (broken since Dependabot #17 auto-merged `8.6.1` while it was still too new).
- Make Dependabot auto-merge wait for the CI `validate` job before squash-merging patch PRs. Main has no branch protection, so `gh pr merge --auto` was merging immediately and ignoring failing CI.
- Fix a pre-existing `tsc` cast in `hooks.test.ts` that blocked the pre-push hook.

## Test plan
- [ ] CI `validate` passes on this PR (install, lint, tests, build)
- [ ] After merge, a fresh push to `main` gets a green `validate` job
- [ ] Optional: enable branch protection requiring `validate` so GitHub-native auto-merge also waits for CI


Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Ensure Dependabot auto-merges only after CI validation and unblock pnpm installs by pinning dependencies.

Bug Fixes:
- Pin express-rate-limit to version 8.6.0 to restore successful pnpm install with frozen lockfile.
- Adjust useMcpDiagnosticKeyed test to avoid a TypeScript casting error in the pre-push hooks.

CI:
- Update Dependabot auto-merge workflow to wait for the CI validate job and only squash-merge patch dependency updates.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unblocks `pnpm install --frozen-lockfile` by pinning `express-rate-limit` to 8.6.0. Also makes Dependabot auto-merge wait for the CI `validate` job and fixes a test type error that broke pre-push checks.

- **Bug Fixes**
  - Pin `express-rate-limit` to `8.6.0` to satisfy `pnpm` 24h `minimumReleaseAge` and fix installs.
  - Auto-merge waits for `validate` and squashes only patch updates to avoid merging failing lockfile bumps.
  - Use `vi.mocked` in `hooks.test.ts` to resolve `tsc` error in the pre-push hook.

<sup>Written for commit 6604d8aba10ac053c5fe81ed28a06a8127d753dc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tonythethompson/Olive-Studio/pull/23?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

