### PR TITLE
docs: add Cursor Cloud setup notes to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3714,7 +3714,7 @@ This repo also contains `olive-mcp-server/`, a Python MCP server for Microsoft O
 
 Windows:
 
-```bash
+```powershell
 cd olive-mcp-server
 python -m venv .venv
 .venv\Scripts\pip install -e ".[dev]"
@@ -3732,7 +3732,7 @@ python3 -m venv .venv
 
 Windows:
 
-```bash
+```powershell
 .venv\Scripts\python -m pytest tests -q
 ```
 
@@ -3746,7 +3746,7 @@ Linux/macOS:
 
 Windows:
 
-```bash
+```powershell
 .venv\Scripts\python -m olive_mcp_server
 # or
 .venv\Scripts\olive-mcp-server
@@ -3803,11 +3803,13 @@ Durable notes for Cloud Agents. The startup update script already runs `pnpm ins
 
 - Not started by the app; it is an optional stdio MCP server under `olive-mcp-server/`. The web app can proxy to it via `POST /api/mcp/tool`, but the app runs fine without it.
 - To set it up on a fresh pod (system `python3.12-venv` is required to create a venv and is not part of the update script):
+
   ```bash
   sudo apt-get update && sudo apt-get install -y python3.12-venv
   cd olive-mcp-server && python3 -m venv .venv && .venv/bin/pip install -e ".[dev]"
   ```
-- Gotcha: `pip install -e ".[dev]"` resolves `mcp` to 2.x, which removed `mcp.server.fastmcp` and breaks imports/tests. Pin `mcp<2` (mcp 1.29.0 works): `.venv/bin/pip install "mcp<2"`. Then `\.venv/bin/python -m pytest tests -q` passes.
+
+- Gotcha: `pip install -e ".[dev]"` resolves `mcp` to 2.x, which removed `mcp.server.fastmcp` and breaks imports/tests. Pin `mcp<2` (mcp 1.29.0 works): `.venv/bin/pip install "mcp<2"`. Then `.venv/bin/python -m pytest tests -q` passes.
 
 ### Misc
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3713,6 +3713,7 @@ This repo also contains `olive-mcp-server/`, a Python MCP server for Microsoft O
 ### Setup
 
 Windows:
+
 ```bash
 cd olive-mcp-server
 python -m venv .venv
@@ -3720,6 +3721,7 @@ python -m venv .venv
 ```
 
 Linux/macOS:
+
 ```bash
 cd olive-mcp-server
 python3 -m venv .venv
@@ -3729,11 +3731,13 @@ python3 -m venv .venv
 ### Test
 
 Windows:
+
 ```bash
 .venv\Scripts\python -m pytest tests -q
 ```
 
 Linux/macOS:
+
 ```bash
 .venv/bin/python -m pytest tests -q
 ```
@@ -3741,6 +3745,7 @@ Linux/macOS:
 ### Run the server
 
 Windows:
+
 ```bash
 .venv\Scripts\python -m olive_mcp_server
 # or
@@ -3748,6 +3753,7 @@ Windows:
 ```
 
 Linux/macOS:
+
 ```bash
 .venv/bin/python -m olive_mcp_server
 # or
@@ -3778,3 +3784,31 @@ The repo root has `.mcp.json`, which registers the server in Claude Code. By def
 
 Reinstall the package if the venv is recreated.
 
+---
+
+## Cursor Cloud specific instructions
+
+Durable notes for Cloud Agents. The startup update script already runs `pnpm install`, so Node deps are ready when a session begins. Node 22 and pnpm 11.17 are available on the base image.
+
+### Primary product: Olive Studio web app (Node/Express + Vite + React)
+
+- Run it with `pnpm dev` (script: `tsx server.ts`). One process runs Express + Vite middleware and listens on `0.0.0.0:3000` → open `http://localhost:3000`. There is no separate frontend/backend to start.
+- Standard commands live in `package.json` scripts and the README "Scripts" table: `pnpm lint` (tsc + eslint), `pnpm test` (Vitest), `pnpm validate:recipe`, `pnpm build`, `pnpm start` (serves the built `dist/server.mjs`).
+- Gotcha: `pnpm lint` prints ESLint warnings but still exits 0 (it runs `eslint --max-warnings 20`). Warnings are expected; only treat a non-zero exit or reported errors as a failure.
+- Gotcha: `npm install` is blocked by a `preinstall` guard — always use `pnpm`.
+- You can build/lint/test/run the app and use the full recipe-builder + validation UI with no Python and no GPU. The hardware probe reports CPU-only in the VM, which is expected.
+- Do NOT trigger an actual Olive optimization ("Execute Live"/batch run) in the cloud VM: on first run the server creates `.venv/` and downloads `olive-ai` (plus CUDA/TensorRT wheels for GPU recipes) and models — heavy, network-dependent, and there is no GPU. Recipe building, JSON export, and validation are the CPU-only flows to exercise.
+
+### Secondary component: Olive MCP server (Python, optional)
+
+- Not started by the app; it is an optional stdio MCP server under `olive-mcp-server/`. The web app can proxy to it via `POST /api/mcp/tool`, but the app runs fine without it.
+- To set it up on a fresh pod (system `python3.12-venv` is required to create a venv and is not part of the update script):
+  ```bash
+  sudo apt-get update && sudo apt-get install -y python3.12-venv
+  cd olive-mcp-server && python3 -m venv .venv && .venv/bin/pip install -e ".[dev]"
+  ```
+- Gotcha: `pip install -e ".[dev]"` resolves `mcp` to 2.x, which removed `mcp.server.fastmcp` and breaks imports/tests. Pin `mcp<2` (mcp 1.29.0 works): `.venv/bin/pip install "mcp<2"`. Then `\.venv/bin/python -m pytest tests -q` passes.
+
+### Misc
+
+- `pnpm a11y:scan` invokes `python` (not `python3`); `python` is not on PATH by default, so alias/symlink it if you need that script.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and verifies the development environment for Olive Studio, and records durable Cloud Agent notes in `AGENTS.md`.

No application code was changed. The only committed change is a new `## Cursor Cloud specific instructions` section in `AGENTS.md`.

## Environment setup

- Startup update script: `pnpm install` (Node deps for the primary web app).
- Node 22 + pnpm 11.17 already present; `npm install` is blocked by a `preinstall` guard.
- Optional Python MCP server (`olive-mcp-server/`) setup and the `mcp<2` pin gotcha are documented in AGENTS.md (kept out of the update script since it needs the `python3.12-venv` system package).

## Verification (all passing)

| Component | Command | Result |
| --- | --- | --- |
| Web app | `pnpm lint` | pass (0 errors, 10 warnings within `--max-warnings 20`) |
| Web app | `pnpm test` (Vitest) | 393 tests passed (12 files) |
| Web app | `pnpm validate:recipe` | `ok` |
| Web app | `pnpm build` | produced `dist/server.mjs` |
| Web app | `pnpm dev` | serves `http://localhost:3000` (HTTP 200); backend `GET /api/system/hardware-probe` returns live JSON |
| MCP server | `pytest tests -q` | 132 tests passed (after pinning `mcp<2`) |

## Hello-world demo

Built and validated an Olive recipe end-to-end in the running UI: applied a preset recipe → selected the CPU execution provider → viewed the generated recipe JSON → saw the green "Recipe validated" indicator.

<a href="https://cursor.com/agents/bc-f87090b2-2930-4dc3-bb9c-b34b4c8f9be2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Folive_studio_recipe_build_and_validate.mp4"><img src="https://cursor.com/artifacts/c/art-96f4489b-fea9-4653-9ba3-dd517f0cc11c" alt="olive_studio_recipe_build_and_validate.mp4" /></a>

![Generated Olive recipe JSON](https://cursor.com/artifacts/c/art-50ea8705-41c4-46d6-a850-650145bba650)
![Recipe validated](https://cursor.com/artifacts/c/art-a55b48e1-ff38-4e76-b094-143f64e59d98)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f87090b2-2930-4dc3-bb9c-b34b4c8f9be2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f87090b2-2930-4dc3-bb9c-b34b4c8f9be2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Cursor Cloud setup notes to `AGENTS.md` to run Olive Studio in cloud sessions without code changes. Covers starting the app (`pnpm dev` on 0.0.0.0:3000), expected ESLint warnings, `pnpm`-only installs, avoiding heavy optimizations, optional `olive-mcp-server` setup (`python3.12-venv`, pin `mcp<2`), a `pnpm a11y:scan`/`python` PATH note, and fixes Windows code blocks to `powershell`.

<sup>Written for commit d986dc853e5a415278d5eed4cadf0ebf4b38ac28. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tonythethompson/Olive-Studio/pull/27?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

