### PR TITLE
fix: land server hardening follow-ups from PR #28 into main

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   ],
   "packageManager": "pnpm@11.17.0",
   "engines": {
-    "node": ">=22"
+    "node": ">=22.16"
   },
   "scripts": {
     "preinstall": "node -e \"if (!/pnpm/.test(process.env.npm_execpath || \\\"\\\")) { console.error('Use pnpm install, not npm install'); process.exit(1); }\"",

--- a/src/server/__tests__/setup.integration.ts
+++ b/src/server/__tests__/setup.integration.ts
@@ -75,8 +75,11 @@ function createMockedFetch(): typeof globalThis.fetch {
     return _realFetch!(input, init);
   };
   // Preserve static fetch helpers (e.g. preconnect) required by newer DOM typings.
+  // Read via Reflect.get so we don't depend on undeclared properties on typeof fetch.
+  const preconnect = Reflect.get(globalThis.fetch, "preconnect") as
+    ((this: typeof globalThis.fetch, ...args: unknown[]) => unknown) | undefined;
   return Object.assign(mocked, {
-    preconnect: globalThis.fetch.preconnect?.bind(globalThis.fetch),
+    preconnect: typeof preconnect === "function" ? preconnect.bind(globalThis.fetch) : undefined,
   }) as typeof globalThis.fetch;
 }
 

--- a/src/server/__tests__/setup.integration.ts
+++ b/src/server/__tests__/setup.integration.ts
@@ -67,13 +67,17 @@ vi.mock("../services/ai/index.ts", async (importOriginal) => {
 let _realFetch: typeof globalThis.fetch | null = null;
 
 function createMockedFetch(): typeof globalThis.fetch {
-  return async (input: RequestInfo | URL, init?: RequestInit) => {
+  const mocked = async (input: RequestInfo | URL, init?: RequestInit) => {
     const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
     if (url.includes("127.0.0.1:1234")) return mockLmStudio(url, init);
     if (url.includes("127.0.0.1:11434")) return mockOllama(url, init);
 
     return _realFetch!(input, init);
   };
+  // Preserve static fetch helpers (e.g. preconnect) required by newer DOM typings.
+  return Object.assign(mocked, {
+    preconnect: globalThis.fetch.preconnect?.bind(globalThis.fetch),
+  }) as typeof globalThis.fetch;
 }
 
 async function mockLmStudio(url: string, _init?: RequestInit): Promise<Response> {

--- a/src/server/routes/mcp.test.ts
+++ b/src/server/routes/mcp.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Route-level coverage for the MCP KB endpoints: the failure taxonomy
+ * (missing / unreadable / invalid JSON / schema-invalid), sanitized client
+ * error messages, caching of a successful status, and the non-2xx sync failure.
+ *
+ * `fs.readFileSync` is stubbed per-test so no real KB file is required.
+ */
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach, vi } from "vitest";
+import express from "express";
+import type { Server } from "http";
+import fs from "fs";
+
+import { mountMcpRoutes } from "./mcp.ts";
+import { setKbStatusCache } from "../services/mcp/state.ts";
+
+const VALID_KB = JSON.stringify({
+  version: "2.0",
+  last_updated: "2026-01-01",
+  passes: [
+    {
+      name: "OnnxConversion",
+      type: "onnx",
+      input_formats: ["pytorch"],
+      output_formats: ["onnx"],
+      required_params: [],
+      optional_params: { opset: { type: "int", default: 17 } },
+    },
+  ],
+});
+
+function fsError(code: string): NodeJS.ErrnoException {
+  const err = new Error(code) as NodeJS.ErrnoException;
+  err.code = code;
+  return err;
+}
+
+let server: Server;
+let baseUrl: string;
+
+beforeAll(async () => {
+  const app = express();
+  app.use(express.json());
+  const router = express.Router();
+  mountMcpRoutes(router);
+  app.use("/api", router);
+  await new Promise<void>((resolve, reject) => {
+    server = app.listen(0, "127.0.0.1", () => {
+      const addr = server.address();
+      if (!addr || typeof addr === "string") return reject(new Error("no port"));
+      baseUrl = `http://127.0.0.1:${addr.port}`;
+      resolve();
+    });
+    server.on("error", reject);
+  });
+});
+
+afterAll(async () => {
+  if (server) await new Promise<void>((resolve) => server.close(() => resolve()));
+});
+
+beforeEach(() => {
+  setKbStatusCache(null);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("GET /api/mcp/kb-status", () => {
+  it("returns available:true for a valid KB and caches the result", async () => {
+    const spy = vi.spyOn(fs, "readFileSync").mockReturnValue(VALID_KB);
+
+    const res1 = await fetch(`${baseUrl}/api/mcp/kb-status`);
+    expect(res1.status).toBe(200);
+    const body1 = await res1.json();
+    expect(body1).toMatchObject({ available: true, version: "2.0", passCount: 1 });
+    expect(spy).toHaveBeenCalledTimes(1);
+
+    // Second call is served from cache — no additional file read.
+    const res2 = await fetch(`${baseUrl}/api/mcp/kb-status`);
+    expect((await res2.json()).available).toBe(true);
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports a missing KB with a sanitized message", async () => {
+    vi.spyOn(fs, "readFileSync").mockImplementation(() => {
+      throw fsError("ENOENT");
+    });
+
+    const res = await fetch(`${baseUrl}/api/mcp/kb-status`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toMatchObject({ available: false, reason: "missing" });
+    expect(body.error).toBe("Knowledge base has not been generated yet.");
+    // Raw fs error / path detail must not leak to the client.
+    expect(body.error).not.toContain("ENOENT");
+  });
+
+  it("reports an unreadable KB (permission error)", async () => {
+    vi.spyOn(fs, "readFileSync").mockImplementation(() => {
+      throw fsError("EACCES");
+    });
+
+    const body = await (await fetch(`${baseUrl}/api/mcp/kb-status`)).json();
+    expect(body).toMatchObject({ available: false, reason: "unreadable" });
+    expect(body.error).toBe("Knowledge base could not be read.");
+    expect(body.error).not.toContain("EACCES");
+  });
+
+  it("reports malformed JSON as invalid", async () => {
+    vi.spyOn(fs, "readFileSync").mockReturnValue("{ not json ");
+
+    const body = await (await fetch(`${baseUrl}/api/mcp/kb-status`)).json();
+    expect(body).toMatchObject({ available: false, reason: "invalid" });
+    expect(body.error).toBe("Knowledge base file is malformed.");
+  });
+
+  it("reports schema-invalid content (bad pass entry) as invalid", async () => {
+    // Valid JSON, but a pass entry violates the schema (non-string array field).
+    vi.spyOn(fs, "readFileSync").mockReturnValue(
+      JSON.stringify({ version: "1", passes: [{ name: "P", input_formats: [1, 2, 3] }] }),
+    );
+
+    const body = await (await fetch(`${baseUrl}/api/mcp/kb-status`)).json();
+    expect(body).toMatchObject({ available: false, reason: "invalid" });
+  });
+});
+
+describe("POST /api/mcp/sync-kb", () => {
+  // NOTE: kbSyncRateLimit allows only 2 requests/min — keep to exactly two here.
+  it("returns ok:true on a successful sync", async () => {
+    vi.spyOn(fs, "readFileSync").mockReturnValue(VALID_KB);
+
+    const res = await fetch(`${baseUrl}/api/mcp/sync-kb`, { method: "POST" });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toMatchObject({ ok: true, available: true, passCount: 1 });
+  });
+
+  it("returns a non-2xx status with ok:false when the KB can't be read", async () => {
+    vi.spyOn(fs, "readFileSync").mockImplementation(() => {
+      throw fsError("ENOENT");
+    });
+
+    const res = await fetch(`${baseUrl}/api/mcp/sync-kb`, { method: "POST" });
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body).toMatchObject({ ok: false, reason: "missing" });
+    expect(body.error).toBe("Knowledge base has not been generated yet.");
+  });
+});

--- a/src/server/routes/mcp.ts
+++ b/src/server/routes/mcp.ts
@@ -64,19 +64,44 @@ async function callOliveMcpTool(
   }
 }
 
-/** Read the passes.json KB file synchronously (ESM-safe, no require()). */
-function readPassesJson(): PassesJson | null {
+type KbReadResult =
+  | { ok: true; data: PassesJson }
+  | { ok: false; reason: "missing" | "unreadable" | "invalid"; message: string };
+
+/**
+ * Read the passes.json KB file synchronously (ESM-safe, no require()).
+ * Distinguishes a genuinely missing KB from a read/parse failure so callers
+ * don't report a corrupt-but-present KB as merely "unavailable".
+ */
+function readPassesJson(): KbReadResult {
+  const passesPath = path.join(
+    process.cwd(),
+    "olive-mcp-server",
+    "olive_mcp_server",
+    "knowledge_base",
+    "passes.json",
+  );
+  let raw: string;
   try {
-    const passesPath = path.join(
-      process.cwd(),
-      "olive-mcp-server",
-      "olive_mcp_server",
-      "knowledge_base",
-      "passes.json",
-    );
-    return JSON.parse(fs.readFileSync(passesPath, "utf-8")) as PassesJson;
-  } catch {
-    return null;
+    raw = fs.readFileSync(passesPath, "utf-8");
+  } catch (err: unknown) {
+    const code =
+      err && typeof err === "object" && "code" in err ? (err as { code?: string }).code : undefined;
+    if (code === "ENOENT") {
+      return {
+        ok: false,
+        reason: "missing",
+        message: "passes.json not found — KB has not been generated yet.",
+      };
+    }
+    const message = err instanceof Error ? err.message : String(err);
+    return { ok: false, reason: "unreadable", message };
+  }
+  try {
+    return { ok: true, data: JSON.parse(raw) as PassesJson };
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { ok: false, reason: "invalid", message: `passes.json is not valid JSON: ${message}` };
   }
 }
 
@@ -101,15 +126,16 @@ export function mountMcpRoutes(router: Router): void {
     const cached = getKbStatusCache();
     if (cached) return res.json(cached);
 
-    const data = readPassesJson();
-    if (!data) {
-      return res.json({ available: false, error: "Cannot read passes.json" });
+    const kb = readPassesJson();
+    if (!kb.ok) {
+      // Don't cache a failure — a missing/corrupt KB may be fixed at runtime.
+      return res.json({ available: false, reason: kb.reason, error: kb.message });
     }
     const status = {
       available: true,
-      version: data.version ?? "unknown",
-      lastUpdated: data.last_updated ?? null,
-      passCount: data.passes?.length ?? 0,
+      version: kb.data.version ?? "unknown",
+      lastUpdated: kb.data.last_updated ?? null,
+      passCount: kb.data.passes?.length ?? 0,
     };
     setKbStatusCache(status);
     return res.json(status);
@@ -122,16 +148,16 @@ export function mountMcpRoutes(router: Router): void {
     }
     setKbSyncInProgress(true);
     try {
-      const data = readPassesJson();
-      if (!data) {
-        return res.json({ ok: false, error: "Cannot read passes.json" });
+      const kb = readPassesJson();
+      if (!kb.ok) {
+        return res.json({ ok: false, reason: kb.reason, error: kb.message });
       }
-      reloadPassSchemas(data);
+      reloadPassSchemas(kb.data);
       const status = {
         available: true,
-        version: data.version ?? "unknown",
-        lastUpdated: data.last_updated ?? null,
-        passCount: data.passes?.length ?? 0,
+        version: kb.data.version ?? "unknown",
+        lastUpdated: kb.data.last_updated ?? null,
+        passCount: kb.data.passes?.length ?? 0,
         lastSync: new Date().toISOString(),
       };
       setKbStatusCache(status);

--- a/src/server/routes/mcp.ts
+++ b/src/server/routes/mcp.ts
@@ -75,19 +75,44 @@ const KB_CLIENT_MESSAGE: Record<KbFailureReason, string> = {
   invalid: "Knowledge base file is malformed.",
 };
 
+function isStringArray(value: unknown): boolean {
+  return Array.isArray(value) && value.every((v) => typeof v === "string");
+}
+
+/**
+ * Validate a single pass entry against the fields `buildParamSchemas` consumes.
+ * Optional fields are only checked when present, so absent fields still fall back
+ * to their defaults — but a present-but-malformed field is rejected before it
+ * reaches schema rebuilding.
+ */
+function isValidPassEntry(value: unknown): boolean {
+  if (!isObjectRecord(value)) return false;
+  if (typeof value.name !== "string") return false;
+  if (value.type !== undefined && typeof value.type !== "string") return false;
+  if (value.class !== undefined && typeof value.class !== "string") return false;
+  if (value.description !== undefined && typeof value.description !== "string") return false;
+  if (value.typical_compression !== undefined && typeof value.typical_compression !== "string") return false;
+  if (value.input_formats !== undefined && !isStringArray(value.input_formats)) return false;
+  if (value.output_formats !== undefined && !isStringArray(value.output_formats)) return false;
+  if (value.required_params !== undefined && !isStringArray(value.required_params)) return false;
+  if (value.hardware_requirements !== undefined && !isStringArray(value.hardware_requirements)) return false;
+  if (value.gotchas !== undefined && !isStringArray(value.gotchas)) return false;
+  // optional_params is a Record<string, ParamSchema>: object of objects.
+  if (value.optional_params !== undefined) {
+    if (!isObjectRecord(value.optional_params)) return false;
+    if (!Object.values(value.optional_params).every((v) => isObjectRecord(v))) return false;
+  }
+  return true;
+}
+
 /** Runtime shape check for the fields `/mcp/kb-status` and `reloadPassSchemas` consume. */
 function isValidPassesJson(value: unknown): value is PassesJson {
-  if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
-  const obj = value as Record<string, unknown>;
-  if (obj.version !== undefined && typeof obj.version !== "string") return false;
-  if (obj.last_updated !== undefined && typeof obj.last_updated !== "string") return false;
-  if (obj.passes !== undefined) {
-    if (!Array.isArray(obj.passes)) return false;
-    // Every entry must be an object with a string `name` (schema keys off it).
-    const entriesOk = obj.passes.every(
-      (p) => typeof p === "object" && p !== null && typeof (p as { name?: unknown }).name === "string",
-    );
-    if (!entriesOk) return false;
+  if (!isObjectRecord(value)) return false;
+  if (value.version !== undefined && typeof value.version !== "string") return false;
+  if (value.last_updated !== undefined && typeof value.last_updated !== "string") return false;
+  if (value.passes !== undefined) {
+    if (!Array.isArray(value.passes)) return false;
+    if (!value.passes.every((p) => isValidPassEntry(p))) return false;
   }
   return true;
 }
@@ -188,7 +213,8 @@ export function mountMcpRoutes(router: Router): void {
     try {
       const kb = readPassesJson();
       if (!kb.ok) {
-        return res.json({ ok: false, ...kbFailureResponse(kb) });
+        // Non-2xx so the client's sync hook enters its error path.
+        return res.status(500).json({ ok: false, ...kbFailureResponse(kb) });
       }
       reloadPassSchemas(kb.data);
       const status = {

--- a/src/server/routes/mcp.ts
+++ b/src/server/routes/mcp.ts
@@ -64,13 +64,37 @@ async function callOliveMcpTool(
   }
 }
 
-type KbReadResult =
-  | { ok: true; data: PassesJson }
-  | { ok: false; reason: "missing" | "unreadable" | "invalid"; message: string };
+type KbFailureReason = "missing" | "unreadable" | "invalid";
+
+type KbReadResult = { ok: true; data: PassesJson } | { ok: false; reason: KbFailureReason; message: string };
+
+/** Stable, non-sensitive client-facing messages (server logs keep the detail). */
+const KB_CLIENT_MESSAGE: Record<KbFailureReason, string> = {
+  missing: "Knowledge base has not been generated yet.",
+  unreadable: "Knowledge base could not be read.",
+  invalid: "Knowledge base file is malformed.",
+};
+
+/** Runtime shape check for the fields `/mcp/kb-status` and `reloadPassSchemas` consume. */
+function isValidPassesJson(value: unknown): value is PassesJson {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
+  const obj = value as Record<string, unknown>;
+  if (obj.version !== undefined && typeof obj.version !== "string") return false;
+  if (obj.last_updated !== undefined && typeof obj.last_updated !== "string") return false;
+  if (obj.passes !== undefined) {
+    if (!Array.isArray(obj.passes)) return false;
+    // Every entry must be an object with a string `name` (schema keys off it).
+    const entriesOk = obj.passes.every(
+      (p) => typeof p === "object" && p !== null && typeof (p as { name?: unknown }).name === "string",
+    );
+    if (!entriesOk) return false;
+  }
+  return true;
+}
 
 /**
  * Read the passes.json KB file synchronously (ESM-safe, no require()).
- * Distinguishes a genuinely missing KB from a read/parse failure so callers
+ * Distinguishes a genuinely missing KB from a read/parse/schema failure so callers
  * don't report a corrupt-but-present KB as merely "unavailable".
  */
 function readPassesJson(): KbReadResult {
@@ -97,12 +121,26 @@ function readPassesJson(): KbReadResult {
     const message = err instanceof Error ? err.message : String(err);
     return { ok: false, reason: "unreadable", message };
   }
+  let parsed: unknown;
   try {
-    return { ok: true, data: JSON.parse(raw) as PassesJson };
+    parsed = JSON.parse(raw);
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : String(err);
     return { ok: false, reason: "invalid", message: `passes.json is not valid JSON: ${message}` };
   }
+  if (!isValidPassesJson(parsed)) {
+    return { ok: false, reason: "invalid", message: "passes.json does not match the expected KB schema." };
+  }
+  return { ok: true, data: parsed };
+}
+
+/** Log the detailed reason server-side; return a stable, safe message to clients. */
+function kbFailureResponse(kb: { reason: KbFailureReason; message: string }): {
+  reason: KbFailureReason;
+  error: string;
+} {
+  console.warn(`[mcp] KB unavailable (${kb.reason}): ${kb.message}`);
+  return { reason: kb.reason, error: KB_CLIENT_MESSAGE[kb.reason] };
 }
 
 export function mountMcpRoutes(router: Router): void {
@@ -129,7 +167,7 @@ export function mountMcpRoutes(router: Router): void {
     const kb = readPassesJson();
     if (!kb.ok) {
       // Don't cache a failure — a missing/corrupt KB may be fixed at runtime.
-      return res.json({ available: false, reason: kb.reason, error: kb.message });
+      return res.json({ available: false, ...kbFailureResponse(kb) });
     }
     const status = {
       available: true,
@@ -150,7 +188,7 @@ export function mountMcpRoutes(router: Router): void {
     try {
       const kb = readPassesJson();
       if (!kb.ok) {
-        return res.json({ ok: false, reason: kb.reason, error: kb.message });
+        return res.json({ ok: false, ...kbFailureResponse(kb) });
       }
       reloadPassSchemas(kb.data);
       const status = {

--- a/src/server/routes/olive.cancel.test.ts
+++ b/src/server/routes/olive.cancel.test.ts
@@ -1,29 +1,39 @@
 /**
  * Route-level coverage for cancelling an Olive job *during* environment setup,
- * before the child process exists. A gated `ensureVenv` mock lets us hold the
- * run in `setting_up`, cancel it, then assert the run aborts without spawning.
+ * before the child process exists. Gated `ensureVenv` / `buildOliveRunEnvironment`
+ * mocks let us hold the run in `setting_up` at each setup await, cancel it, then
+ * assert the run aborts without writing a recipe or spawning Olive.
  */
 import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach, vi } from "vitest";
 import express from "express";
 import type { Server } from "http";
 import fs from "fs";
 
-// ── Controllable ensureVenv gate ──────────────────────────────────────────
+// ── Controllable setup gates ──────────────────────────────────────────────
+// ensureVenv always pauses on its gate. buildOliveRunEnvironment only pauses
+// when `gateBuildEnv` is set, so most tests aren't blocked by it.
 let releaseEnsureVenv: (() => void) | null = null;
-function ensureVenvGate(): Promise<void> {
-  return new Promise<void>((resolve) => {
-    releaseEnsureVenv = resolve;
-  });
-}
+let releaseBuildEnv: (() => void) | null = null;
+let gateBuildEnv = false;
 
 vi.mock("../services/venv/index.ts", () => ({
   ensureVenv: vi.fn(async (onLine: (line: string) => void) => {
     onLine("[setup] (mock) creating venv…");
-    await ensureVenvGate();
+    await new Promise<void>((resolve) => {
+      releaseEnsureVenv = resolve;
+    });
     return { ok: true };
   }),
-  buildOliveRunEnvironment: vi.fn(async () => ({}) as NodeJS.ProcessEnv),
+  buildOliveRunEnvironment: vi.fn(async () => {
+    if (gateBuildEnv) {
+      await new Promise<void>((resolve) => {
+        releaseBuildEnv = resolve;
+      });
+    }
+    return {} as NodeJS.ProcessEnv;
+  }),
   resolveOliveCommand: vi.fn(() => ({ executable: "python", args: ["-m", "olive"] })),
+  detachVenvListener: vi.fn(),
 }));
 
 // spawn must never be called once the job was cancelled during setup.
@@ -71,6 +81,8 @@ beforeEach(() => {
   jobRegistry.clear();
   spawnSpy.mockClear();
   releaseEnsureVenv = null;
+  releaseBuildEnv = null;
+  gateBuildEnv = false;
 });
 
 afterEach(() => {
@@ -121,6 +133,44 @@ describe("POST /api/olive/cancel during setup", () => {
 
     expect(spawnSpy).not.toHaveBeenCalled();
     expect(jobRegistry.get(jobId)?.status).toBe("cancelled");
+  });
+
+  it("cancels during buildOliveRunEnvironment (after venv) and never writes a recipe or spawns", async () => {
+    gateBuildEnv = true;
+    const writeSpy = vi.spyOn(fs, "writeFileSync").mockReturnValue(undefined);
+
+    const runPromise = fetch(`${baseUrl}/api/olive/run`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ recipeJson: "{}" }),
+    });
+
+    // Advance past ensureVenv, then hold inside buildOliveRunEnvironment.
+    (await waitFor(() => releaseEnsureVenv ?? undefined))();
+    await waitFor(() => releaseBuildEnv ?? undefined);
+
+    const jobId = await waitFor(() => {
+      for (const [id, job] of jobRegistry) {
+        if (job.status === "setting_up") return id;
+      }
+      return undefined;
+    });
+
+    const cancelRes = await fetch(`${baseUrl}/api/olive/cancel`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ jobId }),
+    });
+    expect(await cancelRes.json()).toMatchObject({ ok: true, status: "cancelled" });
+
+    // Release the build gate; the run must abort at the post-build cancel check.
+    releaseBuildEnv?.();
+    const runBody = await (await runPromise).json();
+    expect(runBody).toMatchObject({ ok: false, status: "cancelled" });
+
+    expect(jobRegistry.get(jobId)?.status).toBe("cancelled");
+    expect(writeSpy).not.toHaveBeenCalled(); // recipe file never created
+    expect(spawnSpy).not.toHaveBeenCalled();
   });
 
   it("returns terminal status without side effects when the job already finished", async () => {

--- a/src/server/routes/olive.cancel.test.ts
+++ b/src/server/routes/olive.cancel.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Route-level coverage for cancelling an Olive job *during* environment setup,
+ * before the child process exists. A gated `ensureVenv` mock lets us hold the
+ * run in `setting_up`, cancel it, then assert the run aborts without spawning.
+ */
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from "vitest";
+import express from "express";
+import type { Server } from "http";
+
+// ── Controllable ensureVenv gate ──────────────────────────────────────────
+let releaseEnsureVenv: (() => void) | null = null;
+function ensureVenvGate(): Promise<void> {
+  return new Promise<void>((resolve) => {
+    releaseEnsureVenv = resolve;
+  });
+}
+
+vi.mock("../services/venv/index.ts", () => ({
+  ensureVenv: vi.fn(async (onLine: (line: string) => void) => {
+    onLine("[setup] (mock) creating venv…");
+    await ensureVenvGate();
+    return { ok: true };
+  }),
+  buildOliveRunEnvironment: vi.fn(async () => ({}) as NodeJS.ProcessEnv),
+  resolveOliveCommand: vi.fn(() => ({ executable: "python", args: ["-m", "olive"] })),
+}));
+
+// spawn must never be called once the job was cancelled during setup.
+const spawnSpy = vi.fn(() => {
+  throw new Error("spawn() must not run after cancellation");
+});
+vi.mock("child_process", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("child_process")>();
+  return { ...actual, spawn: spawnSpy };
+});
+
+vi.mock("../../lib/oliveRecipeSchema.ts", () => ({
+  validateOliveRecipeStructure: () => ({ valid: true, errors: [] }),
+}));
+
+// Imported after mocks are registered.
+const { mountOliveRoutes } = await import("./olive.ts");
+const { jobRegistry } = await import("../services/olive/state.ts");
+
+let server: Server;
+let baseUrl: string;
+
+beforeAll(async () => {
+  const app = express();
+  app.use(express.json());
+  const router = express.Router();
+  mountOliveRoutes(router);
+  app.use("/api", router);
+  await new Promise<void>((resolve, reject) => {
+    server = app.listen(0, "127.0.0.1", () => {
+      const addr = server.address();
+      if (!addr || typeof addr === "string") return reject(new Error("no port"));
+      baseUrl = `http://127.0.0.1:${addr.port}`;
+      resolve();
+    });
+    server.on("error", reject);
+  });
+});
+
+afterAll(async () => {
+  if (server) await new Promise<void>((resolve) => server.close(() => resolve()));
+});
+
+beforeEach(() => {
+  jobRegistry.clear();
+  spawnSpy.mockClear();
+  releaseEnsureVenv = null;
+});
+
+async function waitFor<T>(fn: () => T | undefined, timeoutMs = 2000): Promise<T> {
+  const start = Date.now();
+  for (;;) {
+    const v = fn();
+    if (v !== undefined) return v;
+    if (Date.now() - start > timeoutMs) throw new Error("waitFor timed out");
+    await new Promise((r) => setTimeout(r, 5));
+  }
+}
+
+describe("POST /api/olive/cancel during setup", () => {
+  it("cancels a setting_up job and prevents Olive from spawning", async () => {
+    const runPromise = fetch(`${baseUrl}/api/olive/run`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ recipeJson: "{}" }),
+    });
+
+    // Job is registered synchronously before the first await; grab it while
+    // ensureVenv is gated in "setting_up".
+    const jobId = await waitFor(() => {
+      for (const [id, job] of jobRegistry) {
+        if (job.status === "setting_up") return id;
+      }
+      return undefined;
+    });
+
+    const cancelRes = await fetch(`${baseUrl}/api/olive/cancel`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ jobId }),
+    });
+    expect(cancelRes.status).toBe(200);
+    const cancelBody = await cancelRes.json();
+    expect(cancelBody).toMatchObject({ ok: true, status: "cancelled" });
+
+    // Let the gated ensureVenv resolve; the run must now abort, not spawn.
+    releaseEnsureVenv?.();
+    const runRes = await runPromise;
+    const runBody = await runRes.json();
+    expect(runBody).toMatchObject({ ok: false, status: "cancelled" });
+
+    expect(spawnSpy).not.toHaveBeenCalled();
+    expect(jobRegistry.get(jobId)?.status).toBe("cancelled");
+  });
+
+  it("returns terminal status without side effects when the job already finished", async () => {
+    // Seed a completed job directly.
+    jobRegistry.set("done-job", {
+      id: "done-job",
+      status: "completed",
+      exitCode: 0,
+      logs: [],
+      subscribers: [],
+      metricSubscribers: [],
+      process: null,
+      latestMetrics: null,
+      metricsTimer: null,
+      sampling: false,
+      tempRecipePath: null,
+      finishedAt: Date.now(),
+      doneSubscribers: [],
+    });
+
+    const res = await fetch(`${baseUrl}/api/olive/cancel`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ jobId: "done-job" }),
+    });
+    const body = await res.json();
+    expect(body).toMatchObject({ ok: true, status: "completed" });
+  });
+});

--- a/src/server/routes/olive.cancel.test.ts
+++ b/src/server/routes/olive.cancel.test.ts
@@ -3,9 +3,10 @@
  * before the child process exists. A gated `ensureVenv` mock lets us hold the
  * run in `setting_up`, cancel it, then assert the run aborts without spawning.
  */
-import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach, vi } from "vitest";
 import express from "express";
 import type { Server } from "http";
+import fs from "fs";
 
 // ── Controllable ensureVenv gate ──────────────────────────────────────────
 let releaseEnsureVenv: (() => void) | null = null;
@@ -70,6 +71,10 @@ beforeEach(() => {
   jobRegistry.clear();
   spawnSpy.mockClear();
   releaseEnsureVenv = null;
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
 });
 
 async function waitFor<T>(fn: () => T | undefined, timeoutMs = 2000): Promise<T> {
@@ -143,5 +148,40 @@ describe("POST /api/olive/cancel during setup", () => {
     });
     const body = await res.json();
     expect(body).toMatchObject({ ok: true, status: "completed" });
+  });
+});
+
+describe("POST /api/olive/run temp-recipe write failure", () => {
+  it("reclaims the temp recipe file when writing it fails", async () => {
+    vi.spyOn(fs, "mkdirSync").mockReturnValue(undefined as unknown as string);
+    vi.spyOn(fs, "writeFileSync").mockImplementation(() => {
+      throw new Error("ENOSPC: no space left on device");
+    });
+    // Records whether cleanup tried to remove the (partially/never) written file.
+    const rmSpy = vi.spyOn(fs, "rmSync").mockReturnValue(undefined);
+
+    const runPromise = fetch(`${baseUrl}/api/olive/run`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ recipeJson: "{}" }),
+    });
+
+    // ensureVenv is gated — release it so setup proceeds to the failing write.
+    const release = await waitFor(() => releaseEnsureVenv ?? undefined);
+    release();
+
+    const res = await runPromise;
+    const body = await res.json();
+    expect(body).toMatchObject({ ok: false });
+    expect(spawnSpy).not.toHaveBeenCalled();
+
+    // tempRecipePath was recorded before the write, so cleanup targeted it.
+    const rmTarget = rmSpy.mock.calls[0]?.[0];
+    expect(String(rmTarget)).toContain("recipe-");
+    expect(String(rmTarget)).toContain(".json");
+
+    const job = [...jobRegistry.values()].at(-1);
+    expect(job?.status).toBe("failed");
+    expect(job?.tempRecipePath).toBeNull();
   });
 });

--- a/src/server/routes/olive.cancel.test.ts
+++ b/src/server/routes/olive.cancel.test.ts
@@ -199,6 +199,66 @@ describe("POST /api/olive/cancel during setup", () => {
     const body = await res.json();
     expect(body).toMatchObject({ ok: true, status: "completed" });
   });
+
+  it("escalates SIGTERM to SIGKILL when the child ignores cancellation", async () => {
+    const kill = vi.fn();
+    const once = vi.fn();
+    const proc = {
+      kill,
+      exitCode: null as number | null,
+      signalCode: null as NodeJS.Signals | null,
+      once,
+    };
+
+    jobRegistry.set("stuck-job", {
+      id: "stuck-job",
+      status: "running",
+      exitCode: null,
+      logs: [],
+      subscribers: [],
+      metricSubscribers: [],
+      process: proc as unknown as import("child_process").ChildProcess,
+      latestMetrics: null,
+      metricsTimer: null,
+      sampling: false,
+      tempRecipePath: null,
+      finishedAt: null,
+      doneSubscribers: [],
+    });
+
+    const { CANCEL_SIGKILL_GRACE_MS } = await import("./olive.ts");
+    let escalate: (() => void) | undefined;
+    const realSetTimeout = globalThis.setTimeout.bind(globalThis);
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout").mockImplementation(((
+      fn: TimerHandler,
+      ms?: number,
+      ...args: unknown[]
+    ) => {
+      if (ms === CANCEL_SIGKILL_GRACE_MS && typeof fn === "function") {
+        escalate = () => (fn as (...a: unknown[]) => void)(...args);
+        return { unref() {} } as unknown as ReturnType<typeof setTimeout>;
+      }
+      return realSetTimeout(fn as never, ms as never, ...(args as never[]));
+    }) as typeof setTimeout);
+
+    try {
+      const res = await fetch(`${baseUrl}/api/olive/cancel`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ jobId: "stuck-job" }),
+      });
+      expect(await res.json()).toMatchObject({ ok: true, status: "cancelled" });
+      expect(kill).toHaveBeenCalledWith("SIGTERM");
+      expect(kill).not.toHaveBeenCalledWith("SIGKILL");
+      expect(escalate).toBeTypeOf("function");
+      expect(once).toHaveBeenCalledWith("close", expect.any(Function));
+
+      escalate!();
+      expect(kill).toHaveBeenCalledWith("SIGKILL");
+    } finally {
+      setTimeoutSpy.mockRestore();
+    }
+  });
 });
 
 describe("POST /api/olive/run temp-recipe write failure", () => {

--- a/src/server/routes/olive.cancel.test.ts
+++ b/src/server/routes/olive.cancel.test.ts
@@ -239,7 +239,7 @@ describe("POST /api/olive/cancel during setup", () => {
         return { unref() {} } as unknown as ReturnType<typeof setTimeout>;
       }
       return realSetTimeout(fn as never, ms as never, ...(args as never[]));
-    }) as typeof setTimeout);
+    }) as unknown as typeof setTimeout);
 
     try {
       const res = await fetch(`${baseUrl}/api/olive/cancel`, {

--- a/src/server/routes/olive.ts
+++ b/src/server/routes/olive.ts
@@ -108,8 +108,11 @@ export function mountOliveRoutes(router: Router): void {
       const tmpDir = path.join(process.cwd(), ".olive-runs");
       fs.mkdirSync(tmpDir, { recursive: true });
       const configPath = path.join(tmpDir, `recipe-${jobId}.json`);
-      fs.writeFileSync(configPath, JSON.stringify(enrichedRecipe, null, 2), "utf-8");
+      // Record the path before writing so a failed/partial write is still
+      // reclaimable by cleanupJobArtifacts (rmSync force:true tolerates a
+      // never-created file).
       job.tempRecipePath = configPath;
+      fs.writeFileSync(configPath, JSON.stringify(enrichedRecipe, null, 2), "utf-8");
 
       pushLog(job, "[setup] Starting Olive optimization...");
       job.status = "running";

--- a/src/server/routes/olive.ts
+++ b/src/server/routes/olive.ts
@@ -178,7 +178,11 @@ export function mountOliveRoutes(router: Router): void {
 
       return res.json({ ok: true, jobId });
     } catch (err: unknown) {
-      job.status = "failed";
+      // Preserve intentional cancellation — e.g. ensureVenv/buildOliveRunEnvironment
+      // rejecting after /olive/cancel already stamped "cancelled".
+      if (job.status !== "cancelled") {
+        job.status = "failed";
+      }
       cleanupJobArtifacts(job);
       const msg = err instanceof Error ? err.message : String(err);
       pushLog(job, `[error] ${msg}`);

--- a/src/server/routes/olive.ts
+++ b/src/server/routes/olive.ts
@@ -13,7 +13,12 @@ import { validateOliveRecipeStructure } from "../../lib/oliveRecipeSchema.ts";
 import { enrichRecipeMemoryOffloadForRun } from "../../lib/memoryOffload.ts";
 import { isGpuExecutionProvider } from "../../lib/oliveGpuRuntime.ts";
 
-import { jobRegistry, getRuntimeHfToken } from "../services/olive/state.ts";
+import {
+  jobRegistry,
+  getRuntimeHfToken,
+  cleanupJobArtifacts,
+  startJobRegistrySweeper,
+} from "../services/olive/state.ts";
 import { pushLog, startGpuMetricsTimer, stopGpuMetricsTimer } from "../services/olive/gpu.ts";
 import { getVenvPython } from "../services/venv/paths.ts";
 import { ensureVenv, buildOliveRunEnvironment, resolveOliveCommand } from "../services/venv/index.ts";
@@ -21,6 +26,9 @@ import type { OliveRecipe, OliveJob } from "../types.ts";
 import { oliveRunRateLimit } from "../middleware/rateLimit.ts";
 
 export function mountOliveRoutes(router: Router): void {
+  // Reclaim finished jobs + their temp recipe files on a timer.
+  startJobRegistrySweeper();
+
   // ─── POST /api/olive/run ──────────────────────────────────────────────
   router.post("/olive/run", oliveRunRateLimit, async (req, res) => {
     const { recipeJson, cudaVersion = "auto" } = req.body as { recipeJson?: string; cudaVersion?: string };
@@ -52,6 +60,8 @@ export function mountOliveRoutes(router: Router): void {
       latestMetrics: null,
       metricsTimer: null,
       sampling: false,
+      tempRecipePath: null,
+      finishedAt: null,
     };
     jobRegistry.set(jobId, job);
 
@@ -81,6 +91,7 @@ export function mountOliveRoutes(router: Router): void {
       fs.mkdirSync(tmpDir, { recursive: true });
       const configPath = path.join(tmpDir, `recipe-${jobId}.json`);
       fs.writeFileSync(configPath, JSON.stringify(enrichedRecipe, null, 2), "utf-8");
+      job.tempRecipePath = configPath;
 
       pushLog(job, "[setup] Starting Olive optimization...");
       job.status = "running";
@@ -109,14 +120,18 @@ export function mountOliveRoutes(router: Router): void {
         if (job.status !== "cancelled") {
           job.status = code === 0 ? "completed" : "failed";
         }
+        job.finishedAt = Date.now();
         stopGpuMetricsTimer(job);
+        cleanupJobArtifacts(job);
         pushLog(job, `[done] Olive exited with code ${code ?? "unknown"}`);
       });
       proc.on("error", (err) => {
         if (job.status !== "cancelled") {
           job.status = "failed";
         }
+        job.finishedAt = Date.now();
         stopGpuMetricsTimer(job);
+        cleanupJobArtifacts(job);
         pushLog(job, `[error] Failed to start Olive: ${err.message}`);
       });
 
@@ -127,6 +142,8 @@ export function mountOliveRoutes(router: Router): void {
       return res.json({ ok: true, jobId });
     } catch (err: unknown) {
       job.status = "failed";
+      job.finishedAt = Date.now();
+      cleanupJobArtifacts(job);
       const msg = err instanceof Error ? err.message : String(err);
       pushLog(job, `[error] ${msg}`);
       return res.status(500).json({ ok: false, jobId, error: msg });
@@ -151,15 +168,47 @@ export function mountOliveRoutes(router: Router): void {
       res.write(`data: ${JSON.stringify({ line })}\n\n`);
     }
 
+    const isTerminal = () =>
+      job.status === "completed" || job.status === "failed" || job.status === "cancelled";
+
+    // If the job already finished, flush a terminal event and close immediately.
+    if (isTerminal()) {
+      res.write(`data: ${JSON.stringify({ done: true, status: job.status, exitCode: job.exitCode })}\n\n`);
+      return res.end();
+    }
+
+    let heartbeat: ReturnType<typeof setInterval> | null = null;
+    const cleanup = () => {
+      if (heartbeat) {
+        clearInterval(heartbeat);
+        heartbeat = null;
+      }
+      const idx = job.subscribers.indexOf(sub);
+      if (idx >= 0) job.subscribers.splice(idx, 1);
+    };
+
     const sub = (line: string) => {
       if (!res.writableEnded) res.write(`data: ${JSON.stringify({ line })}\n\n`);
     };
     job.subscribers.push(sub);
 
-    req.on("close", () => {
-      const idx = job.subscribers.indexOf(sub);
-      if (idx >= 0) job.subscribers.splice(idx, 1);
-    });
+    // Heartbeat keeps proxies from buffering/closing an idle stream, and lets us
+    // detect job completion so the stream actually terminates instead of hanging.
+    heartbeat = setInterval(() => {
+      if (res.writableEnded) {
+        cleanup();
+        return;
+      }
+      if (isTerminal()) {
+        res.write(`data: ${JSON.stringify({ done: true, status: job.status, exitCode: job.exitCode })}\n\n`);
+        cleanup();
+        res.end();
+        return;
+      }
+      res.write(`: ping\n\n`);
+    }, 15_000);
+
+    req.on("close", cleanup);
   });
 
   // ─── Job Status ───────────────────────────────────────────────────────
@@ -184,6 +233,7 @@ export function mountOliveRoutes(router: Router): void {
     if (!job) return res.status(404).json({ error: "Job not found" });
     if (job.process) {
       job.status = "cancelled";
+      job.finishedAt = Date.now();
       job.process.kill("SIGTERM");
       stopGpuMetricsTimer(job);
     }

--- a/src/server/routes/olive.ts
+++ b/src/server/routes/olive.ts
@@ -22,7 +22,12 @@ import {
 } from "../services/olive/state.ts";
 import { pushLog, startGpuMetricsTimer, stopGpuMetricsTimer } from "../services/olive/gpu.ts";
 import { getVenvPython } from "../services/venv/paths.ts";
-import { ensureVenv, buildOliveRunEnvironment, resolveOliveCommand } from "../services/venv/index.ts";
+import {
+  ensureVenv,
+  buildOliveRunEnvironment,
+  resolveOliveCommand,
+  detachVenvListener,
+} from "../services/venv/index.ts";
 import type { OliveRecipe, OliveJob } from "../types.ts";
 import { oliveRunRateLimit } from "../middleware/rateLimit.ts";
 
@@ -82,7 +87,12 @@ export function mountOliveRoutes(router: Router): void {
     };
 
     try {
-      const venvResult = await ensureVenv((line) => pushLog(job, line));
+      // Retain the listener so /olive/cancel can detach it if setup is pending.
+      const venvListener = (line: string) => pushLog(job, line);
+      job.venvListener = venvListener;
+      const venvResult = await ensureVenv(venvListener);
+      // Setup finished for this caller — the listener is no longer registered.
+      job.venvListener = undefined;
       if (bailIfCancelled()) return;
       if (!venvResult.ok) {
         job.status = "failed";
@@ -275,6 +285,12 @@ export function mountOliveRoutes(router: Router): void {
     // setup loop checks this status after each await and aborts before spawning.
     job.status = "cancelled";
     pushLog(job, "[cancel] Cancellation requested.");
+    // Detach from shared venv setup so the cancelled job stops receiving install
+    // output while setup (which may serve other jobs) keeps running.
+    if (job.venvListener) {
+      detachVenvListener(job.venvListener);
+      job.venvListener = undefined;
+    }
     if (job.process) {
       job.process.kill("SIGTERM");
       stopGpuMetricsTimer(job);

--- a/src/server/routes/olive.ts
+++ b/src/server/routes/olive.ts
@@ -127,6 +127,8 @@ export function mountOliveRoutes(router: Router): void {
         stopGpuMetricsTimer(job);
         cleanupJobArtifacts(job);
         pushLog(job, `[done] Olive exited with code ${code ?? "unknown"}`);
+        // Process has exited — clear the handle so the sweeper may reclaim it.
+        job.process = null;
         finalizeJob(job);
       });
       proc.on("error", (err) => {
@@ -136,6 +138,7 @@ export function mountOliveRoutes(router: Router): void {
         stopGpuMetricsTimer(job);
         cleanupJobArtifacts(job);
         pushLog(job, `[error] Failed to start Olive: ${err.message}`);
+        job.process = null;
         finalizeJob(job);
       });
 

--- a/src/server/routes/olive.ts
+++ b/src/server/routes/olive.ts
@@ -70,8 +70,20 @@ export function mountOliveRoutes(router: Router): void {
     const provider = (recipe.systems?.local_system?.config?.accelerators?.[0]?.execution_providers?.[0] ??
       "CPUExecutionProvider") as IHVProvider;
 
+    // Cancellation can arrive during the long setup awaits below, before a
+    // process exists. Bail out (and respond) instead of spawning Olive anyway.
+    const bailIfCancelled = (): boolean => {
+      if (job.status !== "cancelled") return false;
+      pushLog(job, "[cancel] Cancelled during environment setup.");
+      cleanupJobArtifacts(job);
+      finalizeJob(job);
+      res.json({ ok: false, jobId, status: "cancelled" });
+      return true;
+    };
+
     try {
       const venvResult = await ensureVenv((line) => pushLog(job, line));
+      if (bailIfCancelled()) return;
       if (!venvResult.ok) {
         job.status = "failed";
         // Log before finalizeJob so the error reaches any stream before it drains.
@@ -83,6 +95,7 @@ export function mountOliveRoutes(router: Router): void {
 
       const venvPython = getVenvPython();
       const env = await buildOliveRunEnvironment(venvPython, provider, process.env);
+      if (bailIfCancelled()) return;
 
       if (cudaVersion !== "auto") {
         env.CUDA_VERSION = cudaVersion;
@@ -249,14 +262,23 @@ export function mountOliveRoutes(router: Router): void {
     const { jobId } = req.body ?? {};
     const job = jobRegistry.get(jobId);
     if (!job) return res.status(404).json({ error: "Job not found" });
+
+    // Already terminal — nothing to cancel.
+    if (job.status === "completed" || job.status === "failed" || job.status === "cancelled") {
+      return res.json({ ok: true, status: job.status });
+    }
+
+    // Mark cancelled even during "setting_up" (no process yet). The /olive/run
+    // setup loop checks this status after each await and aborts before spawning.
+    job.status = "cancelled";
+    pushLog(job, "[cancel] Cancellation requested.");
     if (job.process) {
-      job.status = "cancelled";
       job.process.kill("SIGTERM");
       stopGpuMetricsTimer(job);
-      // Fallback finalize in case the process never emits "close"; the close
-      // handler is idempotent (finishedAt is only stamped once).
-      finalizeJob(job);
     }
-    return res.json({ ok: true });
+    // Finalize so open SSE streams close now; the "close" handler (if a process
+    // is running) is idempotent — finishedAt is only stamped once.
+    finalizeJob(job);
+    return res.json({ ok: true, status: job.status });
   });
 }

--- a/src/server/routes/olive.ts
+++ b/src/server/routes/olive.ts
@@ -74,9 +74,10 @@ export function mountOliveRoutes(router: Router): void {
       const venvResult = await ensureVenv((line) => pushLog(job, line));
       if (!venvResult.ok) {
         job.status = "failed";
-        finalizeJob(job);
-        cleanupJobArtifacts(job);
+        // Log before finalizeJob so the error reaches any stream before it drains.
         pushLog(job, `[error] ${venvResult.error}`);
+        cleanupJobArtifacts(job);
+        finalizeJob(job);
         return res.status(500).json({ ok: false, jobId, error: venvResult.error });
       }
 
@@ -135,11 +136,11 @@ export function mountOliveRoutes(router: Router): void {
         if (job.status !== "cancelled") {
           job.status = "failed";
         }
-        stopGpuMetricsTimer(job);
-        cleanupJobArtifacts(job);
         pushLog(job, `[error] Failed to start Olive: ${err.message}`);
-        job.process = null;
-        finalizeJob(job);
+        // Terminal cleanup (stop metrics, remove artifacts, clear the handle,
+        // finalize) is handled by the "close" listener, which fires after "error"
+        // for spawn failures. A post-spawn error (e.g. a failed kill) must not drop
+        // the process handle while the child may still be alive.
       });
 
       if (isGpuExecutionProvider(provider)) {

--- a/src/server/routes/olive.ts
+++ b/src/server/routes/olive.ts
@@ -18,6 +18,7 @@ import {
   getRuntimeHfToken,
   cleanupJobArtifacts,
   startJobRegistrySweeper,
+  finalizeJob,
 } from "../services/olive/state.ts";
 import { pushLog, startGpuMetricsTimer, stopGpuMetricsTimer } from "../services/olive/gpu.ts";
 import { getVenvPython } from "../services/venv/paths.ts";
@@ -62,6 +63,7 @@ export function mountOliveRoutes(router: Router): void {
       sampling: false,
       tempRecipePath: null,
       finishedAt: null,
+      doneSubscribers: [],
     };
     jobRegistry.set(jobId, job);
 
@@ -72,6 +74,8 @@ export function mountOliveRoutes(router: Router): void {
       const venvResult = await ensureVenv((line) => pushLog(job, line));
       if (!venvResult.ok) {
         job.status = "failed";
+        finalizeJob(job);
+        cleanupJobArtifacts(job);
         pushLog(job, `[error] ${venvResult.error}`);
         return res.status(500).json({ ok: false, jobId, error: venvResult.error });
       }
@@ -120,19 +124,19 @@ export function mountOliveRoutes(router: Router): void {
         if (job.status !== "cancelled") {
           job.status = code === 0 ? "completed" : "failed";
         }
-        job.finishedAt = Date.now();
         stopGpuMetricsTimer(job);
         cleanupJobArtifacts(job);
         pushLog(job, `[done] Olive exited with code ${code ?? "unknown"}`);
+        finalizeJob(job);
       });
       proc.on("error", (err) => {
         if (job.status !== "cancelled") {
           job.status = "failed";
         }
-        job.finishedAt = Date.now();
         stopGpuMetricsTimer(job);
         cleanupJobArtifacts(job);
         pushLog(job, `[error] Failed to start Olive: ${err.message}`);
+        finalizeJob(job);
       });
 
       if (isGpuExecutionProvider(provider)) {
@@ -142,10 +146,10 @@ export function mountOliveRoutes(router: Router): void {
       return res.json({ ok: true, jobId });
     } catch (err: unknown) {
       job.status = "failed";
-      job.finishedAt = Date.now();
       cleanupJobArtifacts(job);
       const msg = err instanceof Error ? err.message : String(err);
       pushLog(job, `[error] ${msg}`);
+      finalizeJob(job);
       return res.status(500).json({ ok: false, jobId, error: msg });
     }
   });
@@ -183,8 +187,10 @@ export function mountOliveRoutes(router: Router): void {
         clearInterval(heartbeat);
         heartbeat = null;
       }
-      const idx = job.subscribers.indexOf(sub);
-      if (idx >= 0) job.subscribers.splice(idx, 1);
+      const subIdx = job.subscribers.indexOf(sub);
+      if (subIdx >= 0) job.subscribers.splice(subIdx, 1);
+      const doneIdx = job.doneSubscribers.indexOf(onDone);
+      if (doneIdx >= 0) job.doneSubscribers.splice(doneIdx, 1);
     };
 
     const sub = (line: string) => {
@@ -192,17 +198,25 @@ export function mountOliveRoutes(router: Router): void {
     };
     job.subscribers.push(sub);
 
-    // Heartbeat keeps proxies from buffering/closing an idle stream, and lets us
-    // detect job completion so the stream actually terminates instead of hanging.
+    // Fired the instant the job reaches a terminal state — closes the stream
+    // immediately rather than waiting up to one heartbeat interval.
+    const onDone = () => {
+      if (res.writableEnded) return;
+      res.write(`data: ${JSON.stringify({ done: true, status: job.status, exitCode: job.exitCode })}\n\n`);
+      cleanup();
+      res.end();
+    };
+    job.doneSubscribers.push(onDone);
+
+    // Heartbeat keeps proxies from buffering/closing an idle stream, and acts as
+    // a fallback terminator if the done event was somehow missed.
     heartbeat = setInterval(() => {
       if (res.writableEnded) {
         cleanup();
         return;
       }
       if (isTerminal()) {
-        res.write(`data: ${JSON.stringify({ done: true, status: job.status, exitCode: job.exitCode })}\n\n`);
-        cleanup();
-        res.end();
+        onDone();
         return;
       }
       res.write(`: ping\n\n`);
@@ -233,9 +247,11 @@ export function mountOliveRoutes(router: Router): void {
     if (!job) return res.status(404).json({ error: "Job not found" });
     if (job.process) {
       job.status = "cancelled";
-      job.finishedAt = Date.now();
       job.process.kill("SIGTERM");
       stopGpuMetricsTimer(job);
+      // Fallback finalize in case the process never emits "close"; the close
+      // handler is idempotent (finishedAt is only stamped once).
+      finalizeJob(job);
     }
     return res.json({ ok: true });
   });

--- a/src/server/routes/olive.ts
+++ b/src/server/routes/olive.ts
@@ -31,6 +31,9 @@ import {
 import type { OliveRecipe, OliveJob } from "../types.ts";
 import { oliveRunRateLimit } from "../middleware/rateLimit.ts";
 
+/** Grace period after SIGTERM before escalating cancel to SIGKILL. */
+export const CANCEL_SIGKILL_GRACE_MS = 10_000;
+
 export function mountOliveRoutes(router: Router): void {
   // Reclaim finished jobs + their temp recipe files on a timer.
   startJobRegistrySweeper();
@@ -292,7 +295,17 @@ export function mountOliveRoutes(router: Router): void {
       job.venvListener = undefined;
     }
     if (job.process) {
-      job.process.kill("SIGTERM");
+      const proc = job.process;
+      proc.kill("SIGTERM");
+      // SIGTERM is best-effort; escalate so a stuck Olive child cannot outlive cancel.
+      const killTimer = setTimeout(() => {
+        if (proc.exitCode === null && proc.signalCode === null) {
+          proc.kill("SIGKILL");
+          pushLog(job, "[cancel] Process did not exit after SIGTERM; sent SIGKILL.");
+        }
+      }, CANCEL_SIGKILL_GRACE_MS);
+      if (typeof killTimer.unref === "function") killTimer.unref();
+      proc.once("close", () => clearTimeout(killTimer));
       stopGpuMetricsTimer(job);
     }
     // Finalize so open SSE streams close now; the "close" handler (if a process

--- a/src/server/services/ai/anthropic.ts
+++ b/src/server/services/ai/anthropic.ts
@@ -11,20 +11,24 @@ async function call(
   const sysText = wantJson
     ? `${system}\n\nIMPORTANT: Respond with valid JSON only. No markdown, no text outside the JSON object.`
     : system;
-  const resp = await fetchWithTimeout("https://api.anthropic.com/v1/messages", {
-    method: "POST",
-    headers: {
-      "x-api-key": cfg.apiKey,
-      "anthropic-version": "2023-06-01",
-      "Content-Type": "application/json",
+  const resp = await fetchWithTimeout(
+    "https://api.anthropic.com/v1/messages",
+    {
+      method: "POST",
+      headers: {
+        "x-api-key": cfg.apiKey,
+        "anthropic-version": "2023-06-01",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        model: cfg.model,
+        max_tokens: 4096,
+        system: sysText,
+        messages: messages.map((m) => ({ role: m.role, content: m.content })),
+      }),
     },
-    body: JSON.stringify({
-      model: cfg.model,
-      max_tokens: 4096,
-      system: sysText,
-      messages: messages.map((m) => ({ role: m.role, content: m.content })),
-    }),
-  });
+    cfg.timeoutMs,
+  );
   if (!resp.ok) {
     const err = (await resp.json().catch(() => ({}))) as ApiErrorResponse;
     throw new Error(`Anthropic ${resp.status}: ${err.error?.message ?? resp.statusText}`);

--- a/src/server/services/ai/anthropic.ts
+++ b/src/server/services/ai/anthropic.ts
@@ -1,5 +1,6 @@
 import type { ProviderConfig, AIChatMessage, AnthropicResponse, ApiErrorResponse } from "../../types.ts";
 import { registerProvider } from "./registry.ts";
+import { fetchWithTimeout } from "../shared/http.ts";
 
 async function call(
   cfg: ProviderConfig,
@@ -10,7 +11,7 @@ async function call(
   const sysText = wantJson
     ? `${system}\n\nIMPORTANT: Respond with valid JSON only. No markdown, no text outside the JSON object.`
     : system;
-  const resp = await fetch("https://api.anthropic.com/v1/messages", {
+  const resp = await fetchWithTimeout("https://api.anthropic.com/v1/messages", {
     method: "POST",
     headers: {
       "x-api-key": cfg.apiKey,
@@ -29,7 +30,10 @@ async function call(
     throw new Error(`Anthropic ${resp.status}: ${err.error?.message ?? resp.statusText}`);
   }
   const data = (await resp.json()) as AnthropicResponse;
-  return data.content?.[0]?.text ?? "";
+  const text = data.content?.[0]?.text ?? "";
+  // Match gemini/copilot: surface an empty response instead of silently returning "".
+  if (!text.trim()) throw new Error("Anthropic returned an empty response.");
+  return text;
 }
 
 registerProvider({

--- a/src/server/services/ai/gemini.ts
+++ b/src/server/services/ai/gemini.ts
@@ -23,11 +23,15 @@ async function call(
     })),
   };
   if (wantJson) body.generationConfig = { responseMimeType: "application/json" };
-  const resp = await fetchWithTimeout(url, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(body),
-  });
+  const resp = await fetchWithTimeout(
+    url,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    },
+    cfg.timeoutMs,
+  );
   if (!resp.ok) {
     const err = (await resp.json().catch(() => ({}))) as ApiErrorResponse;
     throw new Error(`Gemini ${resp.status}: ${err.error?.message ?? resp.statusText}`);

--- a/src/server/services/ai/gemini.ts
+++ b/src/server/services/ai/gemini.ts
@@ -6,6 +6,7 @@ import type {
   ApiErrorResponse,
 } from "../../types.ts";
 import { registerProvider } from "./registry.ts";
+import { fetchWithTimeout } from "../shared/http.ts";
 
 async function call(
   cfg: ProviderConfig,
@@ -22,7 +23,7 @@ async function call(
     })),
   };
   if (wantJson) body.generationConfig = { responseMimeType: "application/json" };
-  const resp = await fetch(url, {
+  const resp = await fetchWithTimeout(url, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(body),

--- a/src/server/services/ai/openai.ts
+++ b/src/server/services/ai/openai.ts
@@ -5,8 +5,9 @@ import type {
   OpenAIChatResponse,
   ApiErrorResponse,
 } from "../../types.ts";
-import { registerProvider } from "./registry.ts";
+import { registerProvider, getProvider, providerSupportsJsonResponse } from "./registry.ts";
 import { stripTrailingSlashes } from "./security.ts";
+import { fetchWithTimeout } from "../shared/http.ts";
 
 // ─── Shared OpenAI-compatible call helper ─────────────────────────────────────
 
@@ -42,7 +43,7 @@ export async function callOpenAICompat(
     headers["X-Title"] = "Olive Studio";
   }
 
-  const resp = await fetch(`${base}/chat/completions`, {
+  const resp = await fetchWithTimeout(`${base}/chat/completions`, {
     method: "POST",
     headers,
     body: JSON.stringify(body),
@@ -57,39 +58,20 @@ export async function callOpenAICompat(
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
+/**
+ * Resolve the API base URL for an OpenAI-compatible provider.
+ * Single source of truth: an explicit `baseUrl` override, else the provider's
+ * registered `defaultBaseUrl`, else OpenAI. No per-provider table duplicated here.
+ */
 function resolveOpenAiCompatBase(cfg: ProviderConfig): string {
   if (cfg.baseUrl?.trim()) return stripTrailingSlashes(cfg.baseUrl.trim());
-  switch (cfg.provider) {
-    case "mistral":
-      return "https://api.mistral.ai/v1";
-    case "xai":
-      return "https://api.x.ai/v1";
-    case "openrouter":
-      return "https://openrouter.ai/api/v1";
-    case "groq":
-      return "https://api.groq.com/openai/v1";
-    case "together":
-      return "https://api.together.xyz/v1";
-    case "kilocode":
-      return "https://api.kilo.ai/api/gateway";
-    case "chatgpt-sub":
-    case "openai":
-    case "openai-compat":
-    default:
-      return "https://api.openai.com/v1";
-  }
+  const registered = getProvider(cfg.provider)?.defaultBaseUrl;
+  return stripTrailingSlashes(registered ?? "https://api.openai.com/v1");
 }
 
+/** Delegates to the registry's `supportsJsonResponseFormat` flag (no duplicated switch). */
 export function supportsJsonResponseFormat(cfg: ProviderConfig): boolean {
-  return (
-    cfg.provider === "openai" ||
-    cfg.provider === "chatgpt-sub" ||
-    cfg.provider === "mistral" ||
-    cfg.provider === "xai" ||
-    cfg.provider === "openrouter" ||
-    cfg.provider === "groq" ||
-    cfg.provider === "together"
-  );
+  return providerSupportsJsonResponse(cfg);
 }
 
 // ─── GitHub Copilot (special OpenAI-compat with extra headers) ────────────────
@@ -117,7 +99,7 @@ async function callGitHubCopilot(
     ],
   };
 
-  const resp = await fetch(endpoint, {
+  const resp = await fetchWithTimeout(endpoint, {
     method: "POST",
     headers: {
       Authorization: `Bearer ${cfg.apiKey}`,

--- a/src/server/services/ai/openai.ts
+++ b/src/server/services/ai/openai.ts
@@ -43,17 +43,24 @@ export async function callOpenAICompat(
     headers["X-Title"] = "Olive Studio";
   }
 
-  const resp = await fetchWithTimeout(`${base}/chat/completions`, {
-    method: "POST",
-    headers,
-    body: JSON.stringify(body),
-  });
+  const resp = await fetchWithTimeout(
+    `${base}/chat/completions`,
+    {
+      method: "POST",
+      headers,
+      body: JSON.stringify(body),
+    },
+    cfg.timeoutMs,
+  );
   if (!resp.ok) {
     const err = (await resp.json().catch(() => ({}))) as ApiErrorResponse;
     throw new Error(`${cfg.provider} ${resp.status}: ${err.error?.message ?? resp.statusText}`);
   }
   const data = (await resp.json()) as OpenAIChatResponse;
-  return data.choices?.[0]?.message?.content ?? "";
+  const text = data.choices?.[0]?.message?.content ?? "";
+  // Match gemini/copilot/anthropic: surface an empty response instead of returning "".
+  if (!text.trim()) throw new Error(`${cfg.provider} returned an empty response.`);
+  return text;
 }
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
@@ -65,6 +72,11 @@ export async function callOpenAICompat(
  */
 function resolveOpenAiCompatBase(cfg: ProviderConfig): string {
   if (cfg.baseUrl?.trim()) return stripTrailingSlashes(cfg.baseUrl.trim());
+  // The generic "openai-compat" provider has no canonical host — require an
+  // explicit baseUrl rather than silently sending keys to api.openai.com.
+  if (cfg.provider === "openai-compat") {
+    throw new Error("openai-compat provider requires an explicit baseUrl.");
+  }
   const registered = getProvider(cfg.provider)?.defaultBaseUrl;
   return stripTrailingSlashes(registered ?? "https://api.openai.com/v1");
 }
@@ -99,21 +111,25 @@ async function callGitHubCopilot(
     ],
   };
 
-  const resp = await fetchWithTimeout(endpoint, {
-    method: "POST",
-    headers: {
-      Authorization: `Bearer ${cfg.apiKey}`,
-      "Content-Type": "application/json",
-      Accept: "application/json",
-      "Copilot-Integration-Id": "vscode-chat",
-      "Editor-Version": "vscode/1.98.2",
-      "Editor-Plugin-Version": "copilot-chat/0.26.7",
-      "User-Agent": "GitHubCopilotChat/0.26.7",
-      "Openai-Intent": "conversation-panel",
-      "X-Request-Id": crypto.randomUUID(),
+  const resp = await fetchWithTimeout(
+    endpoint,
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${cfg.apiKey}`,
+        "Content-Type": "application/json",
+        Accept: "application/json",
+        "Copilot-Integration-Id": "vscode-chat",
+        "Editor-Version": "vscode/1.98.2",
+        "Editor-Plugin-Version": "copilot-chat/0.26.7",
+        "User-Agent": "GitHubCopilotChat/0.26.7",
+        "Openai-Intent": "conversation-panel",
+        "X-Request-Id": crypto.randomUUID(),
+      },
+      body: JSON.stringify(body),
     },
-    body: JSON.stringify(body),
-  });
+    cfg.timeoutMs,
+  );
 
   if (!resp.ok) {
     const errText = await resp.text().catch(() => "");

--- a/src/server/services/ai/providers.validation.test.ts
+++ b/src/server/services/ai/providers.validation.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Validation behavior for empty provider responses and openai-compat base URL.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("../shared/http.ts", () => ({
+  fetchWithTimeout: vi.fn(),
+  DEFAULT_FETCH_TIMEOUT_MS: 120_000,
+}));
+
+// Side-effect import registers real providers before we call them.
+import "./index.ts";
+import { callProvider } from "./registry.ts";
+import { callOpenAICompat } from "./openai.ts";
+import { fetchWithTimeout } from "../shared/http.ts";
+import type { ProviderConfig } from "../../types.ts";
+
+const mockedFetch = vi.mocked(fetchWithTimeout);
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("AI provider empty-response validation", () => {
+  beforeEach(() => {
+    mockedFetch.mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("callOpenAICompat throws when content is empty or whitespace", async () => {
+    mockedFetch.mockResolvedValue(jsonResponse({ choices: [{ message: { content: "   " } }] }));
+    await expect(
+      callOpenAICompat({ provider: "openai", apiKey: "k", model: "gpt-4o-mini" }, "sys", [], false),
+    ).rejects.toThrow("openai returned an empty response.");
+  });
+
+  it("rejects openai-compat without an explicit baseUrl", async () => {
+    await expect(
+      callOpenAICompat({ provider: "openai-compat", apiKey: "k", model: "gpt-4o-mini" }, "sys", [], false),
+    ).rejects.toThrow("openai-compat provider requires an explicit baseUrl.");
+    expect(mockedFetch).not.toHaveBeenCalled();
+  });
+
+  it("resolves registered OpenAI default base and unregistered fallback", async () => {
+    mockedFetch.mockResolvedValue(jsonResponse({ choices: [{ message: { content: "ok" } }] }));
+
+    await callOpenAICompat({ provider: "openai", apiKey: "k", model: "gpt-4o-mini" }, "sys", [], false);
+    expect(String(mockedFetch.mock.calls[0]?.[0])).toBe("https://api.openai.com/v1/chat/completions");
+
+    mockedFetch.mockClear();
+    mockedFetch.mockResolvedValue(jsonResponse({ choices: [{ message: { content: "ok" } }] }));
+    // Cast: simulate a provider id that is not registered so defaultBaseUrl is missing.
+    const unregistered = {
+      provider: "not-a-real-provider",
+      apiKey: "k",
+      model: "m",
+    } as unknown as ProviderConfig;
+    await callOpenAICompat(unregistered, "sys", [], false);
+    expect(String(mockedFetch.mock.calls[0]?.[0])).toBe("https://api.openai.com/v1/chat/completions");
+  });
+
+  it("Anthropic throws on empty or whitespace text", async () => {
+    mockedFetch.mockResolvedValue(jsonResponse({ content: [{ text: "\n" }] }));
+    await expect(
+      callProvider({ provider: "anthropic", apiKey: "k", model: "claude" }, "sys", [], false),
+    ).rejects.toThrow("Anthropic returned an empty response.");
+  });
+
+  it("Gemini throws on empty or whitespace text", async () => {
+    mockedFetch.mockResolvedValue(jsonResponse({ candidates: [{ content: { parts: [{ text: "" }] } }] }));
+    await expect(
+      callProvider({ provider: "gemini", apiKey: "k", model: "gemini-2.5-flash" }, "sys", [], false),
+    ).rejects.toThrow("Gemini returned an empty response.");
+  });
+});

--- a/src/server/services/olive/cuda.test.ts
+++ b/src/server/services/olive/cuda.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "vitest";
+import { pickCudaTag, parseCudaVersionFromNvidiaSmi } from "./cuda.ts";
+
+describe("pickCudaTag", () => {
+  it("maps modern CUDA versions to the matching wheel tier", () => {
+    expect(pickCudaTag(12, 8)).toBe("cu126");
+    expect(pickCudaTag(12, 6)).toBe("cu126");
+    expect(pickCudaTag(12, 4)).toBe("cu124");
+    expect(pickCudaTag(12, 1)).toBe("cu121");
+    expect(pickCudaTag(11, 8)).toBe("cu118");
+  });
+
+  it("returns cpu for versions below the lowest supported tier", () => {
+    // CUDA 11.7 and older have no compatible wheel — do not force cu118.
+    expect(pickCudaTag(11, 7)).toBe("cpu");
+    expect(pickCudaTag(10, 2)).toBe("cpu");
+  });
+});
+
+describe("parseCudaVersionFromNvidiaSmi", () => {
+  it("extracts version and tag from nvidia-smi output", () => {
+    const out = "NVIDIA-SMI 550.00   Driver Version: 550.00   CUDA Version: 12.4";
+    expect(parseCudaVersionFromNvidiaSmi(out)).toEqual({ cudaVersion: "12.4", cudaTag: "cu124" });
+  });
+
+  it("returns cpu tag for an old CUDA version", () => {
+    const out = "CUDA Version: 11.6";
+    expect(parseCudaVersionFromNvidiaSmi(out)).toEqual({ cudaVersion: "11.6", cudaTag: "cpu" });
+  });
+
+  it("returns null when no CUDA version present", () => {
+    expect(parseCudaVersionFromNvidiaSmi("no gpu here")).toBeNull();
+  });
+});

--- a/src/server/services/olive/cuda.ts
+++ b/src/server/services/olive/cuda.ts
@@ -22,6 +22,9 @@ export function parseCudaVersionFromNvidiaSmi(
  * Map a CUDA major.minor version to the closest PyTorch wheel tag.
  * Tiers ordered from newest to oldest — matches the first tier where
  * the detected version is >= the tier's version.
+ *
+ * Versions below the lowest supported tier (CUDA 11.8) return `"cpu"` rather
+ * than forcing an incompatible `cu118` wheel onto e.g. CUDA 11.7 or older.
  */
 export function pickCudaTag(major: number, minor: number): string {
   const tiers = [
@@ -33,7 +36,7 @@ export function pickCudaTag(major: number, minor: number): string {
   for (const t of tiers) {
     if (major > t.major || (major === t.major && minor >= t.minor)) return t.tag;
   }
-  return "cu118";
+  return "cpu";
 }
 
 /**

--- a/src/server/services/olive/gpu.ts
+++ b/src/server/services/olive/gpu.ts
@@ -1,9 +1,6 @@
-import { execFile } from "child_process";
-import { promisify } from "util";
 import type { GpuMetrics } from "../../../lib/gpuMetrics.ts";
 import type { OliveJob } from "../../types.ts";
-
-const execFileAsync = promisify(execFile);
+import { execFileAsync } from "../shared/exec.ts";
 
 /** Records a job log line and notifies its active subscribers. */
 export function pushLog(job: OliveJob, line: string): void {

--- a/src/server/services/olive/state.test.ts
+++ b/src/server/services/olive/state.test.ts
@@ -57,6 +57,33 @@ describe("olive job registry cleanup", () => {
       expect(sweepJobRegistry(Date.now())).toBe(0);
       expect(jobRegistry.has("weird")).toBe(true);
     });
+
+    it("does not evict a cancelled job whose process has not exited (avoids orphaning)", () => {
+      const now = 10_000_000_000;
+      const oldMs = now - 31 * 60_000;
+      // SIGTERM ignored: still-running process (exitCode/signalCode both null).
+      const liveProcess = { exitCode: null, signalCode: null } as unknown as NonNullable<OliveJob["process"]>;
+      jobRegistry.set(
+        "hung",
+        makeJob("hung", { status: "cancelled", finishedAt: oldMs, process: liveProcess }),
+      );
+
+      expect(sweepJobRegistry(now)).toBe(0);
+      expect(jobRegistry.has("hung")).toBe(true);
+    });
+
+    it("evicts a terminal job once its process has exited", () => {
+      const now = 10_000_000_000;
+      const oldMs = now - 31 * 60_000;
+      const exited = { exitCode: 0, signalCode: null } as unknown as NonNullable<OliveJob["process"]>;
+      jobRegistry.set(
+        "exited",
+        makeJob("exited", { status: "completed", finishedAt: oldMs, process: exited }),
+      );
+
+      expect(sweepJobRegistry(now)).toBe(1);
+      expect(jobRegistry.has("exited")).toBe(false);
+    });
   });
 
   describe("cleanupJobArtifacts", () => {

--- a/src/server/services/olive/state.test.ts
+++ b/src/server/services/olive/state.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { jobRegistry, cleanupJobArtifacts, sweepJobRegistry } from "./state.ts";
+import type { OliveJob } from "../../types.ts";
+import fs from "fs";
+import os from "os";
+import path from "path";
+
+function makeJob(id: string, overrides: Partial<OliveJob> = {}): OliveJob {
+  return {
+    id,
+    status: "completed",
+    exitCode: 0,
+    logs: [],
+    subscribers: [],
+    metricSubscribers: [],
+    process: null,
+    latestMetrics: null,
+    metricsTimer: null,
+    sampling: false,
+    tempRecipePath: null,
+    finishedAt: null,
+    ...overrides,
+  };
+}
+
+describe("olive job registry cleanup", () => {
+  beforeEach(() => {
+    jobRegistry.clear();
+  });
+
+  describe("sweepJobRegistry", () => {
+    it("removes terminal jobs older than the TTL", () => {
+      const now = 10_000_000_000;
+      const oldMs = now - 31 * 60_000;
+      jobRegistry.set("old", makeJob("old", { status: "completed", finishedAt: oldMs }));
+      jobRegistry.set("recent", makeJob("recent", { status: "failed", finishedAt: now - 1_000 }));
+
+      const removed = sweepJobRegistry(now);
+
+      expect(removed).toBe(1);
+      expect(jobRegistry.has("old")).toBe(false);
+      expect(jobRegistry.has("recent")).toBe(true);
+    });
+
+    it("never removes running or setting_up jobs", () => {
+      const now = 10_000_000_000;
+      jobRegistry.set("running", makeJob("running", { status: "running", finishedAt: null }));
+      jobRegistry.set("setup", makeJob("setup", { status: "setting_up", finishedAt: null }));
+
+      expect(sweepJobRegistry(now)).toBe(0);
+      expect(jobRegistry.size).toBe(2);
+    });
+
+    it("keeps terminal jobs with no finishedAt (defensive)", () => {
+      jobRegistry.set("weird", makeJob("weird", { status: "cancelled", finishedAt: null }));
+      expect(sweepJobRegistry(Date.now())).toBe(0);
+      expect(jobRegistry.has("weird")).toBe(true);
+    });
+  });
+
+  describe("cleanupJobArtifacts", () => {
+    it("deletes the temp recipe file and clears the path", () => {
+      const tmp = path.join(os.tmpdir(), `olive-state-test-${Date.now()}.json`);
+      fs.writeFileSync(tmp, "{}", "utf-8");
+      const job = makeJob("j", { tempRecipePath: tmp });
+
+      cleanupJobArtifacts(job);
+
+      expect(fs.existsSync(tmp)).toBe(false);
+      expect(job.tempRecipePath).toBeNull();
+    });
+
+    it("is a no-op when there is no temp file", () => {
+      const job = makeJob("j", { tempRecipePath: null });
+      expect(() => cleanupJobArtifacts(job)).not.toThrow();
+    });
+
+    it("tolerates an already-deleted temp file", () => {
+      const job = makeJob("j", { tempRecipePath: path.join(os.tmpdir(), "does-not-exist-xyz.json") });
+      expect(() => cleanupJobArtifacts(job)).not.toThrow();
+      expect(job.tempRecipePath).toBeNull();
+    });
+  });
+});

--- a/src/server/services/olive/state.test.ts
+++ b/src/server/services/olive/state.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { jobRegistry, cleanupJobArtifacts, sweepJobRegistry, finalizeJob } from "./state.ts";
 import type { OliveJob } from "../../types.ts";
 import fs from "fs";
@@ -27,6 +27,10 @@ function makeJob(id: string, overrides: Partial<OliveJob> = {}): OliveJob {
 describe("olive job registry cleanup", () => {
   beforeEach(() => {
     jobRegistry.clear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   describe("sweepJobRegistry", () => {
@@ -84,6 +88,31 @@ describe("olive job registry cleanup", () => {
       expect(sweepJobRegistry(now)).toBe(1);
       expect(jobRegistry.has("exited")).toBe(false);
     });
+
+    it("retains a job (and its path) when temp-file cleanup fails, for retry", () => {
+      const now = 10_000_000_000;
+      const oldMs = now - 31 * 60_000;
+      const tmp = path.join(os.tmpdir(), "olive-sweep-retry.json");
+      jobRegistry.set(
+        "stuck",
+        makeJob("stuck", { status: "completed", finishedAt: oldMs, tempRecipePath: tmp }),
+      );
+
+      // Simulate a permission/transient FS error on delete.
+      const spy = vi.spyOn(fs, "rmSync").mockImplementation(() => {
+        throw new Error("EPERM");
+      });
+
+      expect(sweepJobRegistry(now)).toBe(0);
+      expect(jobRegistry.has("stuck")).toBe(true);
+      expect(jobRegistry.get("stuck")?.tempRecipePath).toBe(tmp);
+
+      // Once cleanup can succeed again, the next sweep reclaims it.
+      spy.mockRestore();
+      vi.spyOn(fs, "rmSync").mockImplementation(() => undefined);
+      expect(sweepJobRegistry(now)).toBe(1);
+      expect(jobRegistry.has("stuck")).toBe(false);
+    });
   });
 
   describe("cleanupJobArtifacts", () => {
@@ -100,13 +129,23 @@ describe("olive job registry cleanup", () => {
 
     it("is a no-op when there is no temp file", () => {
       const job = makeJob("j", { tempRecipePath: null });
-      expect(() => cleanupJobArtifacts(job)).not.toThrow();
+      expect(cleanupJobArtifacts(job)).toBe(true);
     });
 
     it("tolerates an already-deleted temp file", () => {
       const job = makeJob("j", { tempRecipePath: path.join(os.tmpdir(), "does-not-exist-xyz.json") });
-      expect(() => cleanupJobArtifacts(job)).not.toThrow();
+      expect(cleanupJobArtifacts(job)).toBe(true);
       expect(job.tempRecipePath).toBeNull();
+    });
+
+    it("returns false and keeps the path when deletion errors", () => {
+      vi.spyOn(fs, "rmSync").mockImplementation(() => {
+        throw new Error("EPERM");
+      });
+      const tmp = path.join(os.tmpdir(), "olive-cleanup-fail.json");
+      const job = makeJob("j", { tempRecipePath: tmp });
+      expect(cleanupJobArtifacts(job)).toBe(false);
+      expect(job.tempRecipePath).toBe(tmp);
     });
   });
 

--- a/src/server/services/olive/state.test.ts
+++ b/src/server/services/olive/state.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect, beforeEach } from "vitest";
-import { jobRegistry, cleanupJobArtifacts, sweepJobRegistry } from "./state.ts";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { jobRegistry, cleanupJobArtifacts, sweepJobRegistry, finalizeJob } from "./state.ts";
 import type { OliveJob } from "../../types.ts";
 import fs from "fs";
 import os from "os";
@@ -19,6 +19,7 @@ function makeJob(id: string, overrides: Partial<OliveJob> = {}): OliveJob {
     sampling: false,
     tempRecipePath: null,
     finishedAt: null,
+    doneSubscribers: [],
     ...overrides,
   };
 }
@@ -79,6 +80,36 @@ describe("olive job registry cleanup", () => {
       const job = makeJob("j", { tempRecipePath: path.join(os.tmpdir(), "does-not-exist-xyz.json") });
       expect(() => cleanupJobArtifacts(job)).not.toThrow();
       expect(job.tempRecipePath).toBeNull();
+    });
+  });
+
+  describe("finalizeJob", () => {
+    it("stamps finishedAt once and fires done-subscribers", () => {
+      const sub = vi.fn();
+      const job = makeJob("j", { status: "completed", finishedAt: null, doneSubscribers: [sub] });
+
+      finalizeJob(job);
+
+      expect(job.finishedAt).toBeTypeOf("number");
+      expect(sub).toHaveBeenCalledOnce();
+      // Subscribers are drained so a second finalize won't double-notify.
+      expect(job.doneSubscribers).toHaveLength(0);
+    });
+
+    it("does not overwrite an existing finishedAt", () => {
+      const job = makeJob("j", { status: "cancelled", finishedAt: 123 });
+      finalizeJob(job);
+      expect(job.finishedAt).toBe(123);
+    });
+
+    it("swallows a throwing subscriber", () => {
+      const bad = vi.fn(() => {
+        throw new Error("gone");
+      });
+      const good = vi.fn();
+      const job = makeJob("j", { doneSubscribers: [bad, good] });
+      expect(() => finalizeJob(job)).not.toThrow();
+      expect(good).toHaveBeenCalledOnce();
     });
   });
 });

--- a/src/server/services/olive/state.ts
+++ b/src/server/services/olive/state.ts
@@ -23,6 +23,22 @@ const SWEEP_INTERVAL_MS = 5 * 60_000;
 
 const TERMINAL_STATUSES = new Set<OliveJob["status"]>(["completed", "failed", "cancelled"]);
 
+/**
+ * Mark a job terminal: stamp `finishedAt` (idempotent) and fire done-subscribers
+ * so open SSE streams close immediately instead of waiting for the heartbeat.
+ */
+export function finalizeJob(job: OliveJob): void {
+  if (job.finishedAt == null) job.finishedAt = Date.now();
+  const subs = job.doneSubscribers.splice(0);
+  for (const sub of subs) {
+    try {
+      sub();
+    } catch {
+      /* subscriber gone */
+    }
+  }
+}
+
 /** Best-effort removal of a job's temp recipe file. */
 export function cleanupJobArtifacts(job: OliveJob): void {
   if (job.tempRecipePath) {

--- a/src/server/services/olive/state.ts
+++ b/src/server/services/olive/state.ts
@@ -51,11 +51,27 @@ export function cleanupJobArtifacts(job: OliveJob): void {
   }
 }
 
+/**
+ * Whether the job's child process has actually exited. `/olive/cancel` stamps
+ * `finishedAt` on SIGTERM before the process is confirmed dead, so the sweeper
+ * must not evict a job whose process is still alive (that would orphan it).
+ */
+function hasProcessExited(job: OliveJob): boolean {
+  const proc = job.process;
+  if (proc == null) return true;
+  return proc.exitCode !== null || proc.signalCode !== null;
+}
+
 /** Remove terminal jobs older than the TTL and reclaim their temp files. */
 export function sweepJobRegistry(now: number = Date.now()): number {
   let removed = 0;
   for (const [id, job] of jobRegistry) {
-    if (job.finishedAt != null && TERMINAL_STATUSES.has(job.status) && now - job.finishedAt > JOB_TTL_MS) {
+    if (
+      job.finishedAt != null &&
+      TERMINAL_STATUSES.has(job.status) &&
+      now - job.finishedAt > JOB_TTL_MS &&
+      hasProcessExited(job)
+    ) {
       cleanupJobArtifacts(job);
       jobRegistry.delete(id);
       removed += 1;

--- a/src/server/services/olive/state.ts
+++ b/src/server/services/olive/state.ts
@@ -39,15 +39,19 @@ export function finalizeJob(job: OliveJob): void {
   }
 }
 
-/** Best-effort removal of a job's temp recipe file. */
-export function cleanupJobArtifacts(job: OliveJob): void {
-  if (job.tempRecipePath) {
-    try {
-      fs.rmSync(job.tempRecipePath, { force: true });
-    } catch {
-      /* already gone */
-    }
+/**
+ * Remove a job's temp recipe file. Returns whether cleanup succeeded.
+ * `force: true` treats a missing file as success; a permission/transient FS
+ * error returns `false` and keeps `tempRecipePath` so a later sweep can retry.
+ */
+export function cleanupJobArtifacts(job: OliveJob): boolean {
+  if (!job.tempRecipePath) return true;
+  try {
+    fs.rmSync(job.tempRecipePath, { force: true });
     job.tempRecipePath = null;
+    return true;
+  } catch {
+    return false;
   }
 }
 
@@ -72,9 +76,11 @@ export function sweepJobRegistry(now: number = Date.now()): number {
       now - job.finishedAt > JOB_TTL_MS &&
       hasProcessExited(job)
     ) {
-      cleanupJobArtifacts(job);
-      jobRegistry.delete(id);
-      removed += 1;
+      // Only evict once the temp file is gone; otherwise retain for retry.
+      if (cleanupJobArtifacts(job)) {
+        jobRegistry.delete(id);
+        removed += 1;
+      }
     }
   }
   return removed;

--- a/src/server/services/olive/state.ts
+++ b/src/server/services/olive/state.ts
@@ -1,3 +1,4 @@
+import fs from "fs";
 import type { OliveJob } from "../../types.ts";
 import { appConfig } from "../../config.ts";
 
@@ -11,4 +12,48 @@ export function getRuntimeHfToken(): string | null {
 
 export function setRuntimeHfToken(token: string | null): void {
   appConfig.hfToken = token;
+}
+
+// ─── Job lifecycle / cleanup ────────────────────────────────────────────────
+
+/** Keep terminal jobs this long so the UI can still poll status/logs. */
+const JOB_TTL_MS = 30 * 60_000;
+/** How often the sweeper runs. */
+const SWEEP_INTERVAL_MS = 5 * 60_000;
+
+const TERMINAL_STATUSES = new Set<OliveJob["status"]>(["completed", "failed", "cancelled"]);
+
+/** Best-effort removal of a job's temp recipe file. */
+export function cleanupJobArtifacts(job: OliveJob): void {
+  if (job.tempRecipePath) {
+    try {
+      fs.rmSync(job.tempRecipePath, { force: true });
+    } catch {
+      /* already gone */
+    }
+    job.tempRecipePath = null;
+  }
+}
+
+/** Remove terminal jobs older than the TTL and reclaim their temp files. */
+export function sweepJobRegistry(now: number = Date.now()): number {
+  let removed = 0;
+  for (const [id, job] of jobRegistry) {
+    if (job.finishedAt != null && TERMINAL_STATUSES.has(job.status) && now - job.finishedAt > JOB_TTL_MS) {
+      cleanupJobArtifacts(job);
+      jobRegistry.delete(id);
+      removed += 1;
+    }
+  }
+  return removed;
+}
+
+let sweeper: ReturnType<typeof setInterval> | null = null;
+
+/** Start the periodic TTL sweeper once. Safe to call multiple times. */
+export function startJobRegistrySweeper(): void {
+  if (sweeper) return;
+  sweeper = setInterval(() => sweepJobRegistry(), SWEEP_INTERVAL_MS);
+  // Don't keep the process (or tests) alive just for the sweeper.
+  if (typeof sweeper.unref === "function") sweeper.unref();
 }

--- a/src/server/services/shared/http.test.ts
+++ b/src/server/services/shared/http.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { fetchWithTimeout, DEFAULT_FETCH_TIMEOUT_MS } from "./http.ts";
+
+const realFetch = globalThis.fetch;
+
+describe("fetchWithTimeout", () => {
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+    vi.restoreAllMocks();
+  });
+
+  it("resolves normally when the request completes in time", async () => {
+    const ok = new Response("hello", { status: 200 });
+    globalThis.fetch = vi.fn(async () => ok) as unknown as typeof fetch;
+
+    const res = await fetchWithTimeout("https://example.com", {}, 1_000);
+    expect(res.status).toBe(200);
+  });
+
+  it("passes an AbortSignal through to fetch", async () => {
+    const spy = vi.fn(async (_input: unknown, init?: RequestInit) => {
+      expect(init?.signal).toBeInstanceOf(AbortSignal);
+      return new Response("ok");
+    });
+    globalThis.fetch = spy as unknown as typeof fetch;
+
+    await fetchWithTimeout("https://example.com");
+    expect(spy).toHaveBeenCalledOnce();
+  });
+
+  it("throws a friendly timeout error when the signal fires", async () => {
+    // Simulate fetch rejecting with a TimeoutError like the platform does.
+    globalThis.fetch = vi.fn(async () => {
+      throw new DOMException("The operation timed out.", "TimeoutError");
+    }) as unknown as typeof fetch;
+
+    await expect(fetchWithTimeout("https://example.com", {}, 5)).rejects.toThrow(/timed out after 5ms/);
+  });
+
+  it("exposes a sane default timeout", () => {
+    expect(DEFAULT_FETCH_TIMEOUT_MS).toBeGreaterThan(0);
+  });
+});

--- a/src/server/services/shared/http.ts
+++ b/src/server/services/shared/http.ts
@@ -1,0 +1,31 @@
+/**
+ * Shared HTTP helpers.
+ *
+ * `fetchWithTimeout` wraps the global `fetch` with an AbortSignal so a slow or
+ * hung upstream can never pin a request open indefinitely. Use it for all
+ * outbound provider/API calls.
+ */
+
+/** Default timeout for outbound AI/provider calls (generous — model latency). */
+export const DEFAULT_FETCH_TIMEOUT_MS = 120_000;
+
+/**
+ * `fetch` with an abort-based timeout. Merges any caller-provided `signal`
+ * with the timeout signal so either can abort the request.
+ */
+export async function fetchWithTimeout(
+  input: string | URL,
+  init: RequestInit = {},
+  timeoutMs: number = DEFAULT_FETCH_TIMEOUT_MS,
+): Promise<Response> {
+  const timeoutSignal = AbortSignal.timeout(timeoutMs);
+  const signal = init.signal ? AbortSignal.any([init.signal, timeoutSignal]) : timeoutSignal;
+  try {
+    return await fetch(input, { ...init, signal });
+  } catch (err) {
+    if (err instanceof DOMException && err.name === "TimeoutError") {
+      throw new Error(`Request timed out after ${timeoutMs}ms`);
+    }
+    throw err;
+  }
+}

--- a/src/server/services/venv/config.test.ts
+++ b/src/server/services/venv/config.test.ts
@@ -26,6 +26,7 @@ const EXPORT = `export PATH="${RESOLVED}:$PATH"  # olive-studio .venv`;
 describe("addVenvToUserPath (unix)", () => {
   const originalPlatform = process.platform;
   const originalShell = process.env.SHELL;
+  const originalPath = process.env.PATH;
 
   beforeEach(() => {
     Object.defineProperty(process, "platform", { value: "linux", configurable: true });
@@ -46,6 +47,8 @@ describe("addVenvToUserPath (unix)", () => {
     Object.defineProperty(process, "platform", { value: originalPlatform, configurable: true });
     if (originalShell === undefined) delete process.env.SHELL;
     else process.env.SHELL = originalShell;
+    if (originalPath === undefined) delete process.env.PATH;
+    else process.env.PATH = originalPath;
     vi.restoreAllMocks();
   });
 

--- a/src/server/services/venv/config.test.ts
+++ b/src/server/services/venv/config.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Unit coverage for addVenvToUserPath shell-profile targeting (non-Windows).
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import path from "path";
+import os from "os";
+import fs from "fs";
+
+vi.mock("./paths.ts", () => ({
+  getVenvScriptsDir: () => "/tmp/olive-studio-test/.venv/bin",
+  getVenvPython: () => "/tmp/olive-studio-test/.venv/bin/python",
+  getVenvPip: () => "/tmp/olive-studio-test/.venv/bin/pip",
+}));
+
+vi.mock("../../config.ts", () => ({
+  appConfig: { systemPython: undefined },
+}));
+
+import { addVenvToUserPath } from "./config.ts";
+
+const HOME = "/tmp/olive-home-test";
+const SCRIPTS = "/tmp/olive-studio-test/.venv/bin";
+const RESOLVED = path.resolve(SCRIPTS);
+const EXPORT = `export PATH="${RESOLVED}:$PATH"  # olive-studio .venv`;
+
+describe("addVenvToUserPath (unix)", () => {
+  const originalPlatform = process.platform;
+  const originalShell = process.env.SHELL;
+
+  beforeEach(() => {
+    Object.defineProperty(process, "platform", { value: "linux", configurable: true });
+    process.env.SHELL = "/bin/bash";
+    vi.spyOn(os, "homedir").mockReturnValue(HOME);
+    vi.spyOn(fs, "existsSync").mockImplementation((p) => {
+      const s = String(p);
+      if (s === SCRIPTS || s === RESOLVED) return true;
+      if (s === path.join(HOME, ".bash_profile")) return false;
+      if (s === path.join(HOME, ".bash_login")) return false;
+      if (s === path.join(HOME, ".profile")) return true;
+      if (s === path.join(HOME, ".bashrc")) return true;
+      return false;
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(process, "platform", { value: originalPlatform, configurable: true });
+    if (originalShell === undefined) delete process.env.SHELL;
+    else process.env.SHELL = originalShell;
+    vi.restoreAllMocks();
+  });
+
+  it("does not create ~/.bash_profile when none exists", async () => {
+    const append = vi.spyOn(fs, "appendFileSync").mockReturnValue(undefined);
+    vi.spyOn(fs, "readFileSync").mockReturnValue("");
+
+    const result = await addVenvToUserPath();
+    expect(result).toMatchObject({ ok: true, already: false });
+
+    const written = append.mock.calls.map((c) => String(c[0]));
+    expect(written).toContain(path.join(HOME, ".profile"));
+    expect(written).toContain(path.join(HOME, ".bashrc"));
+    expect(written).not.toContain(path.join(HOME, ".bash_profile"));
+  });
+
+  it("dedupes on the exact export line, not a bare path substring", async () => {
+    const append = vi.spyOn(fs, "appendFileSync").mockReturnValue(undefined);
+    vi.spyOn(fs, "readFileSync").mockReturnValue(`# note about ${RESOLVED}-old\necho ${RESOLVED}\n`);
+
+    const result = await addVenvToUserPath();
+    expect(result).toMatchObject({ ok: true, already: false });
+    expect(append).toHaveBeenCalled();
+    expect(String(append.mock.calls[0]?.[1])).toContain(EXPORT);
+  });
+
+  it("skips append when the exact export line is already present", async () => {
+    const append = vi.spyOn(fs, "appendFileSync").mockReturnValue(undefined);
+    vi.spyOn(fs, "readFileSync").mockReturnValue(`${EXPORT}\n`);
+
+    const result = await addVenvToUserPath();
+    expect(result).toMatchObject({ ok: true, already: true });
+    expect(append).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/services/venv/config.ts
+++ b/src/server/services/venv/config.ts
@@ -1,13 +1,13 @@
 import path from "path";
-import { execFile } from "child_process";
-import { promisify } from "util";
 import fs from "fs";
 import os from "os";
 import { envWithPrependedPaths } from "../../../lib/tensorrtDeps.ts";
 import { getVenvPython, getVenvPip, getVenvScriptsDir } from "./paths.ts";
 import { appConfig } from "../../config.ts";
+import { execFileAsync } from "../shared/exec.ts";
 
-export const execFileAsync = promisify(execFile);
+// Re-export the shared helper so existing importers keep working.
+export { execFileAsync };
 
 /** Prepend project .venv Scripts/bin (and optional python dir) so Olive works without system PATH. */
 export function envWithVenvOnPath(base: NodeJS.ProcessEnv = process.env): NodeJS.ProcessEnv {
@@ -63,16 +63,30 @@ Write-Output 'ADDED'
     }
   }
 
-  const profile = path.join(os.homedir(), ".profile");
+  // Target the shells the user actually loads. zsh (macOS default) does not read
+  // ~/.profile for interactive shells, so also write ~/.zshrc there; keep ~/.profile
+  // for bash/sh. Writing to a profile that is never sourced would report a false success.
+  const home = os.homedir();
   const exportLine = `export PATH="${resolved}:$PATH"  # olive-studio .venv`;
+  const targets = new Set<string>([path.join(home, ".profile")]);
+  const shell = process.env.SHELL ?? "";
+  if (process.platform === "darwin" || shell.endsWith("zsh")) {
+    targets.add(path.join(home, ".zshrc"));
+  }
+  if (shell.endsWith("bash")) {
+    targets.add(path.join(home, ".bashrc"));
+  }
+
   try {
-    const existing = fs.existsSync(profile) ? fs.readFileSync(profile, "utf-8") : "";
-    if (existing.includes(resolved)) {
-      return { ok: true, already: true };
+    let allAlready = true;
+    for (const profile of targets) {
+      const existing = fs.existsSync(profile) ? fs.readFileSync(profile, "utf-8") : "";
+      if (existing.includes(resolved)) continue;
+      fs.appendFileSync(profile, `\n${exportLine}\n`, "utf-8");
+      allAlready = false;
     }
-    fs.appendFileSync(profile, `\n${exportLine}\n`, "utf-8");
     process.env.PATH = envWithVenvOnPath(process.env).PATH ?? process.env.PATH;
-    return { ok: true, already: false };
+    return { ok: true, already: allAlready };
   } catch (err: unknown) {
     const msg = err instanceof Error ? err.message : String(err);
     return { ok: false, error: msg };

--- a/src/server/services/venv/config.ts
+++ b/src/server/services/venv/config.ts
@@ -75,20 +75,23 @@ Write-Output 'ADDED'
   }
   if (shell.endsWith("bash")) {
     // Interactive non-login bash reads ~/.bashrc; login bash reads the first of
-    // ~/.bash_profile / ~/.bash_login / ~/.profile. Cover the login path too so
-    // a fresh login shell actually picks up the export.
+    // ~/.bash_profile / ~/.bash_login / ~/.profile. Cover an existing login
+    // profile when present. Never create ~/.bash_profile: that would shadow
+    // ~/.profile (already in targets) and drop the user's login setup.
     targets.add(path.join(home, ".bashrc"));
     const loginProfile = [".bash_profile", ".bash_login"]
       .map((f) => path.join(home, f))
       .find((p) => fs.existsSync(p));
-    targets.add(loginProfile ?? path.join(home, ".bash_profile"));
+    if (loginProfile) targets.add(loginProfile);
   }
 
   try {
     let allAlready = true;
     for (const profile of targets) {
       const existing = fs.existsSync(profile) ? fs.readFileSync(profile, "utf-8") : "";
-      if (existing.includes(resolved)) continue;
+      // Match the exact export line we write, not a bare path substring (comments
+      // or superstring paths would otherwise false-skip the append).
+      if (existing.split(/\r?\n/).some((l) => l.trim() === exportLine)) continue;
       fs.appendFileSync(profile, `\n${exportLine}\n`, "utf-8");
       allAlready = false;
     }

--- a/src/server/services/venv/config.ts
+++ b/src/server/services/venv/config.ts
@@ -74,7 +74,14 @@ Write-Output 'ADDED'
     targets.add(path.join(home, ".zshrc"));
   }
   if (shell.endsWith("bash")) {
+    // Interactive non-login bash reads ~/.bashrc; login bash reads the first of
+    // ~/.bash_profile / ~/.bash_login / ~/.profile. Cover the login path too so
+    // a fresh login shell actually picks up the export.
     targets.add(path.join(home, ".bashrc"));
+    const loginProfile = [".bash_profile", ".bash_login"]
+      .map((f) => path.join(home, f))
+      .find((p) => fs.existsSync(p));
+    targets.add(loginProfile ?? path.join(home, ".bash_profile"));
   }
 
   try {

--- a/src/server/services/venv/gpu.ts
+++ b/src/server/services/venv/gpu.ts
@@ -1,8 +1,5 @@
 import fs from "fs";
-import { execFile } from "child_process";
-import { promisify } from "util";
-
-const execFileAsync = promisify(execFile);
+import { execFileAsync } from "../shared/exec.ts";
 
 export async function getNativeGpuLibPaths(python: string): Promise<string[]> {
   const script = `

--- a/src/server/services/venv/index.ts
+++ b/src/server/services/venv/index.ts
@@ -190,6 +190,16 @@ export function ensureVenv(onLine: SetupListener): Promise<{ ok: boolean; error?
   return promise;
 }
 
+/**
+ * Detach a previously-registered `ensureVenv` progress listener. Used when a
+ * job is cancelled while setup is still pending, so a cancelled job stops
+ * receiving install output and its closure can be released immediately.
+ * No-op once setup has finished (the listener set is discarded then).
+ */
+export function detachVenvListener(onLine: SetupListener): void {
+  venvSetupInFlight?.listeners.delete(onLine);
+}
+
 async function ensureVenvInner(onLine: (line: string) => void): Promise<{ ok: boolean; error?: string }> {
   const systemPython = await findSystemPython();
   if (!systemPython) {

--- a/src/server/services/venv/index.ts
+++ b/src/server/services/venv/index.ts
@@ -140,18 +140,40 @@ export async function findSystemPython(): Promise<string | null> {
  * In-progress guard: venv creation + `pip install` are not concurrency-safe
  * (two callers can corrupt the same `.venv`). Concurrent callers share the
  * single in-flight promise instead of racing.
+ *
+ * Progress is fanned out to every attached `onLine` listener, so later callers
+ * (a second `/env/venv-install` stream or a concurrent `/olive/run`) still
+ * receive live install output rather than going silent.
  */
-let venvSetupInFlight: Promise<{ ok: boolean; error?: string }> | null = null;
+interface VenvSetupInFlight {
+  promise: Promise<{ ok: boolean; error?: string }>;
+  listeners: Set<(line: string) => void>;
+}
+let venvSetupInFlight: VenvSetupInFlight | null = null;
 
 export function ensureVenv(onLine: (line: string) => void): Promise<{ ok: boolean; error?: string }> {
   if (venvSetupInFlight) {
-    onLine("[setup] Environment setup already in progress — waiting for it to finish...");
-    return venvSetupInFlight;
+    venvSetupInFlight.listeners.add(onLine);
+    onLine("[setup] Environment setup already in progress — attaching to live output...");
+    return venvSetupInFlight.promise;
   }
-  venvSetupInFlight = ensureVenvInner(onLine).finally(() => {
+
+  const listeners = new Set<(line: string) => void>([onLine]);
+  const broadcast = (line: string) => {
+    for (const listener of listeners) {
+      try {
+        listener(line);
+      } catch {
+        /* listener gone (e.g. closed response) */
+      }
+    }
+  };
+
+  const promise = ensureVenvInner(broadcast).finally(() => {
     venvSetupInFlight = null;
   });
-  return venvSetupInFlight;
+  venvSetupInFlight = { promise, listeners };
+  return promise;
 }
 
 async function ensureVenvInner(onLine: (line: string) => void): Promise<{ ok: boolean; error?: string }> {

--- a/src/server/services/venv/index.ts
+++ b/src/server/services/venv/index.ts
@@ -136,7 +136,25 @@ export async function findSystemPython(): Promise<string | null> {
  * Ensures the .venv exists and olive-ai is installed.
  * Streams progress lines through the provided callback.
  */
-export async function ensureVenv(onLine: (line: string) => void): Promise<{ ok: boolean; error?: string }> {
+/**
+ * In-progress guard: venv creation + `pip install` are not concurrency-safe
+ * (two callers can corrupt the same `.venv`). Concurrent callers share the
+ * single in-flight promise instead of racing.
+ */
+let venvSetupInFlight: Promise<{ ok: boolean; error?: string }> | null = null;
+
+export function ensureVenv(onLine: (line: string) => void): Promise<{ ok: boolean; error?: string }> {
+  if (venvSetupInFlight) {
+    onLine("[setup] Environment setup already in progress — waiting for it to finish...");
+    return venvSetupInFlight;
+  }
+  venvSetupInFlight = ensureVenvInner(onLine).finally(() => {
+    venvSetupInFlight = null;
+  });
+  return venvSetupInFlight;
+}
+
+async function ensureVenvInner(onLine: (line: string) => void): Promise<{ ok: boolean; error?: string }> {
   const systemPython = await findSystemPython();
   if (!systemPython) {
     return {

--- a/src/server/services/venv/index.ts
+++ b/src/server/services/venv/index.ts
@@ -145,28 +145,42 @@ export async function findSystemPython(): Promise<string | null> {
  * (a second `/env/venv-install` stream or a concurrent `/olive/run`) still
  * receive live install output rather than going silent.
  */
+type SetupListener = (line: string) => void;
+
 interface VenvSetupInFlight {
   promise: Promise<{ ok: boolean; error?: string }>;
-  listeners: Set<(line: string) => void>;
+  listeners: Set<SetupListener>;
 }
 let venvSetupInFlight: VenvSetupInFlight | null = null;
 
-export function ensureVenv(onLine: (line: string) => void): Promise<{ ok: boolean; error?: string }> {
+/**
+ * Deliver a line to one listener; on failure (e.g. a closed SSE response) drop
+ * it so a broken listener isn't retried on every subsequent line.
+ */
+function notifyListener(listeners: Set<SetupListener>, listener: SetupListener, line: string): void {
+  try {
+    listener(line);
+  } catch {
+    listeners.delete(listener);
+  }
+}
+
+export function ensureVenv(onLine: SetupListener): Promise<{ ok: boolean; error?: string }> {
   if (venvSetupInFlight) {
-    venvSetupInFlight.listeners.add(onLine);
-    onLine("[setup] Environment setup already in progress — attaching to live output...");
+    const { listeners } = venvSetupInFlight;
+    listeners.add(onLine);
+    notifyListener(
+      listeners,
+      onLine,
+      "[setup] Environment setup already in progress — attaching to live output...",
+    );
     return venvSetupInFlight.promise;
   }
 
-  const listeners = new Set<(line: string) => void>([onLine]);
+  const listeners = new Set<SetupListener>([onLine]);
   const broadcast = (line: string) => {
-    for (const listener of listeners) {
-      try {
-        listener(line);
-      } catch {
-        /* listener gone (e.g. closed response) */
-      }
-    }
+    // Snapshot so deleting a throwing listener mid-iteration is safe.
+    for (const listener of [...listeners]) notifyListener(listeners, listener, line);
   };
 
   const promise = ensureVenvInner(broadcast).finally(() => {

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -33,6 +33,8 @@ export interface ProviderConfig {
   apiKey: string;
   model: string;
   baseUrl?: string;
+  /** Optional per-provider request timeout (ms). Falls back to the shared default. */
+  timeoutMs?: number;
 }
 
 export interface AIChatMessage {
@@ -121,6 +123,8 @@ export interface OliveJob {
   tempRecipePath: string | null;
   /** Epoch ms when the job reached a terminal state (for TTL cleanup). */
   finishedAt: number | null;
+  /** Listeners fired once when the job reaches a terminal state (SSE close). */
+  doneSubscribers: Array<() => void>;
 }
 
 // ─── Venv / Config Types ──────────────────────────────────────────────────────

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -125,6 +125,8 @@ export interface OliveJob {
   finishedAt: number | null;
   /** Listeners fired once when the job reaches a terminal state (SSE close). */
   doneSubscribers: Array<() => void>;
+  /** The venv-setup progress listener, retained so it can be detached on cancel. */
+  venvListener?: (line: string) => void;
 }
 
 // ─── Venv / Config Types ──────────────────────────────────────────────────────

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -117,6 +117,10 @@ export interface OliveJob {
   latestMetrics: GpuMetrics | null;
   metricsTimer: ReturnType<typeof setInterval> | null;
   sampling: boolean;
+  /** Temp recipe file written for this run; reclaimed when the job finishes. */
+  tempRecipePath: string | null;
+  /** Epoch ms when the job reached a terminal state (for TTL cleanup). */
+  finishedAt: number | null;
 }
 
 // ─── Venv / Config Types ──────────────────────────────────────────────────────


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

PR [#25](https://github.com/tonythethompson/Olive-Studio/pull/25) (server modularization) was **squash-merged** into `main`. The follow-up hardening from PR [#28](https://github.com/tonythethompson/Olive-Studio/pull/28) merged into the `refactor/server-modularization` branch **but never reached `main`** (there was no branch→main hop after #28). PR #31 re-opens that whole branch and shows a bloated, conflicting diff because of the squash.

This PR lands **only** the missing #28 follow-up delta as a clean cherry-pick onto current `main` (7 commits, no conflicts), so #31 can be closed.

## What's included (cherry-picked `868ce13..823390d`)

- **AI providers:** shared `fetchWithTimeout` (per-provider `timeoutMs`), base URL + JSON-format resolved from the registry (no duplicated tables), throw on empty output (openai/anthropic parity), require explicit `baseUrl` for generic `openai-compat`.
- **Olive jobs:** TTL sweeper + temp-recipe cleanup (retry-safe, only evicts once the child has exited), SSE heartbeat + immediate terminal close via done-subscribers, effective cancellation during `setting_up` (before spawn), `tempRecipePath` recorded before write, venv listener detached on cancel.
- **venv:** concurrent-install lock with progress fan-out to all listeners, `~/.zshrc`/`~/.bash_profile`/`~/.bashrc` PATH targets.
- **MCP:** KB error taxonomy (missing/unreadable/invalid) with sanitized client messages + full `passes.json` schema validation; `/mcp/sync-kb` returns non-2xx on failure.
- **CUDA:** `pickCudaTag` returns `cpu` for CUDA < 11.8 instead of forcing `cu118`.
- **Cleanup + tests:** `execFileAsync` deduped onto `shared/exec.ts`; new `shared/http`, `olive/state`, `olive/cuda`, `routes/mcp`, `routes/olive.cancel` test suites.

## Validation
- `tsc --noEmit` clean, eslint clean (only pre-existing unrelated warnings).
- Local: unit **547**, server **112**, integration **42**.

## Follow-up
Once this merges, PR #31 and PR #28 can be closed and `refactor/server-modularization` retired.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f87090b2-2930-4dc3-bb9c-b34b4c8f9be2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f87090b2-2930-4dc3-bb9c-b34b4c8f9be2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lands server hardening follow-ups into `main`. Adds request timeouts for provider calls, strengthens Olive job lifecycle and cancellation (now escalates to SIGKILL), hardens MCP KB validation, and improves venv setup, PATH export, and CUDA detection.

- **New Features**
  - Shared `fetchWithTimeout` for provider calls; honors per-provider `timeoutMs` (OpenAI/Copilot/Gemini/Anthropic).
  - Olive: job TTL sweeper with temp recipe cleanup; done-subscribers and SSE heartbeat for timely stream closure.
  - `ensureVenv`: concurrency lock with progress fan-out; `detachVenvListener` to stop output on cancel.
  - MCP KB: runtime validation of `passes.json` with sanitized client errors; `/mcp/sync-kb` returns non-2xx on failure.
  - OpenAI compat: base URL resolved from the provider registry; require explicit `baseUrl` for `openai-compat`.

- **Bug Fixes**
  - Olive cancel is effective during `setting_up`; aborts before writing the recipe or spawning; artifacts cleaned; finalization stamps `finishedAt`; escalates from SIGTERM to SIGKILL after a short grace period; cancelled runs no longer flip to failed on setup errors.
  - SSE streams close immediately on terminal status; avoids hanging connections.
  - PATH export now targets `~/.zshrc`, `~/.bashrc`, and existing bash login profiles; does not create `~/.bash_profile`; dedupes on the exact export line.
  - CUDA < 11.8 maps to `cpu` instead of forcing `cu118`.
  - Empty model responses now error out across providers.
  - Node engines pinned to `>=22.16`.

<sup>Written for commit 15da473fef1b57af9f122e02d6a7b44ec524d901. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tonythethompson/Olive-Studio/pull/32?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

