### PR TITLE
Add Dependabot auto-merge GitHub Action

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,92 @@
+name: Dependabot auto-merge
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+  check_suite:
+    types: [completed]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Check if PR can be merged
+        id: check
+        uses: actions/github-script@v7
+        with:
+          result-encoding: string
+          script: |
+            const prNumber = context.payload.pull_request?.number;
+            
+            if (!prNumber) {
+              console.log('No PR number found in payload');
+              return 'no_pr';
+            }
+            
+            // Get the PR details
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber,
+            });
+            
+            // Check if PR is still open and mergeable
+            if (pr.state !== 'open') {
+              console.log('PR is not open');
+              return 'not_open';
+            }
+            
+            if (!pr.mergeable) {
+              console.log('PR has merge conflicts');
+              return 'merge_conflict';
+            }
+            
+            // Get all check runs for this PR's head SHA
+            const { data: checks } = await github.rest.checks.listForRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: pr.head.sha,
+            });
+            
+            console.log(`Found ${checks.check_runs.length} check runs`);
+            
+            // Check if there are any checks running or pending
+            const hasIncompleteChecks = checks.check_runs.some(
+              check => check.status === 'in_progress' || check.status === 'queued'
+            );
+            
+            if (hasIncompleteChecks) {
+              console.log('Some checks are still running');
+              return 'checks_pending';
+            }
+            
+            // Check if all checks passed
+            const failedChecks = checks.check_runs.filter(
+              check => check.conclusion !== 'success'
+            );
+            
+            if (failedChecks.length > 0) {
+              console.log('Failed checks:', failedChecks.map(c => `${c.name}: ${c.conclusion}`));
+              return 'checks_failed';
+            }
+            
+            console.log('All checks passed! PR is ready to merge.');
+            return 'ready';
+
+      - name: Merge the PR
+        if: steps.check.outputs.result == 'ready'
+        run: |
+          pr_number=${{ github.event.pull_request.number }}
+          gh pr merge --admin --merge "$pr_number"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Wait for checks or report status
+        if: steps.check.outputs.result != 'ready' && steps.check.outputs.result != 'no_pr'
+        run: |
+          echo "Could not auto-merge PR. Status: ${{ steps.check.outputs.result }}"


### PR DESCRIPTION
## Summary

This PR adds a GitHub Action workflow that automatically merges Dependabot pull requests when all CI checks pass.

### What the workflow does:

1. **Triggers on:** PR events (opened, synchronize, reopened, ready_for_review) and check_suite completed events
2. **Filters:** Only runs for PRs from `dependabot[bot]`
3. **Checks:**
   - Verifies the PR is still open
   - Checks for merge conflicts (`mergeable` status)
   - Waits for all CI checks to complete
   - Confirms all checks have passed (`success` conclusion)
4. **Merges:** Uses `gh pr merge --admin --merge` to auto-merge when conditions are met

### Open Dependabot PRs to be auto-merged once workflow is deployed:
- #41: bump @types/uuid from 10.0.0 to 11.0.0
- #40: bump @mendable/firecrawl-js from 4.30.1 to 4.31.1
- #39: bump oxlint from 1.75.0 to 1.76.0
- #38: bump jsdom from 29.1.1 to 30.0.0
- #36: bump the actions group with 3 updates

---

*This PR was created by an AI agent (OpenHands) on behalf of the user.*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a GitHub Action that auto-merges Dependabot PRs once all CI checks pass. This reduces manual work and keeps dependencies up to date.

- **New Features**
  - Triggers on PR events and `check_suite: completed`.
  - Runs only for PRs from `dependabot[bot]`.
  - Verifies PR is open and mergeable (no conflicts).
  - Waits for all checks to complete and pass.
  - Merges with `gh pr merge --admin --merge` using `GITHUB_TOKEN`.

<sup>Written for commit 6c3c7be566b977f63cf6ac6a8e8098df9037d59b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tonythethompson/Olive-Studio/pull/42?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

