### PR TITLE
Add workflow_dispatch trigger for manual Dependabot merging

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -5,6 +5,12 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
   check_suite:
     types: [completed]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR number to merge (optional, for manual trigger)'
+        required: false
+        type: string
 
 permissions:
   contents: write
@@ -13,7 +19,6 @@ permissions:
 jobs:
   auto-merge:
     runs-on: ubuntu-latest
-    if: github.actor == 'dependabot[bot]'
     steps:
       - name: Check if PR can be merged
         id: check
@@ -21,19 +26,38 @@ jobs:
         with:
           result-encoding: string
           script: |
-            const prNumber = context.payload.pull_request?.number;
+            // Determine PR number from workflow_dispatch input or pull_request event
+            let prNumber = context.payload.inputs?.pr_number;
+            
+            if (!prNumber && context.payload.pull_request) {
+              prNumber = context.payload.pull_request.number;
+            }
             
             if (!prNumber) {
-              console.log('No PR number found in payload');
+              console.log('No PR number found');
               return 'no_pr';
             }
+            
+            // For auto-trigger, only run for dependabot
+            if (context.eventName === 'pull_request' && context.actor !== 'dependabot[bot]') {
+              console.log('Not a Dependabot PR, skipping');
+              return 'not_dependabot';
+            }
+            
+            console.log(`Checking PR #${prNumber}`);
             
             // Get the PR details
             const { data: pr } = await github.rest.pulls.get({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              pull_number: prNumber,
+              pull_number: parseInt(prNumber),
             });
+            
+            // Check if PR is from Dependabot (for manual trigger)
+            if (context.eventName === 'workflow_dispatch' && pr.user.login !== 'dependabot[bot]') {
+              console.log('PR is not from Dependabot');
+              return 'not_dependabot';
+            }
             
             // Check if PR is still open and mergeable
             if (pr.state !== 'open') {
@@ -76,17 +100,21 @@ jobs:
             }
             
             console.log('All checks passed! PR is ready to merge.');
+            console.log(`::set-output name=pr_number::${prNumber}`);
             return 'ready';
 
       - name: Merge the PR
         if: steps.check.outputs.result == 'ready'
         run: |
-          pr_number=${{ github.event.pull_request.number }}
+          pr_number="${{ github.event.inputs.pr_number || github.event.pull_request.number }}"
+          if [ -z "$pr_number" ]; then
+            pr_number="${{ steps.check.outputs.pr_number }}"
+          fi
           gh pr merge --admin --merge "$pr_number"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Wait for checks or report status
-        if: steps.check.outputs.result != 'ready' && steps.check.outputs.result != 'no_pr'
+      - name: Report status
+        if: steps.check.outputs.result != 'ready' && steps.check.outputs.result != 'no_pr' && steps.check.outputs.result != 'not_dependabot'
         run: |
           echo "Could not auto-merge PR. Status: ${{ steps.check.outputs.result }}"


### PR DESCRIPTION
This PR adds a workflow_dispatch trigger to allow manual merging of Dependabot PRs.

### Changes:
- Added workflow_dispatch trigger with optional pr_number input
- Updated logic to handle both automatic and manual triggers
- For automatic triggers, still only runs for dependabot[bot]

This allows you to manually trigger the auto-merge workflow from the Actions tab if needed.

---

*This PR was created by an AI agent (OpenHands) on behalf of the user.*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a manual trigger to auto-merge Dependabot PRs via `workflow_dispatch`. Accepts an optional `pr_number` and keeps automatic runs restricted to `dependabot[bot]`.

- New Features
  - Added `workflow_dispatch` with optional `pr_number` input.
  - Updated `actions/github-script@v7` logic to resolve PR number from input or event and ensure PR is from `dependabot[bot]`.
  - Merge step now uses the resolved PR number and reports status when not ready to merge.

<sup>Written for commit d224fbd1f387a2d352659959310b4e39f3b13eef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tonythethompson/Olive-Studio/pull/43?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

