### PR TITLE
fix: restore linter and fix act component tests warnings

### DIFF
--- a/src/components/features/BatchProcessingPanel.test.tsx
+++ b/src/components/features/BatchProcessingPanel.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, act } from "@testing-library/react";
 import { createMockUIState, useFetchRoutesMock } from "./__tests__/testUtils";
 
 // Mock the pipeline store to avoid zustand coupling
@@ -24,7 +24,12 @@ vi.mock("@/lib/hooks", () => ({
 
 // Mock hardware probe
 vi.mock("@/lib/hardwareProbe", () => ({
-  fetchHardwareProbe: () => Promise.resolve({ providers: ["CPUExecutionProvider"] }),
+  fetchHardwareProbe: () =>
+    Promise.resolve({
+      providers: ["CPUExecutionProvider"],
+      detectedProviders: ["CPUExecutionProvider"],
+      cpuModel: "Test CPU",
+    }),
   getSelectableProviders: () => ["CPUExecutionProvider"],
 }));
 
@@ -35,25 +40,33 @@ describe("BatchProcessingPanel", () => {
     "hardware-probe": { providers: ["CPUExecutionProvider"] },
   });
 
-  it("renders the panel heading", () => {
-    render(<BatchProcessingPanel />);
+  it("renders the panel heading", async () => {
+    await act(async () => {
+      render(<BatchProcessingPanel />);
+    });
     expect(screen.getAllByText(/batch/i).length).toBeGreaterThan(0);
   });
 
-  it("renders with controlled state props", () => {
+  it("renders with controlled state props", async () => {
     const state = createMockUIState();
-    render(<BatchProcessingPanel state={state} setState={mockSetState} />);
+    await act(async () => {
+      render(<BatchProcessingPanel state={state} setState={mockSetState} />);
+    });
     expect(screen.getAllByText(/batch/i).length).toBeGreaterThan(0);
   });
 
-  it("shows empty state when no jobs exist", () => {
-    render(<BatchProcessingPanel />);
+  it("shows empty state when no jobs exist", async () => {
+    await act(async () => {
+      render(<BatchProcessingPanel />);
+    });
     // The panel should render without errors when no batch jobs are present
     expect(screen.queryByText(/running/i)).toBeNull();
   });
 
-  it("renders the Custom Job button to add jobs", () => {
-    render(<BatchProcessingPanel />);
+  it("renders the Custom Job button to add jobs", async () => {
+    await act(async () => {
+      render(<BatchProcessingPanel />);
+    });
     const addButton = screen.getByRole("button", { name: /custom job/i });
     expect(addButton).toBeDefined();
   });

--- a/src/components/features/BatchProcessingPanel.test.tsx
+++ b/src/components/features/BatchProcessingPanel.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from "vitest";
 import { render, screen, act } from "@testing-library/react";
 import { createMockUIState, useFetchRoutesMock } from "./__tests__/testUtils";
+import { BatchProcessingPanel } from "./BatchProcessingPanel";
 
 // Mock the pipeline store to avoid zustand coupling
 const mockSetState = vi.fn();
@@ -34,8 +35,6 @@ vi.mock("@/lib/hardwareProbe", () => ({
     }),
   getSelectableProviders: () => ["CPUExecutionProvider"],
 }));
-
-import { BatchProcessingPanel } from "./BatchProcessingPanel";
 
 describe("BatchProcessingPanel", () => {
   useFetchRoutesMock({

--- a/src/components/features/BatchProcessingPanel.test.tsx
+++ b/src/components/features/BatchProcessingPanel.test.tsx
@@ -26,9 +26,11 @@ vi.mock("@/lib/hooks", () => ({
 vi.mock("@/lib/hardwareProbe", () => ({
   fetchHardwareProbe: () =>
     Promise.resolve({
-      providers: ["CPUExecutionProvider"],
+      probedAt: "now",
+      platform: { cpuModel: "Test CPU", cpuCores: 8, os: "win", arch: "x64" },
       detectedProviders: ["CPUExecutionProvider"],
-      cpuModel: "Test CPU",
+      recommendedProvider: "CPUExecutionProvider",
+      notes: [],
     }),
   getSelectableProviders: () => ["CPUExecutionProvider"],
 }));
@@ -37,7 +39,13 @@ import { BatchProcessingPanel } from "./BatchProcessingPanel";
 
 describe("BatchProcessingPanel", () => {
   useFetchRoutesMock({
-    "hardware-probe": { providers: ["CPUExecutionProvider"] },
+    "hardware-probe": {
+      probedAt: "now",
+      platform: { cpuModel: "Test CPU", cpuCores: 8, os: "win", arch: "x64" },
+      detectedProviders: ["CPUExecutionProvider"],
+      recommendedProvider: "CPUExecutionProvider",
+      notes: [],
+    },
   });
 
   it("renders the panel heading", async () => {

--- a/src/components/features/ExecutionWorkspace.test.tsx
+++ b/src/components/features/ExecutionWorkspace.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, act } from "@testing-library/react";
 import { createMockUIState, useFetchRoutesMock } from "./__tests__/testUtils";
 
 // Mock the pipeline store
@@ -24,7 +24,13 @@ vi.mock("@/lib/hooks", () => ({
 
 // Mock hardware probe
 vi.mock("@/lib/hardwareProbe", () => ({
-  fetchHardwareProbe: () => Promise.resolve({ providers: ["CPUExecutionProvider"] }),
+  fetchHardwareProbe: () =>
+    Promise.resolve({
+      providers: ["CPUExecutionProvider"],
+      detectedProviders: ["CPUExecutionProvider"],
+      cpuModel: "Test CPU",
+    }),
+  getProviderAvailabilityBlock: () => null,
 }));
 
 // Mock vram estimate (accesses state.passes fields not in minimal mock)
@@ -76,17 +82,25 @@ import { ExecutionWorkspace } from "./ExecutionWorkspace";
 
 describe("ExecutionWorkspace", () => {
   useFetchRoutesMock({
-    "hardware-probe": { providers: ["CPUExecutionProvider"] },
+    "hardware-probe": {
+      providers: ["CPUExecutionProvider"],
+      detectedProviders: ["CPUExecutionProvider"],
+      cpuModel: "Test CPU",
+    },
   });
 
-  it("renders the workspace heading", () => {
-    render(<ExecutionWorkspace />);
+  it("renders the workspace heading", async () => {
+    await act(async () => {
+      render(<ExecutionWorkspace />);
+    });
     expect(screen.getAllByText(/execute/i).length).toBeGreaterThan(0);
   });
 
-  it("renders with controlled state props", () => {
+  it("renders with controlled state props", async () => {
     const state = createMockUIState();
-    render(<ExecutionWorkspace state={state} setState={mockSetState} />);
+    await act(async () => {
+      render(<ExecutionWorkspace state={state} setState={mockSetState} />);
+    });
     expect(screen.getAllByText(/execute/i).length).toBeGreaterThan(0);
   });
 
@@ -103,8 +117,10 @@ describe("ExecutionWorkspace", () => {
     }).toThrow(/both be provided or both omitted/);
   });
 
-  it("renders recipe JSON view controls", () => {
-    render(<ExecutionWorkspace />);
+  it("renders recipe JSON view controls", async () => {
+    await act(async () => {
+      render(<ExecutionWorkspace />);
+    });
     // Should have a JSON/code view toggle or recipe-related control
     const jsonControl = screen.queryByText(/json/i) || screen.queryByText(/recipe/i);
     expect(jsonControl).not.toBeNull();

--- a/src/components/features/ExecutionWorkspace.test.tsx
+++ b/src/components/features/ExecutionWorkspace.test.tsx
@@ -26,9 +26,11 @@ vi.mock("@/lib/hooks", () => ({
 vi.mock("@/lib/hardwareProbe", () => ({
   fetchHardwareProbe: () =>
     Promise.resolve({
-      providers: ["CPUExecutionProvider"],
+      probedAt: "now",
+      platform: { cpuModel: "Test CPU", cpuCores: 8, os: "win", arch: "x64" },
       detectedProviders: ["CPUExecutionProvider"],
-      cpuModel: "Test CPU",
+      recommendedProvider: "CPUExecutionProvider",
+      notes: [],
     }),
   getProviderAvailabilityBlock: () => null,
 }));
@@ -83,9 +85,11 @@ import { ExecutionWorkspace } from "./ExecutionWorkspace";
 describe("ExecutionWorkspace", () => {
   useFetchRoutesMock({
     "hardware-probe": {
-      providers: ["CPUExecutionProvider"],
+      probedAt: "now",
+      platform: { cpuModel: "Test CPU", cpuCores: 8, os: "win", arch: "x64" },
       detectedProviders: ["CPUExecutionProvider"],
-      cpuModel: "Test CPU",
+      recommendedProvider: "CPUExecutionProvider",
+      notes: [],
     },
   });
 

--- a/src/components/features/GeminiSidebar.test.tsx
+++ b/src/components/features/GeminiSidebar.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeAll } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, act } from "@testing-library/react";
 import { createMockUIState, useFetchRoutesMock } from "./__tests__/testUtils";
 
 // Mock the pipeline store
@@ -48,36 +48,48 @@ describe("GeminiSidebar", () => {
     Element.prototype.scrollIntoView = vi.fn();
   });
 
-  it("renders when isOpen is true", () => {
-    render(<GeminiSidebar {...defaultProps} />);
+  it("renders when isOpen is true", async () => {
+    await act(async () => {
+      render(<GeminiSidebar {...defaultProps} />);
+    });
     // Sidebar should be visible with tab content
     expect(screen.getAllByText(/audit/i).length).toBeGreaterThan(0);
   });
 
-  it("renders tab navigation (audit, chat, settings)", () => {
-    render(<GeminiSidebar {...defaultProps} />);
+  it("renders tab navigation (audit, chat, settings)", async () => {
+    await act(async () => {
+      render(<GeminiSidebar {...defaultProps} />);
+    });
     expect(screen.getAllByText(/chat/i).length).toBeGreaterThan(0);
     expect(screen.getAllByText(/settings/i).length).toBeGreaterThan(0);
   });
 
-  it("calls onClose when close button is clicked", () => {
+  it("calls onClose when close button is clicked", async () => {
     const onClose = vi.fn();
-    render(<GeminiSidebar isOpen={true} onClose={onClose} />);
+    await act(async () => {
+      render(<GeminiSidebar isOpen={true} onClose={onClose} />);
+    });
     const closeButton = screen.getByRole("button", { name: /close sidebar/i });
     fireEvent.click(closeButton);
     expect(onClose).toHaveBeenCalled();
   });
 
-  it("renders with controlled state props", () => {
+  it("renders with controlled state props", async () => {
     const state = createMockUIState();
-    render(<GeminiSidebar {...defaultProps} state={state} setState={mockSetState} />);
+    await act(async () => {
+      render(<GeminiSidebar {...defaultProps} state={state} setState={mockSetState} />);
+    });
     expect(screen.getAllByText(/audit/i).length).toBeGreaterThan(0);
   });
 
-  it("sets aria-hidden when isOpen is false", () => {
-    const { container } = render(<GeminiSidebar {...defaultProps} isOpen={false} />);
+  it("sets aria-hidden when isOpen is false", async () => {
+    let container: HTMLElement;
+    await act(async () => {
+      const result = render(<GeminiSidebar {...defaultProps} isOpen={false} />);
+      container = result.container;
+    });
     // The sidebar uses aria-hidden + w-0 rather than conditional rendering
-    const sidebar = container.querySelector("[aria-hidden='true']");
+    const sidebar = container!.querySelector("[aria-hidden='true']");
     expect(sidebar).not.toBeNull();
   });
 });

--- a/src/components/features/GeminiSidebar.test.tsx
+++ b/src/components/features/GeminiSidebar.test.tsx
@@ -83,7 +83,7 @@ describe("GeminiSidebar", () => {
   });
 
   it("sets aria-hidden when isOpen is false", async () => {
-    let container: HTMLElement;
+    let container: HTMLElement | undefined;
     await act(async () => {
       const result = render(<GeminiSidebar {...defaultProps} isOpen={false} />);
       container = result.container;

--- a/src/components/features/IHVIntegrationPanel.test.tsx
+++ b/src/components/features/IHVIntegrationPanel.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, act } from "@testing-library/react";
 import { createMockUIState, useFetchRoutesMock } from "./__tests__/testUtils";
 
 // Mock the pipeline store
@@ -13,7 +13,14 @@ vi.mock("@/lib/stores/pipelineStore", () => ({
 
 // Mock hardware probe
 vi.mock("@/lib/hardwareProbe", () => ({
-  fetchHardwareProbe: () => Promise.resolve({ providers: ["CPUExecutionProvider"] }),
+  fetchHardwareProbe: () =>
+    Promise.resolve({
+      probedAt: "now",
+      platform: { cpuModel: "Test CPU", cpuCores: 8, os: "win", arch: "x64" },
+      detectedProviders: ["CPUExecutionProvider"],
+      recommendedProvider: "CPUExecutionProvider",
+      notes: [],
+    }),
   getSelectableProviders: () => ["CPUExecutionProvider", "CUDAExecutionProvider"],
   isProviderDetectedLocally: () => false,
 }));
@@ -55,18 +62,28 @@ import { IHVIntegrationPanel, getCellCompatibility } from "./IHVIntegrationPanel
 
 describe("IHVIntegrationPanel", () => {
   useFetchRoutesMock({
-    "hardware-probe": { providers: ["CPUExecutionProvider"] },
+    "hardware-probe": {
+      probedAt: "now",
+      platform: { cpuModel: "Test CPU", cpuCores: 8, os: "win", arch: "x64" },
+      detectedProviders: ["CPUExecutionProvider"],
+      recommendedProvider: "CPUExecutionProvider",
+      notes: [],
+    },
   });
 
-  it("renders the provider selection panel", () => {
-    render(<IHVIntegrationPanel />);
+  it("renders the provider selection panel", async () => {
+    await act(async () => {
+      render(<IHVIntegrationPanel />);
+    });
     // Panel should render with provider-related content
     expect(screen.getAllByText(/provider/i).length).toBeGreaterThan(0);
   });
 
-  it("renders with controlled state props", () => {
+  it("renders with controlled state props", async () => {
     const state = createMockUIState({ ihvProvider: "CUDAExecutionProvider" });
-    render(<IHVIntegrationPanel state={state} setState={mockSetState} />);
+    await act(async () => {
+      render(<IHVIntegrationPanel state={state} setState={mockSetState} />);
+    });
     expect(screen.getAllByText(/provider/i).length).toBeGreaterThan(0);
   });
 });

--- a/src/components/features/InputEnvironmentPanel.test.tsx
+++ b/src/components/features/InputEnvironmentPanel.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, act } from "@testing-library/react";
 import { createMockUIState, useFetchRoutesMock } from "./__tests__/testUtils";
 
 // Mock the pipeline store
@@ -13,7 +13,14 @@ vi.mock("@/lib/stores/pipelineStore", () => ({
 
 // Mock hardware probe
 vi.mock("@/lib/hardwareProbe", () => ({
-  fetchHardwareProbe: () => Promise.resolve({ providers: ["CPUExecutionProvider"] }),
+  fetchHardwareProbe: () =>
+    Promise.resolve({
+      probedAt: "now",
+      platform: { cpuModel: "Test CPU", cpuCores: 8, os: "win", arch: "x64" },
+      detectedProviders: ["CPUExecutionProvider"],
+      recommendedProvider: "CPUExecutionProvider",
+      notes: [],
+    }),
 }));
 
 // Mock olive recipe hub (network-heavy)
@@ -55,24 +62,36 @@ import { InputEnvironmentPanel } from "./InputEnvironmentPanel";
 
 describe("InputEnvironmentPanel", () => {
   useFetchRoutesMock({
-    "hardware-probe": { providers: ["CPUExecutionProvider"] },
+    "hardware-probe": {
+      probedAt: "now",
+      platform: { cpuModel: "Test CPU", cpuCores: 8, os: "win", arch: "x64" },
+      detectedProviders: ["CPUExecutionProvider"],
+      recommendedProvider: "CPUExecutionProvider",
+      notes: [],
+    },
     "olive-recipes": [],
   });
 
-  it("renders the model source tabs", () => {
-    render(<InputEnvironmentPanel />);
+  it("renders the model source tabs", async () => {
+    await act(async () => {
+      render(<InputEnvironmentPanel />);
+    });
     // Should show HuggingFace tab by default
     expect(screen.getAllByText(/hugging\s*face/i).length).toBeGreaterThan(0);
   });
 
-  it("renders with controlled state props", () => {
+  it("renders with controlled state props", async () => {
     const state = createMockUIState({ modelSource: "local" });
-    render(<InputEnvironmentPanel state={state} setState={mockSetState} />);
+    await act(async () => {
+      render(<InputEnvironmentPanel state={state} setState={mockSetState} />);
+    });
     expect(screen.getAllByText(/local/i).length).toBeGreaterThan(0);
   });
 
-  it("displays the model ID input for HuggingFace source", () => {
-    render(<InputEnvironmentPanel />);
+  it("displays the model ID input for HuggingFace source", async () => {
+    await act(async () => {
+      render(<InputEnvironmentPanel />);
+    });
     // The HF model ID input should be pre-populated with the default model
     const input = screen.getByDisplayValue(/meta-llama/i);
     expect(input).toBeDefined();

--- a/src/components/features/LocalModelManager.test.tsx
+++ b/src/components/features/LocalModelManager.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
 import { LocalModelManager } from "./LocalModelManager";
 
 // ── Mock fetch with proper spy cleanup ─────────────────────────────────────
@@ -61,7 +61,11 @@ describe("LocalModelManager — empty states", () => {
   it("renders nothing when no models and not loading", async () => {
     mockFetch();
 
-    const { container } = render(<LocalModelManager isOpen />);
+    let container: HTMLElement;
+    await act(async () => {
+      const res = render(<LocalModelManager isOpen />);
+      container = res.container;
+    });
 
     // After fetch resolves and models stay empty, the component returns null
     await waitFor(() => {
@@ -73,7 +77,9 @@ describe("LocalModelManager — empty states", () => {
     // Return a never-resolving promise to keep loading true
     fetchSpy.mockImplementation(() => new Promise(() => {}));
 
-    render(<LocalModelManager isOpen />);
+    act(() => {
+      render(<LocalModelManager isOpen />);
+    });
 
     expect(screen.getByText("Refreshing…")).toBeDefined();
   });
@@ -90,7 +96,9 @@ describe("LocalModelManager — models display", () => {
       },
     });
 
-    render(<LocalModelManager isOpen />);
+    await act(async () => {
+      render(<LocalModelManager isOpen />);
+    });
 
     await waitFor(() => {
       expect(screen.getByText("Installed Models")).toBeDefined();
@@ -109,7 +117,9 @@ describe("LocalModelManager — models display", () => {
       },
     });
 
-    render(<LocalModelManager isOpen />);
+    await act(async () => {
+      render(<LocalModelManager isOpen />);
+    });
 
     await waitFor(() => {
       expect(screen.getByText("Load")).toBeDefined();
@@ -124,7 +134,9 @@ describe("LocalModelManager — models display", () => {
       },
     });
 
-    render(<LocalModelManager isOpen />);
+    await act(async () => {
+      render(<LocalModelManager isOpen />);
+    });
 
     await waitFor(() => {
       expect(screen.getByText("Unload")).toBeDefined();
@@ -143,7 +155,9 @@ describe("LocalModelManager — search filtering", () => {
       },
     });
 
-    render(<LocalModelManager isOpen />);
+    await act(async () => {
+      render(<LocalModelManager isOpen />);
+    });
 
     await waitFor(() => {
       expect(screen.getByPlaceholderText("Search models…")).toBeDefined();
@@ -158,7 +172,9 @@ describe("LocalModelManager — search filtering", () => {
       },
     });
 
-    render(<LocalModelManager isOpen />);
+    await act(async () => {
+      render(<LocalModelManager isOpen />);
+    });
 
     await waitFor(() => {
       expect(screen.getByText("Alpha")).toBeDefined();
@@ -180,7 +196,9 @@ describe("LocalModelManager — search filtering", () => {
       },
     });
 
-    render(<LocalModelManager isOpen />);
+    await act(async () => {
+      render(<LocalModelManager isOpen />);
+    });
 
     await waitFor(() => {
       expect(screen.getByText("Alpha")).toBeDefined();
@@ -200,7 +218,9 @@ describe("LocalModelManager — search filtering", () => {
       },
     });
 
-    render(<LocalModelManager isOpen />);
+    await act(async () => {
+      render(<LocalModelManager isOpen />);
+    });
 
     await waitFor(() => {
       expect(screen.getByText("Alpha")).toBeDefined();
@@ -227,7 +247,9 @@ describe("LocalModelManager — publisher groups", () => {
       },
     });
 
-    render(<LocalModelManager isOpen />);
+    await act(async () => {
+      render(<LocalModelManager isOpen />);
+    });
 
     await waitFor(() => {
       expect(screen.getByText("meta-llama")).toBeDefined();
@@ -253,7 +275,9 @@ describe("LocalModelManager — keyboard shortcut", () => {
       },
     });
 
-    render(<LocalModelManager isOpen />);
+    await act(async () => {
+      render(<LocalModelManager isOpen />);
+    });
 
     await waitFor(() => {
       expect(screen.getByPlaceholderText("Search models…")).toBeDefined();
@@ -264,10 +288,12 @@ describe("LocalModelManager — keyboard shortcut", () => {
     expect(document.activeElement).toBe(input);
   });
 
-  it("does not crash when Cmd+K is used while sidebar is closed", () => {
+  it("does not crash when Cmd+K is used while sidebar is closed", async () => {
     mockFetch();
 
-    render(<LocalModelManager isOpen={false} />);
+    await act(async () => {
+      render(<LocalModelManager isOpen={false} />);
+    });
 
     // No crash
     fireEvent.keyDown(window, { key: "k", metaKey: true });

--- a/src/components/features/LocalModelManager.test.tsx
+++ b/src/components/features/LocalModelManager.test.tsx
@@ -73,11 +73,11 @@ describe("LocalModelManager — empty states", () => {
     });
   });
 
-  it("shows refreshing text while loading", () => {
+  it("shows refreshing text while loading", async () => {
     // Return a never-resolving promise to keep loading true
     fetchSpy.mockImplementation(() => new Promise(() => {}));
 
-    act(() => {
+    await act(async () => {
       render(<LocalModelManager isOpen />);
     });
 

--- a/src/components/features/LocalModelManager.test.tsx
+++ b/src/components/features/LocalModelManager.test.tsx
@@ -61,7 +61,7 @@ describe("LocalModelManager — empty states", () => {
   it("renders nothing when no models and not loading", async () => {
     mockFetch();
 
-    let container: HTMLElement;
+    let container: HTMLElement | undefined;
     await act(async () => {
       const res = render(<LocalModelManager isOpen />);
       container = res.container;
@@ -69,7 +69,7 @@ describe("LocalModelManager — empty states", () => {
 
     // After fetch resolves and models stay empty, the component returns null
     await waitFor(() => {
-      expect(container.innerHTML).toBe("");
+      expect(container!.innerHTML).toBe("");
     });
   });
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,5 +18,6 @@
     },
     "allowImportingTsExtensions": true,
     "noEmit": true
-  }
+  },
+  "exclude": ["src-tauri/target", "dist", "node_modules"]
 }


### PR DESCRIPTION
This PR resolves the tsconfig linter issues by adding the exclude pattern for src-tauri/target, and cleans up all act(...) console warnings across the component tests suite by wrapping renders in await act and adjusting hardwareProbe mock shapes to match the HardwareProbeResult interface.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restored TypeScript linter by excluding Tauri build outputs and removed React act warnings across component tests for stable, quiet runs. Also fixed TS2454 errors in tests by safely initializing `container` variables used inside `act`.

- **Bug Fixes**
  - Added `tsconfig.json` `exclude`: `src-tauri/target`, `dist`, `node_modules`.
  - Wrapped component test renders in `await act` via `@testing-library/react`.
  - Aligned hardware probe mocks and route stubs to full `HardwareProbeResult` (added `probedAt`, `platform`, `detectedProviders`, `recommendedProvider`, `notes`); stubbed `getSelectableProviders`/`getProviderAvailabilityBlock` where used.
  - Typed test `container` as `HTMLElement | undefined` and assigned inside `act` to avoid TS2454; hardened `LocalModelManager` tests with stable fetch spies and a non-resolving loading case.
  - Applied minor test cleanups from review.

<sup>Written for commit a94a161e981022f9f9bd41f6db1685eabaf947e1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tonythethompson/Olive-Studio/pull/53?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

