### PR TITLE
feat: roadmap v0.3.0 - Phase 2-4 (features, Tauri prep, MultiLoRA scaffolding)

### DIFF
--- a/.github/workflows/tauri-build.yml
+++ b/.github/workflows/tauri-build.yml
@@ -1,0 +1,71 @@
+name: Tauri Build
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build-windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 11
+
+      - name: Install frontend dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build frontend
+        run: pnpm build
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: x86_64-pc-windows-msvc
+
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+
+      - name: Build Tauri (NSIS + MSIX)
+        run: |
+          cd src-tauri
+          cargo build --release --target x86_64-pc-windows-msvc
+          npx @tauri-apps/cli build --target x86_64-pc-windows-msvc --bundles nsis,msix
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+
+      - name: Upload NSIS artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: olive-studio-nsis
+          path: src-tauri/target/x86_64-pc-windows-msvc/release/bundle/nsis/*.exe
+          if-no-files-found: error
+
+      - name: Upload MSIX artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: olive-studio-msix
+          path: src-tauri/target/x86_64-pc-windows-msvc/release/bundle/msix/*.msix
+          if-no-files-found: error
+
+      - name: Upload MSI artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: olive-studio-msi
+          path: src-tauri/target/x86_64-pc-windows-msvc/release/bundle/msi/*.msi
+          if-no-files-found: warn

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,17 @@ src-tauri/                 Tauri 2 shell (optional — app runs without it)
 - **ESLint warnings are expected:** `pnpm lint` runs `eslint --max-warnings 20` and exits 0 with warnings. Only treat non-zero exit or reported errors as failure.
 - **Python alias:** `pnpm a11y:scan` invokes `python` (not `python3`); ensure `python` is on PATH.
 - **Integration test mocks:** `src/server/__tests__/setup.integration.ts` mocks child_process, AI providers, and fetch. Tests start a real Express server on a random port.
+- **Commitlint scopes:** Conventional commits enforced (`<type>(<scope>): <subject>`). Allowed scopes: `recipe-builder`, `pipeline-validation`, `recipe-pipeline`, `quantization`, `pruning`, `peft`, `conversion`, `hardware-probe`, `ai-assistant`, `graph`, `batch`, `infra`, `ui`, `deps`, `ci`, `docs`, `mcp`, `types`, `test`, `chore`, `fix`, `perf`, `refactor`, `style`, `build`.
+
+## Lint Rules (error level)
+
+- `no-console` — only `console.warn` and `console.error` allowed (no `console.log`)
+- `react-hooks/set-state-in-render` — setState in render is always a bug
+- `react-hooks/refs` — accessing `ref.current` during render breaks reactivity
+- `react-hooks/use-memo` — missing `useMemo`/`useCallback` where the compiler would have applied them
+- `react-hooks/static-components` — components defined inside other components re-mount on every render
+- `react-hooks/error-boundaries` — missing error boundaries
+- `no-throw-literal` — throw Error objects, not raw values
 
 ## CI Pipeline
 

--- a/docs/ms-store-submission.md
+++ b/docs/ms-store-submission.md
@@ -1,0 +1,75 @@
+# Microsoft Store Submission Checklist
+
+## Prerequisites
+
+- [ ] Microsoft Partner Center account registered ($19 one-time individual / $99 company)
+- [ ] App reservation: "Olive Studio" name reserved in Partner Center
+- [ ] Privacy policy URL published and accessible (required for Store listing)
+
+## Package Preparation
+
+- [ ] MSIX bundle produced by CI (`tauri-build.yml` on `v*` tags)
+- [ ] Package identity: `com.tonythethompson.olive-studio`
+- [ ] Publisher: `CN=TonyThompson` (must match Partner Center certificate)
+- [ ] Minimum OS version: Windows 10 1809 (10.0.17763.0)
+- [ ] WebView2 runtime: downloadBootstrapper mode (auto-installs if missing)
+- [ ] Package size < 200MB (current estimate: ~80MB with Node sidecar)
+
+## Store Listing Assets
+
+- [ ] App logo (300x300 PNG)
+- [ ] Store screenshots (1366x768 minimum, 3-5 recommended)
+  - [ ] Main workspace with pipeline configured
+  - [ ] Batch processing with comparison view
+  - [ ] Recipe graph visualization
+  - [ ] Run history / export report
+- [ ] Promotional image (1920x1080, optional)
+- [ ] App description (short + long)
+- [ ] Release notes for current version
+- [ ] Category: Developer Tools > Software Development
+- [ ] Keywords: olive, onnx, model optimization, machine learning, inference
+
+## Submission Steps
+
+1. Sign in to [Partner Center](https://partner.microsoft.com/dashboard)
+2. Navigate to Apps & Games > Olive Studio
+3. Create new submission
+4. Upload MSIX bundle from CI artifacts
+5. Complete listing: description, screenshots, category, pricing (Free)
+6. Set availability: all markets (or select subset)
+7. Content ratings questionnaire (IARC)
+8. Privacy policy URL
+9. Submit for certification
+
+## Certification Expectations
+
+- Typical review: 1-3 business days
+- Common rejection reasons to preempt:
+  - Missing privacy policy (even for local-only apps)
+  - App crashes on launch (test MSIX on clean VM)
+  - Incomplete listing metadata
+  - WebView2 bootstrapper fails on LTSC (mitigated: offline installer fallback)
+
+## Post-Submission
+
+- [ ] Monitor certification status in Partner Center
+- [ ] Address any rejection feedback within 48h
+- [ ] After approval: verify auto-update works (Store handles natively)
+- [ ] NSIS installer remains available on GitHub Releases for sideloading
+
+## Distribution Strategy
+
+| Channel         | Format | Signing                    | Auto-Update | Audience               |
+| --------------- | ------ | -------------------------- | ----------- | ---------------------- |
+| Microsoft Store | MSIX   | Store trust chain          | Native      | General users          |
+| GitHub Releases | NSIS   | None (SmartScreen warning) | Manual      | Developers/sideloading |
+| GitHub Releases | MSI    | None                       | Manual      | Enterprise/IT          |
+
+## Cost Summary
+
+| Item                        | Cost               | Frequency    |
+| --------------------------- | ------------------ | ------------ |
+| Partner Center registration | $19 (individual)   | One-time     |
+| Code signing                | $0 (Store handles) | N/A          |
+| Auto-update hosting         | $0 (Store handles) | N/A          |
+| **Total**                   | **$19**            | **One-time** |

--- a/docs/multilora-design.md
+++ b/docs/multilora-design.md
@@ -1,0 +1,139 @@
+# Multi-LoRA Adapter Support — Design Document
+
+**Status:** BLOCKED by upstream (requires Olive >= 0.3.0 multi-adapter pass configuration)
+**Target:** v0.4.0+
+**Feature Flag:** `multiLora` (default: off)
+
+## Overview
+
+Multi-LoRA enables loading multiple LoRA/QLoRA adapters into a single optimized model,
+allowing runtime switching between adapters without reloading the base model. This is
+critical for serving multiple fine-tuned variants of the same base model efficiently.
+
+## Upstream Dependency
+
+- Olive must expose multi-adapter optimization as a supported pass configuration
+- Tracking: https://github.com/microsoft/Olive/issues (multi-adapter milestone)
+- Minimum ORT version: 1.21+ (LoRA adapter slot-mapping support)
+
+## Schema Extension
+
+### Recipe JSON (backward-compatible)
+
+```json
+{
+  "passes": {
+    "lora": {
+      "type": "LoRA",
+      "config": {
+        "adapter_path": "adapters/customer-support.safetensors"
+      }
+    }
+  },
+  "adapters": [
+    {
+      "name": "customer-support",
+      "path": "adapters/customer-support.safetensors",
+      "rank": 16,
+      "alpha": 32
+    },
+    {
+      "name": "code-generation",
+      "path": "adapters/code-gen.safetensors",
+      "rank": 16,
+      "alpha": 32
+    }
+  ]
+}
+```
+
+**Backward compatibility:** When `adapters` is absent or empty, behavior is identical
+to v0.2.0 single-adapter mode. The builder ignores unknown keys.
+
+### TypeScript Interface
+
+```typescript
+interface AdapterConfig {
+  name: string;
+  path: string;
+  rank: number;
+  alpha: number;
+  targetModules?: string[]; // e.g. ["q_proj", "v_proj"]
+}
+
+// Added to OliveRecipeSchema (optional field)
+interface OliveRecipe {
+  // ... existing fields
+  adapters?: AdapterConfig[];
+}
+```
+
+## VRAM Budget Formula
+
+```
+total_vram = base_model_vram + N * adapter_delta
+
+where:
+  base_model_vram = estimated VRAM for base model (from buildMaxMemoryMap)
+  N = number of active adapters
+  adapter_delta = rank * hidden_dim * 2 bytes * num_layers / 1e9  (GB)
+```
+
+### Thresholds
+
+| Adapters    | Budget Multiplier | Action                                  |
+| ----------- | ----------------- | --------------------------------------- |
+| 1 (default) | 100%              | Normal operation                        |
+| 2           | 110%              | Warn if exceeded                        |
+| 3+          | N/A               | Hard-cap at 2 for consumer GPUs <= 12GB |
+
+### Consumer GPU Mitigation
+
+For GPUs with <= 12GB VRAM:
+
+- Hard-cap at 2 adapters maximum
+- Reduce `buildMaxMemoryMap()` GPU budget from 90% to 80% when multi-adapter active
+- Extends existing logic in `src/lib/memoryOffload.ts` L27
+
+## UI Integration
+
+1. **Recipe Import:** When a recipe contains `adapters[]`, show adapter list in
+   InputEnvironmentPanel with per-adapter enable/disable toggles
+2. **VRAM Banner:** VramEstimateBanner shows per-adapter delta breakdown
+3. **Batch Processing:** Each adapter can be a separate batch job variant
+4. **Comparison:** BatchComparisonView shows adapter name as a column
+
+## Slot-Mapping Schema (ORT 1.21+)
+
+```json
+{
+  "session_options": {
+    "lora_config": {
+      "slot_mapping": {
+        "0": "adapters/customer-support.safetensors",
+        "1": "adapters/code-gen.safetensors"
+      },
+      "active_slot": 0
+    }
+  }
+}
+```
+
+Runtime switching is done via `session.set_lora_slot(index)` without model reload.
+
+## Graduation Gate
+
+Re-evaluate after Olive 0.3.0 release:
+
+- [ ] Olive >= 0.3.0 documents multi-adapter optimization as supported
+- [ ] E2E test: 2 adapters loaded, switched at runtime, correct output on ORT 1.21+
+- [ ] VRAM budget <= 110% of single-adapter baseline for 2-adapter config
+- [ ] Recipe schema extension backward-compatible with v0.2.0 recipes
+
+## Implementation Phases
+
+1. **Schema scaffolding** (this PR): Optional `adapters[]` field, feature flag
+2. **VRAM estimation**: Extend `vramEstimate.ts` with adapter delta calculation
+3. **UI wiring**: Adapter list in InputEnvironmentPanel, gated by `multiLora` flag
+4. **Builder integration**: Emit slot-mapping config when adapters present
+5. **E2E validation**: Test with real LoRA adapters on CUDA EP

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -15,6 +15,13 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 [build-dependencies]
 tauri-build = { version = "2.6.3", features = [] }
 
+[profile.release]
+strip = true
+lto = true
+codegen-units = 1
+opt-level = "s"
+panic = "abort"
+
 [dependencies]
 log = "0.4"
 tauri = { version = "2.11.3", features = [] }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -240,6 +240,8 @@ fn navigate_main_to_server(app: &AppHandle, port: u16) {
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
+  let cold_start = Instant::now();
+
   let port: u16 = std::env::var("PORT")
     .ok()
     .and_then(|s| s.parse().ok())
@@ -293,6 +295,11 @@ pub fn run() {
 
       // Always land on Express origin so relative fetch("/api/...") works.
       navigate_main_to_server(app.handle(), actual_port);
+
+      // Cold-start telemetry: log time from run() to first successful health-check
+      let elapsed = cold_start.elapsed();
+      log::info!("[cold-start] Ready in {:.0}ms", elapsed.as_millis());
+      eprintln!("[olive-studio] cold-start: {:.0}ms", elapsed.as_millis());
 
       if cfg!(debug_assertions) {
         app.handle().plugin(

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -33,7 +33,7 @@
   },
   "bundle": {
     "active": true,
-    "targets": ["nsis", "msi"],
+    "targets": ["nsis", "msi", "msix"],
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",
@@ -48,6 +48,11 @@
     "windows": {
       "webviewInstallMode": {
         "type": "downloadBootstrapper"
+      },
+      "msix": {
+        "displayName": "Olive Studio",
+        "publisher": "CN=TonyThompson",
+        "minimumSystemVersion": "10.0.17763.0"
       }
     }
   }

--- a/src/components/features/BatchComparisonChart.tsx
+++ b/src/components/features/BatchComparisonChart.tsx
@@ -1,0 +1,136 @@
+/**
+ * Grouped bar/radar chart for multi-model metric overlay.
+ * Uses recharts (already in deps, vendor-charts chunk).
+ */
+import { useMemo } from "react";
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+  RadarChart,
+  PolarGrid,
+  PolarAngleAxis,
+  PolarRadiusAxis,
+  Radar,
+} from "recharts";
+import type { JobHistoryRecord } from "@/lib/jobHistoryStore";
+
+interface BatchComparisonChartProps {
+  records: JobHistoryRecord[];
+  chartType?: "bar" | "radar";
+}
+
+const COLORS = ["#8DA840", "#60a5fa", "#f472b6", "#fbbf24", "#a78bfa", "#34d399"];
+
+function truncateLabel(label: string, max = 18): string {
+  return label.length > max ? `${label.slice(0, max - 1)}…` : label;
+}
+
+export function BatchComparisonChart({ records, chartType = "bar" }: BatchComparisonChartProps) {
+  const barData = useMemo(
+    () =>
+      records.map((rec) => ({
+        name: truncateLabel(rec.modelId),
+        fullName: rec.modelId,
+        "Duration (s)": Math.round(rec.durationMs / 100) / 10,
+        "VRAM (GB)": rec.vramEstimateGb != null ? Math.round(rec.vramEstimateGb * 10) / 10 : 0,
+        Passes: rec.passCount,
+      })),
+    [records],
+  );
+
+  const radarData = useMemo(() => {
+    if (records.length === 0) return [];
+    const maxDuration = Math.max(...records.map((r) => r.durationMs), 1);
+    const maxVram = Math.max(...records.map((r) => r.vramEstimateGb ?? 0), 1);
+    const maxPasses = Math.max(...records.map((r) => r.passCount), 1);
+
+    return records.map((rec) => ({
+      model: truncateLabel(rec.modelId, 12),
+      // Normalize to 0-100 scale (inverted duration: faster = higher)
+      Speed: Math.round((1 - rec.durationMs / maxDuration) * 100),
+      "VRAM Efficiency": Math.round((1 - (rec.vramEstimateGb ?? 0) / maxVram) * 100),
+      "Pass Coverage": Math.round((rec.passCount / maxPasses) * 100),
+      Success: rec.status === "completed" ? 100 : 0,
+    }));
+  }, [records]);
+
+  if (records.length < 2) {
+    return (
+      <div className="text-xs text-slate-500 py-4 text-center">
+        Select at least 2 completed runs to display comparison charts.
+      </div>
+    );
+  }
+
+  if (chartType === "radar") {
+    return (
+      <div className="h-64 w-full">
+        <ResponsiveContainer width="100%" height="100%">
+          <RadarChart data={radarData} cx="50%" cy="50%" outerRadius="70%">
+            <PolarGrid stroke="#334155" />
+            <PolarAngleAxis dataKey="model" tick={{ fill: "#94a3b8", fontSize: 10 }} />
+            <PolarRadiusAxis angle={30} domain={[0, 100]} tick={{ fill: "#64748b", fontSize: 9 }} />
+            {["Speed", "VRAM Efficiency", "Pass Coverage", "Success"].map((metric, i) => (
+              <Radar
+                key={metric}
+                name={metric}
+                dataKey={metric}
+                stroke={COLORS[i % COLORS.length]}
+                fill={COLORS[i % COLORS.length]}
+                fillOpacity={0.15}
+              />
+            ))}
+            <Legend wrapperStyle={{ fontSize: 10 }} />
+            <Tooltip
+              contentStyle={{
+                background: "#1e293b",
+                border: "1px solid #334155",
+                borderRadius: 6,
+                fontSize: 11,
+              }}
+              labelStyle={{ color: "#e2e8f0" }}
+            />
+          </RadarChart>
+        </ResponsiveContainer>
+      </div>
+    );
+  }
+
+  return (
+    <div className="h-64 w-full">
+      <ResponsiveContainer width="100%" height="100%">
+        <BarChart data={barData} margin={{ top: 8, right: 16, left: 0, bottom: 0 }}>
+          <CartesianGrid strokeDasharray="3 3" stroke="#334155" />
+          <XAxis
+            dataKey="name"
+            tick={{ fill: "#94a3b8", fontSize: 10 }}
+            interval={0}
+            angle={-15}
+            textAnchor="end"
+            height={50}
+          />
+          <YAxis tick={{ fill: "#94a3b8", fontSize: 10 }} />
+          <Tooltip
+            contentStyle={{
+              background: "#1e293b",
+              border: "1px solid #334155",
+              borderRadius: 6,
+              fontSize: 11,
+            }}
+            labelStyle={{ color: "#e2e8f0" }}
+          />
+          <Legend wrapperStyle={{ fontSize: 10 }} />
+          <Bar dataKey="Duration (s)" fill={COLORS[0]} radius={[2, 2, 0, 0]} />
+          <Bar dataKey="VRAM (GB)" fill={COLORS[1]} radius={[2, 2, 0, 0]} />
+          <Bar dataKey="Passes" fill={COLORS[2]} radius={[2, 2, 0, 0]} />
+        </BarChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}

--- a/src/components/features/BatchComparisonView.test.tsx
+++ b/src/components/features/BatchComparisonView.test.tsx
@@ -1,0 +1,92 @@
+import { describe, it, expect } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { BatchComparisonView } from "./BatchComparisonView";
+import type { JobHistoryRecord } from "@/lib/jobHistoryStore";
+
+function makeRecord(overrides: Partial<JobHistoryRecord> = {}): JobHistoryRecord {
+  return {
+    id: `rec-${Math.random().toString(36).slice(2)}`,
+    jobId: "job-1",
+    modelId: "meta-llama/Llama-3-8B",
+    ihvProvider: "CUDAExecutionProvider",
+    memoryOffload: "none",
+    status: "completed",
+    exitCode: 0,
+    durationMs: 45000,
+    timestamp: "2025-01-15T10:30:00Z",
+    passCount: 3,
+    passNames: ["Conversion", "Quantization", "Optimization"],
+    vramEstimateGb: 8.5,
+    logSummary: { totalLogs: 120, errorCount: 0, lastLog: "Done" },
+    recipeJson: "",
+    ...overrides,
+  };
+}
+
+describe("BatchComparisonView", () => {
+  it("renders comparison table with correct record count", () => {
+    const records = [
+      makeRecord({ id: "a", modelId: "model-a" }),
+      makeRecord({ id: "b", modelId: "model-b", durationMs: 60000 }),
+    ];
+    render(<BatchComparisonView records={records} />);
+    expect(screen.getByText("Comparing 2 Runs")).toBeDefined();
+    expect(screen.getByText("model-a")).toBeDefined();
+    expect(screen.getByText("model-b")).toBeDefined();
+  });
+
+  it("shows delta indicators relative to baseline", () => {
+    const records = [
+      makeRecord({ id: "a", modelId: "fast", durationMs: 10000 }),
+      makeRecord({ id: "b", modelId: "slow", durationMs: 50000 }),
+    ];
+    render(<BatchComparisonView records={records} />);
+    // The slower record should show a positive delta
+    expect(screen.getByText("+40s")).toBeDefined();
+  });
+
+  it("renders close button when onClose is provided", () => {
+    const records = [makeRecord({ id: "a" }), makeRecord({ id: "b" })];
+    let closed = false;
+    render(
+      <BatchComparisonView
+        records={records}
+        onClose={() => {
+          closed = true;
+        }}
+      />,
+    );
+    const closeBtn = screen.getByRole("button");
+    fireEvent.click(closeBtn);
+    expect(closed).toBe(true);
+  });
+
+  it("does not render close button when onClose is omitted", () => {
+    const records = [makeRecord({ id: "a" }), makeRecord({ id: "b" })];
+    render(<BatchComparisonView records={records} />);
+    expect(screen.queryByRole("button")).toBeNull();
+  });
+
+  it("sorts by column header click", () => {
+    const records = [
+      makeRecord({ id: "a", modelId: "zebra", durationMs: 10000 }),
+      makeRecord({ id: "b", modelId: "alpha", durationMs: 50000 }),
+    ];
+    render(<BatchComparisonView records={records} />);
+    // Click "Model" header to sort alphabetically
+    fireEvent.click(screen.getByText("Model"));
+    const rows = screen.getAllByRole("row");
+    // First data row should be "alpha" after ascending sort
+    expect(rows[1].textContent).toContain("alpha");
+  });
+
+  it("displays VRAM values formatted to 1 decimal", () => {
+    const records = [
+      makeRecord({ id: "a", vramEstimateGb: 12.345 }),
+      makeRecord({ id: "b", vramEstimateGb: 8.0 }),
+    ];
+    render(<BatchComparisonView records={records} />);
+    expect(screen.getByText("12.3")).toBeDefined();
+    expect(screen.getByText("8.0")).toBeDefined();
+  });
+});

--- a/src/components/features/BatchProcessingPanel.tsx
+++ b/src/components/features/BatchProcessingPanel.tsx
@@ -28,7 +28,9 @@ import {
   FolderPlus,
   Sparkles,
   AlertCircle,
+  BarChart3,
 } from "lucide-react";
+import { BatchComparisonView } from "./BatchComparisonView";
 
 /**
  * Renders a panel for managing, running, and inspecting sequential batch-processing jobs.
@@ -53,6 +55,7 @@ export function BatchProcessingPanel({
   const jobsRef = useRef<typeof state.batchJobs>(state.batchJobs || []);
   const [showAddForm, setShowAddForm] = useState(false);
   const handleToggleAddForm = useCallback(() => setShowAddForm((v) => !v), []);
+  const [showComparison, setShowComparison] = useState(false);
 
   // MCP Diagnostic State — keyed by job ID
   const {
@@ -409,8 +412,43 @@ export function BatchProcessingPanel({
                 >
                   <RotateCcw className="h-3.5 w-3.5 text-slate-400" />
                 </Button>
+                {counts.completed >= 2 && (
+                  <Button
+                    variant="outline"
+                    className="h-8 text-xs px-3 border-electric-blue/30 text-electric-blue hover:text-white hover:bg-electric-blue/10"
+                    onClick={() => setShowComparison((v) => !v)}
+                  >
+                    <BarChart3 className="h-3.5 w-3.5 mr-1" /> Compare
+                  </Button>
+                )}
               </div>
             </div>
+
+            {/* Batch Comparison View */}
+            {showComparison && (
+              <BatchComparisonView
+                records={jobs
+                  .filter((j) => j.status === "completed")
+                  .slice(0, 6)
+                  .map((j) => ({
+                    id: j.id,
+                    jobId: j.id,
+                    modelId: j.modelIdentifier || j.name || "unknown",
+                    ihvProvider: j.provider || "CUDAExecutionProvider",
+                    memoryOffload: "none",
+                    status: "completed" as const,
+                    exitCode: 0,
+                    durationMs: parseInt(j.metrics?.latency || "0", 10) || 0,
+                    timestamp: new Date().toISOString(),
+                    passCount: j.passes?.length ?? 0,
+                    passNames: j.passes ?? [],
+                    vramEstimateGb: j.metrics?.memory ? parseFloat(j.metrics.memory) : undefined,
+                    logSummary: undefined,
+                    recipeJson: j.recipeJson ?? "",
+                  }))}
+                onClose={() => setShowComparison(false)}
+              />
+            )}
 
             {/* Slide down Custom form */}
             {showAddForm && (

--- a/src/components/features/ExecutionWorkspace.tsx
+++ b/src/components/features/ExecutionWorkspace.tsx
@@ -48,8 +48,9 @@ import { fetchHardwareProbe, type HardwareProbeResult } from "@/lib/hardwareProb
 import { VramEstimateBanner } from "@/components/features/VramEstimateBanner";
 import { GpuMetricsBar } from "@/components/features/GpuMetricsBar";
 import { parseGpuMetrics, type GpuMetrics } from "@/lib/gpuMetrics";
-import { saveJobHistory } from "@/lib/jobHistoryStore";
+import { saveJobHistory, getJobHistory } from "@/lib/jobHistoryStore";
 import { JobHistoryModal } from "@/components/features/JobHistoryModal";
+import { downloadMarkdownReport } from "@/lib/reportGenerator";
 
 const RecipeGraphView = lazy(() => import("./RecipeGraphView").then((m) => ({ default: m.RecipeGraphView })));
 
@@ -1314,6 +1315,16 @@ ${
                 onClick={() => setIsHistoryOpen(true)}
               >
                 <History className="h-3.5 w-3.5 mr-1.5" /> Run History
+              </Button>
+              <Button
+                variant="outline"
+                className="h-8 px-3 text-xs border-electric-blue/30 text-electric-blue hover:text-white hover:bg-electric-blue/10"
+                onClick={async () => {
+                  const history = await getJobHistory();
+                  if (history.length > 0) downloadMarkdownReport(history.slice(0, 6));
+                }}
+              >
+                <Download className="h-3.5 w-3.5 mr-1.5" /> Export Report
               </Button>
               <Button
                 variant="outline"

--- a/src/components/features/InputEnvironmentPanel.tsx
+++ b/src/components/features/InputEnvironmentPanel.tsx
@@ -21,7 +21,9 @@ import {
   fetchGitHubRecipeJson,
   fetchOliveRecipesCatalogItem,
   getCatalogDeviceFromRecipe,
-  OLIVE_RECIPES_BRANCH,
+  getRecipesBranch,
+  setRecipesBranch,
+  OLIVE_RECIPES_BRANCH_DEFAULT,
   OLIVE_RECIPES_REPO,
   type RecipeCatalogItem,
 } from "@/lib/oliveRecipeHub";
@@ -165,7 +167,7 @@ export function InputEnvironmentPanel({
   const [syncStatus, setSyncStatus] = useState<"idle" | "loading" | "success" | "error">("idle");
   const [syncError, setSyncError] = useState("");
   const [repoUrl, setRepoUrl] = useState(`https://github.com/${OLIVE_RECIPES_REPO}`);
-  const [repoBranch, setRepoBranch] = useState(OLIVE_RECIPES_BRANCH);
+  const [repoBranch, setRepoBranch] = useState(getRecipesBranch());
   const [repoPath, setRepoPath] = useState(
     "Qwen-Qwen2.5-1.5B-Instruct/NvTensorRtRtx/Qwen2.5-1.5B-Instruct_model_builder_fp16.json",
   );
@@ -1146,11 +1148,37 @@ export function InputEnvironmentPanel({
                               <GitBranch className="h-3.5 w-3.5 text-electric-blue" />
                               Target Branch
                             </Label>
-                            <Input
-                              value={repoBranch}
-                              onChange={(e) => setRepoBranch(e.target.value)}
-                              className="font-mono text-xs h-9"
-                            />
+                            <div className="flex gap-1.5">
+                              <Input
+                                value={repoBranch}
+                                onChange={(e) => setRepoBranch(e.target.value)}
+                                className="font-mono text-xs h-9 flex-1"
+                              />
+                              <button
+                                type="button"
+                                title={
+                                  repoBranch !== OLIVE_RECIPES_BRANCH_DEFAULT
+                                    ? `Pinned to ${repoBranch} — click to reset`
+                                    : "Pin this branch for all recipe fetches"
+                                }
+                                className="h-9 px-2 rounded border text-[10px] font-medium transition-colors shrink-0"
+                                style={{
+                                  borderColor:
+                                    repoBranch !== OLIVE_RECIPES_BRANCH_DEFAULT ? "#8DA840" : undefined,
+                                  color: repoBranch !== OLIVE_RECIPES_BRANCH_DEFAULT ? "#8DA840" : undefined,
+                                }}
+                                onClick={() => {
+                                  if (repoBranch !== OLIVE_RECIPES_BRANCH_DEFAULT) {
+                                    setRecipesBranch(null);
+                                    setRepoBranch(OLIVE_RECIPES_BRANCH_DEFAULT);
+                                  } else {
+                                    setRecipesBranch(repoBranch);
+                                  }
+                                }}
+                              >
+                                {repoBranch !== OLIVE_RECIPES_BRANCH_DEFAULT ? "Unpin" : "Pin"}
+                              </button>
+                            </div>
                           </div>
                           <div className="space-y-2">
                             <Label className="text-xs font-semibold text-slate-300 flex items-center gap-1.5">
@@ -1207,19 +1235,19 @@ export function InputEnvironmentPanel({
                             {
                               label: "Qwen2.5 TRT-RTX FP16",
                               repo: `https://github.com/${OLIVE_RECIPES_REPO}`,
-                              branch: OLIVE_RECIPES_BRANCH,
+                              branch: OLIVE_RECIPES_BRANCH_DEFAULT,
                               path: "Qwen-Qwen2.5-1.5B-Instruct/NvTensorRtRtx/Qwen2.5-1.5B-Instruct_model_builder_fp16.json",
                             },
                             {
                               label: "Whisper Tiny CPU INT8",
                               repo: `https://github.com/${OLIVE_RECIPES_REPO}`,
-                              branch: OLIVE_RECIPES_BRANCH,
+                              branch: OLIVE_RECIPES_BRANCH_DEFAULT,
                               path: "openai-whisper-tiny/cpu/whisper-tiny_cpu_int8.json",
                             },
                             {
                               label: "Phi-3.5 Mini DirectML",
                               repo: `https://github.com/${OLIVE_RECIPES_REPO}`,
-                              branch: OLIVE_RECIPES_BRANCH,
+                              branch: OLIVE_RECIPES_BRANCH_DEFAULT,
                               path: "microsoft-Phi-3.5-mini-instruct/aitk/phi3_5_dml_config.json",
                             },
                             {

--- a/src/components/features/JobHistoryModal.tsx
+++ b/src/components/features/JobHistoryModal.tsx
@@ -140,7 +140,7 @@ export function JobHistoryModal({ isOpen, onClose, onSelectRecipe }: JobHistoryM
 
   const toggleSelect = (id: string) => {
     setSelectedIds((prev) =>
-      prev.includes(id) ? prev.filter((item) => item !== id) : prev.length < 3 ? [...prev, id] : prev,
+      prev.includes(id) ? prev.filter((item) => item !== id) : prev.length < 6 ? [...prev, id] : prev,
     );
   };
 
@@ -174,7 +174,7 @@ export function JobHistoryModal({ isOpen, onClose, onSelectRecipe }: JobHistoryM
                 Run History & Side-by-Side Comparison
               </h2>
               <p className="text-xs text-slate-400">
-                Persisted in local IndexedDB. Select up to 3 runs to compare side-by-side.
+                Persisted in local IndexedDB. Select up to 6 runs to compare side-by-side.
               </p>
             </div>
           </div>
@@ -459,7 +459,7 @@ export function JobHistoryModal({ isOpen, onClose, onSelectRecipe }: JobHistoryM
         {/* Modal Footer */}
         <div className="px-6 py-3 border-t border-slate-800 bg-slate-900/60 flex items-center justify-between text-xs text-slate-400">
           <div>
-            Showing {filteredHistory.length} of {history.length} runs. Select up to 3 runs to compare.
+            Showing {filteredHistory.length} of {history.length} runs. Select up to 6 runs to compare.
           </div>
           <button
             type="button"

--- a/src/data/recipes.ts
+++ b/src/data/recipes.ts
@@ -1,7 +1,38 @@
-import { OLIVE_RECIPES_CATALOG } from "./olive-recipes-catalog";
 import type { RecipeCatalogItem } from "@/lib/oliveRecipeHub";
 
 export type RecipeItem = RecipeCatalogItem;
 
-/** Presets tab: full microsoft/olive-recipes catalog (lazy-loaded from GitHub on apply). */
-export const SUGGESTED_RECIPES: RecipeItem[] = OLIVE_RECIPES_CATALOG;
+/**
+ * Presets tab: full microsoft/olive-recipes catalog.
+ * Lazy-loaded via dynamic import so Vite code-splits the 215KB bundle
+ * out of the initial chunk. Falls back to an empty array if the import
+ * fails (offline / Tauri edge case) — the server-side /api/github/catalog
+ * endpoint is the primary source in production.
+ */
+let _cachedCatalog: RecipeItem[] | null = null;
+
+export async function loadSuggestedRecipes(): Promise<RecipeItem[]> {
+  if (_cachedCatalog) return _cachedCatalog;
+  try {
+    const mod = await import("./olive-recipes-catalog");
+    _cachedCatalog = mod.OLIVE_RECIPES_CATALOG;
+  } catch {
+    _cachedCatalog = [];
+  }
+  return _cachedCatalog;
+}
+
+/**
+ * Synchronous accessor for backward compatibility.
+ * Returns the cached catalog if already loaded, otherwise an empty array.
+ * Prefer `loadSuggestedRecipes()` for new code.
+ */
+export const SUGGESTED_RECIPES: RecipeItem[] = [];
+
+// Eagerly kick off the dynamic import so the catalog is warm by the time
+// the user opens the recipe browser (non-blocking).
+loadSuggestedRecipes().then((items) => {
+  // Mutate the exported array in-place so existing consumers see the data.
+  SUGGESTED_RECIPES.length = 0;
+  SUGGESTED_RECIPES.push(...items);
+});

--- a/src/index.css
+++ b/src/index.css
@@ -2,36 +2,36 @@
 
 @theme {
   /* Warm olive-tinted dark palette — kills the cold blue-black AI default */
-  --color-slate-50:  #F5F3EC;
-  --color-slate-100: #EDEAE0;
-  --color-slate-200: #DEDBD0;
-  --color-slate-300: #C8C5B8;
-  --color-slate-400: #8E9082;
+  --color-slate-50: #f5f3ec;
+  --color-slate-100: #edeae0;
+  --color-slate-200: #dedbd0;
+  --color-slate-300: #c8c5b8;
+  --color-slate-400: #8e9082;
   --color-slate-500: #636556;
   --color-slate-600: #474937;
   --color-slate-700: #343625;
-  --color-slate-750: #2A2C20;
-  --color-slate-800: #22241A;
-  --color-slate-850: #1C1E15;
-  --color-slate-900: #14150F;
-  --color-slate-950: #0D0E0A;
+  --color-slate-750: #2a2c20;
+  --color-slate-800: #22241a;
+  --color-slate-850: #1c1e15;
+  --color-slate-900: #14150f;
+  --color-slate-950: #0d0e0a;
 
   /* Olive accent — the actual color the product is named after */
-  --color-electric-blue: #8DA840;
-  --color-electric-blue-dark: #6B8A28;
-  --color-olive: #8DA840;
-  --color-olive-dark: #6B8A28;
+  --color-electric-blue: #8da840;
+  --color-electric-blue-dark: #6b8a28;
+  --color-olive: #8da840;
+  --color-olive-dark: #6b8a28;
 
   /* Adjusted greens for success states */
-  --color-emerald-accent: #7DB060;
-  --color-emerald-dark: #5C8A44;
+  --color-emerald-accent: #7db060;
+  --color-emerald-dark: #5c8a44;
 
   /* Flatten border-radius — precision tool, not marketing dashboard */
-  --radius-sm:  1px;
-  --radius:     2px;
-  --radius-md:  2px;
-  --radius-lg:  3px;
-  --radius-xl:  3px;
+  --radius-sm: 1px;
+  --radius: 2px;
+  --radius-md: 2px;
+  --radius-lg: 3px;
+  --radius-xl: 3px;
   --radius-2xl: 4px;
   --radius-3xl: 4px;
 
@@ -72,16 +72,80 @@
 
 /* Olive pulse — replaces the cyan neon glow */
 @keyframes pulsar-glow {
-  0%, 100% {
+  0%,
+  100% {
     r: 3px;
-    filter: drop-shadow(0 0 2px #8DA840);
+    filter: drop-shadow(0 0 2px #8da840);
   }
   50% {
     r: 5px;
-    filter: drop-shadow(0 0 5px #8DA840);
+    filter: drop-shadow(0 0 5px #8da840);
   }
 }
 
 .glow-pulsar {
   animation: pulsar-glow 2s ease-in-out infinite;
+}
+
+/* ─── Print styles for PDF export via window.print() ─────────────────────── */
+@media print {
+  body {
+    background: #fff !important;
+    color: #1a1a2e !important;
+    font-size: 11px;
+  }
+
+  /* Hide app chrome — only print the report container */
+  .no-print,
+  nav,
+  header,
+  footer,
+  aside,
+  [data-print-hide] {
+    display: none !important;
+  }
+
+  .print-only {
+    display: block !important;
+  }
+
+  /* Ensure report content fills the page */
+  [data-print-area] {
+    position: static !important;
+    width: 100% !important;
+    max-height: none !important;
+    overflow: visible !important;
+    background: #fff !important;
+    color: #1a1a2e !important;
+    border: none !important;
+    box-shadow: none !important;
+    padding: 0 !important;
+  }
+
+  /* Tables in print */
+  table {
+    border-collapse: collapse;
+    width: 100%;
+  }
+  th,
+  td {
+    border: 1px solid #cbd5e1;
+    padding: 4px 8px;
+    text-align: left;
+    font-size: 10px;
+  }
+  th {
+    background: #f1f5f9 !important;
+    -webkit-print-color-adjust: exact;
+    print-color-adjust: exact;
+  }
+
+  /* Avoid page breaks inside table rows */
+  tr {
+    page-break-inside: avoid;
+  }
+
+  a[href]::after {
+    content: none; /* Don't append URLs */
+  }
 }

--- a/src/lib/__tests__/reportGenerator.test.ts
+++ b/src/lib/__tests__/reportGenerator.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from "vitest";
+import { generateMarkdownReport } from "@/lib/reportGenerator";
+import type { JobHistoryRecord } from "@/lib/jobHistoryStore";
+
+function makeRecord(overrides: Partial<JobHistoryRecord> = {}): JobHistoryRecord {
+  return {
+    id: "test-1",
+    jobId: "test-1",
+    modelId: "meta-llama/Llama-3-8B",
+    ihvProvider: "CUDAExecutionProvider",
+    memoryOffload: "none",
+    status: "completed",
+    exitCode: 0,
+    durationMs: 45000,
+    timestamp: "2025-01-15T10:30:00Z",
+    passCount: 3,
+    passNames: ["Conversion", "Quantization", "Optimization"],
+    vramEstimateGb: 8.5,
+    logSummary: { totalLogs: 120, errorCount: 0, lastLog: "Optimization complete" },
+    recipeJson: "",
+    ...overrides,
+  };
+}
+
+describe("generateMarkdownReport", () => {
+  it("produces a valid Markdown report for a single record", () => {
+    const md = generateMarkdownReport([makeRecord()]);
+    expect(md).toContain("# Olive Studio Optimization Report");
+    expect(md).toContain("meta-llama/Llama-3-8B");
+    expect(md).toContain("CUDAExecutionProvider");
+    expect(md).toContain("45s");
+    expect(md).toContain("8.5");
+    expect(md).toContain("Conversion → Quantization → Optimization");
+  });
+
+  it("includes comparison section for multiple records", () => {
+    const records = [
+      makeRecord({ id: "a", modelId: "model-a", durationMs: 30000 }),
+      makeRecord({ id: "b", modelId: "model-b", durationMs: 60000, vramEstimateGb: 12.0 }),
+    ];
+    const md = generateMarkdownReport(records);
+    expect(md).toContain("## Comparison");
+    expect(md).toContain("Fastest");
+    expect(md).toContain("model-a");
+    expect(md).toContain("Average duration");
+  });
+
+  it("omits comparison section for single record", () => {
+    const md = generateMarkdownReport([makeRecord()]);
+    expect(md).not.toContain("## Comparison");
+  });
+
+  it("respects custom title option", () => {
+    const md = generateMarkdownReport([makeRecord()], { title: "Custom Report" });
+    expect(md).toContain("# Custom Report");
+  });
+
+  it("includes recipe JSON when option is set", () => {
+    const rec = makeRecord({ recipeJson: '{"passes":{}}' });
+    const md = generateMarkdownReport([rec], { includeRecipeJson: true });
+    expect(md).toContain("```json");
+    expect(md).toContain('"passes"');
+  });
+
+  it("handles records without VRAM estimate", () => {
+    const rec = makeRecord({ vramEstimateGb: undefined });
+    const md = generateMarkdownReport([rec]);
+    expect(md).toContain("—");
+  });
+
+  it("handles failed status emoji", () => {
+    const rec = makeRecord({ status: "failed", exitCode: 1 });
+    const md = generateMarkdownReport([rec]);
+    expect(md).toContain("❌");
+  });
+});

--- a/src/lib/featureFlags.ts
+++ b/src/lib/featureFlags.ts
@@ -1,0 +1,97 @@
+/**
+ * Feature flag infrastructure for gating experimental features.
+ * Flags are read from URL query params (?flagName=1) and localStorage.
+ * Zero runtime cost when flags are off — checks are simple boolean reads.
+ */
+
+type FlagKey = "multiLora" | "lazyCatalog" | "batchComparison" | "reportExport";
+
+interface FlagDefinition {
+  key: FlagKey;
+  description: string;
+  defaultEnabled: boolean;
+}
+
+const FLAG_DEFINITIONS: FlagDefinition[] = [
+  {
+    key: "multiLora",
+    description: "Multi-LoRA adapter support (requires Olive >= 0.3.0)",
+    defaultEnabled: false,
+  },
+  {
+    key: "lazyCatalog",
+    description: "Lazy-load recipe catalog from server instead of static bundle",
+    defaultEnabled: false,
+  },
+  {
+    key: "batchComparison",
+    description: "Multi-model batch comparison view with charts",
+    defaultEnabled: true,
+  },
+  { key: "reportExport", description: "Export optimization reports as Markdown/PDF", defaultEnabled: true },
+];
+
+const STORAGE_PREFIX = "olive:flag:";
+
+function readUrlParam(key: string): boolean | null {
+  try {
+    const params = new URLSearchParams(window.location.search);
+    const val = params.get(key);
+    if (val === "1" || val === "true") return true;
+    if (val === "0" || val === "false") return false;
+  } catch {
+    // SSR / non-browser
+  }
+  return null;
+}
+
+function readStorage(key: string): boolean | null {
+  try {
+    const val = localStorage.getItem(`${STORAGE_PREFIX}${key}`);
+    if (val === "1") return true;
+    if (val === "0") return false;
+  } catch {
+    // noop
+  }
+  return null;
+}
+
+/**
+ * Check if a feature flag is enabled.
+ * Priority: URL param > localStorage > default.
+ */
+export function isFeatureEnabled(key: FlagKey): boolean {
+  const urlVal = readUrlParam(key);
+  if (urlVal !== null) return urlVal;
+
+  const storageVal = readStorage(key);
+  if (storageVal !== null) return storageVal;
+
+  const def = FLAG_DEFINITIONS.find((d) => d.key === key);
+  return def?.defaultEnabled ?? false;
+}
+
+/**
+ * Persist a feature flag override to localStorage.
+ * Pass null to clear the override and revert to default.
+ */
+export function setFeatureFlag(key: FlagKey, enabled: boolean | null): void {
+  try {
+    if (enabled === null) {
+      localStorage.removeItem(`${STORAGE_PREFIX}${key}`);
+    } else {
+      localStorage.setItem(`${STORAGE_PREFIX}${key}`, enabled ? "1" : "0");
+    }
+  } catch {
+    // noop
+  }
+}
+
+/** Get all flag definitions with their current resolved state. */
+export function getAllFlags(): { key: FlagKey; description: string; enabled: boolean }[] {
+  return FLAG_DEFINITIONS.map((def) => ({
+    key: def.key,
+    description: def.description,
+    enabled: isFeatureEnabled(def.key),
+  }));
+}

--- a/src/lib/oliveRecipeHub.ts
+++ b/src/lib/oliveRecipeHub.ts
@@ -3,7 +3,38 @@ import { createInactivePasses, DEFAULT_PASSES } from "@/lib/defaultPasses";
 import { memoryOffloadFromRecipe } from "@/lib/memoryOffload";
 
 export const OLIVE_RECIPES_REPO = "microsoft/olive-recipes";
-export const OLIVE_RECIPES_BRANCH = "main";
+export const OLIVE_RECIPES_BRANCH_DEFAULT = "main";
+
+/**
+ * Returns the active recipes branch/ref.
+ * Reads from localStorage pin first, then falls back to default.
+ * Allows users to pin a specific tag/branch for reproducible recipe imports.
+ */
+export function getRecipesBranch(): string {
+  try {
+    const pinned = localStorage.getItem("olive:recipes-branch");
+    if (pinned && /^[A-Za-z0-9_./-]+$/.test(pinned)) return pinned;
+  } catch {
+    // localStorage unavailable (SSR / Tauri edge case)
+  }
+  return OLIVE_RECIPES_BRANCH_DEFAULT;
+}
+
+/** Pin the recipes branch/ref for subsequent fetches. Pass null to reset. */
+export function setRecipesBranch(ref: string | null): void {
+  try {
+    if (ref) {
+      localStorage.setItem("olive:recipes-branch", ref);
+    } else {
+      localStorage.removeItem("olive:recipes-branch");
+    }
+  } catch {
+    // noop
+  }
+}
+
+/** @deprecated Use getRecipesBranch() for dynamic resolution. */
+export const OLIVE_RECIPES_BRANCH = OLIVE_RECIPES_BRANCH_DEFAULT;
 
 export interface RecipeCatalogItem {
   name: string;
@@ -114,7 +145,7 @@ export async function fetchGitHubRecipeJson(
 export async function fetchOliveRecipesCatalogItem(
   item: RecipeCatalogItem,
   repo = OLIVE_RECIPES_REPO,
-  branch = OLIVE_RECIPES_BRANCH,
+  branch = getRecipesBranch(),
 ): Promise<unknown> {
   const { json } = await fetchGitHubRecipeJson(repo, branch, item.repoPath);
   return json;

--- a/src/lib/schemaEngine.ts
+++ b/src/lib/schemaEngine.ts
@@ -420,6 +420,30 @@ export function validateRecipeSchema(recipe: unknown): SchemaValidationResult {
     validateSystemRef(recipe.systems, recipe.engine.target, "target", errors);
   }
 
+  // ── adapters (optional, multi-LoRA scaffolding) ────────────────
+  if (recipe.adapters !== undefined) {
+    if (!Array.isArray(recipe.adapters)) {
+      errors.push("adapters must be an array when present");
+    } else {
+      for (let i = 0; i < recipe.adapters.length; i++) {
+        const adapter = recipe.adapters[i];
+        if (!isObject(adapter)) {
+          errors.push(`adapters[${i}] must be an object`);
+          continue;
+        }
+        if (typeof adapter.name !== "string" || adapter.name.trim().length === 0) {
+          errors.push(`adapters[${i}].name must be a non-empty string`);
+        }
+        if (typeof adapter.path !== "string" || adapter.path.trim().length === 0) {
+          errors.push(`adapters[${i}].path must be a non-empty string`);
+        }
+        if (adapter.rank !== undefined && typeof adapter.rank !== "number") {
+          errors.push(`adapters[${i}].rank must be a number when present`);
+        }
+      }
+    }
+  }
+
   return { valid: errors.length === 0, errors };
 }
 

--- a/src/server/routes/env.ts
+++ b/src/server/routes/env.ts
@@ -128,8 +128,8 @@ export function mountEnvRoutes(router: Router): void {
   // ─── Olive Version Detection ────────────────────────────────────────────
   router.get("/olive/version", async (_req, res) => {
     try {
-      const { getVenvPythonPath } = await import("../services/venv/paths.ts");
-      const python = getVenvPythonPath();
+      const { getVenvPython } = await import("../services/venv/paths.ts");
+      const python = getVenvPython();
       if (!python) {
         return res.json({ installed: false, version: null });
       }

--- a/src/server/routes/github.ts
+++ b/src/server/routes/github.ts
@@ -2,9 +2,60 @@
  * GitHub recipe proxy route handler.
  * Proxies raw.githubusercontent.com fetches to avoid browser CORS issues.
  * Also serves a paginated recipe catalog endpoint.
+ * Includes server-side LRU cache + ETag support to reduce GitHub API usage.
  */
-import type { Router } from "express";
+import type { Router, Request, Response } from "express";
+import { createHash } from "node:crypto";
 import { githubProxyRateLimit } from "../middleware/rateLimit.ts";
+
+// ─── LRU Cache (50 entries, 5-min TTL) ────────────────────────────────────────
+interface CacheEntry {
+  body: string;
+  etag: string;
+  timestamp: number;
+}
+
+const CACHE_MAX = 50;
+const CACHE_TTL_MS = 5 * 60 * 1000;
+const cache = new Map<string, CacheEntry>();
+
+function cacheGet(key: string): CacheEntry | undefined {
+  const entry = cache.get(key);
+  if (!entry) return undefined;
+  if (Date.now() - entry.timestamp > CACHE_TTL_MS) {
+    cache.delete(key);
+    return undefined;
+  }
+  // Move to end (most recently used)
+  cache.delete(key);
+  cache.set(key, entry);
+  return entry;
+}
+
+function cacheSet(key: string, body: string): string {
+  const etag = `"${createHash("md5").update(body).digest("hex").slice(0, 16)}"`;
+  if (cache.size >= CACHE_MAX) {
+    // Evict oldest (first key)
+    const oldest = cache.keys().next().value;
+    if (oldest !== undefined) cache.delete(oldest);
+  }
+  cache.set(key, { body, etag, timestamp: Date.now() });
+  return etag;
+}
+
+/** Middleware: respond 304 if client sends matching If-None-Match. */
+function etagConditional(req: Request, res: Response, etag: string, body: string): boolean {
+  res.setHeader("ETag", etag);
+  res.setHeader("Cache-Control", "private, max-age=60");
+  const clientEtag = req.headers["if-none-match"];
+  if (clientEtag === etag) {
+    res.status(304).end();
+    return true;
+  }
+  res.setHeader("Content-Type", "application/json");
+  res.send(body);
+  return false;
+}
 
 const OWNER_REPO_RE = /^[A-Za-z0-9_.-]+$/;
 const BRANCH_RE = /^[A-Za-z0-9_./-]+$/;
@@ -100,9 +151,21 @@ export function mountGithubRoutes(router: Router): void {
       return res.status(400).json({ error: "Refusing to fetch from non-GitHub host." });
     }
 
+    const cacheKey = `raw:${parsed.owner}/${parsed.repo}/${branch}/${filePath}`;
+    const cached = cacheGet(cacheKey);
+    if (cached) {
+      etagConditional(req, res, cached.etag, cached.body);
+      return;
+    }
+
     try {
+      const headers: Record<string, string> = { "User-Agent": "olive-studio" };
+      // Use GITHUB_TOKEN for higher rate limits (5000 req/hr vs 60)
+      const token = process.env.GITHUB_TOKEN;
+      if (token) headers["Authorization"] = `Bearer ${token}`;
+
       const upstream = await fetch(rawUrl, {
-        headers: { "User-Agent": "olive-studio" },
+        headers,
         signal: AbortSignal.timeout(10_000),
       });
       if (!upstream.ok) {
@@ -115,11 +178,10 @@ export function mountGithubRoutes(router: Router): void {
       if (text.length > 5_000_000) {
         return res.status(413).json({ error: "Remote file is too large to proxy." });
       }
-      try {
-        return res.json(JSON.parse(text));
-      } catch {
-        return res.status(415).json({ error: "Remote file is not valid JSON." });
-      }
+      // Validate JSON before caching
+      JSON.parse(text);
+      const etag = cacheSet(cacheKey, text);
+      etagConditional(req, res, etag, text);
     } catch (error: unknown) {
       const msg = error instanceof Error ? error.message : String(error);
       console.error("GitHub raw proxy error:", error);


### PR DESCRIPTION
## Summary

Stacked on #55. Implements Phase 2 (product features), Phase 3 (Tauri prep), and Phase 4 (MultiLoRA scaffolding).

### Phase 2.1 - Recipe Import Lazy-Load + Version Pinning
- LRU cache (50 entries, 5-min TTL) + ETag/If-None-Match for GitHub proxy
- GITHUB_TOKEN env support for 5000 req/hr rate limit
- Dynamic import() fallback for static catalog (code-splits 215KB out of initial bundle)
- Version pinning: getRecipesBranch()/setRecipesBranch() with localStorage persistence
- Branch/tag Pin/Unpin button in recipe import dialog

### Phase 2.2 - Multi-Model Batch Comparison
- BatchComparisonChart.tsx: recharts grouped bar + radar chart overlay
- Compare button in BatchProcessingPanel (visible when >=2 completed jobs)
- JobHistoryModal upgraded from 3 to 6 max comparison slots
- Component test: 6 passing cases

### Phase 2.3 - Export Optimization Report
- Print CSS (@media print) for PDF export via window.print()
- Export Report button in ExecutionWorkspace toolbar
- Unit test: 7 passing cases

### Phase 3 - Tauri Production Preparatory Work
- MSIX packaging target in tauri.conf.json (Store-compatible)
- Release profile: strip=true, lto=true, codegen-units=1, opt-level=s
- tauri-build.yml workflow (NSIS + MSIX artifacts on v* tags)
- MS Store submission checklist (docs/ms-store-submission.md)
- Cold-start telemetry in lib.rs (Instant::now to first health-check)

### Phase 4 - MultiLoRA Adapter Support (scaffolding only)
- Optional adapters[] validation in schemaEngine.ts (backward-compatible)
- multilora-design.md: VRAM budget formula, slot-mapping schema, graduation gate
- featureFlags.ts: multiLora, lazyCatalog, batchComparison, reportExport flags

## Test Results
- reportGenerator.test.ts: 7/7 passing
- BatchComparisonView.test.tsx: 6/6 passing
- TypeScript: zero errors (tsc --noEmit clean)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds recipe import caching and branch pinning, batch comparison with charts, and report export. Prepares Tauri production (MSIX + CI) with cold-start telemetry and scaffolds Multi‑LoRA support behind a flag.

- **New Features**
  - Recipe import: server LRU cache with ETag, optional `GITHUB_TOKEN`, lazy-load catalog (code-splits ~215 KB), and branch/tag pinning via localStorage with Pin/Unpin UI.
  - Batch comparison: compare up to 6 completed runs; grouped bar/radar charts using `recharts`; Compare button in Batch Processing.
  - Report export: toolbar button to generate a Markdown/PDF-ready optimization report with print CSS; unit tests added.
  - Multi‑LoRA scaffolding: optional `adapters[]` validation in schema, design doc, gated by `multiLora` flag (backward-compatible).
  - Feature flags: `multiLora`, `lazyCatalog`, `batchComparison`, `reportExport`.

- **Tauri Prep**
  - MSIX bundling enabled; CI workflow builds NSIS/MSIX on `v*` tags using `@tauri-apps/cli`.
  - Rust release profile tuned (strip, LTO, codegen-units=1, opt-level=s); cold-start telemetry logs time to first health-check.
  - Microsoft Store submission checklist added.

<sup>Written for commit ff33b8ccb0a511a8c0651e82cd96778c8a161f1d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tonythethompson/Olive-Studio/pull/56?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

