### PR TITLE
feat(infra): v0.3.0 Phase 4 — Strategic Bets

### DIFF
--- a/docs/multilora-design.md
+++ b/docs/multilora-design.md
@@ -14,7 +14,7 @@ critical for serving multiple fine-tuned variants of the same base model efficie
 
 - Olive must expose multi-adapter optimization as a supported pass configuration
 - Tracking: https://github.com/microsoft/Olive/issues (multi-adapter milestone)
-- Minimum ORT version: 1.21+ (LoRA adapter slot-mapping support)
+- Minimum ORT version: 1.21+ (ORT GenAI `Adapters` API / `set_active_adapter` support)
 
 ## Schema Extension
 
@@ -57,7 +57,8 @@ emitted. When both `adapters[].path` and `passes.lora.config.adapter_path` are p
 the validator does not reject this as a conflict; however, only the pass-level
 `adapter_path` will be used by the builder until multi-adapter builder support is
 implemented (requires Olive >= 0.3.0). For recipes using `adapters[]` today, the
-slot-mapping output will NOT be emitted until builder integration (Phase 4) is complete.
+runtime adapter-loading artifacts will NOT be emitted until builder integration (Phase 4)
+is complete.
 
 ### TypeScript Interface
 
@@ -65,8 +66,8 @@ slot-mapping output will NOT be emitted until builder integration (Phase 4) is c
 interface AdapterConfig {
   name: string;
   path: string;
-  rank: number;
-  alpha: number;
+  rank: number;        // must be a finite number (not NaN/Infinity); NOT required to be positive or integer
+  alpha: number;       // must be a finite number; NOT required to be positive
   targetModules?: string[]; // e.g. ["q_proj", "v_proj"]
 }
 
@@ -77,16 +78,30 @@ interface OliveRecipe {
 }
 ```
 
+**Validation notes (as of `validateRecipeSchema` in `src/lib/schemaEngine.ts`):**
+- `rank` and `alpha` are only validated to be finite numbers (not `NaN` or `Infinity`).
+- They are NOT currently required to be positive or integers by the schema validator.
+- This may be tightened in future versions to enforce positivity and/or integer constraints for `rank`.
+
 ## VRAM Budget Formula
 
 ```
-total_vram = base_model_vram + N * adapter_delta
+total_vram = base_model_vram + sum(adapter_delta_i for i in active_adapters)
 
 where:
   base_model_vram = estimated VRAM for base model (from buildMaxMemoryMap)
-  N = number of active adapters
-  adapter_delta = rank * hidden_dim * 2 bytes * num_layers / 1e9  (GB)
+  adapter_delta_i = rank_i * len(targetModules_i) * hidden_dim * bytes_per_param * 2 / 1e9  (GB)
+    - rank_i, targetModules_i: this adapter's own rank and target module list
+    - bytes_per_param: dtype-dependent (e.g. 4 for fp32, 2 for fp16/bf16)
+    - the "* 2" accounts for both LoRA A and B matrices per targeted module
 ```
+
+**Assumptions:** This estimate assumes LoRA adapters (A/B low-rank matrices) applied to the
+listed `targetModules` only, and that adapter weights use the specified dtype (default
+assumption fp16 if unspecified). It may underestimate for QLoRA or other adapter types with
+different structures. **Implementation status:** This is Phase 2 (not yet implemented); no
+`adapter_delta` calculation currently exists in `src/lib/vramEstimate.ts` or
+`src/lib/memoryOffload.ts`.
 
 ### Thresholds
 
@@ -112,23 +127,38 @@ For GPUs with <= 12GB VRAM:
 3. **Batch Processing:** Each adapter can be a separate batch job variant
 4. **Comparison:** BatchComparisonView shows adapter name as a column
 
-## Slot-Mapping Schema (ORT 1.21+)
+## Runtime Adapter Loading (ORT GenAI Adapters API)
 
-```json
-{
-  "session_options": {
-    "lora_config": {
-      "slot_mapping": {
-        "0": "adapters/customer-support.safetensors",
-        "1": "adapters/code-gen.safetensors"
-      },
-      "active_slot": 0
-    }
-  }
-}
+Adapters are prepared/exported via Olive (Olive-prepared adapter artifacts), then loaded at
+runtime using the ONNX Runtime GenAI `Adapters` API:
+
+```python
+# Load adapters at runtime
+adapters = og.Adapters(model)
+adapters.load("adapters/customer-support", "customer-support")
+adapters.load("adapters/code-gen", "code-generation")
+
+# Switch active adapter during generation
+generator = og.Generator(model, params)
+generator.set_active_adapter(adapters, "customer-support")
+# ... generate with customer-support adapter ...
+
+generator.set_active_adapter(adapters, "code-generation")
+# ... generate with code-generation adapter ...
 ```
 
-Runtime switching is done via `session.set_lora_slot(index)` without model reload.
+**Key behaviors:**
+- Each adapter must be registered with a unique name (the `adapter_name` / `AdapterConfig.name`
+  field serves this purpose); loading two adapters with the same name is treated as a conflict.
+- **Disabling an adapter:** Stop referencing it as the active adapter (base model behavior
+  resumes).
+- **Reordering:** Order does not affect runtime behavior since adapters are referenced by name,
+  not index/slot.
+- **Removing an adapter:** Unload via the Adapters API / drop from the active recipe's
+  `adapters[]` list.
+
+**Integration status:** Runtime and builder integration remain BLOCKED until the E2E test in
+the Graduation Gate passes (2 adapters loaded, switched at runtime, correct output on ORT 1.21+).
 
 ## Graduation Gate
 
@@ -144,5 +174,5 @@ Re-evaluate after Olive 0.3.0 release:
 1. **Schema scaffolding** (this PR): Optional `adapters[]` field, feature flag
 2. **VRAM estimation**: Extend `vramEstimate.ts` with adapter delta calculation
 3. **UI wiring**: Adapter list in InputEnvironmentPanel, gated by `multiLora` flag
-4. **Builder integration**: Emit slot-mapping config when adapters present
+4. **Builder integration**: Emit runtime adapter-loading config (ORT GenAI `Adapters` API) when adapters present
 5. **E2E validation**: Test with real LoRA adapters on CUDA EP

--- a/docs/multilora-design.md
+++ b/docs/multilora-design.md
@@ -66,8 +66,10 @@ is complete.
 interface AdapterConfig {
   name: string;
   path: string;
-  rank: number;        // must be a finite number (not NaN/Infinity); NOT required to be positive or integer
-  alpha: number;       // must be a finite number; NOT required to be positive
+  /** Positive integer (> 0). Matches the LoRA pass `lora_rank` constraint. */
+  rank: number;
+  /** Positive finite number (> 0). */
+  alpha: number;
   targetModules?: string[]; // e.g. ["q_proj", "v_proj"]
 }
 
@@ -79,17 +81,18 @@ interface OliveRecipe {
 ```
 
 **Validation notes (as of `validateRecipeSchema` in `src/lib/schemaEngine.ts`):**
-- `rank` and `alpha` are only validated to be finite numbers (not `NaN` or `Infinity`).
-- They are NOT currently required to be positive or integers by the schema validator.
-- This may be tightened in future versions to enforce positivity and/or integer constraints for `rank`.
+- `rank` must be a positive integer (`> 0`).
+- `alpha` must be a positive finite number (`> 0`, not `NaN` or `Infinity`).
+- `targetModules`, when present, must be an array of non-empty strings.
 
 ## VRAM Budget Formula
 
-```
+```text
 total_vram = base_model_vram + sum(adapter_delta_i for i in active_adapters)
 
 where:
   base_model_vram = estimated VRAM for base model (from buildMaxMemoryMap)
+  active_adapters = enabled entries in adapters[]
   adapter_delta_i = rank_i * len(targetModules_i) * hidden_dim * bytes_per_param * 2 / 1e9  (GB)
     - rank_i, targetModules_i: this adapter's own rank and target module list
     - bytes_per_param: dtype-dependent (e.g. 4 for fp32, 2 for fp16/bf16)
@@ -135,8 +138,8 @@ runtime using the ONNX Runtime GenAI `Adapters` API:
 ```python
 # Load adapters at runtime
 adapters = og.Adapters(model)
-adapters.load("adapters/customer-support", "customer-support")
-adapters.load("adapters/code-gen", "code-generation")
+adapters.load("adapters/customer-support.onnx_adapter", "customer-support")
+adapters.load("adapters/code-gen.onnx_adapter", "code-generation")
 
 # Switch active adapter during generation
 generator = og.Generator(model, params)

--- a/docs/multilora-design.md
+++ b/docs/multilora-design.md
@@ -93,7 +93,7 @@ For GPUs with <= 12GB VRAM:
 
 - Hard-cap at 2 adapters maximum
 - Reduce `buildMaxMemoryMap()` GPU budget from 90% to 80% when multi-adapter active
-- Extends existing logic in `src/lib/memoryOffload.ts` L27
+- Extends existing logic in `src/lib/memoryOffload.ts` (`buildMaxMemoryMap()`)
 
 ## UI Integration
 

--- a/docs/multilora-design.md
+++ b/docs/multilora-design.md
@@ -1,0 +1,139 @@
+# Multi-LoRA Adapter Support — Design Document
+
+**Status:** BLOCKED by upstream (requires Olive >= 0.3.0 multi-adapter pass configuration)
+**Target:** v0.4.0+
+**Feature Flag:** `multiLora` (default: off)
+
+## Overview
+
+Multi-LoRA enables loading multiple LoRA/QLoRA adapters into a single optimized model,
+allowing runtime switching between adapters without reloading the base model. This is
+critical for serving multiple fine-tuned variants of the same base model efficiently.
+
+## Upstream Dependency
+
+- Olive must expose multi-adapter optimization as a supported pass configuration
+- Tracking: https://github.com/microsoft/Olive/issues (multi-adapter milestone)
+- Minimum ORT version: 1.21+ (LoRA adapter slot-mapping support)
+
+## Schema Extension
+
+### Recipe JSON (backward-compatible)
+
+```json
+{
+  "passes": {
+    "lora": {
+      "type": "LoRA",
+      "config": {
+        "adapter_path": "adapters/customer-support.safetensors"
+      }
+    }
+  },
+  "adapters": [
+    {
+      "name": "customer-support",
+      "path": "adapters/customer-support.safetensors",
+      "rank": 16,
+      "alpha": 32
+    },
+    {
+      "name": "code-generation",
+      "path": "adapters/code-gen.safetensors",
+      "rank": 16,
+      "alpha": 32
+    }
+  ]
+}
+```
+
+**Backward compatibility:** When `adapters` is absent or empty, behavior is identical
+to v0.2.0 single-adapter mode. The builder ignores unknown keys.
+
+### TypeScript Interface
+
+```typescript
+interface AdapterConfig {
+  name: string;
+  path: string;
+  rank: number;
+  alpha: number;
+  targetModules?: string[]; // e.g. ["q_proj", "v_proj"]
+}
+
+// Added to OliveRecipeSchema (optional field)
+interface OliveRecipe {
+  // ... existing fields
+  adapters?: AdapterConfig[];
+}
+```
+
+## VRAM Budget Formula
+
+```
+total_vram = base_model_vram + N * adapter_delta
+
+where:
+  base_model_vram = estimated VRAM for base model (from buildMaxMemoryMap)
+  N = number of active adapters
+  adapter_delta = rank * hidden_dim * 2 bytes * num_layers / 1e9  (GB)
+```
+
+### Thresholds
+
+| Adapters    | Budget Multiplier | Action                                  |
+| ----------- | ----------------- | --------------------------------------- |
+| 1 (default) | 100%              | Normal operation                        |
+| 2           | 110%              | Warn if exceeded                        |
+| 3+          | N/A               | Hard-cap at 2 for consumer GPUs <= 12GB |
+
+### Consumer GPU Mitigation
+
+For GPUs with <= 12GB VRAM:
+
+- Hard-cap at 2 adapters maximum
+- Reduce `buildMaxMemoryMap()` GPU budget from 90% to 80% when multi-adapter active
+- Extends existing logic in `src/lib/memoryOffload.ts` L27
+
+## UI Integration
+
+1. **Recipe Import:** When a recipe contains `adapters[]`, show adapter list in
+   InputEnvironmentPanel with per-adapter enable/disable toggles
+2. **VRAM Banner:** VramEstimateBanner shows per-adapter delta breakdown
+3. **Batch Processing:** Each adapter can be a separate batch job variant
+4. **Comparison:** BatchComparisonView shows adapter name as a column
+
+## Slot-Mapping Schema (ORT 1.21+)
+
+```json
+{
+  "session_options": {
+    "lora_config": {
+      "slot_mapping": {
+        "0": "adapters/customer-support.safetensors",
+        "1": "adapters/code-gen.safetensors"
+      },
+      "active_slot": 0
+    }
+  }
+}
+```
+
+Runtime switching is done via `session.set_lora_slot(index)` without model reload.
+
+## Graduation Gate
+
+Re-evaluate after Olive 0.3.0 release:
+
+- [ ] Olive >= 0.3.0 documents multi-adapter optimization as supported
+- [ ] E2E test: 2 adapters loaded, switched at runtime, correct output on ORT 1.21+
+- [ ] VRAM budget <= 110% of single-adapter baseline for 2-adapter config
+- [ ] Recipe schema extension backward-compatible with v0.2.0 recipes
+
+## Implementation Phases
+
+1. **Schema scaffolding** (this PR): Optional `adapters[]` field, feature flag
+2. **VRAM estimation**: Extend `vramEstimate.ts` with adapter delta calculation
+3. **UI wiring**: Adapter list in InputEnvironmentPanel, gated by `multiLora` flag
+4. **Builder integration**: Emit slot-mapping config when adapters present
+5. **E2E validation**: Test with real LoRA adapters on CUDA EP

--- a/docs/multilora-design.md
+++ b/docs/multilora-design.md
@@ -50,6 +50,15 @@ critical for serving multiple fine-tuned variants of the same base model efficie
 **Backward compatibility:** When `adapters` is absent or empty, behavior is identical
 to v0.2.0 single-adapter mode. The builder ignores unknown keys.
 
+**Current implementation status:** The recipe schema validator accepts the `adapters[]`
+field for forward-compatibility validation, but the current builder (`buildOliveRecipe`)
+does not consume it — only `passes.lora.config.adapter_path` (single-adapter mode) is
+emitted. When both `adapters[].path` and `passes.lora.config.adapter_path` are present,
+the validator does not reject this as a conflict; however, only the pass-level
+`adapter_path` will be used by the builder until multi-adapter builder support is
+implemented (requires Olive >= 0.3.0). For recipes using `adapters[]` today, the
+slot-mapping output will NOT be emitted until builder integration (Phase 4) is complete.
+
 ### TypeScript Interface
 
 ```typescript

--- a/src/lib/__tests__/schemaEngine.test.ts
+++ b/src/lib/__tests__/schemaEngine.test.ts
@@ -304,6 +304,124 @@ describe("validateRecipeSchema", () => {
     );
     expect(r.valid).toBe(true);
   });
+
+  it("accepts a valid adapters array", () => {
+    const r = validateRecipeSchema(
+      validRecipe({
+        adapters: [
+          { name: "support", path: "adapters/support.safetensors", rank: 16, alpha: 32 },
+          { name: "code", path: "adapters/code.safetensors", rank: 8, alpha: 16 },
+        ],
+      }),
+    );
+    expect(r.valid).toBe(true);
+    expect(r.errors).toEqual([]);
+  });
+
+  it("rejects non-array adapters", () => {
+    const r = validateRecipeSchema(validRecipe({ adapters: "not-an-array" }));
+    expect(r.valid).toBe(false);
+    expect(r.errors.some((e) => e.includes("adapters must be an array"))).toBe(true);
+  });
+
+  it("rejects non-object adapter entries", () => {
+    const r = validateRecipeSchema(validRecipe({ adapters: ["bad"] }));
+    expect(r.valid).toBe(false);
+    expect(r.errors.some((e) => e.includes("adapters[0] must be an object"))).toBe(true);
+  });
+
+  it("rejects empty adapter name", () => {
+    const r = validateRecipeSchema(
+      validRecipe({
+        adapters: [{ name: "", path: "adapters/x.safetensors", rank: 16, alpha: 32 }],
+      }),
+    );
+    expect(r.valid).toBe(false);
+    expect(r.errors.some((e) => e.includes("adapters[0].name"))).toBe(true);
+  });
+
+  it("rejects empty adapter path", () => {
+    const r = validateRecipeSchema(
+      validRecipe({
+        adapters: [{ name: "x", path: "", rank: 16, alpha: 32 }],
+      }),
+    );
+    expect(r.valid).toBe(false);
+    expect(r.errors.some((e) => e.includes("adapters[0].path"))).toBe(true);
+  });
+
+  it("rejects non-positive rank", () => {
+    const zero = validateRecipeSchema(
+      validRecipe({ adapters: [{ name: "x", path: "p", rank: 0, alpha: 32 }] }),
+    );
+    expect(zero.valid).toBe(false);
+    expect(zero.errors.some((e) => e.includes("adapters[0].rank must be a positive integer"))).toBe(true);
+
+    const negative = validateRecipeSchema(
+      validRecipe({ adapters: [{ name: "x", path: "p", rank: -2, alpha: 32 }] }),
+    );
+    expect(negative.valid).toBe(false);
+    expect(negative.errors.some((e) => e.includes("adapters[0].rank must be a positive integer"))).toBe(true);
+  });
+
+  it("rejects fractional rank", () => {
+    const r = validateRecipeSchema(
+      validRecipe({ adapters: [{ name: "x", path: "p", rank: 16.5, alpha: 32 }] }),
+    );
+    expect(r.valid).toBe(false);
+    expect(r.errors.some((e) => e.includes("adapters[0].rank must be a positive integer"))).toBe(true);
+  });
+
+  it("rejects non-positive alpha", () => {
+    const zero = validateRecipeSchema(
+      validRecipe({ adapters: [{ name: "x", path: "p", rank: 16, alpha: 0 }] }),
+    );
+    expect(zero.valid).toBe(false);
+    expect(zero.errors.some((e) => e.includes("adapters[0].alpha must be a positive finite number"))).toBe(
+      true,
+    );
+
+    const negative = validateRecipeSchema(
+      validRecipe({ adapters: [{ name: "x", path: "p", rank: 16, alpha: -1 }] }),
+    );
+    expect(negative.valid).toBe(false);
+    expect(
+      negative.errors.some((e) => e.includes("adapters[0].alpha must be a positive finite number")),
+    ).toBe(true);
+  });
+
+  it("rejects non-finite alpha", () => {
+    const r = validateRecipeSchema(
+      validRecipe({ adapters: [{ name: "x", path: "p", rank: 16, alpha: Number.NaN }] }),
+    );
+    expect(r.valid).toBe(false);
+    expect(r.errors.some((e) => e.includes("adapters[0].alpha must be a positive finite number"))).toBe(true);
+  });
+
+  it("rejects invalid targetModules", () => {
+    const nonArray = validateRecipeSchema(
+      validRecipe({ adapters: [{ name: "x", path: "p", rank: 16, alpha: 32, targetModules: "q_proj" }] }),
+    );
+    expect(nonArray.valid).toBe(false);
+    expect(nonArray.errors.some((e) => e.includes("adapters[0].targetModules"))).toBe(true);
+
+    const emptyString = validateRecipeSchema(
+      validRecipe({
+        adapters: [{ name: "x", path: "p", rank: 16, alpha: 32, targetModules: [""] }],
+      }),
+    );
+    expect(emptyString.valid).toBe(false);
+    expect(emptyString.errors.some((e) => e.includes("adapters[0].targetModules"))).toBe(true);
+  });
+
+  it("accepts valid targetModules", () => {
+    const r = validateRecipeSchema(
+      validRecipe({
+        adapters: [{ name: "x", path: "p", rank: 16, alpha: 32, targetModules: ["q_proj", "v_proj"] }],
+      }),
+    );
+    expect(r.valid).toBe(true);
+  });
 });
 
 // ─── reloadPassSchemas & getKbMetadata ────────────────────────────────────────

--- a/src/lib/featureFlags.ts
+++ b/src/lib/featureFlags.ts
@@ -1,0 +1,97 @@
+/**
+ * Feature flag infrastructure for gating experimental features.
+ * Flags are read from URL query params (?flagName=1) and localStorage.
+ * Zero runtime cost when flags are off — checks are simple boolean reads.
+ */
+
+type FlagKey = "multiLora" | "lazyCatalog" | "batchComparison" | "reportExport";
+
+interface FlagDefinition {
+  key: FlagKey;
+  description: string;
+  defaultEnabled: boolean;
+}
+
+const FLAG_DEFINITIONS: FlagDefinition[] = [
+  {
+    key: "multiLora",
+    description: "Multi-LoRA adapter support (requires Olive >= 0.3.0)",
+    defaultEnabled: false,
+  },
+  {
+    key: "lazyCatalog",
+    description: "Lazy-load recipe catalog from server instead of static bundle",
+    defaultEnabled: false,
+  },
+  {
+    key: "batchComparison",
+    description: "Multi-model batch comparison view with charts",
+    defaultEnabled: true,
+  },
+  { key: "reportExport", description: "Export optimization reports as Markdown/PDF", defaultEnabled: true },
+];
+
+const STORAGE_PREFIX = "olive:flag:";
+
+function readUrlParam(key: string): boolean | null {
+  try {
+    const params = new URLSearchParams(window.location.search);
+    const val = params.get(key);
+    if (val === "1" || val === "true") return true;
+    if (val === "0" || val === "false") return false;
+  } catch {
+    // SSR / non-browser
+  }
+  return null;
+}
+
+function readStorage(key: string): boolean | null {
+  try {
+    const val = localStorage.getItem(`${STORAGE_PREFIX}${key}`);
+    if (val === "1") return true;
+    if (val === "0") return false;
+  } catch {
+    // noop
+  }
+  return null;
+}
+
+/**
+ * Check if a feature flag is enabled.
+ * Priority: URL param > localStorage > default.
+ */
+export function isFeatureEnabled(key: FlagKey): boolean {
+  const urlVal = readUrlParam(key);
+  if (urlVal !== null) return urlVal;
+
+  const storageVal = readStorage(key);
+  if (storageVal !== null) return storageVal;
+
+  const def = FLAG_DEFINITIONS.find((d) => d.key === key);
+  return def?.defaultEnabled ?? false;
+}
+
+/**
+ * Persist a feature flag override to localStorage.
+ * Pass null to clear the override and revert to default.
+ */
+export function setFeatureFlag(key: FlagKey, enabled: boolean | null): void {
+  try {
+    if (enabled === null) {
+      localStorage.removeItem(`${STORAGE_PREFIX}${key}`);
+    } else {
+      localStorage.setItem(`${STORAGE_PREFIX}${key}`, enabled ? "1" : "0");
+    }
+  } catch {
+    // noop
+  }
+}
+
+/** Get all flag definitions with their current resolved state. */
+export function getAllFlags(): { key: FlagKey; description: string; enabled: boolean }[] {
+  return FLAG_DEFINITIONS.map((def) => ({
+    key: def.key,
+    description: def.description,
+    enabled: isFeatureEnabled(def.key),
+  }));
+}

--- a/src/lib/featureFlags.ts
+++ b/src/lib/featureFlags.ts
@@ -73,7 +73,7 @@ export function isFeatureEnabled(key: FlagKey): boolean {
 
 /**
  * Persist a feature flag override to localStorage.
- * Pass null to clear the override and revert to default.
+ * Pass null to clear the localStorage override and fall back to the URL override or default.
  */
 export function setFeatureFlag(key: FlagKey, enabled: boolean | null): void {
   try {

--- a/src/lib/featureFlags.ts
+++ b/src/lib/featureFlags.ts
@@ -4,7 +4,7 @@
  * Zero runtime cost when flags are off — checks are simple boolean reads.
  */
 
-type FlagKey = "multiLora" | "lazyCatalog" | "batchComparison" | "reportExport";
+export type FlagKey = "multiLora" | "lazyCatalog" | "batchComparison" | "reportExport";
 
 interface FlagDefinition {
   key: FlagKey;

--- a/src/lib/featureFlags.ts
+++ b/src/lib/featureFlags.ts
@@ -15,7 +15,7 @@ interface FlagDefinition {
 const FLAG_DEFINITIONS: FlagDefinition[] = [
   {
     key: "multiLora",
-    description: "Multi-LoRA adapter support (requires Olive >= 0.3.0)",
+    description: "Multi-LoRA UI and docs visibility (experimental; Olive >= 0.3.0 required for execution)",
     defaultEnabled: false,
   },
   {

--- a/src/lib/schemaEngine.ts
+++ b/src/lib/schemaEngine.ts
@@ -437,11 +437,22 @@ export function validateRecipeSchema(recipe: unknown): SchemaValidationResult {
         if (typeof adapter.path !== "string" || adapter.path.trim().length === 0) {
           errors.push(`adapters[${i}].path must be a non-empty string`);
         }
-        if (typeof adapter.rank !== "number" || !Number.isFinite(adapter.rank) || adapter.rank <= 0) {
-          errors.push(`adapters[${i}].rank must be a positive finite number`);
+        if (typeof adapter.rank !== "number" || !Number.isFinite(adapter.rank)) {
+          errors.push(`adapters[${i}].rank must be a finite number`);
         }
-        if (typeof adapter.alpha !== "number" || !Number.isFinite(adapter.alpha) || adapter.alpha <= 0) {
-          errors.push(`adapters[${i}].alpha must be a positive finite number`);
+        if (typeof adapter.alpha !== "number" || !Number.isFinite(adapter.alpha)) {
+          errors.push(`adapters[${i}].alpha must be a finite number`);
+        }
+        if (
+          adapter.targetModules !== undefined &&
+          (!Array.isArray(adapter.targetModules) ||
+            adapter.targetModules.some(
+              (module) => typeof module !== "string" || module.trim().length === 0,
+            ))
+        ) {
+          errors.push(
+            `adapters[${i}].targetModules must be an array of non-empty strings when present`,
+          );
         }
       }
     }

--- a/src/lib/schemaEngine.ts
+++ b/src/lib/schemaEngine.ts
@@ -437,8 +437,11 @@ export function validateRecipeSchema(recipe: unknown): SchemaValidationResult {
         if (typeof adapter.path !== "string" || adapter.path.trim().length === 0) {
           errors.push(`adapters[${i}].path must be a non-empty string`);
         }
-        if (adapter.rank !== undefined && typeof adapter.rank !== "number") {
-          errors.push(`adapters[${i}].rank must be a number when present`);
+        if (typeof adapter.rank !== "number" || !Number.isFinite(adapter.rank)) {
+          errors.push(`adapters[${i}].rank must be a finite number`);
+        }
+        if (typeof adapter.alpha !== "number" || !Number.isFinite(adapter.alpha)) {
+          errors.push(`adapters[${i}].alpha must be a finite number`);
         }
       }
     }

--- a/src/lib/schemaEngine.ts
+++ b/src/lib/schemaEngine.ts
@@ -437,11 +437,11 @@ export function validateRecipeSchema(recipe: unknown): SchemaValidationResult {
         if (typeof adapter.path !== "string" || adapter.path.trim().length === 0) {
           errors.push(`adapters[${i}].path must be a non-empty string`);
         }
-        if (typeof adapter.rank !== "number" || !Number.isFinite(adapter.rank)) {
-          errors.push(`adapters[${i}].rank must be a finite number`);
+        if (typeof adapter.rank !== "number" || !Number.isFinite(adapter.rank) || adapter.rank <= 0) {
+          errors.push(`adapters[${i}].rank must be a positive finite number`);
         }
-        if (typeof adapter.alpha !== "number" || !Number.isFinite(adapter.alpha)) {
-          errors.push(`adapters[${i}].alpha must be a finite number`);
+        if (typeof adapter.alpha !== "number" || !Number.isFinite(adapter.alpha) || adapter.alpha <= 0) {
+          errors.push(`adapters[${i}].alpha must be a positive finite number`);
         }
       }
     }

--- a/src/lib/schemaEngine.ts
+++ b/src/lib/schemaEngine.ts
@@ -437,22 +437,18 @@ export function validateRecipeSchema(recipe: unknown): SchemaValidationResult {
         if (typeof adapter.path !== "string" || adapter.path.trim().length === 0) {
           errors.push(`adapters[${i}].path must be a non-empty string`);
         }
-        if (typeof adapter.rank !== "number" || !Number.isFinite(adapter.rank)) {
-          errors.push(`adapters[${i}].rank must be a finite number`);
+        if (typeof adapter.rank !== "number" || !Number.isInteger(adapter.rank) || adapter.rank <= 0) {
+          errors.push(`adapters[${i}].rank must be a positive integer`);
         }
-        if (typeof adapter.alpha !== "number" || !Number.isFinite(adapter.alpha)) {
-          errors.push(`adapters[${i}].alpha must be a finite number`);
+        if (typeof adapter.alpha !== "number" || !Number.isFinite(adapter.alpha) || adapter.alpha <= 0) {
+          errors.push(`adapters[${i}].alpha must be a positive finite number`);
         }
         if (
           adapter.targetModules !== undefined &&
           (!Array.isArray(adapter.targetModules) ||
-            adapter.targetModules.some(
-              (module) => typeof module !== "string" || module.trim().length === 0,
-            ))
+            adapter.targetModules.some((module) => typeof module !== "string" || module.trim().length === 0))
         ) {
-          errors.push(
-            `adapters[${i}].targetModules must be an array of non-empty strings when present`,
-          );
+          errors.push(`adapters[${i}].targetModules must be an array of non-empty strings when present`);
         }
       }
     }

--- a/src/lib/schemaEngine.ts
+++ b/src/lib/schemaEngine.ts
@@ -420,6 +420,30 @@ export function validateRecipeSchema(recipe: unknown): SchemaValidationResult {
     validateSystemRef(recipe.systems, recipe.engine.target, "target", errors);
   }
 
+  // ── adapters (optional, multi-LoRA scaffolding) ────────────────
+  if (recipe.adapters !== undefined) {
+    if (!Array.isArray(recipe.adapters)) {
+      errors.push("adapters must be an array when present");
+    } else {
+      for (let i = 0; i < recipe.adapters.length; i++) {
+        const adapter = recipe.adapters[i];
+        if (!isObject(adapter)) {
+          errors.push(`adapters[${i}] must be an object`);
+          continue;
+        }
+        if (typeof adapter.name !== "string" || adapter.name.trim().length === 0) {
+          errors.push(`adapters[${i}].name must be a non-empty string`);
+        }
+        if (typeof adapter.path !== "string" || adapter.path.trim().length === 0) {
+          errors.push(`adapters[${i}].path must be a non-empty string`);
+        }
+        if (adapter.rank !== undefined && typeof adapter.rank !== "number") {
+          errors.push(`adapters[${i}].rank must be a number when present`);
+        }
+      }
+    }
+  }
+
   return { valid: errors.length === 0, errors };
 }
 


### PR DESCRIPTION
## Phase 4 — Strategic Bets

Part of the v0.3.0 Roadmap mitigation plan (4 of 4 stacked PRs).

### Changes

- **Feature flags** (`src/lib/featureFlags.ts`) — URL param > localStorage > default priority; flags: `multiLora` (off), `lazyCatalog` (off), `batchComparison` (on), `reportExport` (on)
- **Multi-LoRA design doc** (`docs/multilora-design.md`) — schema extension (`adapters[]`), VRAM budget formula, consumer GPU mitigation, slot-mapping schema, graduation gate
- **Schema engine** extended with optional `adapters[]` validation (name, path, rank)

### Stacked PRs

| # | Branch | Phase |
|---|--------|-------|
| 1 | `feat/v030-phase1-perf` | Performance & Stability |
| 2 | `feat/v030-phase2-ux` | UX & Workflow |
| 3 | `feat/v030-phase3-dist` | Distribution & Compliance |
| 4 | `feat/v030-phase4-strategic` (this) | Strategic Bets |

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds feature flags and Multi‑LoRA scaffolding for Phase 4 to control rollouts and prep multi‑adapter support. Tightens adapter schema validation and updates the design doc with runtime/builder behavior and ORT 1.21+ requirements.

- **New Features**
  - Feature flags with URL > `localStorage` > default priority. Flags: `multiLora` (off), `lazyCatalog` (off), `batchComparison` (on), `reportExport` (on). Helpers: `isFeatureEnabled()`, `setFeatureFlag()`, `getAllFlags()`.
  - Recipe schema: optional `adapters[]` with required `name`, `path`, `rank` (>0 integer), `alpha` (>0 finite); optional `targetModules[]` validated as non‑empty strings.
  - Multi‑LoRA design doc: VRAM budget formula; consumer GPU cap (<=12GB: max 2 adapters, GPU budget reduced to 80%); builder uses `passes.lora.config.adapter_path` until multi‑adapter support lands; requires `Olive` >= 0.3.0 and ORT >= 1.21.

- **Bug Fixes**
  - Clarified flag docs, removed a stale reference, and enforced required `rank` and `alpha` in adapter validation.

<sup>Written for commit 3169fbbd92590aa8e6acd90a7f49b02d0f2bd4f0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tonythethompson/Olive-Studio/pull/60?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

