### PR TITLE
test(playground): core verification for Req 1-10 ship

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,4 @@ bun.lock
 .storybook/
 .air/
 .kiro/
+/.playwright-mcp

--- a/docs/playground-handoff.md
+++ b/docs/playground-handoff.md
@@ -1,0 +1,38 @@
+# Playground Tab — status handoff
+
+Specs originally lived under `.kiro/specs/playground-tab/` (requirements, design, tasks, HANDOFF). That tree was untracked via `.gitignore` on main; this note tracks ship status for core Req 1–10.
+
+## Core (Req 1–10) — implemented + verified
+
+| Area | Status |
+| --- | --- |
+| Nav / `pipelineNavigation` / App wiring | Done |
+| `playgroundStore` (session-scoped, no `persist`) | Done |
+| Arena cloud proxy + SSRF boundary | Done |
+| `PlaygroundPanel` / `ArenaPanel` / ExecutionWorkspace cleanup | Done |
+| Unit tests (navigation, store, arena constants, local inference) | Done |
+| Server arena tests | Done |
+| Component tests (Tasks 11.1–11.5) | Done — co-located under `src/components/features/*.test.tsx` |
+| PBT suite Properties 1, 3, 4, 6, 7, 13 | Done — `src/lib/__tests__/playgroundPBT.test.ts` |
+
+Parent tasks **6** and **7** are complete (all sub-items landed). Checkpoint **8** / **13**: lint green (warnings only); unit + server + component + `validate:recipe` green on Windows after:
+
+- POSIX path expectations in `arenaOliveOutputs` unit tests
+- Cloudflare credential isolation mocks in `detect.test.ts` / `registry.test.ts`
+
+## Req 18 (partial)
+
+| Piece | Status |
+| --- | --- |
+| Path helpers + Olive-output scan + list/file routes | Done |
+| Properties 20 / 20b (server PBT) | Done |
+| `GET /arena/assistant-cloud-snapshot` | **Not done** (Track 2) |
+| ArenaPanel “From Olive outputs” / Assistant snapshot UI | **Not done** (Track 2) |
+| Properties 21 / 21b / 22 | **Not done** (Track 2) |
+
+## Deferred (not in core ship)
+
+- Req 11 — benchmark input profiles
+- Req 12 — MCP KB via GeminiSidebar
+- Req 13–15 — scoring + quality vote + baseline download (no tasks yet)
+- Req 16–17 — run history + recommendations

--- a/docs/playground-handoff.md
+++ b/docs/playground-handoff.md
@@ -13,7 +13,9 @@ Specs originally lived under `.kiro/specs/playground-tab/` (requirements, design
 | Unit tests (navigation, store, arena constants, local inference) | Done |
 | Server arena tests | Done |
 | Component tests (Tasks 11.1–11.5) | Done — co-located under `src/components/features/*.test.tsx` |
-| PBT suite Properties 1, 3, 4, 6, 7, 13 | Done — `src/lib/__tests__/playgroundPBT.test.ts` |
+| PBT suite Properties 1, 4, 6, 13 | Done — pure helpers in `src/lib/__tests__/playgroundPBT.test.ts` |
+| Property 3 (blank cloud prompt blocks run) | Done — helper PBT (`isArenaPromptBlank` ⇔ `trim()`) + behavior component test (cloud slot, blank prompt does not start fetch; prior results preserved) |
+| Property 7 (new run clears prior outputs) | Done — helper PBT (clear replaces any prior slot pair) + behavior component test (second run drops prior outputs before inference) |
 
 Parent tasks **6** and **7** are complete (all sub-items landed). Checkpoint **8** / **13**: lint green (warnings only); unit + server + component + `validate:recipe` green on Windows after:
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ overrides:
   body-parser@<1.20.6: '>=1.20.6'
   uuid@<11.1.1: '>=11.1.1'
   minimatch: ^10.2.5
-  brace-expansion: 5.0.8
+  brace-expansion: '>=5.0.9'
   adm-zip@<0.6.0: '>=0.6.0 <1.0.0'
   sharp@<0.35.0: '>=0.35.0 <1.0.0'
   onnxruntime-web: 1.27.0
@@ -214,7 +214,7 @@ importers:
         version: 0.5.1(supports-color@7.2.0)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@types/node@26.1.2)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+        version: 4.1.10(@types/node@26.1.2)(@vitest/coverage-v8@4.1.10)(jsdom@30.0.1)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
 
 packages:
 
@@ -2508,8 +2508,8 @@ packages:
     resolution: {integrity: sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==}
     deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
 
-  brace-expansion@5.0.8:
-    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
     engines: {node: 20 || >=22}
 
   browser-assert@1.2.1:
@@ -6862,7 +6862,7 @@ snapshots:
       obug: 2.1.4
       std-env: 4.2.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(@types/node@26.1.2)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+      vitest: 4.1.10(@types/node@26.1.2)(@vitest/coverage-v8@4.1.10)(jsdom@30.0.1)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
 
   '@vitest/expect@2.0.5':
     dependencies:
@@ -7133,7 +7133,7 @@ snapshots:
 
   boolean@3.2.0: {}
 
-  brace-expansion@5.0.8:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
@@ -8579,7 +8579,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.8
+      brace-expansion: 5.0.9
 
   minimist@1.2.8: {}
 
@@ -9638,7 +9638,7 @@ snapshots:
       tsx: 4.23.1
       yaml: 2.9.0
 
-  vitest@4.1.10(@types/node@26.1.2)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)):
+  vitest@4.1.10(@types/node@26.1.2)(@vitest/coverage-v8@4.1.10)(jsdom@30.0.1)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.10
       '@vitest/mocker': 4.1.10(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -13,7 +13,7 @@ overrides:
   body-parser@<1.20.6: '>=1.20.6'
   uuid@<11.1.1: '>=11.1.1'
   minimatch: '^10.2.5'
-  brace-expansion: '5.0.8'
+  brace-expansion: '>=5.0.9'
   # @huggingface/transformers → onnxruntime-node / sharp (arena local NLP).
   # Target only vulnerable release lines; bound replacements to compatible majors.
   'adm-zip@<0.6.0': '>=0.6.0 <1.0.0'

--- a/src/components/features/ArenaPanel.test.tsx
+++ b/src/components/features/ArenaPanel.test.tsx
@@ -164,6 +164,96 @@ describe("ArenaPanel", () => {
       }
     }
   });
+
+  it("Property 3 behavior: blank cloud prompt does not start execution and keeps prior results", async () => {
+    // Feature: playground-tab, Property 3 (behavior)
+    const user = userEvent.setup();
+    fetchSpy.mockResolvedValue(
+      new Response(JSON.stringify({ output: "prior-cloud-output" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    render(<ArenaPanel />);
+
+    await user.click(screen.getAllByRole("button", { name: /cloud \/ api/i })[0]!);
+    await user.type(screen.getByLabelText(/endpoint url/i), "https://api.example.com/v1");
+    await user.type(screen.getByLabelText(/^prompt$/i), "first run");
+
+    await act(async () => {
+      await user.click(screen.getByRole("button", { name: /run arena/i }));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("prior-cloud-output")).toBeTruthy();
+    });
+    const callsAfterFirstRun = fetchSpy.mock.calls.length;
+    expect(callsAfterFirstRun).toBeGreaterThan(0);
+
+    // Whitespace-only prompt: Run stays disabled, no new network call, prior output remains.
+    await user.clear(screen.getByLabelText(/^prompt$/i));
+    await user.type(screen.getByLabelText(/^prompt$/i), "   \t\n");
+
+    const runButton = screen.getByRole("button", { name: /run arena/i }) as HTMLButtonElement;
+    expect(runButton.disabled).toBe(true);
+    expect(fetchSpy.mock.calls.length).toBe(callsAfterFirstRun);
+    expect(screen.getByText("prior-cloud-output")).toBeTruthy();
+  });
+
+  it("Property 7 behavior: starting a new run clears prior slot outputs", async () => {
+    // Feature: playground-tab, Property 7 (behavior)
+    const user = userEvent.setup();
+    let resolveSecond: ((value: Response) => void) | undefined;
+
+    fetchSpy
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ output: "first-wave-output" }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      )
+      .mockImplementationOnce(
+        () =>
+          new Promise<Response>((resolve) => {
+            resolveSecond = resolve;
+          }),
+      );
+
+    render(<ArenaPanel />);
+
+    await user.click(screen.getAllByRole("button", { name: /cloud \/ api/i })[0]!);
+    await user.type(screen.getByLabelText(/endpoint url/i), "https://api.example.com/v1");
+    await user.type(screen.getByLabelText(/^prompt$/i), "wave one");
+
+    await act(async () => {
+      await user.click(screen.getByRole("button", { name: /run arena/i }));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("first-wave-output")).toBeTruthy();
+    });
+
+    await act(async () => {
+      await user.click(screen.getByRole("button", { name: /run arena/i }));
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByText("first-wave-output")).toBeNull();
+      expect(screen.getAllByText(/running inference/i).length).toBeGreaterThan(0);
+    });
+
+    // Unblock hanging second request so afterEach cleanup is clean.
+    resolveSecond?.(
+      new Response(JSON.stringify({ output: "second-wave-output" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    await waitFor(() => {
+      expect(screen.getByText("second-wave-output")).toBeTruthy();
+    });
+  });
 });
 
 describe("SlotResultPanel highlighting and error layout (Tasks 11.3, 11.5)", () => {

--- a/src/components/features/ArenaPanel.test.tsx
+++ b/src/components/features/ArenaPanel.test.tsx
@@ -1,10 +1,15 @@
 /**
- * Component tests for ArenaPanel user-facing Run / prompt validation.
+ * Component tests for ArenaPanel (Tasks 11.2, 11.3, 11.5).
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { render, screen, waitFor, act } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { ArenaPanel, localOptsForArenaSlot } from "./ArenaPanel";
+import {
+  ArenaPanel,
+  SlotResultPanel,
+  localOptsForArenaSlot,
+  type ArenaRunResult,
+} from "./ArenaPanel";
 import { usePlaygroundStore } from "@/lib/stores/playgroundStore";
 
 function resetArenaSlots(): void {
@@ -22,6 +27,25 @@ describe("ArenaPanel", () => {
   afterEach(() => {
     fetchSpy.mockRestore();
     resetArenaSlots();
+  });
+
+  it("renders a local file drop-zone by default", () => {
+    render(<ArenaPanel />);
+    expect(screen.getAllByLabelText(/select onnx model file/i).length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText(/drop a model here/i).length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByRole("button", { name: /local file/i }).length).toBe(2);
+  });
+
+  it("selecting Cloud / API renders endpoint, API key, and model ID inputs", async () => {
+    const user = userEvent.setup();
+    render(<ArenaPanel />);
+
+    const cloudToggles = screen.getAllByRole("button", { name: /cloud \/ api/i });
+    await user.click(cloudToggles[0]!);
+
+    expect(screen.getByLabelText(/endpoint url/i)).toBeTruthy();
+    expect(screen.getByLabelText(/^api key/i)).toBeTruthy();
+    expect(screen.getByLabelText(/^model id/i)).toBeTruthy();
   });
 
   it("disables Run Arena when a cloud slot needs a prompt", async () => {
@@ -111,5 +135,82 @@ describe("ArenaPanel", () => {
       tokenizerId: "org/tokenizer-b",
     });
     expect(optsA.tokenizerId).not.toBe(optsB.tokenizerId);
+  });
+
+  it("uses items-start on the two-column slot grid for unequal-height columns", () => {
+    const { container } = render(<ArenaPanel />);
+    const grid = container.querySelector(".items-start");
+    expect(grid).toBeTruthy();
+    expect(grid?.className).toMatch(/grid-cols-1/);
+    expect(grid?.className).toMatch(/lg:grid-cols-2/);
+  });
+
+  it("does not call scrollIntoView on initial render", () => {
+    // jsdom does not implement scrollIntoView — define a stub before spying.
+    Element.prototype.scrollIntoView = vi.fn();
+    const scrollSpy = vi.spyOn(Element.prototype, "scrollIntoView");
+    render(<ArenaPanel />);
+    expect(scrollSpy).not.toHaveBeenCalled();
+    scrollSpy.mockRestore();
+  });
+});
+
+describe("SlotResultPanel highlighting and error layout (Tasks 11.3, 11.5)", () => {
+  it("applies emerald classes to the faster slot's latency", () => {
+    const resultA: ArenaRunResult = {
+      output: "fast",
+      elapsedMs: 100,
+      status: "done",
+    };
+    const resultB: ArenaRunResult = {
+      output: "slow",
+      elapsedMs: 200,
+      status: "done",
+    };
+
+    render(
+      <div>
+        <SlotResultPanel label="Slot A" result={resultA} isWinner />
+        <SlotResultPanel label="Slot B" result={resultB} isWinner={false} />
+      </div>,
+    );
+
+    const fasterLatency = screen.getByText(/100\.0 ms/);
+    const slowerLatency = screen.getByText(/200\.0 ms/);
+
+    expect(fasterLatency.className).toMatch(/text-emerald-400/);
+    expect(fasterLatency.className).toMatch(/font-semibold/);
+    expect(slowerLatency.className).not.toMatch(/text-emerald-400/);
+    expect(screen.getByText(/· faster/i)).toBeTruthy();
+  });
+
+  it("bounds long error strings with max height + overflow scroll", () => {
+    const longError = "x".repeat(5000);
+    render(
+      <SlotResultPanel
+        label="Slot A"
+        result={{ output: "", elapsedMs: 0, status: "error", error: longError }}
+      />,
+    );
+
+    const errorEl = screen.getByTestId("slot-a-error");
+    expect(errorEl.textContent).toBe(longError);
+    expect(errorEl.className).toMatch(/max-h-24/);
+    expect(errorEl.className).toMatch(/overflow-y-auto/);
+  });
+});
+
+describe("playgroundStore lifecycle contract (Task 11.5)", () => {
+  it("does not wrap create in persist middleware", async () => {
+    const store = usePlaygroundStore as typeof usePlaygroundStore & {
+      persist?: unknown;
+    };
+    expect(store.persist).toBeUndefined();
+
+    // Regression: session reset still clears slots after store mutations
+    usePlaygroundStore.getState().setSlotA({ type: "cloud", apiKey: "sk" });
+    usePlaygroundStore.getState().resetPlayground();
+    expect(usePlaygroundStore.getState().slotA.type).toBe("local");
+    expect(usePlaygroundStore.getState().slotA.apiKey).toBe("");
   });
 });

--- a/src/components/features/ArenaPanel.test.tsx
+++ b/src/components/features/ArenaPanel.test.tsx
@@ -146,12 +146,23 @@ describe("ArenaPanel", () => {
   });
 
   it("does not call scrollIntoView on initial render", () => {
-    // jsdom does not implement scrollIntoView — define a stub before spying.
-    Element.prototype.scrollIntoView = vi.fn();
-    const scrollSpy = vi.spyOn(Element.prototype, "scrollIntoView");
-    render(<ArenaPanel />);
-    expect(scrollSpy).not.toHaveBeenCalled();
-    scrollSpy.mockRestore();
+    const originalDescriptor = Object.getOwnPropertyDescriptor(Element.prototype, "scrollIntoView");
+    let scrollSpy: ReturnType<typeof vi.spyOn> | undefined;
+
+    try {
+      // jsdom does not implement scrollIntoView — define a stub before spying.
+      Element.prototype.scrollIntoView = vi.fn();
+      scrollSpy = vi.spyOn(Element.prototype, "scrollIntoView");
+      render(<ArenaPanel />);
+      expect(scrollSpy).not.toHaveBeenCalled();
+    } finally {
+      scrollSpy?.mockRestore();
+      if (originalDescriptor) {
+        Object.defineProperty(Element.prototype, "scrollIntoView", originalDescriptor);
+      } else {
+        delete (Element.prototype as { scrollIntoView?: unknown }).scrollIntoView;
+      }
+    }
   });
 });
 

--- a/src/components/features/ArenaPanel.tsx
+++ b/src/components/features/ArenaPanel.tsx
@@ -62,6 +62,11 @@ export function clearRunResults(): { resultA: ArenaRunResult; resultB: ArenaRunR
   };
 }
 
+/** True when prompt is empty or whitespace-only (blocks cloud Arena runs). */
+export function isArenaPromptBlank(prompt: string): boolean {
+  return prompt.trim() === "";
+}
+
 /* ------------------------------------------------------------------ */
 /*  File size formatter                                                */
 /* ------------------------------------------------------------------ */
@@ -386,13 +391,14 @@ function SlotConfig({
 /*  SlotResultPanel — displays status/output for one result slot      */
 /* ------------------------------------------------------------------ */
 
-interface SlotResultPanelProps {
+export interface SlotResultPanelProps {
   label: "Slot A" | "Slot B";
   result: ArenaRunResult;
   isWinner?: boolean;
 }
 
-function SlotResultPanel({ label, result, isWinner }: SlotResultPanelProps) {
+/** Exported for component tests of winner highlighting / error layout (Tasks 11.3, 11.5). */
+export function SlotResultPanel({ label, result, isWinner }: SlotResultPanelProps) {
   const [copied, setCopied] = useState(false);
   const copyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -453,7 +459,10 @@ function SlotResultPanel({ label, result, isWinner }: SlotResultPanelProps) {
       </div>
 
       {result.status === "error" && result.error && (
-        <p className="text-[11px] text-red-400 bg-red-500/5 border border-red-500/20 rounded p-2">
+        <p
+          data-testid={`${label.toLowerCase().replace(" ", "-")}-error`}
+          className="text-[11px] text-red-400 bg-red-500/5 border border-red-500/20 rounded p-2 max-h-24 overflow-y-auto"
+        >
           {result.error}
         </p>
       )}
@@ -728,12 +737,12 @@ export function ArenaPanel() {
 
   const needsPrompt = slotA.type === "cloud" || slotB.type === "cloud";
   // Shared seed / prompt so both local slots compare the same request.
-  const localSeedKey = prompt.trim() || "arena-local-default";
+  const localSeedKey = isArenaPromptBlank(prompt) ? "arena-local-default" : prompt.trim();
 
   const handlePromptChange = useCallback((e: React.ChangeEvent<HTMLTextAreaElement>) => {
     const value = e.target.value;
     setPrompt(value);
-    if (value.trim() !== "") {
+    if (!isArenaPromptBlank(value)) {
       setPromptError(false);
     }
   }, []);
@@ -741,7 +750,7 @@ export function ArenaPanel() {
   const handleRun = useCallback(async () => {
     if (isRunning) return;
 
-    if (needsPrompt && prompt.trim() === "") {
+    if (needsPrompt && isArenaPromptBlank(prompt)) {
       setPromptError(true);
       return;
     }
@@ -909,7 +918,7 @@ export function ArenaPanel() {
         <div className="flex items-center justify-end">
           <Button
             onClick={handleRun}
-            disabled={isRunning || (needsPrompt && prompt.trim() === "")}
+            disabled={isRunning || (needsPrompt && isArenaPromptBlank(prompt))}
             className="flex items-center gap-2"
           >
             {isRunning ? (

--- a/src/components/features/ExecutionWorkspace.test.tsx
+++ b/src/components/features/ExecutionWorkspace.test.tsx
@@ -130,4 +130,27 @@ describe("ExecutionWorkspace", () => {
     const jsonControl = screen.queryByText(/json/i) || screen.queryByText(/recipe/i);
     expect(jsonControl).not.toBeNull();
   });
+
+  it("More menu no longer lists Browser Test or Benchmark (Task 11.4)", async () => {
+    await act(async () => {
+      render(<ExecutionWorkspace />);
+    });
+
+    const moreButton = screen.getByRole("button", { name: /more/i });
+    await act(async () => {
+      moreButton.click();
+    });
+
+    const menu = screen.getByRole("menu");
+    expect(menu).toBeTruthy();
+    expect(screen.getByRole("menuitem", { name: /run history/i })).toBeTruthy();
+    expect(screen.getByRole("menuitem", { name: /export report/i })).toBeTruthy();
+    expect(screen.getByRole("menuitem", { name: /export for owr/i })).toBeTruthy();
+
+    expect(screen.queryByRole("menuitem", { name: /browser test/i })).toBeNull();
+    expect(screen.queryByRole("menuitem", { name: /benchmark/i })).toBeNull();
+    // Text nodes for promoted Playground views must not appear in the menu
+    expect(menu.textContent).not.toMatch(/Browser Test/i);
+    expect(menu.textContent).not.toMatch(/Benchmark/i);
+  });
 });

--- a/src/components/features/PlaygroundPanel.test.tsx
+++ b/src/components/features/PlaygroundPanel.test.tsx
@@ -1,0 +1,89 @@
+/**
+ * Component tests for PlaygroundPanel sub-view tabs (Task 11.1).
+ */
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { PlaygroundPanel } from "./PlaygroundPanel";
+import { usePlaygroundStore } from "@/lib/stores/playgroundStore";
+
+vi.mock("./InBrowserValidation", () => ({
+  InBrowserValidation: () => <div data-testid="browser-test-panel">Browser Test Panel</div>,
+}));
+
+vi.mock("./WebGpuBenchmarkPanel", () => ({
+  WebGpuBenchmarkPanel: () => <div data-testid="benchmark-panel">Benchmark Panel</div>,
+}));
+
+vi.mock("./ArenaPanel", () => ({
+  ArenaPanel: () => <div data-testid="arena-panel">Arena Panel</div>,
+}));
+
+describe("PlaygroundPanel", () => {
+  beforeEach(() => {
+    usePlaygroundStore.getState().resetPlayground();
+  });
+
+  it("renders the three sub-view tab buttons", async () => {
+    render(<PlaygroundPanel />);
+
+    expect(screen.getByRole("tab", { name: /browser test/i })).toBeTruthy();
+    expect(screen.getByRole("tab", { name: /benchmark/i })).toBeTruthy();
+    expect(screen.getByRole("tab", { name: /arena/i })).toBeTruthy();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("browser-test-panel")).toBeTruthy();
+    });
+  });
+
+  it("shows Browser Test by default and keeps it selected", async () => {
+    render(<PlaygroundPanel />);
+
+    const browserTab = screen.getByRole("tab", { name: /browser test/i });
+    expect(browserTab.getAttribute("aria-selected")).toBe("true");
+    expect(usePlaygroundStore.getState().activeSubView).toBe("browser-test");
+
+    await waitFor(() => {
+      expect(screen.getByTestId("browser-test-panel")).toBeTruthy();
+    });
+    expect(screen.getByTestId("browser-test-panel").closest("[role='tabpanel']")?.hasAttribute("hidden")).toBe(
+      false,
+    );
+  });
+
+  it("updates activeSubView in the store when Arena is selected", async () => {
+    const user = userEvent.setup();
+    render(<PlaygroundPanel />);
+
+    await user.click(screen.getByRole("tab", { name: /arena/i }));
+
+    await waitFor(() => {
+      expect(usePlaygroundStore.getState().activeSubView).toBe("arena");
+    });
+    expect(screen.getByRole("tab", { name: /arena/i }).getAttribute("aria-selected")).toBe("true");
+
+    await waitFor(() => {
+      expect(screen.getByTestId("arena-panel")).toBeTruthy();
+    });
+  });
+
+  it("keep-alive mounts Benchmark after first visit without unmounting Browser Test", async () => {
+    const user = userEvent.setup();
+    render(<PlaygroundPanel />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("browser-test-panel")).toBeTruthy();
+    });
+
+    await user.click(screen.getByRole("tab", { name: /benchmark/i }));
+    await waitFor(() => {
+      expect(screen.getByTestId("benchmark-panel")).toBeTruthy();
+    });
+
+    // Browser Test panel remains in the tree (hidden), not unmounted
+    expect(screen.getByTestId("browser-test-panel")).toBeTruthy();
+    expect(screen.getByTestId("browser-test-panel").closest("[role='tabpanel']")?.hasAttribute("hidden")).toBe(
+      true,
+    );
+  });
+});

--- a/src/lib/__tests__/arenaOliveOutputs.test.ts
+++ b/src/lib/__tests__/arenaOliveOutputs.test.ts
@@ -14,9 +14,11 @@ describe("resolveOliveOutputRoots", () => {
       cwd: "/workspace",
       homedir: "/home/olive",
     });
+    // Implementation uses slash-normalized POSIX-style paths (not Node path.resolve),
+    // so expectations must not use path.resolve (which on Windows injects a drive letter).
     expect(roots).toEqual([
-      { label: "cache", absolutePath: path.resolve("/home/olive", ".cache", "olive") },
-      { label: "output", absolutePath: path.resolve("/workspace", "models/optimized") },
+      { label: "cache", absolutePath: "/home/olive/.cache/olive" },
+      { label: "output", absolutePath: "/workspace/models/optimized" },
     ]);
   });
 
@@ -40,8 +42,8 @@ describe("resolveOliveOutputRoots", () => {
       homedir: "/home/olive",
     });
     expect(roots).toEqual([
-      { label: "cache", absolutePath: path.resolve("/workspace", "relative/cache") },
-      { label: "output", absolutePath: path.resolve("/workspace", "relative/output") },
+      { label: "cache", absolutePath: "/workspace/relative/cache" },
+      { label: "output", absolutePath: "/workspace/relative/output" },
     ]);
   });
 

--- a/src/lib/__tests__/pipelineNavigation.test.ts
+++ b/src/lib/__tests__/pipelineNavigation.test.ts
@@ -2,6 +2,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   attemptPipelineNavigate,
+  isPipelineViewId,
   navigatePipeline,
   OLIVE_PIPELINE_NAV_BLOCKED,
   OLIVE_PIPELINE_NAVIGATE,
@@ -14,6 +15,12 @@ afterEach(() => {
 });
 
 describe("pipelineNavigation", () => {
+  it("recognizes playground as a valid pipeline view id", () => {
+    expect(isPipelineViewId("playground")).toBe(true);
+    expect(isPipelineViewId("unknown")).toBe(false);
+    expect(isPipelineViewId(null)).toBe(false);
+  });
+
   it("allows navigation when Olive is not running", () => {
     const navigate = vi.fn();
     const blocked = vi.fn();
@@ -58,6 +65,23 @@ describe("pipelineNavigation", () => {
 
     expect(attemptPipelineNavigate("execute")).toBe(true);
     navigatePipeline("execute");
+
+    expect(navigate).toHaveBeenCalledTimes(1);
+    expect(blocked).not.toHaveBeenCalled();
+
+    window.removeEventListener(OLIVE_PIPELINE_NAVIGATE, navigate);
+    window.removeEventListener(OLIVE_PIPELINE_NAV_BLOCKED, blocked);
+  });
+
+  it("still allows playground navigation during an Olive run", () => {
+    setPipelineOliveRunning(true);
+    const navigate = vi.fn();
+    const blocked = vi.fn();
+    window.addEventListener(OLIVE_PIPELINE_NAVIGATE, navigate);
+    window.addEventListener(OLIVE_PIPELINE_NAV_BLOCKED, blocked);
+
+    expect(attemptPipelineNavigate("playground")).toBe(true);
+    navigatePipeline("playground");
 
     expect(navigate).toHaveBeenCalledTimes(1);
     expect(blocked).not.toHaveBeenCalled();

--- a/src/lib/__tests__/playgroundPBT.test.ts
+++ b/src/lib/__tests__/playgroundPBT.test.ts
@@ -110,12 +110,16 @@ describe("playgroundPBT", () => {
 
   it("Property 7: New run clear fully replaces any prior slot results", () => {
     // Feature: playground-tab, Property 7
-    // Models handleRun's replace-with-clearRunResults() step: for any prior
-    // completed/error/running pair, applying the clear yields the idle baseline
+    // Models handleRun's replace-with-clearRunResults() step for both branches:
+    // sequential (A running, B idle) and parallel (both running). For any prior
+    // completed/error/running pair, applying the clear yields empty outputs
     // (full replace, not merge). Component-level second-run lifecycle is in
-    // ArenaPanel.test.tsx.
+    // ArenaPanel.test.tsx (parallel/cloud path).
     const statusArb = fc.constantFrom("idle", "running", "done", "error") as fc.Arbitrary<
       "idle" | "running" | "done" | "error"
+    >;
+    const modeArb = fc.constantFrom("sequential", "parallel") as fc.Arbitrary<
+      "sequential" | "parallel"
     >;
     fc.assert(
       fc.property(
@@ -129,7 +133,8 @@ describe("playgroundPBT", () => {
           errorA: fc.option(fc.string(), { nil: undefined }),
           errorB: fc.option(fc.string(), { nil: undefined }),
         }),
-        (prior) => {
+        modeArb,
+        (prior, mode) => {
           const priorState = {
             resultA: {
               output: prior.outputA,
@@ -146,22 +151,29 @@ describe("playgroundPBT", () => {
           };
 
           // handleRun does not merge prior into cleared — it assigns clearRunResults()
-          // then sets status to "running" (parallel path). Sequential path runs Slot A
-          // first with the same clear baseline for both slots.
+          // then sets branch-specific running/idle statuses before inference.
           const cleared = clearRunResults();
-          const afterClear = {
-            resultA: { ...cleared.resultA, status: "running" as const },
-            resultB: { ...cleared.resultB, status: "running" as const },
-          };
+          const afterClear =
+            mode === "sequential"
+              ? {
+                  resultA: { ...cleared.resultA, status: "running" as const },
+                  resultB: { ...cleared.resultB, status: "idle" as const },
+                }
+              : {
+                  resultA: { ...cleared.resultA, status: "running" as const },
+                  resultB: { ...cleared.resultB, status: "running" as const },
+                };
 
           expect(cleared).toEqual({
             resultA: { output: "", elapsedMs: 0, status: "idle" },
             resultB: { output: "", elapsedMs: 0, status: "idle" },
           });
-          expect(afterClear).toEqual({
-            resultA: { output: "", elapsedMs: 0, status: "running" },
-            resultB: { output: "", elapsedMs: 0, status: "running" },
-          });
+          expect(afterClear.resultA.output).toBe("");
+          expect(afterClear.resultB.output).toBe("");
+          expect(afterClear.resultA.elapsedMs).toBe(0);
+          expect(afterClear.resultB.elapsedMs).toBe(0);
+          expect(afterClear.resultA.status).toBe("running");
+          expect(afterClear.resultB.status).toBe(mode === "sequential" ? "idle" : "running");
           // Full replace: residual prior keys (e.g. error) are not kept.
           expect("error" in afterClear.resultA).toBe(false);
           expect("error" in afterClear.resultB).toBe(false);
@@ -170,6 +182,11 @@ describe("playgroundPBT", () => {
           if (prior.errorA !== undefined) {
             expect("error" in mergedA).toBe(true);
             expect("error" in afterClear.resultA).toBe(false);
+          }
+          // Prior non-empty outputs never survive either branch.
+          if (prior.outputA !== "" || prior.outputB !== "") {
+            expect(afterClear.resultA.output).toBe("");
+            expect(afterClear.resultB.output).toBe("");
           }
         },
       ),

--- a/src/lib/__tests__/playgroundPBT.test.ts
+++ b/src/lib/__tests__/playgroundPBT.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Property-based tests for Playground core pure helpers (Task 12.1).
+ * Tags follow design.md: // Feature: playground-tab, Property N
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import fc from "fast-check";
+import { usePlaygroundStore, type PlaygroundSubView } from "@/lib/stores/playgroundStore";
+import {
+  ARENA_CLOUD_TIMEOUT_MIN_MS,
+  ARENA_CLOUD_TIMEOUT_MAX_MS,
+  resolveCloudTimeoutMs,
+} from "@/lib/arenaConstants";
+import {
+  clearRunResults,
+  computeElapsed,
+  getFasterSlot,
+  isArenaPromptBlank,
+} from "@/components/features/ArenaPanel";
+
+const SUB_VIEWS = ["browser-test", "benchmark", "arena"] as const satisfies readonly PlaygroundSubView[];
+
+describe("playgroundPBT", () => {
+  beforeEach(() => {
+    usePlaygroundStore.getState().resetPlayground();
+  });
+
+  it("Property 1: Sub-view selection round-trip", () => {
+    // Feature: playground-tab, Property 1
+    fc.assert(
+      fc.property(fc.constantFrom(...SUB_VIEWS), (v) => {
+        usePlaygroundStore.getState().setActiveSubView(v);
+        expect(usePlaygroundStore.getState().activeSubView).toBe(v);
+      }),
+      { numRuns: 100 },
+    );
+  });
+
+  it("Property 3: Whitespace prompt blocks run", () => {
+    // Feature: playground-tab, Property 3
+    const whitespaceChar = fc.constantFrom(" ", "\t", "\n", "\r");
+    fc.assert(
+      fc.property(fc.stringOf(whitespaceChar, { maxLength: 32 }), (prompt) => {
+        expect(isArenaPromptBlank(prompt)).toBe(true);
+        expect(prompt.trim() === "").toBe(true);
+      }),
+      { numRuns: 100 },
+    );
+  });
+
+  it("Property 4: Elapsed time positive for completed runs", () => {
+    // Feature: playground-tab, Property 4
+    fc.assert(
+      fc.property(
+        fc
+          .tuple(fc.nat({ max: 1_000_000 }), fc.nat({ max: 1_000_000 }))
+          .map(([a, b]) => [Math.min(a, b), Math.max(a, b) + 1] as const),
+        ([start, end]) => {
+          expect(end).toBeGreaterThan(start);
+          expect(computeElapsed(start, end)).toBeGreaterThan(0);
+        },
+      ),
+      { numRuns: 100 },
+    );
+  });
+
+  it("Property 6: Faster slot gets emerald highlight", () => {
+    // Feature: playground-tab, Property 6
+    fc.assert(
+      fc.property(
+        fc
+          .tuple(
+            fc.double({ min: 0.1, max: 10_000, noNaN: true }),
+            fc.double({ min: 0.1, max: 10_000, noNaN: true }),
+          )
+          .filter(([a, b]) => Math.abs(a - b) > 0.0001),
+        ([a, b]) => {
+          expect(getFasterSlot(a, b)).toBe(a < b ? "a" : "b");
+        },
+      ),
+      { numRuns: 100 },
+    );
+  });
+
+  it("Property 7: New run clears prior outputs", () => {
+    // Feature: playground-tab, Property 7
+    fc.assert(
+      fc.property(
+        fc.record({
+          outputA: fc.string(),
+          outputB: fc.string(),
+          elapsedA: fc.nat(),
+          elapsedB: fc.nat(),
+        }),
+        (_prior) => {
+          // Prior values are only used to document the property's "for any prior state"
+          // premise; clearRunResults always returns the idle baseline regardless of input.
+          void _prior;
+          const cleared = clearRunResults();
+          expect(cleared.resultA.output).toBe("");
+          expect(cleared.resultB.output).toBe("");
+          expect(cleared.resultA.elapsedMs).toBe(0);
+          expect(cleared.resultB.elapsedMs).toBe(0);
+          expect(cleared.resultA.status).toBe("idle");
+          expect(cleared.resultB.status).toBe("idle");
+        },
+      ),
+      { numRuns: 100 },
+    );
+  });
+
+  it("Property 13: Cloud timeout resolution always bounded", () => {
+    // Feature: playground-tab, Property 13
+    const edgeCases = [
+      undefined,
+      null,
+      Number.NaN,
+      Number.POSITIVE_INFINITY,
+      Number.NEGATIVE_INFINITY,
+      0,
+      -1,
+      1e9,
+      "30000",
+      {},
+      [],
+    ];
+
+    for (const edge of edgeCases) {
+      expect(() => resolveCloudTimeoutMs(edge)).not.toThrow();
+      const ms = resolveCloudTimeoutMs(edge);
+      expect(Number.isFinite(ms)).toBe(true);
+      expect(ms).toBeGreaterThanOrEqual(ARENA_CLOUD_TIMEOUT_MIN_MS);
+      expect(ms).toBeLessThanOrEqual(ARENA_CLOUD_TIMEOUT_MAX_MS);
+    }
+
+    fc.assert(
+      fc.property(fc.anything(), (raw) => {
+        expect(() => resolveCloudTimeoutMs(raw)).not.toThrow();
+        const ms = resolveCloudTimeoutMs(raw);
+        expect(Number.isFinite(ms)).toBe(true);
+        expect(ms).toBeGreaterThanOrEqual(ARENA_CLOUD_TIMEOUT_MIN_MS);
+        expect(ms).toBeLessThanOrEqual(ARENA_CLOUD_TIMEOUT_MAX_MS);
+      }),
+      { numRuns: 100 },
+    );
+  });
+});

--- a/src/lib/__tests__/playgroundPBT.test.ts
+++ b/src/lib/__tests__/playgroundPBT.test.ts
@@ -35,13 +35,40 @@ describe("playgroundPBT", () => {
     );
   });
 
-  it("Property 3: Whitespace prompt blocks run", () => {
+  it("Property 3: isArenaPromptBlank matches trim() for blank and non-blank prompts", () => {
     // Feature: playground-tab, Property 3
+    // Helper invariant: blank ⇔ trim() === "". UI/behavior (cloud run blocked,
+    // prior results preserved) is covered in ArenaPanel.test.tsx.
     const whitespaceChar = fc.constantFrom(" ", "\t", "\n", "\r");
+
+    // Blank-only inputs must be blank.
     fc.assert(
       fc.property(fc.stringOf(whitespaceChar, { maxLength: 32 }), (prompt) => {
         expect(isArenaPromptBlank(prompt)).toBe(true);
-        expect(prompt.trim() === "").toBe(true);
+      }),
+      { numRuns: 50 },
+    );
+
+    // Contrapositive: any string with a non-whitespace character is not blank.
+    fc.assert(
+      fc.property(
+        fc.tuple(
+          fc.stringOf(whitespaceChar, { maxLength: 8 }),
+          fc.string({ minLength: 1 }).filter((s) => /\S/.test(s)),
+          fc.stringOf(whitespaceChar, { maxLength: 8 }),
+        ),
+        ([pre, mid, post]) => {
+          const prompt = `${pre}${mid}${post}`;
+          expect(isArenaPromptBlank(prompt)).toBe(false);
+        },
+      ),
+      { numRuns: 50 },
+    );
+
+    // Full equivalence over arbitrary strings (covers both directions).
+    fc.assert(
+      fc.property(fc.string(), (prompt) => {
+        expect(isArenaPromptBlank(prompt)).toBe(prompt.trim() === "");
       }),
       { numRuns: 100 },
     );
@@ -81,27 +108,69 @@ describe("playgroundPBT", () => {
     );
   });
 
-  it("Property 7: New run clears prior outputs", () => {
+  it("Property 7: New run clear fully replaces any prior slot results", () => {
     // Feature: playground-tab, Property 7
+    // Models handleRun's replace-with-clearRunResults() step: for any prior
+    // completed/error/running pair, applying the clear yields the idle baseline
+    // (full replace, not merge). Component-level second-run lifecycle is in
+    // ArenaPanel.test.tsx.
+    const statusArb = fc.constantFrom("idle", "running", "done", "error") as fc.Arbitrary<
+      "idle" | "running" | "done" | "error"
+    >;
     fc.assert(
       fc.property(
         fc.record({
           outputA: fc.string(),
           outputB: fc.string(),
-          elapsedA: fc.nat(),
-          elapsedB: fc.nat(),
+          elapsedA: fc.nat({ max: 1_000_000 }),
+          elapsedB: fc.nat({ max: 1_000_000 }),
+          statusA: statusArb,
+          statusB: statusArb,
+          errorA: fc.option(fc.string(), { nil: undefined }),
+          errorB: fc.option(fc.string(), { nil: undefined }),
         }),
-        (_prior) => {
-          // Prior values are only used to document the property's "for any prior state"
-          // premise; clearRunResults always returns the idle baseline regardless of input.
-          void _prior;
+        (prior) => {
+          const priorState = {
+            resultA: {
+              output: prior.outputA,
+              elapsedMs: prior.elapsedA,
+              status: prior.statusA,
+              ...(prior.errorA !== undefined ? { error: prior.errorA } : {}),
+            },
+            resultB: {
+              output: prior.outputB,
+              elapsedMs: prior.elapsedB,
+              status: prior.statusB,
+              ...(prior.errorB !== undefined ? { error: prior.errorB } : {}),
+            },
+          };
+
+          // handleRun does not merge prior into cleared — it assigns clearRunResults()
+          // then sets status to "running" (parallel path). Sequential path runs Slot A
+          // first with the same clear baseline for both slots.
           const cleared = clearRunResults();
-          expect(cleared.resultA.output).toBe("");
-          expect(cleared.resultB.output).toBe("");
-          expect(cleared.resultA.elapsedMs).toBe(0);
-          expect(cleared.resultB.elapsedMs).toBe(0);
-          expect(cleared.resultA.status).toBe("idle");
-          expect(cleared.resultB.status).toBe("idle");
+          const afterClear = {
+            resultA: { ...cleared.resultA, status: "running" as const },
+            resultB: { ...cleared.resultB, status: "running" as const },
+          };
+
+          expect(cleared).toEqual({
+            resultA: { output: "", elapsedMs: 0, status: "idle" },
+            resultB: { output: "", elapsedMs: 0, status: "idle" },
+          });
+          expect(afterClear).toEqual({
+            resultA: { output: "", elapsedMs: 0, status: "running" },
+            resultB: { output: "", elapsedMs: 0, status: "running" },
+          });
+          // Full replace: residual prior keys (e.g. error) are not kept.
+          expect("error" in afterClear.resultA).toBe(false);
+          expect("error" in afterClear.resultB).toBe(false);
+          // Contrast with merge semantics which would retain prior.error.
+          const mergedA = { ...priorState.resultA, ...cleared.resultA };
+          if (prior.errorA !== undefined) {
+            expect("error" in mergedA).toBe(true);
+            expect("error" in afterClear.resultA).toBe(false);
+          }
         },
       ),
       { numRuns: 100 },

--- a/src/lib/__tests__/playgroundStore.test.ts
+++ b/src/lib/__tests__/playgroundStore.test.ts
@@ -6,6 +6,32 @@ describe("playgroundStore", () => {
     usePlaygroundStore.getState().resetPlayground();
   });
 
+  it("defaults to browser-test with empty local slots", () => {
+    const store = usePlaygroundStore.getState();
+    expect(store.activeSubView).toBe("browser-test");
+    expect(store.slotA.type).toBe("local");
+    expect(store.slotA.file).toBeNull();
+    expect(store.slotB.type).toBe("local");
+    expect(store.slotB.file).toBeNull();
+  });
+
+  it("setActiveSubView updates the active playground sub-view", () => {
+    usePlaygroundStore.getState().setActiveSubView("arena");
+    expect(usePlaygroundStore.getState().activeSubView).toBe("arena");
+    usePlaygroundStore.getState().setActiveSubView("benchmark");
+    expect(usePlaygroundStore.getState().activeSubView).toBe("benchmark");
+  });
+
+  it("setSlotB patches independently of slotA", () => {
+    usePlaygroundStore.getState().setSlotA({ type: "cloud", endpointUrl: "https://a.example" });
+    usePlaygroundStore.getState().setSlotB({ modelId: "model-b", type: "cloud" });
+    const { slotA, slotB } = usePlaygroundStore.getState();
+    expect(slotA.endpointUrl).toBe("https://a.example");
+    expect(slotA.modelId).toBe("");
+    expect(slotB.modelId).toBe("model-b");
+    expect(slotB.endpointUrl).toBe("");
+  });
+
   it("setSlotA merges patches without clobbering other fields", () => {
     usePlaygroundStore.getState().setSlotA({ endpointUrl: "https://api.example.com/v1", type: "cloud" });
     usePlaygroundStore.getState().setSlotA({ apiKey: "secret" });

--- a/src/lib/stores/playgroundStore.ts
+++ b/src/lib/stores/playgroundStore.ts
@@ -6,6 +6,11 @@ import { create } from "zustand";
  * Intentionally separate from `pipelineStore`: Playground holds non-serializable
  * `File` handles and cloud credential fields that must not participate in recipe
  * import / replace / pipeline persistence.
+ *
+ * Deliberately **not** wrapped in Zustand `persist`. `slotA.file` / `slotB.file`
+ * are `File` handles that would serialize to `{}` and rehydrate as slots that look
+ * configured but hold no model. If `activeSubView` is ever worth persisting, use a
+ * `partialize` allowlist — never whole-store persistence.
  */
 export type PlaygroundSubView = "browser-test" | "benchmark" | "arena";
 

--- a/src/server/services/ai/detect.test.ts
+++ b/src/server/services/ai/detect.test.ts
@@ -6,6 +6,16 @@ vi.mock("../../../lib/aiResponse.ts", () => ({
   readEnvApiKey: vi.fn(),
 }));
 
+// Cloudflare auth reads a local credential file and bypasses readEnvApiKey —
+// stub it so machine-local credentials cannot leak into provider detection tests.
+vi.mock("../../../lib/cloudflare/client.ts", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../../lib/cloudflare/client.ts")>();
+  return {
+    ...actual,
+    resolveCloudflareAuth: vi.fn(() => null),
+  };
+});
+
 import { readEnvApiKey } from "../../../lib/aiResponse.ts";
 
 describe("detectEnvProvider", () => {

--- a/src/server/services/ai/registry.test.ts
+++ b/src/server/services/ai/registry.test.ts
@@ -6,6 +6,16 @@ vi.mock("../../../lib/aiResponse.ts", () => ({
   isPlaceholderEnvValue: vi.fn((v: string) => !v || v.startsWith("my_")),
 }));
 
+// Cloudflare auth reads a local credential file and bypasses readEnvApiKey —
+// stub it so machine-local credentials cannot leak into provider detection tests.
+vi.mock("../../../lib/cloudflare/client.ts", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../../lib/cloudflare/client.ts")>();
+  return {
+    ...actual,
+    resolveCloudflareAuth: vi.fn(() => null),
+  };
+});
+
 // Side-effect import: triggers all providers to register themselves.
 import "./index.ts";
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -41,7 +41,7 @@ export default defineConfig(() => {
     ],
     resolve: {
       alias: {
-        '@': path.resolve(__dirname, './src'),
+        '@': path.resolve(import.meta.dirname, './src'),
       },
     },
     server: {

--- a/vitest.component.config.ts
+++ b/vitest.component.config.ts
@@ -11,7 +11,7 @@ import path from "path";
 export default defineConfig({
   resolve: {
     alias: {
-      "@": path.resolve(__dirname, "./src"),
+      "@": path.resolve(import.meta.dirname, "./src"),
     },
   },
   test: {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,7 +4,7 @@ import path from "path";
 export default defineConfig({
   resolve: {
     alias: {
-      "@": path.resolve(__dirname, "./src"),
+      "@": path.resolve(import.meta.dirname, "./src"),
     },
   },
   test: {

--- a/vitest.server.config.ts
+++ b/vitest.server.config.ts
@@ -8,7 +8,7 @@ import path from "path";
 export default defineConfig({
   resolve: {
     alias: {
-      "@": path.resolve(__dirname, "./src"),
+      "@": path.resolve(import.meta.dirname, "./src"),
     },
   },
   test: {


### PR DESCRIPTION
## Summary

Closes core Playground verification (Tasks 11–12.1 / checkpoint 8) so Req 1–10 can ship with confidence.

- **Component tests**: `PlaygroundPanel` tabs + keep-alive; `ArenaPanel` local/cloud config, Run disabled for blank cloud prompts, winner emerald highlight, error height bound, no `scrollIntoView` on mount, `items-start` grid; `ExecutionWorkspace` More menu no longer lists Browser Test / Benchmark.
- **PBT**: `playgroundPBT.test.ts` Properties 1, 3, 4, 6, 7, 13 (≥100 iterations, `// Feature: playground-tab` tags).
- **Unit gaps**: `isPipelineViewId("playground")`, playground nav during Olive run, store defaults / independent slotB patches.
- **Checkpoint hygiene**: Windows-safe Olive-output path expectations; mock `resolveCloudflareAuth` so local Cloudflare credentials cannot leak into detect/registry tests; `import.meta.dirname` for Vite/Vitest configs; status note in `docs/playground-handoff.md`.

## Test plan

- [x] `pnpm test` — 586 passed
- [x] `pnpm test:server` — 213 passed
- [x] `pnpm test:component` — 83 passed
- [x] `pnpm lint` — 0 errors (pre-existing warnings only)
- [x] `pnpm validate:recipe` — ok

## Follow-up

Track 2 (Req 18 remainder): assistant-cloud-snapshot route, ArenaPanel Olive-output / Assistant UI, Properties 21/21b/22.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Completes core Playground verification for Req 1–10 so we can ship. Adds component and PBT coverage for tabs and Arena flows (Properties 3/7 behavior), tightens prompt handling, error display, and menus, and updates `brace-expansion` override to address an audit.

- **Bug Fixes**
  - Arena: block Run on blank cloud prompts; emerald-highlight faster slot; bound long errors; align slot grid; avoid initial scrollIntoView.
  - ExecutionWorkspace: remove Browser Test and Benchmark from the More menu.
  - Pipeline nav: allow Playground navigation during Olive runs.

- **Refactors**
  - Add `isArenaPromptBlank`; export `SlotResultPanel` for targeted tests; minor disabled-state wiring.
  - Tests: component coverage for `PlaygroundPanel` tabs/keep-alive and Arena behaviors; PBT for Properties 1/3/4/6/7/13 (Property 7 covers sequential and parallel clear branches); store defaults and independent Slot B patches; pipeline `isPipelineViewId("playground")`.
  - Config: use `import.meta.dirname` for `@` alias in `vite`/`vitest`; ignore `/.playwright-mcp`.
  - Stability: POSIX path expectations for Olive outputs; mock Cloudflare auth to isolate provider-detection tests.
  - Docs: update `docs/playground-handoff.md` with Property 3/7 verification and remaining Req 18 work.
  - Dependencies: override `brace-expansion` to `>=5.0.9` to resolve audit (GHSA-rgw5-rvv9-x895).

<sup>Written for commit c608080a865865321846f1695df13da1ae43b83a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tonythethompson/Olive-Studio/pull/91?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

