### PR TITLE
Improve assistant model picker UX and launch-tauri cleanup

### DIFF
--- a/launch-tauri.cmd
+++ b/launch-tauri.cmd
@@ -4,11 +4,22 @@ REM Delegates to launch-tauri.ps1 (includes stop-before-start of port 3000 / lef
 setlocal
 cd /d "%~dp0"
 
+set "PS_EXE="
 where powershell >nul 2>&1
-if errorlevel 1 (
+if not errorlevel 1 (
+  set "PS_EXE=powershell"
+) else (
+  where pwsh >nul 2>&1
+  if not errorlevel 1 (
+    set "PS_EXE=pwsh"
+  )
+)
+
+if not defined PS_EXE (
   echo PowerShell is required to launch Olive Studio desktop.
+  echo Install Windows PowerShell or PowerShell 7 ^(pwsh^).
   exit /b 1
 )
 
-powershell -NoProfile -ExecutionPolicy Bypass -File "%~dp0launch-tauri.ps1" %*
+"%PS_EXE%" -NoProfile -ExecutionPolicy Bypass -File "%~dp0launch-tauri.ps1" %*
 exit /b %ERRORLEVEL%

--- a/launch-tauri.cmd
+++ b/launch-tauri.cmd
@@ -1,29 +1,14 @@
 @echo off
 REM Double-click / cmd launcher for Olive Studio (Tauri desktop)
+REM Delegates to launch-tauri.ps1 (includes stop-before-start of port 3000 / leftovers).
 setlocal
 cd /d "%~dp0"
 
-where pnpm >nul 2>&1
+where powershell >nul 2>&1
 if errorlevel 1 (
-  echo pnpm is required. Install with: npm install -g pnpm@11.17.0
+  echo PowerShell is required to launch Olive Studio desktop.
   exit /b 1
 )
 
-where cargo >nul 2>&1
-if errorlevel 1 (
-  echo Rust / cargo is required for the Tauri shell.
-  echo Install from https://rustup.rs/ then reopen this terminal.
-  exit /b 1
-)
-
-if not exist "node_modules\" (
-  echo node_modules missing — running pnpm install...
-  call pnpm install
-  if errorlevel 1 exit /b 1
-)
-
-echo Starting Olive Studio desktop ^(Tauri dev^)...
-echo   Web backend: http://127.0.0.1:3000 ^(auto via beforeDevCommand^)
-echo   Ctrl+C to stop both the window and the web server.
-call pnpm tauri:dev
+powershell -NoProfile -ExecutionPolicy Bypass -File "%~dp0launch-tauri.ps1" %*
 exit /b %ERRORLEVEL%

--- a/launch-tauri.ps1
+++ b/launch-tauri.ps1
@@ -4,18 +4,91 @@
 # Usage:
 #   .\launch-tauri.ps1           # tauri dev (default)
 #   .\launch-tauri.ps1 -Build    # tauri build (package installer; does not open the app)
+#   .\launch-tauri.ps1 --build   # same (CLI-style flag)
 
 [CmdletBinding()]
 param(
-  [switch]$Build
+  [switch]$Build,
+  [Parameter(ValueFromRemainingArguments = $true)]
+  [string[]]$RemainingArgs
 )
 
 $ErrorActionPreference = "Stop"
 $Root = $PSScriptRoot
 Set-Location $Root
 
+if ($RemainingArgs -contains "--build" -or $RemainingArgs -contains "-Build") {
+  $Build = $true
+}
+
 function Test-Command($Name) {
   return [bool](Get-Command $Name -ErrorAction SilentlyContinue)
+}
+
+function Stop-OliveStudioDevStack {
+  <#
+    Free port 3000 and stop leftover Olive Studio / Tauri processes for this repo
+    so a new `tauri:dev` can bind cleanly.
+  #>
+  Write-Host "Stopping any running Olive Studio servers / Tauri leftovers..." -ForegroundColor DarkGray
+
+  $listenPids = @()
+  try {
+    $listenPids = @(
+      Get-NetTCPConnection -LocalPort 3000 -State Listen -ErrorAction SilentlyContinue |
+        Select-Object -ExpandProperty OwningProcess -Unique
+    )
+  } catch {
+    # Older Windows / restricted environments: fall back to netstat parsing
+    $netstat = & netstat -ano -p tcp 2>$null
+    foreach ($line in $netstat) {
+      if ($line -match '^\s*TCP\s+\S+:3000\s+\S+\s+LISTENING\s+(\d+)\s*$') {
+        $listenPids += [int]$Matches[1]
+      }
+    }
+    $listenPids = @($listenPids | Select-Object -Unique)
+  }
+
+  foreach ($procId in $listenPids) {
+    if ($procId -le 4) { continue }
+    try {
+      $proc = Get-Process -Id $procId -ErrorAction Stop
+      Write-Host "  Port 3000: stopping PID $procId ($($proc.ProcessName))" -ForegroundColor DarkGray
+      Stop-Process -Id $procId -Force -ErrorAction SilentlyContinue
+    } catch {
+      # already gone
+    }
+  }
+
+  foreach ($name in @("Olive Studio", "olive-studio")) {
+    Get-Process -Name $name -ErrorAction SilentlyContinue | ForEach-Object {
+      Write-Host "  Stopping $($_.ProcessName) PID $($_.Id)" -ForegroundColor DarkGray
+      Stop-Process -Id $_.Id -Force -ErrorAction SilentlyContinue
+    }
+  }
+
+  try {
+    Get-CimInstance Win32_Process -ErrorAction SilentlyContinue |
+      Where-Object {
+        $_.CommandLine -and
+        $_.CommandLine -match [regex]::Escape($Root) -and
+        (
+          $_.CommandLine -match 'tauri(\.cmd|\.exe)?(\s|$)' -or
+          $_.CommandLine -match 'tauri:dev' -or
+          $_.CommandLine -match 'server\.ts' -or
+          $_.CommandLine -match 'dist[/\\]server\.mjs'
+        )
+      } |
+      ForEach-Object {
+        Write-Host "  Stopping leftover $($_.Name) PID $($_.ProcessId)" -ForegroundColor DarkGray
+        Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue
+      }
+  } catch {
+    # CIM may be unavailable; port + named-process cleanup is enough for most cases
+    Write-Host "  (Skipped command-line process scan: $($_.Exception.Message))" -ForegroundColor DarkGray
+  }
+
+  Start-Sleep -Milliseconds 400
 }
 
 if (-not (Test-Command "pnpm")) {
@@ -32,9 +105,19 @@ Install from https://rustup.rs/ then reopen this terminal.
 }
 
 if (-not (Test-Path (Join-Path $Root "node_modules"))) {
-  Write-Host "node_modules missing — running pnpm install..." -ForegroundColor Yellow
+  Write-Host "node_modules missing - running pnpm install..." -ForegroundColor Yellow
   pnpm install
   if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+}
+
+Stop-OliveStudioDevStack
+
+# Tauri bundle.resources maps ../dist -> dist and validates the path at cargo build,
+# including `tauri dev`. Fresh clones/worktrees often have no dist/ yet.
+$distDir = Join-Path $Root "dist"
+if (-not (Test-Path $distDir)) {
+  Write-Host "Creating empty dist/ so Tauri resource paths resolve (run pnpm build for a production bundle)..." -ForegroundColor DarkGray
+  New-Item -ItemType Directory -Path $distDir | Out-Null
 }
 
 # @tauri-apps/cli is a project dep; pnpm tauri resolves it via package scripts

--- a/launch-tauri.ps1
+++ b/launch-tauri.ps1
@@ -67,13 +67,6 @@ function Stop-OliveStudioDevStack {
     }
   }
 
-  foreach ($name in @("Olive Studio", "olive-studio")) {
-    Get-Process -Name $name -ErrorAction SilentlyContinue | ForEach-Object {
-      Write-Host "  Stopping $($_.ProcessName) PID $($_.Id)" -ForegroundColor DarkGray
-      Stop-Process -Id $_.Id -Force -ErrorAction SilentlyContinue
-    }
-  }
-
   try {
     Get-CimInstance Win32_Process -ErrorAction SilentlyContinue |
       Where-Object {
@@ -83,7 +76,10 @@ function Stop-OliveStudioDevStack {
           $_.CommandLine -match 'tauri(\.cmd|\.exe)?(\s|$)' -or
           $_.CommandLine -match 'tauri:dev' -or
           $_.CommandLine -match 'server\.ts' -or
-          $_.CommandLine -match 'dist[/\\]server\.mjs'
+          $_.CommandLine -match 'dist[/\\]server\.mjs' -or
+          $_.CommandLine -match 'olive-studio\.exe' -or
+          $_.Name -eq 'Olive Studio' -or
+          $_.Name -eq 'olive-studio'
         )
       } |
       ForEach-Object {
@@ -91,7 +87,7 @@ function Stop-OliveStudioDevStack {
         Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue
       }
   } catch {
-    # CIM may be unavailable; port + named-process cleanup is enough for most cases
+    # CIM may be unavailable; port cleanup is enough for most cases
     Write-Host "  (Skipped command-line process scan: $($_.Exception.Message))" -ForegroundColor DarkGray
   }
 

--- a/launch-tauri.ps1
+++ b/launch-tauri.ps1
@@ -52,11 +52,20 @@ function Stop-OliveStudioDevStack {
   foreach ($procId in $listenPids) {
     if ($procId -le 4) { continue }
     try {
+      $processInfo = Get-CimInstance Win32_Process -Filter "ProcessId=$procId" -ErrorAction Stop
+      $commandLine = $processInfo.CommandLine
+      if (-not $commandLine -or $commandLine -notmatch [regex]::Escape($Root)) {
+        continue
+      }
       $proc = Get-Process -Id $procId -ErrorAction Stop
-      Write-Host "  Port 3000: stopping PID $procId ($($proc.ProcessName))" -ForegroundColor DarkGray
-      Stop-Process -Id $procId -Force -ErrorAction SilentlyContinue
+      Write-Host "  Port 3000: stopping Olive Studio PID $procId ($($proc.ProcessName))" -ForegroundColor DarkGray
+      Stop-Process -Id $procId -ErrorAction SilentlyContinue
+      Start-Sleep -Milliseconds 300
+      if (Get-Process -Id $procId -ErrorAction SilentlyContinue) {
+        Stop-Process -Id $procId -Force -ErrorAction SilentlyContinue
+      }
     } catch {
-      # already gone
+      # already gone or unavailable
     }
   }
 
@@ -110,7 +119,9 @@ if (-not (Test-Path (Join-Path $Root "node_modules"))) {
   if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 }
 
-Stop-OliveStudioDevStack
+if (-not $Build) {
+  Stop-OliveStudioDevStack
+}
 
 # Tauri bundle.resources maps ../dist -> dist and validates the path at cargo build,
 # including `tauri dev`. Fresh clones/worktrees often have no dist/ yet.

--- a/launch-tauri.ps1
+++ b/launch-tauri.ps1
@@ -25,6 +25,20 @@ function Test-Command($Name) {
   return [bool](Get-Command $Name -ErrorAction SilentlyContinue)
 }
 
+function Test-CommandLineBelongsToRepo {
+  <#
+    Match $Root as a full path token, not a prefix of a sibling checkout
+    (e.g. C:\dev\olive must not match C:\dev\olive-pr-98).
+  #>
+  param(
+    [string]$CommandLine,
+    [string]$RepoRoot
+  )
+  if (-not $CommandLine) { return $false }
+  $pattern = [regex]::Escape($RepoRoot) + '(?:[/\\]|$|[\s"'']|\))'
+  return [bool]([regex]::IsMatch($CommandLine, $pattern))
+}
+
 function Stop-OliveStudioDevStack {
   <#
     Free port 3000 and stop leftover Olive Studio / Tauri processes for this repo
@@ -54,7 +68,7 @@ function Stop-OliveStudioDevStack {
     $processInfo = Get-CimInstance Win32_Process -Filter "ProcessId=$procId" -ErrorAction SilentlyContinue
     if (-not $processInfo) { continue }
     $commandLine = $processInfo.CommandLine
-    if (-not $commandLine -or $commandLine -notmatch [regex]::Escape($Root)) {
+    if (-not (Test-CommandLineBelongsToRepo -CommandLine $commandLine -RepoRoot $Root)) {
       continue
     }
     $proc = Get-Process -Id $procId -ErrorAction SilentlyContinue
@@ -70,8 +84,7 @@ function Stop-OliveStudioDevStack {
   try {
     Get-CimInstance Win32_Process -ErrorAction SilentlyContinue |
       Where-Object {
-        $_.CommandLine -and
-        $_.CommandLine -match [regex]::Escape($Root) -and
+        (Test-CommandLineBelongsToRepo -CommandLine $_.CommandLine -RepoRoot $Root) -and
         (
           $_.CommandLine -match 'tauri(\.cmd|\.exe)?(\s|$)' -or
           $_.CommandLine -match 'tauri:dev' -or

--- a/launch-tauri.ps1
+++ b/launch-tauri.ps1
@@ -51,21 +51,19 @@ function Stop-OliveStudioDevStack {
 
   foreach ($procId in $listenPids) {
     if ($procId -le 4) { continue }
-    try {
-      $processInfo = Get-CimInstance Win32_Process -Filter "ProcessId=$procId" -ErrorAction Stop
-      $commandLine = $processInfo.CommandLine
-      if (-not $commandLine -or $commandLine -notmatch [regex]::Escape($Root)) {
-        continue
-      }
-      $proc = Get-Process -Id $procId -ErrorAction Stop
-      Write-Host "  Port 3000: stopping Olive Studio PID $procId ($($proc.ProcessName))" -ForegroundColor DarkGray
-      Stop-Process -Id $procId -ErrorAction SilentlyContinue
-      Start-Sleep -Milliseconds 300
-      if (Get-Process -Id $procId -ErrorAction SilentlyContinue) {
-        Stop-Process -Id $procId -Force -ErrorAction SilentlyContinue
-      }
-    } catch {
-      # already gone or unavailable
+    $processInfo = Get-CimInstance Win32_Process -Filter "ProcessId=$procId" -ErrorAction SilentlyContinue
+    if (-not $processInfo) { continue }
+    $commandLine = $processInfo.CommandLine
+    if (-not $commandLine -or $commandLine -notmatch [regex]::Escape($Root)) {
+      continue
+    }
+    $proc = Get-Process -Id $procId -ErrorAction SilentlyContinue
+    if (-not $proc) { continue }
+    Write-Host "  Port 3000: stopping Olive Studio PID $procId ($($proc.ProcessName))" -ForegroundColor DarkGray
+    Stop-Process -Id $procId -ErrorAction SilentlyContinue
+    Start-Sleep -Milliseconds 300
+    if (Get-Process -Id $procId -ErrorAction SilentlyContinue) {
+      Stop-Process -Id $procId -Force -ErrorAction SilentlyContinue
     }
   }
 

--- a/launch-tauri.sh
+++ b/launch-tauri.sh
@@ -52,6 +52,26 @@ stop_olive_studio_dev_stack() {
     return 1
   }
 
+  # True when $ROOT appears as a full path token (not a prefix of a sibling checkout
+  # such as /tmp/olive matching /tmp/olive-pr-98).
+  cmdline_belongs_to_repo() {
+    local cmd="$1"
+    local root="$ROOT"
+    local root_len=${#root}
+    local search="$cmd"
+    local prefix idx after
+    while [[ "$search" == *"$root"* ]]; do
+      prefix="${search%%"$root"*}"
+      idx=${#prefix}
+      after="${search:$((idx + root_len)):1}"
+      if [[ -z "$after" || "$after" == "/" || "$after" == "\\" || "$after" == " " || "$after" == $'\t' || "$after" == '"' || "$after" == "'" ]]; then
+        return 0
+      fi
+      search="${search:$((idx + 1))}"
+    done
+    return 1
+  }
+
   if command -v lsof >/dev/null 2>&1; then
     while read -r pid; do
       [[ -z "$pid" ]] && continue
@@ -61,7 +81,7 @@ stop_olive_studio_dev_stack() {
       local cmd
       cmd="$(ps -p "$pid" -o args= 2>/dev/null || true)"
       # Only stop listeners whose command line belongs to this checkout.
-      if [[ "$cmd" == *"$ROOT"* ]]; then
+      if cmdline_belongs_to_repo "$cmd"; then
         echo "  Port ${port}: stopping Olive Studio PID ${pid}"
         kill "$pid" 2>/dev/null || true
         sleep 0.3
@@ -72,37 +92,36 @@ stop_olive_studio_dev_stack() {
 
   # Repo-scoped leftover tauri / server / desktop processes (avoid nuking unrelated installs).
   # Skip this shell and its parent: absolute-path launchers include $ROOT and "tauri" in argv.
+  # Broad pgrep, then boundary-filter so sibling checkouts are not force-killed.
   if command -v pgrep >/dev/null 2>&1; then
     local match_pids
     match_pids="$(pgrep -f "$ROOT" 2>/dev/null || true)"
     if [[ -n "$match_pids" ]]; then
       local pid cmd
+      local repo_pids=()
       for pid in $match_pids; do
         if is_self_or_parent "$pid"; then
           continue
         fi
         cmd="$(ps -p "$pid" -o args= 2>/dev/null || true)"
+        if ! cmdline_belongs_to_repo "$cmd"; then
+          continue
+        fi
         if [[ "$cmd" == *launch-tauri.sh* || "$cmd" == *launch-tauri.ps1* || "$cmd" == *launch-tauri.cmd* ]]; then
           continue
         fi
         if [[ "$cmd" == *tauri* || "$cmd" == *server.ts* || "$cmd" == *server.mjs* || "$cmd" == *olive-studio* || "$cmd" == *"Olive Studio"* ]]; then
-          echo "  Stopping leftover PID $pid"
-          kill "$pid" 2>/dev/null || true
+          repo_pids+=("$pid")
         fi
       done
+      for pid in "${repo_pids[@]+"${repo_pids[@]}"}"; do
+        echo "  Stopping leftover PID $pid"
+        kill "$pid" 2>/dev/null || true
+      done
       sleep 0.2
-      for pid in $match_pids; do
-        if is_self_or_parent "$pid"; then
-          continue
-        fi
+      for pid in "${repo_pids[@]+"${repo_pids[@]}"}"; do
         if kill -0 "$pid" 2>/dev/null; then
-          cmd="$(ps -p "$pid" -o args= 2>/dev/null || true)"
-          if [[ "$cmd" == *launch-tauri.sh* || "$cmd" == *launch-tauri.ps1* || "$cmd" == *launch-tauri.cmd* ]]; then
-            continue
-          fi
-          if [[ "$cmd" == *tauri* || "$cmd" == *server.ts* || "$cmd" == *server.mjs* || "$cmd" == *olive-studio* || "$cmd" == *"Olive Studio"* ]]; then
-            kill -9 "$pid" 2>/dev/null || true
-          fi
+          kill -9 "$pid" 2>/dev/null || true
         fi
       done
     fi

--- a/launch-tauri.sh
+++ b/launch-tauri.sh
@@ -70,16 +70,7 @@ stop_olive_studio_dev_stack() {
     done < <(lsof -nP -t -iTCP:"$port" -sTCP:LISTEN 2>/dev/null || true)
   fi
 
-  # Named desktop app processes (best-effort across platforms)
-  if command -v pkill >/dev/null 2>&1; then
-    pkill -f "Olive Studio" 2>/dev/null || true
-    pkill -x "olive-studio" 2>/dev/null || true
-  elif command -v taskkill.exe >/dev/null 2>&1; then
-    taskkill.exe /F /IM "Olive Studio.exe" >/dev/null 2>&1 || true
-    taskkill.exe /F /IM "olive-studio.exe" >/dev/null 2>&1 || true
-  fi
-
-  # Repo-scoped leftover tauri / server processes (avoid nuking unrelated node apps).
+  # Repo-scoped leftover tauri / server / desktop processes (avoid nuking unrelated installs).
   # Skip this shell and its parent: absolute-path launchers include $ROOT and "tauri" in argv.
   if command -v pgrep >/dev/null 2>&1; then
     local match_pids
@@ -94,7 +85,7 @@ stop_olive_studio_dev_stack() {
         if [[ "$cmd" == *launch-tauri.sh* || "$cmd" == *launch-tauri.ps1* || "$cmd" == *launch-tauri.cmd* ]]; then
           continue
         fi
-        if [[ "$cmd" == *tauri* || "$cmd" == *server.ts* || "$cmd" == *server.mjs* ]]; then
+        if [[ "$cmd" == *tauri* || "$cmd" == *server.ts* || "$cmd" == *server.mjs* || "$cmd" == *olive-studio* || "$cmd" == *"Olive Studio"* ]]; then
           echo "  Stopping leftover PID $pid"
           kill "$pid" 2>/dev/null || true
         fi
@@ -109,7 +100,7 @@ stop_olive_studio_dev_stack() {
           if [[ "$cmd" == *launch-tauri.sh* || "$cmd" == *launch-tauri.ps1* || "$cmd" == *launch-tauri.cmd* ]]; then
             continue
           fi
-          if [[ "$cmd" == *tauri* || "$cmd" == *server.ts* || "$cmd" == *server.mjs* ]]; then
+          if [[ "$cmd" == *tauri* || "$cmd" == *server.ts* || "$cmd" == *server.mjs* || "$cmd" == *olive-studio* || "$cmd" == *"Olive Studio"* ]]; then
             kill -9 "$pid" 2>/dev/null || true
           fi
         fi

--- a/launch-tauri.sh
+++ b/launch-tauri.sh
@@ -45,24 +45,18 @@ stop_olive_studio_dev_stack() {
   local pids=""
 
   if command -v lsof >/dev/null 2>&1; then
-    pids="$(lsof -tiTCP:"$port" -sTCP:LISTEN 2>/dev/null || true)"
-  elif command -v fuser >/dev/null 2>&1; then
-    # fuser prints PIDs to stderr; kill directly
-    fuser -k "${port}/tcp" >/dev/null 2>&1 || true
-  elif command -v powershell.exe >/dev/null 2>&1; then
-    # Git Bash / WSL-with-Windows: reuse the PowerShell port killer
-    powershell.exe -NoProfile -Command \
-      "Get-NetTCPConnection -LocalPort $port -State Listen -ErrorAction SilentlyContinue | ForEach-Object { Stop-Process -Id \$_.OwningProcess -Force -ErrorAction SilentlyContinue }" \
-      >/dev/null 2>&1 || true
-  fi
-
-  if [[ -n "${pids}" ]]; then
-    echo "  Port ${port}: stopping PID(s) ${pids//$'\n'/ }"
-    # shellcheck disable=SC2086
-    kill ${pids} 2>/dev/null || true
-    sleep 0.3
-    # shellcheck disable=SC2086
-    kill -9 ${pids} 2>/dev/null || true
+    while read -r pid; do
+      [[ -z "$pid" ]] && continue
+      local cmd
+      cmd="$(ps -p "$pid" -o args= 2>/dev/null || true)"
+      # Only stop listeners whose command line belongs to this checkout.
+      if [[ "$cmd" == *"$ROOT"* ]]; then
+        echo "  Port ${port}: stopping Olive Studio PID ${pid}"
+        kill "$pid" 2>/dev/null || true
+        sleep 0.3
+        kill -0 "$pid" 2>/dev/null && kill -9 "$pid" 2>/dev/null || true
+      fi
+    done < <(lsof -nP -t -iTCP:"$port" -sTCP:LISTEN 2>/dev/null || true)
   fi
 
   # Named desktop app processes (best-effort across platforms)
@@ -102,7 +96,9 @@ stop_olive_studio_dev_stack() {
   sleep 0.3
 }
 
-stop_olive_studio_dev_stack
+if [[ "$BUILD" -eq 0 ]]; then
+  stop_olive_studio_dev_stack
+fi
 
 # Tauri bundle.resources maps ../dist -> dist and validates the path at cargo build,
 # including `tauri dev`. Fresh clones/worktrees often have no dist/ yet.

--- a/launch-tauri.sh
+++ b/launch-tauri.sh
@@ -33,8 +33,82 @@ if ! command -v cargo >/dev/null 2>&1; then
 fi
 
 if [[ ! -d node_modules ]]; then
-  echo "node_modules missing — running pnpm install..."
+  echo "node_modules missing - running pnpm install..."
   pnpm install
+fi
+
+# Free port 3000 and stop leftover Olive Studio / Tauri processes for this repo.
+stop_olive_studio_dev_stack() {
+  echo "Stopping any running Olive Studio servers / Tauri leftovers..."
+
+  local port=3000
+  local pids=""
+
+  if command -v lsof >/dev/null 2>&1; then
+    pids="$(lsof -tiTCP:"$port" -sTCP:LISTEN 2>/dev/null || true)"
+  elif command -v fuser >/dev/null 2>&1; then
+    # fuser prints PIDs to stderr; kill directly
+    fuser -k "${port}/tcp" >/dev/null 2>&1 || true
+  elif command -v powershell.exe >/dev/null 2>&1; then
+    # Git Bash / WSL-with-Windows: reuse the PowerShell port killer
+    powershell.exe -NoProfile -Command \
+      "Get-NetTCPConnection -LocalPort $port -State Listen -ErrorAction SilentlyContinue | ForEach-Object { Stop-Process -Id \$_.OwningProcess -Force -ErrorAction SilentlyContinue }" \
+      >/dev/null 2>&1 || true
+  fi
+
+  if [[ -n "${pids}" ]]; then
+    echo "  Port ${port}: stopping PID(s) ${pids//$'\n'/ }"
+    # shellcheck disable=SC2086
+    kill ${pids} 2>/dev/null || true
+    sleep 0.3
+    # shellcheck disable=SC2086
+    kill -9 ${pids} 2>/dev/null || true
+  fi
+
+  # Named desktop app processes (best-effort across platforms)
+  if command -v pkill >/dev/null 2>&1; then
+    pkill -f "Olive Studio" 2>/dev/null || true
+    pkill -x "olive-studio" 2>/dev/null || true
+  elif command -v taskkill.exe >/dev/null 2>&1; then
+    taskkill.exe /F /IM "Olive Studio.exe" >/dev/null 2>&1 || true
+    taskkill.exe /F /IM "olive-studio.exe" >/dev/null 2>&1 || true
+  fi
+
+  # Repo-scoped leftover tauri / server processes (avoid nuking unrelated node apps)
+  if command -v pgrep >/dev/null 2>&1; then
+    local match_pids
+    match_pids="$(pgrep -f "$ROOT" 2>/dev/null || true)"
+    if [[ -n "$match_pids" ]]; then
+      local pid cmd
+      for pid in $match_pids; do
+        cmd="$(ps -p "$pid" -o args= 2>/dev/null || true)"
+        if [[ "$cmd" == *tauri* || "$cmd" == *server.ts* || "$cmd" == *server.mjs* ]]; then
+          echo "  Stopping leftover PID $pid"
+          kill "$pid" 2>/dev/null || true
+        fi
+      done
+      sleep 0.2
+      for pid in $match_pids; do
+        if kill -0 "$pid" 2>/dev/null; then
+          cmd="$(ps -p "$pid" -o args= 2>/dev/null || true)"
+          if [[ "$cmd" == *tauri* || "$cmd" == *server.ts* || "$cmd" == *server.mjs* ]]; then
+            kill -9 "$pid" 2>/dev/null || true
+          fi
+        fi
+      done
+    fi
+  fi
+
+  sleep 0.3
+}
+
+stop_olive_studio_dev_stack
+
+# Tauri bundle.resources maps ../dist -> dist and validates the path at cargo build,
+# including `tauri dev`. Fresh clones/worktrees often have no dist/ yet.
+if [[ ! -d dist ]]; then
+  echo "Creating empty dist/ so Tauri resource paths resolve (run pnpm build for a production bundle)..."
+  mkdir -p dist
 fi
 
 if [[ "$BUILD" -eq 1 ]]; then

--- a/launch-tauri.sh
+++ b/launch-tauri.sh
@@ -42,11 +42,22 @@ stop_olive_studio_dev_stack() {
   echo "Stopping any running Olive Studio servers / Tauri leftovers..."
 
   local port=3000
-  local pids=""
+  local self_pid=$$
+  local parent_pid=${PPID:-0}
+
+  is_self_or_parent() {
+    local pid="$1"
+    [[ -z "$pid" ]] && return 1
+    [[ "$pid" == "$self_pid" || "$pid" == "$parent_pid" ]] && return 0
+    return 1
+  }
 
   if command -v lsof >/dev/null 2>&1; then
     while read -r pid; do
       [[ -z "$pid" ]] && continue
+      if is_self_or_parent "$pid"; then
+        continue
+      fi
       local cmd
       cmd="$(ps -p "$pid" -o args= 2>/dev/null || true)"
       # Only stop listeners whose command line belongs to this checkout.
@@ -68,14 +79,21 @@ stop_olive_studio_dev_stack() {
     taskkill.exe /F /IM "olive-studio.exe" >/dev/null 2>&1 || true
   fi
 
-  # Repo-scoped leftover tauri / server processes (avoid nuking unrelated node apps)
+  # Repo-scoped leftover tauri / server processes (avoid nuking unrelated node apps).
+  # Skip this shell and its parent: absolute-path launchers include $ROOT and "tauri" in argv.
   if command -v pgrep >/dev/null 2>&1; then
     local match_pids
     match_pids="$(pgrep -f "$ROOT" 2>/dev/null || true)"
     if [[ -n "$match_pids" ]]; then
       local pid cmd
       for pid in $match_pids; do
+        if is_self_or_parent "$pid"; then
+          continue
+        fi
         cmd="$(ps -p "$pid" -o args= 2>/dev/null || true)"
+        if [[ "$cmd" == *launch-tauri.sh* || "$cmd" == *launch-tauri.ps1* || "$cmd" == *launch-tauri.cmd* ]]; then
+          continue
+        fi
         if [[ "$cmd" == *tauri* || "$cmd" == *server.ts* || "$cmd" == *server.mjs* ]]; then
           echo "  Stopping leftover PID $pid"
           kill "$pid" 2>/dev/null || true
@@ -83,8 +101,14 @@ stop_olive_studio_dev_stack() {
       done
       sleep 0.2
       for pid in $match_pids; do
+        if is_self_or_parent "$pid"; then
+          continue
+        fi
         if kill -0 "$pid" 2>/dev/null; then
           cmd="$(ps -p "$pid" -o args= 2>/dev/null || true)"
+          if [[ "$cmd" == *launch-tauri.sh* || "$cmd" == *launch-tauri.ps1* || "$cmd" == *launch-tauri.cmd* ]]; then
+            continue
+          fi
           if [[ "$cmd" == *tauri* || "$cmd" == *server.ts* || "$cmd" == *server.mjs* ]]; then
             kill -9 "$pid" 2>/dev/null || true
           fi

--- a/src/components/features/GeminiSidebar.flows.test.tsx
+++ b/src/components/features/GeminiSidebar.flows.test.tsx
@@ -63,12 +63,13 @@ describe("GeminiSidebar flows", () => {
     const provider = screen.getByLabelText("AI provider") as HTMLSelectElement;
     expect(provider.value).toBe("gemini");
     await waitFor(() => expect(screen.getByText("Live catalog")).toBeTruthy());
-    // Router providers (compat mode) additionally offer a free-text model id
+    // Router providers (compat mode): searchable combobox with catalog membership
     fireEvent.change(provider, { target: { value: "openrouter" } });
     await waitFor(() =>
-      expect((screen.getByLabelText("AI model") as HTMLSelectElement).value).toBe("gemini-2.5-pro"),
+      expect((screen.getByLabelText("AI model") as HTMLInputElement).value).toBe("gemini-2.5-pro"),
     );
-    expect(screen.getByPlaceholderText(/Or type a model id/)).toBeTruthy();
+    expect(screen.getByRole("combobox", { name: "AI model" })).toBeTruthy();
+    expect(screen.queryByText("Model ID not recognized. Requests may fail.")).toBeNull();
     expect(screen.getByPlaceholderText(/localhost:11434/)).toBeTruthy();
     // Local tab: LM Studio / Ollama inventory (not mixed into Cloud)
     fireEvent.click(screen.getByRole("button", { name: "Local settings" }));

--- a/src/components/features/GeminiSidebar.tsx
+++ b/src/components/features/GeminiSidebar.tsx
@@ -10,7 +10,7 @@ import {
 import { chatPatchToUiState, sanitizeChatActionPatch, type ChatAction } from "@/lib/chatActions";
 import { Bot, X, Lightbulb, MessageSquareCode, Settings2 } from "lucide-react";
 import { AuditPanel } from "./AuditPanel";
-import { PROVIDER_OPTIONS } from "./gemini/aiProviderCatalog";
+import { PROVIDER_OPTIONS, normalizeUiProviderId } from "./gemini/aiProviderCatalog";
 import { ChatPanel } from "./gemini/ChatPanel";
 import { SettingsPanel } from "./gemini/SettingsPanel";
 import type { SidebarTab } from "./gemini/types";
@@ -145,7 +145,14 @@ export function GeminiSidebar({
 
   const providerLabel =
     providerSource !== "none"
-      ? `${PROVIDER_OPTIONS.find((p) => p.id === providers.providerStatus.provider)?.name ?? providers.providerStatus.provider} / ${providers.providerStatus.model}`
+      ? `${
+          PROVIDER_OPTIONS.find(
+            (p) =>
+              p.id ===
+              (normalizeUiProviderId(providers.providerStatus.provider ?? "") ??
+                providers.providerStatus.provider),
+          )?.name ?? providers.providerStatus.provider
+        } / ${providers.providerStatus.model}`
       : "No provider set";
 
   return (

--- a/src/components/features/gemini/ManualProviderSetup.tsx
+++ b/src/components/features/gemini/ManualProviderSetup.tsx
@@ -4,6 +4,7 @@ import { cn } from "@/lib/utils";
 import { CATEGORY_LABELS, PROVIDER_OPTIONS, type ProviderId } from "./aiProviderCatalog";
 import { CodexAccountPanel } from "./CodexAccountPanel";
 import { DevinAccountPanel } from "./DevinAccountPanel";
+import { ModelCombobox } from "./ModelCombobox";
 import type { AiProviderSettings } from "./useAiProviderSettings";
 
 interface ProvidersProp {
@@ -40,7 +41,6 @@ function ProviderSelect({ providers }: ProvidersProp) {
           acc.push(
             <option key={p.id} value={p.id}>
               {p.name}
-              {p.description ? `: ${p.description}` : ""}
             </option>,
           );
           return acc;
@@ -79,9 +79,17 @@ function ModelSourceBadge({ providers }: ProvidersProp) {
   );
 }
 
-/** Model input: free text for openai-compat, list + free text for routers, list otherwise. */
+/** Model input: free text for openai-compat, combobox for routers, list otherwise. */
 function ModelInput({ providers }: ProvidersProp) {
-  const { isCompatMode, settingsProvider, displayedModels, customModel, settingsModel } = providers;
+  const {
+    isCompatMode,
+    settingsProvider,
+    displayedModels,
+    customModel,
+    settingsModel,
+    modelsSource,
+    modelsLoading,
+  } = providers;
 
   if (isCompatMode && settingsProvider === "openai-compat") {
     return (
@@ -97,45 +105,19 @@ function ModelInput({ providers }: ProvidersProp) {
   }
 
   if (isCompatMode && displayedModels.length > 0) {
-    // OpenAI-compat routers (xAI, OpenRouter, …): show live list + allow free text
     const selected = customModel || settingsModel;
-    const isKnown = displayedModels.some((m) => m.id === selected);
     return (
-      <div className="space-y-1.5">
-        <select
-          id="gemini-settings-model"
-          aria-label="AI model"
-          value={isKnown ? selected : ""}
-          onChange={(e) => {
-            providers.setSettingsModel(e.target.value);
-            providers.setCustomModel(e.target.value);
-          }}
-          className="w-full bg-slate-900 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:border-electric-blue cursor-pointer"
-        >
-          {!isKnown && <option value="">Select a model…</option>}
-          {displayedModels.map((m) => (
-            <option key={m.id} value={m.id}>
-              {m.label}
-            </option>
-          ))}
-        </select>
-        <div>
-          <label htmlFor="gemini-settings-custom-model" className="sr-only">
-            Custom model id
-          </label>
-          <input
-            id="gemini-settings-custom-model"
-            aria-label="Custom model id"
-            placeholder="Or type a model id…"
-            value={customModel}
-            onChange={(e) => {
-              providers.setCustomModel(e.target.value);
-              providers.setSettingsModel(e.target.value);
-            }}
-            className="w-full bg-slate-900 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:border-electric-blue"
-          />
-        </div>
-      </div>
+      <ModelCombobox
+        id="gemini-settings-model"
+        value={selected}
+        options={displayedModels}
+        modelsSource={modelsSource}
+        modelsLoading={modelsLoading}
+        onChange={(modelId) => {
+          providers.setCustomModel(modelId);
+          providers.setSettingsModel(modelId);
+        }}
+      />
     );
   }
 

--- a/src/components/features/gemini/ModelCombobox.test.tsx
+++ b/src/components/features/gemini/ModelCombobox.test.tsx
@@ -92,4 +92,46 @@ describe("ModelCombobox", () => {
     fireEvent.keyDown(input, { key: "Enter" });
     expect(onChange).not.toHaveBeenCalled();
   });
+
+  it("does not overwrite a freehand id with the first filter match on Enter", () => {
+    const onChange = vi.fn();
+    render(
+      <ModelCombobox
+        value=""
+        options={[
+          { id: "openai/gpt-4o", label: "GPT-4o" },
+          { id: "openai/gpt-4o-mini", label: "GPT-4o mini" },
+        ]}
+        modelsSource="live"
+        onChange={onChange}
+      />,
+    );
+
+    const input = screen.getByRole("combobox");
+    fireEvent.focus(input);
+    fireEvent.change(input, { target: { value: "openai/gpt-4o-my-ft" } });
+    expect(onChange).toHaveBeenLastCalledWith("openai/gpt-4o-my-ft");
+    onChange.mockClear();
+
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(onChange).not.toHaveBeenCalled();
+    expect((input as HTMLInputElement).value).toBe("openai/gpt-4o-my-ft");
+  });
+
+  it("closes the list when focus leaves via Tab", () => {
+    render(
+      <ModelCombobox
+        value="openrouter/openai/gpt-4o"
+        options={options}
+        modelsSource="live"
+        onChange={vi.fn()}
+      />,
+    );
+
+    const input = screen.getByRole("combobox");
+    fireEvent.focus(input);
+    expect(screen.getByRole("listbox")).toBeTruthy();
+    fireEvent.blur(input);
+    expect(screen.queryByRole("listbox")).toBeNull();
+  });
 });

--- a/src/components/features/gemini/ModelCombobox.test.tsx
+++ b/src/components/features/gemini/ModelCombobox.test.tsx
@@ -1,0 +1,62 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { ModelCombobox } from "./ModelCombobox";
+
+describe("ModelCombobox", () => {
+  const options = [
+    { id: "openrouter/google/gemini-2.5-pro", label: "Gemini 2.5 Pro" },
+    { id: "openrouter/openai/gpt-4o", label: "GPT-4o" },
+  ];
+
+  it("lists all models on open even when a model is already selected", () => {
+    render(
+      <ModelCombobox
+        value="openrouter/openai/gpt-4o"
+        options={options}
+        modelsSource="live"
+        onChange={vi.fn()}
+      />,
+    );
+
+    fireEvent.focus(screen.getByRole("combobox"));
+    expect(screen.getByRole("option", { name: /GPT-4o/ })).toBeTruthy();
+    expect(screen.getByRole("option", { name: /Gemini 2.5 Pro/ })).toBeTruthy();
+    expect((screen.getByRole("combobox") as HTMLInputElement).value).toBe(
+      "openrouter/openai/gpt-4o",
+    );
+  });
+
+  it("filters only after the user types", () => {
+    const onChange = vi.fn();
+    render(
+      <ModelCombobox
+        value="openrouter/openai/gpt-4o"
+        options={options}
+        modelsSource="live"
+        onChange={onChange}
+      />,
+    );
+
+    expect(screen.getByRole("combobox", { name: "AI model" })).toBeTruthy();
+    expect(screen.queryByRole("status")).toBeNull();
+
+    fireEvent.focus(screen.getByRole("combobox"));
+    fireEvent.change(screen.getByRole("combobox"), { target: { value: "gemini" } });
+    expect(onChange).toHaveBeenCalledWith("gemini");
+    expect(screen.getByRole("option", { name: /Gemini 2.5 Pro/ })).toBeTruthy();
+    expect(screen.queryByRole("option", { name: /GPT-4o/ })).toBeNull();
+  });
+
+  it("soft-warns when a freehand id is missing from the live catalog", () => {
+    render(
+      <ModelCombobox
+        value="my-org/custom-model"
+        options={options}
+        modelsSource="live"
+        onChange={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Model ID not recognized. Requests may fail.")).toBeTruthy();
+  });
+});

--- a/src/components/features/gemini/ModelCombobox.test.tsx
+++ b/src/components/features/gemini/ModelCombobox.test.tsx
@@ -59,4 +59,37 @@ describe("ModelCombobox", () => {
 
     expect(screen.getByText("Model ID not recognized. Requests may fail.")).toBeTruthy();
   });
+
+  it("does not commit a different model on focus + Enter for freehand ids", () => {
+    const onChange = vi.fn();
+    render(
+      <ModelCombobox
+        value="my-org/custom-model"
+        options={options}
+        modelsSource="live"
+        onChange={onChange}
+      />,
+    );
+
+    const input = screen.getByRole("combobox");
+    fireEvent.focus(input);
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("does not commit a different model on focus + Enter when selection is past the visible window", () => {
+    const many = Array.from({ length: 45 }, (_, i) => ({
+      id: `model-${i}`,
+      label: `Model ${i}`,
+    }));
+    const onChange = vi.fn();
+    render(
+      <ModelCombobox value="model-42" options={many} modelsSource="live" onChange={onChange} />,
+    );
+
+    const input = screen.getByRole("combobox");
+    fireEvent.focus(input);
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(onChange).not.toHaveBeenCalled();
+  });
 });

--- a/src/components/features/gemini/ModelCombobox.tsx
+++ b/src/components/features/gemini/ModelCombobox.tsx
@@ -39,7 +39,8 @@ export function ModelCombobox({
   const listboxId = useId();
   const rootRef = useRef<HTMLDivElement>(null);
   const [open, setOpen] = useState(false);
-  const [highlight, setHighlight] = useState(0);
+  /** null = no keyboard/mouse highlight yet; Enter must not commit a different model. */
+  const [highlight, setHighlight] = useState<number | null>(null);
   /** null = not filtering (show full list); string = active search / freehand edit. */
   const [query, setQuery] = useState<string | null>(null);
 
@@ -56,7 +57,10 @@ export function ModelCombobox({
 
   const membership = getModelCatalogMembership(value, options, modelsSource);
   const membershipLabel = modelCatalogMembershipLabel(membership);
-  const safeHighlight = Math.min(highlight, Math.max(filtered.length - 1, 0));
+  const safeHighlight =
+    highlight === null || filtered.length === 0
+      ? null
+      : Math.min(highlight, filtered.length - 1);
 
   useEffect(() => {
     if (!open) return;
@@ -73,7 +77,7 @@ export function ModelCombobox({
   const pick = (modelId: string) => {
     onChange(modelId);
     setQuery(null);
-    setHighlight(0);
+    setHighlight(null);
     setOpen(false);
   };
 
@@ -82,23 +86,37 @@ export function ModelCombobox({
     // Keep the selected id in the field, but do not filter until the user types.
     setQuery(null);
     const selectedIndex = options.findIndex((option) => option.id === value);
-    setHighlight(selectedIndex >= 0 ? Math.min(selectedIndex, MAX_VISIBLE - 1) : 0);
+    // Only auto-highlight when the current value is in the visible window.
+    // Clamping to MAX_VISIBLE-1 / 0 would make focus+Enter commit a different model.
+    if (selectedIndex >= 0 && selectedIndex < MAX_VISIBLE) {
+      setHighlight(selectedIndex);
+    } else {
+      setHighlight(null);
+    }
   };
 
   const onKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
     if (event.key === "ArrowDown") {
       event.preventDefault();
       setOpen(true);
-      setHighlight((i) => Math.min(i + 1, Math.max(filtered.length - 1, 0)));
+      setHighlight((i) => {
+        if (filtered.length === 0) return null;
+        if (i === null) return 0;
+        return Math.min(i + 1, filtered.length - 1);
+      });
       return;
     }
     if (event.key === "ArrowUp") {
       event.preventDefault();
       setOpen(true);
-      setHighlight((i) => Math.max(i - 1, 0));
+      setHighlight((i) => {
+        if (filtered.length === 0) return null;
+        if (i === null) return filtered.length - 1;
+        return Math.max(i - 1, 0);
+      });
       return;
     }
-    if (event.key === "Enter" && open && filtered[safeHighlight]) {
+    if (event.key === "Enter" && open && safeHighlight !== null && filtered[safeHighlight]) {
       event.preventDefault();
       pick(filtered[safeHighlight]!.id);
       return;
@@ -106,7 +124,7 @@ export function ModelCombobox({
     if (event.key === "Escape") {
       setOpen(false);
       setQuery(null);
-      setHighlight(0);
+      setHighlight(null);
     }
   };
 
@@ -117,10 +135,13 @@ export function ModelCombobox({
         role="combobox"
         aria-label="AI model"
         aria-autocomplete="list"
+        aria-haspopup="listbox"
         aria-expanded={open}
         aria-controls={listboxId}
         aria-activedescendant={
-          open && filtered[safeHighlight] ? `${listboxId}-opt-${safeHighlight}` : undefined
+          open && safeHighlight !== null && filtered[safeHighlight]
+            ? `${listboxId}-opt-${safeHighlight}`
+            : undefined
         }
         autoComplete="off"
         spellCheck={false}
@@ -151,7 +172,7 @@ export function ModelCombobox({
             </li>
           ) : (
             filtered.map((m, index) => {
-              const active = index === safeHighlight;
+              const active = safeHighlight !== null && index === safeHighlight;
               const selected = m.id === value;
               return (
                 <li

--- a/src/components/features/gemini/ModelCombobox.tsx
+++ b/src/components/features/gemini/ModelCombobox.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useId, useMemo, useRef, useState, type KeyboardEvent } from "react";
+import { useEffect, useId, useMemo, useRef, useState, type FocusEvent, type KeyboardEvent } from "react";
 import {
   getModelCatalogMembership,
   modelCatalogMembershipLabel,
@@ -62,12 +62,17 @@ export function ModelCombobox({
       ? null
       : Math.min(highlight, filtered.length - 1);
 
+  const closeList = () => {
+    setOpen(false);
+    setQuery(null);
+    setHighlight(null);
+  };
+
   useEffect(() => {
     if (!open) return;
     const onPointerDown = (event: MouseEvent) => {
       if (!rootRef.current?.contains(event.target as Node)) {
-        setOpen(false);
-        setQuery(null);
+        closeList();
       }
     };
     document.addEventListener("mousedown", onPointerDown);
@@ -76,9 +81,7 @@ export function ModelCombobox({
 
   const pick = (modelId: string) => {
     onChange(modelId);
-    setQuery(null);
-    setHighlight(null);
-    setOpen(false);
+    closeList();
   };
 
   const openList = () => {
@@ -122,10 +125,15 @@ export function ModelCombobox({
       return;
     }
     if (event.key === "Escape") {
-      setOpen(false);
-      setQuery(null);
-      setHighlight(null);
+      event.preventDefault();
+      closeList();
     }
+  };
+
+  const onBlur = (event: FocusEvent<HTMLInputElement>) => {
+    // Options use mousedown.preventDefault so they never steal focus; Tab leaves the root.
+    if (rootRef.current?.contains(event.relatedTarget as Node)) return;
+    closeList();
   };
 
   return (
@@ -150,11 +158,15 @@ export function ModelCombobox({
         onChange={(e) => {
           const next = e.target.value;
           setQuery(next);
-          setHighlight(0);
+          // Do not auto-highlight the first filter match: Enter would overwrite freehand ids
+          // that partially match the catalog (e.g. openai/gpt-4o-my-ft → openai/gpt-4o).
+          // Arrow keys / mouse still set an explicit highlight for intentional commits.
+          setHighlight(null);
           onChange(next);
           setOpen(true);
         }}
         onFocus={openList}
+        onBlur={onBlur}
         onKeyDown={onKeyDown}
         className="w-full bg-slate-900 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:border-electric-blue"
       />

--- a/src/components/features/gemini/ModelCombobox.tsx
+++ b/src/components/features/gemini/ModelCombobox.tsx
@@ -58,8 +58,9 @@ export function ModelCombobox({
   const membershipLabel = modelCatalogMembershipLabel(membership);
 
   useEffect(() => {
-    setHighlight(0);
-  }, [filterText, open]);
+    const selectedIndex = filtered.findIndex((option) => option.id === value);
+    setHighlight(selectedIndex >= 0 ? selectedIndex : 0);
+  }, [filtered, value, filterText, open]);
 
   useEffect(() => {
     if (!open) return;

--- a/src/components/features/gemini/ModelCombobox.tsx
+++ b/src/components/features/gemini/ModelCombobox.tsx
@@ -56,11 +56,7 @@ export function ModelCombobox({
 
   const membership = getModelCatalogMembership(value, options, modelsSource);
   const membershipLabel = modelCatalogMembershipLabel(membership);
-
-  useEffect(() => {
-    const selectedIndex = filtered.findIndex((option) => option.id === value);
-    setHighlight(selectedIndex >= 0 ? selectedIndex : 0);
-  }, [filtered, value, filterText, open]);
+  const safeHighlight = Math.min(highlight, Math.max(filtered.length - 1, 0));
 
   useEffect(() => {
     if (!open) return;
@@ -77,6 +73,7 @@ export function ModelCombobox({
   const pick = (modelId: string) => {
     onChange(modelId);
     setQuery(null);
+    setHighlight(0);
     setOpen(false);
   };
 
@@ -84,6 +81,8 @@ export function ModelCombobox({
     setOpen(true);
     // Keep the selected id in the field, but do not filter until the user types.
     setQuery(null);
+    const selectedIndex = options.findIndex((option) => option.id === value);
+    setHighlight(selectedIndex >= 0 ? Math.min(selectedIndex, MAX_VISIBLE - 1) : 0);
   };
 
   const onKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
@@ -99,14 +98,15 @@ export function ModelCombobox({
       setHighlight((i) => Math.max(i - 1, 0));
       return;
     }
-    if (event.key === "Enter" && open && filtered[highlight]) {
+    if (event.key === "Enter" && open && filtered[safeHighlight]) {
       event.preventDefault();
-      pick(filtered[highlight]!.id);
+      pick(filtered[safeHighlight]!.id);
       return;
     }
     if (event.key === "Escape") {
       setOpen(false);
       setQuery(null);
+      setHighlight(0);
     }
   };
 
@@ -119,7 +119,9 @@ export function ModelCombobox({
         aria-autocomplete="list"
         aria-expanded={open}
         aria-controls={listboxId}
-        aria-activedescendant={open && filtered[highlight] ? `${listboxId}-opt-${highlight}` : undefined}
+        aria-activedescendant={
+          open && filtered[safeHighlight] ? `${listboxId}-opt-${safeHighlight}` : undefined
+        }
         autoComplete="off"
         spellCheck={false}
         placeholder={placeholder}
@@ -127,6 +129,7 @@ export function ModelCombobox({
         onChange={(e) => {
           const next = e.target.value;
           setQuery(next);
+          setHighlight(0);
           onChange(next);
           setOpen(true);
         }}
@@ -148,7 +151,7 @@ export function ModelCombobox({
             </li>
           ) : (
             filtered.map((m, index) => {
-              const active = index === highlight;
+              const active = index === safeHighlight;
               const selected = m.id === value;
               return (
                 <li

--- a/src/components/features/gemini/ModelCombobox.tsx
+++ b/src/components/features/gemini/ModelCombobox.tsx
@@ -1,0 +1,197 @@
+import { useEffect, useId, useMemo, useRef, useState, type KeyboardEvent } from "react";
+import {
+  getModelCatalogMembership,
+  modelCatalogMembershipLabel,
+  type ModelCatalogSource,
+} from "@/lib/modelCatalogMembership";
+import { cn } from "@/lib/utils";
+
+export interface ModelComboboxOption {
+  id: string;
+  label: string;
+}
+
+interface ModelComboboxProps {
+  id?: string;
+  value: string;
+  options: ReadonlyArray<ModelComboboxOption>;
+  modelsSource: ModelCatalogSource | null;
+  modelsLoading?: boolean;
+  placeholder?: string;
+  onChange: (modelId: string) => void;
+}
+
+const MAX_VISIBLE = 40;
+
+/**
+ * Single searchable model control: filter live/fallback options and still accept freehand ids.
+ * Opening the list shows the full catalog; typing then narrows it.
+ */
+export function ModelCombobox({
+  id,
+  value,
+  options,
+  modelsSource,
+  modelsLoading = false,
+  placeholder = "Search or type a model id…",
+  onChange,
+}: ModelComboboxProps) {
+  const listboxId = useId();
+  const rootRef = useRef<HTMLDivElement>(null);
+  const [open, setOpen] = useState(false);
+  const [highlight, setHighlight] = useState(0);
+  /** null = not filtering (show full list); string = active search / freehand edit. */
+  const [query, setQuery] = useState<string | null>(null);
+
+  const inputValue = query ?? value;
+  const filterText = query !== null ? query.trim().toLowerCase() : "";
+
+  const filtered = useMemo(() => {
+    if (!filterText) return options.slice(0, MAX_VISIBLE);
+    const matches = options.filter(
+      (m) => m.id.toLowerCase().includes(filterText) || m.label.toLowerCase().includes(filterText),
+    );
+    return matches.slice(0, MAX_VISIBLE);
+  }, [options, filterText]);
+
+  const membership = getModelCatalogMembership(value, options, modelsSource);
+  const membershipLabel = modelCatalogMembershipLabel(membership);
+
+  useEffect(() => {
+    setHighlight(0);
+  }, [filterText, open]);
+
+  useEffect(() => {
+    if (!open) return;
+    const onPointerDown = (event: MouseEvent) => {
+      if (!rootRef.current?.contains(event.target as Node)) {
+        setOpen(false);
+        setQuery(null);
+      }
+    };
+    document.addEventListener("mousedown", onPointerDown);
+    return () => document.removeEventListener("mousedown", onPointerDown);
+  }, [open]);
+
+  const pick = (modelId: string) => {
+    onChange(modelId);
+    setQuery(null);
+    setOpen(false);
+  };
+
+  const openList = () => {
+    setOpen(true);
+    // Keep the selected id in the field, but do not filter until the user types.
+    setQuery(null);
+  };
+
+  const onKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      setOpen(true);
+      setHighlight((i) => Math.min(i + 1, Math.max(filtered.length - 1, 0)));
+      return;
+    }
+    if (event.key === "ArrowUp") {
+      event.preventDefault();
+      setOpen(true);
+      setHighlight((i) => Math.max(i - 1, 0));
+      return;
+    }
+    if (event.key === "Enter" && open && filtered[highlight]) {
+      event.preventDefault();
+      pick(filtered[highlight]!.id);
+      return;
+    }
+    if (event.key === "Escape") {
+      setOpen(false);
+      setQuery(null);
+    }
+  };
+
+  return (
+    <div ref={rootRef} className="relative space-y-1">
+      <input
+        id={id}
+        role="combobox"
+        aria-label="AI model"
+        aria-autocomplete="list"
+        aria-expanded={open}
+        aria-controls={listboxId}
+        aria-activedescendant={open && filtered[highlight] ? `${listboxId}-opt-${highlight}` : undefined}
+        autoComplete="off"
+        spellCheck={false}
+        placeholder={placeholder}
+        value={inputValue}
+        onChange={(e) => {
+          const next = e.target.value;
+          setQuery(next);
+          onChange(next);
+          setOpen(true);
+        }}
+        onFocus={openList}
+        onKeyDown={onKeyDown}
+        className="w-full bg-slate-900 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:border-electric-blue"
+      />
+
+      {open && (
+        <ul
+          id={listboxId}
+          role="listbox"
+          aria-label={filterText ? "Matching models" : "Available models"}
+          className="absolute z-20 mt-1 max-h-48 w-full overflow-auto rounded-lg border border-slate-700 bg-slate-900 shadow-lg"
+        >
+          {filtered.length === 0 ? (
+            <li className="px-3 py-2 text-xs text-slate-500">
+              No catalog matches. Keep typing to use a freehand model id.
+            </li>
+          ) : (
+            filtered.map((m, index) => {
+              const active = index === highlight;
+              const selected = m.id === value;
+              return (
+                <li
+                  key={m.id}
+                  id={`${listboxId}-opt-${index}`}
+                  role="option"
+                  aria-selected={selected}
+                  onMouseEnter={() => setHighlight(index)}
+                  onMouseDown={(e) => {
+                    e.preventDefault();
+                    pick(m.id);
+                  }}
+                  className={cn(
+                    "cursor-pointer px-3 py-1.5 text-sm",
+                    active ? "bg-electric-blue/20 text-slate-100" : "text-slate-300",
+                    selected && "font-medium",
+                  )}
+                >
+                  <span className="block truncate">{m.label}</span>
+                  {m.label !== m.id && (
+                    <span className="block truncate text-[10px] text-slate-500">{m.id}</span>
+                  )}
+                </li>
+              );
+            })
+          )}
+          {!filterText && options.length > MAX_VISIBLE && (
+            <li className="px-3 py-1.5 text-[10px] text-slate-500 border-t border-slate-800">
+              Showing first {MAX_VISIBLE} models. Type to search the full catalog.
+            </li>
+          )}
+          {filterText && options.length > MAX_VISIBLE && filtered.length === MAX_VISIBLE && (
+            <li className="px-3 py-1.5 text-[10px] text-slate-500 border-t border-slate-800">
+              Showing first {MAX_VISIBLE} matches. Type to narrow further.
+            </li>
+          )}
+        </ul>
+      )}
+
+      {!open && !modelsLoading && membershipLabel && (
+        <p className="text-[10px] leading-snug text-amber-400/90" role="status">
+          {membershipLabel}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/components/features/gemini/SettingsPanel.tsx
+++ b/src/components/features/gemini/SettingsPanel.tsx
@@ -4,7 +4,7 @@ import {
   preferredEngineFromBaseUrl,
   type AssistantSettingsMode,
 } from "@/lib/assistantSettingsMode";
-import { PROVIDER_OPTIONS } from "./aiProviderCatalog";
+import { PROVIDER_OPTIONS, normalizeUiProviderId } from "./aiProviderCatalog";
 import { LocalAiSetupCard } from "./LocalAiSetupCard";
 import { ManualProviderSetup } from "./ManualProviderSetup";
 import type { AiProviderSettings } from "./useAiProviderSettings";
@@ -15,40 +15,34 @@ interface ActiveProviderCardProps {
 }
 
 /**
- * Displays the active AI provider, model, configuration source, and available actions.
- *
- * @param providers - Provider status and management actions used to populate the card
+ * Compact one-line active provider status with an optional Clear action.
  */
 function ActiveProviderCard({ providers }: ActiveProviderCardProps) {
   const { providerStatus } = providers;
+  const providerName =
+    PROVIDER_OPTIONS.find(
+      (p) => p.id === (normalizeUiProviderId(providerStatus.provider ?? "") ?? providerStatus.provider),
+    )?.name ?? providerStatus.provider;
+
   return (
-    <div className="p-3.5 bg-slate-950/60 border border-slate-800 rounded-xl">
-      <p className="text-[10px] font-mono uppercase tracking-wider text-slate-500 font-extrabold mb-2">
-        Active Provider
-      </p>
+    <div className="flex items-center justify-between gap-2 rounded-lg border border-slate-800 bg-slate-950/60 px-2.5 py-1.5">
       {providerStatus.source === "none" ? (
-        <p className="text-xs text-slate-500 italic">No provider. AI features disabled.</p>
+        <p className="truncate text-xs text-slate-500 italic">No provider. AI features disabled.</p>
       ) : (
-        <div className="flex items-center justify-between gap-2">
-          <div>
-            <p className="text-sm font-semibold text-slate-100">
-              {PROVIDER_OPTIONS.find((p) => p.id === providerStatus.provider)?.name ??
-                providerStatus.provider}
-            </p>
-            <p className="text-[10px] font-mono text-slate-400">
-              {providerStatus.model} · {providerStatus.source === "env" ? "env var" : "session key"}
-            </p>
-          </div>
-          {providerStatus.source === "user" && (
-            <button
-              type="button"
-              onClick={() => void providers.clearProvider()}
-              className="text-[10px] text-rose-400 hover:text-rose-200 border border-rose-500/20 rounded px-2 py-1 font-bold transition-all cursor-pointer"
-            >
-              Clear
-            </button>
-          )}
-        </div>
+        <p className="min-w-0 truncate text-xs text-slate-200">
+          <span className="font-medium text-slate-100">{providerName}</span>
+          <span className="text-slate-500">:</span>{" "}
+          <span className="font-mono text-slate-300">{providerStatus.model}</span>
+        </p>
+      )}
+      {providerStatus.source === "user" && (
+        <button
+          type="button"
+          onClick={() => void providers.clearProvider()}
+          className="shrink-0 text-[10px] text-rose-400 hover:text-rose-200 border border-rose-500/20 rounded px-2 py-0.5 font-bold transition-all cursor-pointer"
+        >
+          Clear
+        </button>
       )}
     </div>
   );
@@ -133,7 +127,8 @@ export function SettingsPanel({ providers, local, isOpen }: SettingsPanelProps) 
 
   return (
     <div className="space-y-4">
-      <div className="space-y-3 sticky top-0 z-10 bg-slate-950/95 pb-1 backdrop-blur-sm">
+      {/* Pull into the scroll panel's p-4 so nothing peeks above/behind while sticky */}
+      <div className="sticky top-0 z-10 -mx-4 -mt-4 space-y-3 bg-slate-950 px-4 pt-4 pb-3">
         <ActiveProviderCard providers={providers} />
         <SettingsModeTabs mode={settingsMode} onChange={setSettingsMode} />
       </div>

--- a/src/components/features/gemini/aiProviderCatalog.ts
+++ b/src/components/features/gemini/aiProviderCatalog.ts
@@ -54,7 +54,6 @@ export const PROVIDER_OPTIONS: readonly ProviderOption[] = [
     docsUrl: "console.x.ai",
     baseUrl: "https://api.x.ai/v1",
     category: "direct",
-    description: "Grok models by xAI",
   },
   // ── API Routers & Aggregators ────────────────────────────────────────
   {
@@ -72,7 +71,6 @@ export const PROVIDER_OPTIONS: readonly ProviderOption[] = [
     docsUrl: "openrouter.ai/keys",
     baseUrl: "https://openrouter.ai/api/v1",
     category: "router",
-    description: "Access 200+ models via one API key",
   },
   {
     id: "groq",
@@ -82,7 +80,6 @@ export const PROVIDER_OPTIONS: readonly ProviderOption[] = [
     docsUrl: "console.groq.com/keys",
     baseUrl: "https://api.groq.com/openai/v1",
     category: "router",
-    description: "Ultra-fast inference on Groq LPU",
   },
   {
     id: "together",
@@ -96,7 +93,6 @@ export const PROVIDER_OPTIONS: readonly ProviderOption[] = [
     docsUrl: "api.together.xyz/settings/api-keys",
     baseUrl: "https://api.together.xyz/v1",
     category: "router",
-    description: "Open-source model hosting & inference",
   },
   {
     id: "fireworks",
@@ -106,7 +102,6 @@ export const PROVIDER_OPTIONS: readonly ProviderOption[] = [
     docsUrl: "fireworks.ai/account/api-keys",
     baseUrl: "https://api.fireworks.ai/inference/v1",
     category: "router",
-    description: "Fast OpenAI-compatible inference",
   },
   {
     id: "nvidia",
@@ -116,7 +111,6 @@ export const PROVIDER_OPTIONS: readonly ProviderOption[] = [
     docsUrl: "build.nvidia.com",
     baseUrl: "https://integrate.api.nvidia.com/v1",
     category: "router",
-    description: "NVIDIA hosted OpenAI-compatible endpoints",
   },
   {
     id: "huggingface",
@@ -126,7 +120,6 @@ export const PROVIDER_OPTIONS: readonly ProviderOption[] = [
     docsUrl: "huggingface.co/settings/tokens",
     baseUrl: "https://router.huggingface.co/v1",
     category: "router",
-    description: "HF Inference router (OpenAI-compatible)",
   },
   {
     id: "opencode",
@@ -136,7 +129,6 @@ export const PROVIDER_OPTIONS: readonly ProviderOption[] = [
     docsUrl: "opencode.ai",
     baseUrl: "https://opencode.ai/zen/v1",
     category: "router",
-    description: "OpenCode Zen gateway",
   },
   {
     id: "opencode-go",
@@ -146,7 +138,6 @@ export const PROVIDER_OPTIONS: readonly ProviderOption[] = [
     docsUrl: "opencode.ai",
     baseUrl: "https://opencode.ai/zen/go/v1",
     category: "router",
-    description: "OpenCode Go gateway",
   },
   // ── Subscription / gateway services ─────────────────────────────────
   {
@@ -156,25 +147,14 @@ export const PROVIDER_OPTIONS: readonly ProviderOption[] = [
     keyEnvVar: "CLOUDFLARE_API_TOKEN + CLOUDFLARE_ACCOUNT_ID",
     docsUrl: "developers.cloudflare.com/workers-ai",
     category: "subscription",
-    description: "Token + account id",
   },
   {
     id: "codex",
-    name: "OpenAI Codex",
+    name: "ChatGPT Plus/Pro OAuth",
     models: ["default", "o3", "o4-mini", "gpt-5"],
     keyEnvVar: "",
     docsUrl: "developers.openai.com/codex/auth",
     category: "subscription",
-    description: "ChatGPT Plus/Pro sign-in",
-  },
-  {
-    id: "chatgpt-sub",
-    name: "OpenAI API key",
-    models: ["gpt-4o", "gpt-4o-mini", "o4-mini"],
-    keyEnvVar: "OPENAI_API_KEY",
-    docsUrl: "platform.openai.com/api-keys",
-    category: "subscription",
-    description: "Platform key (usage-based)",
   },
   {
     id: "copilot",
@@ -184,7 +164,6 @@ export const PROVIDER_OPTIONS: readonly ProviderOption[] = [
     docsUrl: "github.com/settings/copilot",
     baseUrl: "https://api.githubcopilot.com",
     category: "subscription",
-    description: "OAuth or session token",
   },
   {
     id: "kilocode",
@@ -194,7 +173,6 @@ export const PROVIDER_OPTIONS: readonly ProviderOption[] = [
     docsUrl: "kilo.ai/docs/gateway",
     baseUrl: "https://api.kilo.ai/api/gateway",
     category: "subscription",
-    description: "OpenAI-compatible gateway",
   },
   {
     id: "devin",
@@ -203,7 +181,6 @@ export const PROVIDER_OPTIONS: readonly ProviderOption[] = [
     keyEnvVar: "",
     docsUrl: "devin.ai",
     category: "subscription",
-    description: "Sign in for plan models",
   },
   // ── Custom / Self-Hosted ─────────────────────────────────────────────
   {
@@ -213,15 +190,24 @@ export const PROVIDER_OPTIONS: readonly ProviderOption[] = [
     keyEnvVar: "",
     docsUrl: "",
     category: "custom",
-    description: "Ollama, vLLM, LiteLLM, or any OpenAI-compatible endpoint",
   },
 ] as const;
 
 export type ProviderId = (typeof PROVIDER_OPTIONS)[number]["id"];
 
+/**
+ * Map legacy / alias provider ids to the catalog entry shown in Settings.
+ * `chatgpt-sub` was a duplicate OpenAI Platform key entry under Subscriptions.
+ */
+export function normalizeUiProviderId(provider: string): ProviderId | null {
+  if (provider === "chatgpt-sub") return "openai";
+  if (PROVIDER_OPTIONS.some((p) => p.id === provider)) return provider as ProviderId;
+  return null;
+}
+
 /** Category labels for the dropdown optgroup headers. */
 export const CATEGORY_LABELS: Record<string, string> = {
-  direct: "Direct API Providers",
+  direct: "Direct API Key Providers",
   router: "API Routers & Aggregators",
   subscription: "Subscription Services",
   custom: "Custom / Self-Hosted",

--- a/src/components/features/gemini/useAiProviderSettings.ts
+++ b/src/components/features/gemini/useAiProviderSettings.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect, useMemo, useRef } from "react";
-import { PROVIDER_OPTIONS, type ProviderId } from "./aiProviderCatalog";
+import { PROVIDER_OPTIONS, normalizeUiProviderId, type ProviderId } from "./aiProviderCatalog";
 import type { ProviderStatus, SidebarTab } from "./types";
 
 interface UseAiProviderSettingsOptions {
@@ -67,21 +67,43 @@ export function useAiProviderSettings({
   /** Last values used for model fetching to avoid redundant refetches. */
   const lastFetchedApiKeyRef = useRef<string>("");
   const lastFetchedBaseUrlRef = useRef<string>("");
+  /**
+   * True once the user (or a saved/active provider) deliberately chose a model id.
+   * Lets catalog refresh preserve freehand ids without blocking the initial live list apply.
+   */
+  const userModelOverrideRef = useRef(false);
 
-  const providerOption = PROVIDER_OPTIONS.find((p) => p.id === settingsProvider)!;
+  const providerOption =
+    PROVIDER_OPTIONS.find((p) => p.id === settingsProvider) ?? PROVIDER_OPTIONS[0]!;
   const isCompatMode = settingsProvider === "openai-compat" || !!providerOption.baseUrl;
 
   const isStaleRefresh = (sequence: number) => sequence !== refreshSequenceRef.current;
+
+  const setSettingsModelFromUi = (modelId: string) => {
+    userModelOverrideRef.current = true;
+    setSettingsModel(modelId);
+  };
+
+  const setCustomModelFromUi = (modelId: string) => {
+    userModelOverrideRef.current = true;
+    setCustomModel(modelId);
+  };
 
   const applyFetchedModels = (providerId: ProviderId, models: Array<{ id: string; label: string }>) => {
     setLiveModelsByProvider((prev) => ({ ...prev, [providerId]: models }));
     if (providerId === "devin") {
       setDevinModels(models.map((m) => ({ id: m.id, name: m.label })));
     }
-    // Keep selection valid when the live list differs from static defaults
-    setSettingsModel((current) => (models.some((m) => m.id === current) ? current : models[0]!.id));
+    // Keep known selections. Preserve freehand only after an explicit UI/saved choice.
+    setSettingsModel((current) => {
+      if (models.some((m) => m.id === current)) return current;
+      if (userModelOverrideRef.current && current.trim()) return current;
+      return models[0]!.id;
+    });
     setCustomModel((current) => {
-      if (!current || models.some((m) => m.id === current)) return current || models[0]!.id;
+      if (!current) return models[0]!.id;
+      if (models.some((m) => m.id === current)) return current;
+      if (userModelOverrideRef.current) return current;
       return models[0]!.id;
     });
   };
@@ -164,10 +186,12 @@ export function useAiProviderSettings({
       }
       const d = (await r.json()) as ProviderStatus;
       setProviderStatus(d);
-      if (d.provider && d.provider in Object.fromEntries(PROVIDER_OPTIONS.map((p) => [p.id, true]))) {
-        setSettingsProvider(d.provider as ProviderId);
+      if (d.provider) {
+        const uiProvider = normalizeUiProviderId(d.provider);
+        if (uiProvider) setSettingsProvider(uiProvider);
       }
       if (d.model) {
+        userModelOverrideRef.current = true;
         setSettingsModel(d.model);
         setCustomModel(d.model);
       }
@@ -250,6 +274,7 @@ export function useAiProviderSettings({
     // Prefer cached live list; otherwise static default until fetch returns
     const cached = liveModelsByProvider[id];
     const first = cached?.[0]?.id ?? opt.models[0] ?? "";
+    userModelOverrideRef.current = false;
     setSettingsModel(first);
     setCustomModel(id === "openai-compat" ? "" : first);
     setSettingsBaseUrl(opt.baseUrl ?? "");
@@ -525,6 +550,7 @@ export function useAiProviderSettings({
       const data = (await r.json().catch(() => ({}))) as { error?: string };
       if (!r.ok) throw new Error(data.error || `HTTP ${r.status}`);
       setSettingsProvider("openai-compat");
+      userModelOverrideRef.current = true;
       setSettingsModel(modelTag);
       setCustomModel(modelTag);
       setSettingsBaseUrl(baseUrl);
@@ -566,7 +592,7 @@ export function useAiProviderSettings({
     settingsProvider,
     selectProvider,
     settingsModel,
-    setSettingsModel,
+    setSettingsModel: setSettingsModelFromUi,
     settingsApiKey,
     setSettingsApiKey,
     settingsCloudflareAccountId,
@@ -574,7 +600,7 @@ export function useAiProviderSettings({
     settingsBaseUrl,
     setSettingsBaseUrl,
     customModel,
-    setCustomModel,
+    setCustomModel: setCustomModelFromUi,
     displayedModels,
     modelsLoading,
     modelsSource,

--- a/src/components/features/gemini/useAiProviderSettings.ts
+++ b/src/components/features/gemini/useAiProviderSettings.ts
@@ -15,6 +15,72 @@ interface UseAiProviderSettingsOptions {
 
 export type AiProviderSettings = ReturnType<typeof useAiProviderSettings>;
 
+function isLocalAllowEmptyKey(baseUrl: string | undefined): boolean {
+  if (!baseUrl) return false;
+  try {
+    const host = new URL(baseUrl).hostname.replace(/^\[|\]$/g, "").toLowerCase();
+    return host === "localhost" || host === "127.0.0.1" || host === "::1";
+  } catch {
+    return false;
+  }
+}
+
+function validateApiKeyProviderForm(input: {
+  settingsProvider: ProviderId;
+  key: string;
+  model: string;
+  isCompatMode: boolean;
+  resolvedBaseUrl: string | undefined;
+  cloudflareAccountId: string;
+}): string | null {
+  const allowEmptyKey =
+    input.settingsProvider === "openai-compat" || isLocalAllowEmptyKey(input.resolvedBaseUrl);
+  if (input.settingsProvider === "cloudflare") {
+    if (!input.key) return "Enter a Cloudflare API token.";
+    if (!input.cloudflareAccountId) return "Enter a Cloudflare account ID (CLOUDFLARE_ACCOUNT_ID).";
+  } else if (!input.key && !allowEmptyKey) {
+    return "Enter an API key.";
+  }
+  if (!input.model || input.model === "n/a") {
+    return input.isCompatMode ? "Enter a model name." : "Select a model.";
+  }
+  if (input.isCompatMode && !input.resolvedBaseUrl) {
+    return "Base URL is required for OpenAI-compatible providers.";
+  }
+  return null;
+}
+
+async function persistApiKeyProvider(input: {
+  settingsProvider: ProviderId;
+  key: string;
+  model: string;
+  resolvedBaseUrl: string | undefined;
+  cloudflareAccountId: string;
+}): Promise<void> {
+  if (input.settingsProvider === "cloudflare") {
+    const credRes = await fetch("/api/cloudflare/login/manual", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ apiToken: input.key, accountId: input.cloudflareAccountId }),
+    });
+    const credData = (await credRes.json().catch(() => ({}))) as { error?: string };
+    if (!credRes.ok) throw new Error(credData.error || `HTTP ${credRes.status}`);
+  }
+  const r = await fetch("/api/ai/provider", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      provider: input.settingsProvider,
+      apiKey: input.key || undefined,
+      model: input.model,
+      baseUrl: input.resolvedBaseUrl,
+    }),
+  });
+  const contentType = r.headers.get("content-type") ?? "";
+  const data = contentType.includes("application/json") ? await r.json().catch(() => ({})) : {};
+  if (!r.ok) throw new Error((data as { error?: string }).error || `HTTP ${r.status}`);
+}
+
 /**
  * Manages AI provider settings, model catalogs, provider status, and Codex and Devin authentication flows.
  *
@@ -463,63 +529,28 @@ export function useAiProviderSettings({
     const model = isCompatMode ? customModel.trim() || settingsModel : settingsModel;
     const resolvedBaseUrl = settingsBaseUrl.trim() || providerOption.baseUrl || undefined;
     const cloudflareAccountId = settingsCloudflareAccountId.trim();
-    const allowEmptyKey =
-      settingsProvider === "openai-compat" ||
-      (() => {
-        if (!resolvedBaseUrl) return false;
-        try {
-          const host = new URL(resolvedBaseUrl).hostname.replace(/^\[|\]$/g, "").toLowerCase();
-          return host === "localhost" || host === "127.0.0.1" || host === "::1";
-        } catch {
-          return false;
-        }
-      })();
-    if (settingsProvider === "cloudflare") {
-      if (!key) {
-        setProviderSaveError("Enter a Cloudflare API token.");
-        return;
-      }
-      if (!cloudflareAccountId) {
-        setProviderSaveError("Enter a Cloudflare account ID (CLOUDFLARE_ACCOUNT_ID).");
-        return;
-      }
-    } else if (!key && !allowEmptyKey) {
-      setProviderSaveError("Enter an API key.");
-      return;
-    }
-    if (!model || model === "n/a") {
-      setProviderSaveError(isCompatMode ? "Enter a model name." : "Select a model.");
-      return;
-    }
-    if (isCompatMode && !resolvedBaseUrl) {
-      setProviderSaveError("Base URL is required for OpenAI-compatible providers.");
+    const validationError = validateApiKeyProviderForm({
+      settingsProvider,
+      key,
+      model,
+      isCompatMode,
+      resolvedBaseUrl,
+      cloudflareAccountId,
+    });
+    if (validationError) {
+      setProviderSaveError(validationError);
       return;
     }
     setIsSavingProvider(true);
     setProviderSaveError("");
     try {
-      if (settingsProvider === "cloudflare") {
-        const credRes = await fetch("/api/cloudflare/login/manual", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ apiToken: key, accountId: cloudflareAccountId }),
-        });
-        const credData = (await credRes.json().catch(() => ({}))) as { error?: string };
-        if (!credRes.ok) throw new Error(credData.error || `HTTP ${credRes.status}`);
-      }
-      const r = await fetch("/api/ai/provider", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          provider: settingsProvider,
-          apiKey: key || undefined,
-          model,
-          baseUrl: resolvedBaseUrl,
-        }),
+      await persistApiKeyProvider({
+        settingsProvider,
+        key,
+        model,
+        resolvedBaseUrl,
+        cloudflareAccountId,
       });
-      const contentType = r.headers.get("content-type") ?? "";
-      const data = contentType.includes("application/json") ? await r.json().catch(() => ({})) : {};
-      if (!r.ok) throw new Error((data as { error?: string }).error || `HTTP ${r.status}`);
       await fetchProviderStatus();
       setSettingsApiKey("");
       setSettingsCloudflareAccountId("");

--- a/src/lib/__tests__/noNotAModelCopy.test.ts
+++ b/src/lib/__tests__/noNotAModelCopy.test.ts
@@ -58,18 +58,11 @@ describe('copy ban: "(not a model)"', () => {
 });
 
 describe("Assistant provider catalog descriptions", () => {
-  const EM_DASH = "\u2014"; // —
-  const EN_DASH = "\u2013"; // –
-
-  it("keeps subscription blurbs short (no em/en dashes, under 40 chars)", () => {
-    const subs = PROVIDER_OPTIONS.filter((p) => p.category === "subscription");
-    expect(subs.length).toBeGreaterThan(0);
-    for (const p of subs) {
-      const d = p.description ?? "";
-      expect(d, `${p.id}: missing description`).not.toBe("");
-      expect(d, `${p.id}: em dash`).not.toContain(EM_DASH);
-      expect(d, `${p.id}: en dash`).not.toContain(EN_DASH);
-      expect(d.length, `${p.id}: too long (${d.length}): ${d}`).toBeLessThanOrEqual(40);
+  it("does not rely on description suffixes in the provider dropdown", () => {
+    // Dropdown renders names only; descriptions are optional metadata.
+    for (const p of PROVIDER_OPTIONS) {
+      expect(p.name.trim(), `${p.id}: empty name`).not.toBe("");
+      expect(p.name, `${p.id}: name should not embed a colon suffix`).not.toMatch(/: /);
     }
   });
 });

--- a/src/lib/modelCatalogMembership.test.ts
+++ b/src/lib/modelCatalogMembership.test.ts
@@ -33,7 +33,7 @@ describe("getModelCatalogMembership", () => {
 });
 
 describe("modelCatalogMembershipLabel", () => {
-  it("only warns for unrecognized ids", () => {
+  it("only warns for unrecognized ids against a live catalog", () => {
     expect(modelCatalogMembershipLabel({ status: "in-catalog", source: "live" })).toBeNull();
     expect(modelCatalogMembershipLabel({ status: "in-catalog", source: "fallback" })).toBeNull();
     expect(
@@ -41,7 +41,7 @@ describe("modelCatalogMembershipLabel", () => {
     ).toBe("Model ID not recognized. Requests may fail.");
     expect(
       modelCatalogMembershipLabel({ status: "not-in-catalog", source: "fallback" }),
-    ).toBe("Model ID not recognized. Requests may fail.");
+    ).toBeNull();
     expect(modelCatalogMembershipLabel({ status: "empty" })).toBeNull();
   });
 });

--- a/src/lib/modelCatalogMembership.test.ts
+++ b/src/lib/modelCatalogMembership.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import {
+  getModelCatalogMembership,
+  modelCatalogMembershipLabel,
+} from "./modelCatalogMembership";
+
+const catalog = [{ id: "gpt-4o" }, { id: "claude-sonnet" }];
+
+describe("getModelCatalogMembership", () => {
+  it("returns empty for blank input", () => {
+    expect(getModelCatalogMembership("  ", catalog, "live")).toEqual({ status: "empty" });
+  });
+
+  it("returns unknown-source when catalog source is unset", () => {
+    expect(getModelCatalogMembership("gpt-4o", catalog, null)).toEqual({
+      status: "unknown-source",
+    });
+  });
+
+  it("detects ids present in a live catalog", () => {
+    expect(getModelCatalogMembership("gpt-4o", catalog, "live")).toEqual({
+      status: "in-catalog",
+      source: "live",
+    });
+  });
+
+  it("flags freehand ids missing from a live catalog", () => {
+    expect(getModelCatalogMembership("my-fine-tune", catalog, "live")).toEqual({
+      status: "not-in-catalog",
+      source: "live",
+    });
+  });
+});
+
+describe("modelCatalogMembershipLabel", () => {
+  it("only warns for unrecognized ids", () => {
+    expect(modelCatalogMembershipLabel({ status: "in-catalog", source: "live" })).toBeNull();
+    expect(modelCatalogMembershipLabel({ status: "in-catalog", source: "fallback" })).toBeNull();
+    expect(
+      modelCatalogMembershipLabel({ status: "not-in-catalog", source: "live" }),
+    ).toBe("Model ID not recognized. Requests may fail.");
+    expect(
+      modelCatalogMembershipLabel({ status: "not-in-catalog", source: "fallback" }),
+    ).toBe("Model ID not recognized. Requests may fail.");
+    expect(modelCatalogMembershipLabel({ status: "empty" })).toBeNull();
+  });
+});

--- a/src/lib/modelCatalogMembership.ts
+++ b/src/lib/modelCatalogMembership.ts
@@ -32,6 +32,8 @@ export function modelCatalogMembershipLabel(membership: ModelCatalogMembership):
     case "in-catalog":
       return null;
     case "not-in-catalog":
+      // Fallback lists are tiny static defaults; missing there does not mean the id is invalid.
+      if (membership.source !== "live") return null;
       return "Model ID not recognized. Requests may fail.";
     default: {
       const _exhaustive: never = membership;

--- a/src/lib/modelCatalogMembership.ts
+++ b/src/lib/modelCatalogMembership.ts
@@ -1,0 +1,41 @@
+export type ModelCatalogSource = "live" | "fallback";
+
+export type ModelCatalogMembership =
+  | { status: "empty" }
+  | { status: "unknown-source" }
+  | { status: "in-catalog"; source: ModelCatalogSource }
+  | { status: "not-in-catalog"; source: ModelCatalogSource };
+
+/**
+ * Soft membership check against a fetched (or fallback) model catalog.
+ * Does not prove the endpoint will accept the id; only whether it appears in the list we know about.
+ */
+export function getModelCatalogMembership(
+  modelId: string,
+  catalog: ReadonlyArray<{ id: string }>,
+  source: ModelCatalogSource | null,
+): ModelCatalogMembership {
+  const trimmed = modelId.trim();
+  if (!trimmed) return { status: "empty" };
+  if (!source) return { status: "unknown-source" };
+  if (catalog.some((m) => m.id === trimmed)) {
+    return { status: "in-catalog", source };
+  }
+  return { status: "not-in-catalog", source };
+}
+
+/** Short status copy for the model picker membership badge. Warning-only. */
+export function modelCatalogMembershipLabel(membership: ModelCatalogMembership): string | null {
+  switch (membership.status) {
+    case "empty":
+    case "unknown-source":
+    case "in-catalog":
+      return null;
+    case "not-in-catalog":
+      return "Model ID not recognized. Requests may fail.";
+    default: {
+      const _exhaustive: never = membership;
+      return _exhaustive;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Replace router dual dropdown+text fields with a searchable model combobox that lists all models on open and only filters after typing.
- Soft-warn only for unrecognized freehand model IDs; simplify provider dropdown labels; keep OpenAI under Direct API Key providers; rename Codex entry to ChatGPT Plus/Pro OAuth.
- Compact sticky active-provider chrome, and make launch-tauri stop leftover Olive Studio/Tauri processes and free port 3000 (plus ensure dist/ exists).

## Test plan
- [ ] Open Assistant Settings → Cloud, pick OpenRouter/xAI: one model combobox, full list on focus, filter after typing.
- [ ] Type an unknown model id; see amber "Model ID not recognized. Requests may fail." when list is closed.
- [ ] Confirm provider dropdown shows names only; ChatGPT Plus/Pro OAuth under Subscriptions; OpenAI only under Direct API Key Providers.
- [ ] Scroll settings: sticky active provider stays opaque with no content peeking through.
- [ ] Run launch-tauri.ps1 with an existing server on :3000 and confirm it stops leftovers then starts cleanly.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced router model inputs with a searchable combobox and hardened Tauri launch scripts to free port 3000 with repo-scoped, path-boundary cleanup. Prevents accidental model changes on Enter, closes on blur, and avoids killing unrelated or sibling-checkout processes.

- **New Features**
  - Single model combobox for router providers: shows the full catalog on focus, filters after typing, accepts freehand IDs, and soft‑warns only when a live catalog doesn’t recognize the ID.
  - Simplified provider dropdown: names only; OpenAI appears under “Direct API Key Providers”; “Codex” renamed to “ChatGPT Plus/Pro OAuth”.

- **Bug Fixes**
  - Selected model is highlighted on open; freehand input is preserved across catalog refreshes; focus+Enter no longer commits a different model; combobox closes on blur.
  - Sticky active-provider bar is compact and opaque; alias provider IDs are normalized in headers and the status bar.
  - `launch-tauri.ps1/.sh` free port 3000 and stop only this repo’s leftovers with path-boundary checks, skipping self/parent PIDs; run only for dev; create `dist/` if missing; `launch-tauri.cmd` delegates to `launch-tauri.ps1`.

<sup>Written for commit 264549357ea3fe182978784be3cb63b3bf2a2906. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tonythethompson/Olive-Studio/pull/98?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

