### PR TITLE
feat: OpenVINO hardware-panel install flow mirroring TensorRT UX

### DIFF
--- a/e2e/scroll-bounds-guardrail.spec.ts
+++ b/e2e/scroll-bounds-guardrail.spec.ts
@@ -1,0 +1,209 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Guardrail for the scroll-bounds fix in src/index.css.
+ *
+ * The fix intentionally locks `html, body` to
+ *   height: 100%; overflow: hidden; overscroll-behavior: none;
+ * but leaves `#root` alone. The reason: React Portals (Radix Tooltip,
+ * Select content, popovers, …) can target `#root` via `createPortal(node,
+ * document.getElementById('root'))`, and an `overflow: hidden` on `#root`
+ * would silently clip those portals to its box.
+ *
+ * This test mounts a Radix Tooltip portal whose `container` is `#root`,
+ * renders its content far enough outside `#root`'s box that any
+ * overflow-clipping ancestor would hide it, then asserts both:
+ *   (a) `#root` itself stays `overflow: visible`, and
+ *   (b) the portal's content is rendered with a non-zero client rect.
+ *
+ * If a future change widens the lock to include `#root`, both assertions
+ * fail loudly — that is the whole point of the test.
+ */
+test.describe('Scroll-bounds fix — #root must not clip React Portals', () => {
+  test('Radix Tooltip portaled into #root renders unclipped', async ({ page }) => {
+    await page.goto('/');
+    // Wait for the dashboard to mount so React is hydrated and a real
+    // React tree is anchored on #root. Same readiness probe as the
+    // existing tab-flicker spec.
+    await page.locator('#node-btn-input').waitFor({ state: 'visible', timeout: 30_000 });
+
+    // (a) Direct guardrail: the CSS-computed overflow of #root must
+    // remain `visible` (or any non-clipping value). If anyone adds
+    // `#root` to the `html, body { overflow: hidden }` lock, this
+    // assertion fails before any portal can be clipped.
+    const rootOverflow = await page.evaluate(
+      () => getComputedStyle(document.getElementById('root')!).overflow,
+    );
+    expect(
+      rootOverflow,
+      '#root must keep overflow:visible so React Portals targeting #root are not clipped',
+    ).toBe('visible');
+
+    // (b) Mount a Radix Tooltip.Portal whose `container` is `#root` and
+    // whose content is positioned absolutely far outside #root's box.
+    // If #root gained overflow:hidden (or any clipping value), the
+    // absolutely-positioned content would lose all `getClientRects()`
+    // entries. The page.evaluate below also tries a direct-DOM
+    // fallback if the dev server cannot resolve bare ESM imports from
+    // inside the eval scope; either way the same overflow-clipping
+    // contract is asserted.
+    const mount = await page.evaluate(async () => {
+      const root = document.getElementById('root')!;
+      if (!root) throw new Error('#root missing');
+
+      // Hold the appended portal target on a tiny sub-root inside #root,
+      // so we don't disturb the app's own React tree.
+      const host = document.createElement('div');
+      host.id = 'portal-mount-host';
+      host.dataset.testSource = 'guardrail';
+      root.appendChild(host);
+
+      const cssString = [
+        'position: absolute',
+        'left: -9999px',
+        'top: -9999px',
+        'width: 180px',
+        'height: 64px',
+        'background: rgb(141, 168, 64)',
+        'color: white',
+        'padding: 8px 12px',
+        'border-radius: 3px',
+        'font: 600 12px/1 system-ui',
+        'z-index: 2147483647',
+        'pointer-events: none',
+        'display: flex',
+        'align-items: center',
+        'justify-content: center',
+      ].join(';');
+
+      // `style` for React/MDX handoff — CSSProperties-shaped object so any
+      // future Radix typing does not reject it.
+      const reactCss: Record<string, string> = {
+        position: 'absolute',
+        left: '-9999px',
+        top: '-9999px',
+        width: '180px',
+        height: '64px',
+        background: 'rgb(141, 168, 64)',
+        color: 'white',
+        padding: '8px 12px',
+        borderRadius: '3px',
+        font: '600 12px/1 system-ui',
+        zIndex: '2147483647',
+        pointerEvents: 'none',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+      };
+
+      // Strategy A: real Radix Tooltip.Portal with container=#root.
+      // In dev mode Vite serves bare ESM imports through its import map.
+      // The dynamic imports are typed as `any` here to keep TS happy — the
+      // test only asserts DOM-level behaviour, not Radix's type surface.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      let ReactDOMClient: any;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      let RdxTooltip: any;
+      try {
+        ReactDOMClient = await import(/* @vite-ignore */ 'react-dom/client');
+        RdxTooltip = await import(/* @vite-ignore */ '@radix-ui/react-tooltip');
+      } catch (_err) {
+        ReactDOMClient = null;
+        RdxTooltip = null;
+      }
+
+      if (ReactDOMClient && RdxTooltip) {
+        const sub = ReactDOMClient.createRoot(host);
+        sub.render(
+          RdxTooltip.Portal({
+            container: root,
+            children: RdxTooltip.Content({
+              'data-testid': 'rdx-portal-sentinel',
+              // Pass a real CSSProperties-shaped object. eslint is happy
+              // because React runtime accepts both objects and strings.
+              style: reactCss as unknown as React.CSSProperties,
+              children: 'Portal into #root',
+            }),
+          }),
+        );
+        // One tick for React to commit.
+        await new Promise((r) => setTimeout(r, 60));
+        return { mode: 'radix' as const };
+      }
+      // No Radix available in eval scope (typical for Vite dev — the runtime
+      // import map that resolves bare specifiers is not exposed to page.evaluate).
+      // Fall back to a direct-DOM sentinel that proves the same contract.
+      // Strategy B fallback: plain DOM sentinel. Same contract, no
+      // dependency on ResolvedRadix being importable inside eval.
+      // The CSS-computed-style guardrail above already covers the
+      // regression; this branch just keeps the rect assertion alive
+      // when Radix can't be reached.
+      const probe = document.createElement('div');
+      probe.dataset.testid = 'rdx-portal-sentinel';
+      probe.textContent = 'Portal into #root';
+      probe.style.cssText = cssString;
+      root.appendChild(probe);
+      return {
+        mode: 'dom-fallback' as const,
+        rdxError: 'Radix bare imports did not resolve inside page.evaluate',
+      };
+    });
+
+    // Diagnostic for the fallback path — surface the import error so a
+    // future breakage is easy to triage.
+    if (mount.mode === 'dom-fallback') {
+      console.warn(
+        `[scroll-bounds guardrail] Radix bare import unavailable in eval scope, ` +
+          `using direct-DOM sentinel. Reason: ${mount.rdxError}`,
+      );
+    }
+
+    // Force layout settle before measuring.
+    await page.evaluate(() => {
+      void document.body.offsetHeight;
+    });
+
+    // (c) The sentinel must exist, be a descendant of #root, and —
+    // critically — have at least one clientRect. An absolute-positioned
+    // child at translate(-9999,-9999) bleeds outside any parent's clip
+    // box; if #root had `overflow:hidden`, the element's `getClientRects()`
+    // would be empty.
+    const probe = await page.evaluate(() => {
+      const el = document.querySelector(
+        '[data-testid="rdx-portal-sentinel"]',
+      ) as HTMLElement | null;
+      if (!el) return null;
+      const rects = el.getClientRects();
+      const bbox = el.getBoundingClientRect();
+      return {
+        found: true,
+        inRoot: !!el.closest('#root'),
+        rectsCount: rects.length,
+        firstRect:
+          rects.length > 0
+            ? { width: rects[0]!.width, height: rects[0]!.height }
+            : null,
+        bboxWidth: bbox.width,
+        bboxHeight: bbox.height,
+      };
+    });
+
+    expect(
+      probe,
+      'Sentinel element must exist in the DOM after the mount step',
+    ).not.toBeNull();
+    expect(probe!.found).toBe(true);
+    expect(
+      probe!.inRoot,
+      'Sentinel must be a descendant of #root — proves the Radix portal container was honoured',
+    ).toBe(true);
+    expect(
+      probe!.rectsCount,
+      `Sentinel must render ≥1 clientRect — empty clientRects() implies #root ` +
+        `now has overflow:hidden and is silently clipping the portal. ` +
+        `Mount mode: ${mount.mode}`,
+    ).toBeGreaterThan(0);
+    expect(probe!.bboxWidth).toBeGreaterThan(50);
+    expect(probe!.bboxHeight).toBeGreaterThan(20);
+  });
+});

--- a/e2e/scroll-bounds-guardrail.spec.ts
+++ b/e2e/scroll-bounds-guardrail.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from "@playwright/test";
 
 /**
  * Guardrail for the scroll-bounds fix in src/index.css.
@@ -10,148 +10,143 @@ import { test, expect } from '@playwright/test';
  * document.getElementById('root'))`, and an `overflow: hidden` on `#root`
  * would silently clip those portals to its box.
  *
- * This test mounts a Radix Tooltip portal whose `container` is `#root`,
- * renders its content far enough outside `#root`'s box that any
+ * This test mounts a Radix Tooltip hierarchy whose portal `container` is
+ * `#root`, renders its content far enough outside `#root`'s box that any
  * overflow-clipping ancestor would hide it, then asserts both:
  *   (a) `#root` itself stays `overflow: visible`, and
- *   (b) the portal's content is rendered with a non-zero client rect.
+ *   (b) the portal's content renders unclipped at paint time — verified
+ *       via `document.elementFromPoint(...)` so we catch the case where an
+ *       ancestor's `overflow: hidden` clips the box visually even though
+ *       `getClientRects()` still returns the original coordinates.
  *
  * If a future change widens the lock to include `#root`, both assertions
  * fail loudly — that is the whole point of the test.
  */
-test.describe('Scroll-bounds fix — #root must not clip React Portals', () => {
-  test('Radix Tooltip portaled into #root renders unclipped', async ({ page }) => {
-    await page.goto('/');
+test.describe("Scroll-bounds fix — #root must not clip React Portals", () => {
+  test("Radix Tooltip portaled into #root renders unclipped at paint time", async ({ page }) => {
+    await page.goto("/");
     // Wait for the dashboard to mount so React is hydrated and a real
-    // React tree is anchored on #root. Same readiness probe as the
-    // existing tab-flicker spec.
-    await page.locator('#node-btn-input').waitFor({ state: 'visible', timeout: 30_000 });
+    // React tree is anchored on #root.
+    await page.locator("#node-btn-input").waitFor({ state: "visible", timeout: 30_000 });
 
     // (a) Direct guardrail: the CSS-computed overflow of #root must
     // remain `visible` (or any non-clipping value). If anyone adds
     // `#root` to the `html, body { overflow: hidden }` lock, this
     // assertion fails before any portal can be clipped.
     const rootOverflow = await page.evaluate(
-      () => getComputedStyle(document.getElementById('root')!).overflow,
+      () => getComputedStyle(document.getElementById("root")!).overflow,
     );
     expect(
       rootOverflow,
-      '#root must keep overflow:visible so React Portals targeting #root are not clipped',
-    ).toBe('visible');
+      "#root must keep overflow:visible so React Portals targeting #root are not clipped",
+    ).toBe("visible");
 
-    // (b) Mount a Radix Tooltip.Portal whose `container` is `#root` and
-    // whose content is positioned absolutely far outside #root's box.
-    // If #root gained overflow:hidden (or any clipping value), the
-    // absolutely-positioned content would lose all `getClientRects()`
-    // entries. The page.evaluate below also tries a direct-DOM
-    // fallback if the dev server cannot resolve bare ESM imports from
-    // inside the eval scope; either way the same overflow-clipping
-    // contract is asserted.
+    // (b) Mount a Radix Tooltip hierarchy whose portal `container` is
+    // `#root`. Earlier drafts called `RdxTooltip.Portal(...)` /
+    // `Content(...)` as plain functions outside the JSX reconciler,
+    // which silently missed Radix's Provider context and never mounted
+    // the sentinel. Drive the tree through `React.createElement` so
+    // every level participates in React reconciliation.
+    //
+    // The mount step also tries a direct-DOM fallback if the dev server
+    // cannot resolve bare ESM imports from inside the eval scope. Both
+    // branches must honour the same overflow-clipping contract.
     const mount = await page.evaluate(async () => {
-      const root = document.getElementById('root')!;
-      if (!root) throw new Error('#root missing');
+      let mountError: string | null = null;
+      const root = document.getElementById("root")!;
+      if (!root) throw new Error("#root missing");
 
-      // Hold the appended portal target on a tiny sub-root inside #root,
-      // so we don't disturb the app's own React tree.
-      const host = document.createElement('div');
-      host.id = 'portal-mount-host';
-      host.dataset.testSource = 'guardrail';
+      const host = document.createElement("div");
+      host.id = "portal-mount-host";
+      host.dataset.testSource = "guardrail";
       root.appendChild(host);
 
-      const cssString = [
-        'position: absolute',
-        'left: -9999px',
-        'top: -9999px',
-        'width: 180px',
-        'height: 64px',
-        'background: rgb(141, 168, 64)',
-        'color: white',
-        'padding: 8px 12px',
-        'border-radius: 3px',
-        'font: 600 12px/1 system-ui',
-        'z-index: 2147483647',
-        'pointer-events: none',
-        'display: flex',
-        'align-items: center',
-        'justify-content: center',
-      ].join(';');
-
-      // `style` for React/MDX handoff — CSSProperties-shaped object so any
-      // future Radix typing does not reject it.
-      const reactCss: Record<string, string> = {
-        position: 'absolute',
-        left: '-9999px',
-        top: '-9999px',
-        width: '180px',
-        height: '64px',
-        background: 'rgb(141, 168, 64)',
-        color: 'white',
-        padding: '8px 12px',
-        borderRadius: '3px',
-        font: '600 12px/1 system-ui',
-        zIndex: '2147483647',
-        pointerEvents: 'none',
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
+      const sentinelStyle: Record<string, string> = {
+        position: "absolute",
+        left: "-9999px",
+        top: "-9999px",
+        width: "180px",
+        height: "64px",
+        background: "rgb(141, 168, 64)",
+        color: "white",
+        padding: "8px 12px",
+        borderRadius: "3px",
+        font: "600 12px/1 system-ui",
+        zIndex: "2147483647",
+        pointerEvents: "none",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
       };
 
-      // Strategy A: real Radix Tooltip.Portal with container=#root.
-      // In dev mode Vite serves bare ESM imports through its import map.
-      // The dynamic imports are typed as `any` here to keep TS happy — the
-      // test only asserts DOM-level behaviour, not Radix's type surface.
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      let ReactDOMClient: any;
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      let RdxTooltip: any;
+      let ReactDOMClient: any = null;
+      let RdxTooltip: any = null;
+      let React: any = null;
       try {
-        ReactDOMClient = await import(/* @vite-ignore */ 'react-dom/client');
-        RdxTooltip = await import(/* @vite-ignore */ '@radix-ui/react-tooltip');
-      } catch (_err) {
-        ReactDOMClient = null;
-        RdxTooltip = null;
+        React = await import(/* @vite-ignore */ "react");
+        ReactDOMClient = await import(/* @vite-ignore */ "react-dom/client");
+        RdxTooltip = await import(/* @vite-ignore */ "@radix-ui/react-tooltip");
+      } catch (err) {
+        mountError = err instanceof Error ? `${err.name}: ${err.message}` : String(err);
       }
 
-      if (ReactDOMClient && RdxTooltip) {
+      if (React && ReactDOMClient && RdxTooltip) {
         const sub = ReactDOMClient.createRoot(host);
+        // Build the React element tree with createElement so it goes
+        // through the JSX reconciler — Radix rejects plain function
+        // calls because the Provider context never wires up.
         sub.render(
-          RdxTooltip.Portal({
-            container: root,
-            children: RdxTooltip.Content({
-              'data-testid': 'rdx-portal-sentinel',
-              // Pass a real CSSProperties-shaped object. eslint is happy
-              // because React runtime accepts both objects and strings.
-              style: reactCss as unknown as React.CSSProperties,
-              children: 'Portal into #root',
-            }),
-          }),
+          React.createElement(
+            RdxTooltip.Provider,
+            null,
+            React.createElement(
+              RdxTooltip.Root,
+              { open: true },
+              React.createElement(
+                RdxTooltip.Trigger,
+                { asChild: true },
+                React.createElement("button", { type: "button" }, "open"),
+              ),
+              React.createElement(
+                RdxTooltip.Portal,
+                { container: root },
+                React.createElement(
+                  RdxTooltip.Content,
+                  {
+                    "data-testid": "rdx-portal-sentinel",
+                    style: sentinelStyle as unknown as React.CSSProperties,
+                    side: "bottom",
+                    sideOffset: 0,
+                  },
+                  "Portal into #root",
+                ),
+              ),
+            ),
+          ),
         );
-        // One tick for React to commit.
-        await new Promise((r) => setTimeout(r, 60));
-        return { mode: 'radix' as const };
+        // Two ticks for Radix's Provider/effect chain to commit.
+        await new Promise((r) => setTimeout(r, 120));
+        return { mode: "radix" as const };
       }
-      // No Radix available in eval scope (typical for Vite dev — the runtime
-      // import map that resolves bare specifiers is not exposed to page.evaluate).
-      // Fall back to a direct-DOM sentinel that proves the same contract.
-      // Strategy B fallback: plain DOM sentinel. Same contract, no
-      // dependency on ResolvedRadix being importable inside eval.
-      // The CSS-computed-style guardrail above already covers the
-      // regression; this branch just keeps the rect assertion alive
-      // when Radix can't be reached.
-      const probe = document.createElement('div');
-      probe.dataset.testid = 'rdx-portal-sentinel';
-      probe.textContent = 'Portal into #root';
-      probe.style.cssText = cssString;
+      // Fallback: no Radix available in eval scope (typical for Vite
+      // dev — the runtime import map that resolves bare specifiers is
+      // not exposed to page.evaluate). Strategy B uses a direct-DOM
+      // sentinel and PRESERVES the real import-error string so a
+      // future failure is filed with enough context to triage at the
+      // source.
+      const probe = document.createElement("div");
+      probe.dataset.testid = "rdx-portal-sentinel";
+      probe.textContent = "Portal into #root";
+      Object.assign(probe.style, sentinelStyle);
       root.appendChild(probe);
       return {
-        mode: 'dom-fallback' as const,
-        rdxError: 'Radix bare imports did not resolve inside page.evaluate',
+        mode: "dom-fallback" as const,
+        rdxError: mountError ?? "Radix bare imports did not resolve inside page.evaluate",
       };
     });
 
-    // Diagnostic for the fallback path — surface the import error so a
-    // future breakage is easy to triage.
-    if (mount.mode === 'dom-fallback') {
+    if (mount.mode === "dom-fallback") {
+      // eslint-disable-next-line no-console -- intentional guardrail diagnostic
       console.warn(
         `[scroll-bounds guardrail] Radix bare import unavailable in eval scope, ` +
           `using direct-DOM sentinel. Reason: ${mount.rdxError}`,
@@ -164,10 +159,18 @@ test.describe('Scroll-bounds fix — #root must not clip React Portals', () => {
     });
 
     // (c) The sentinel must exist, be a descendant of #root, and —
-    // critically — have at least one clientRect. An absolute-positioned
-    // child at translate(-9999,-9999) bleeds outside any parent's clip
-    // box; if #root had `overflow:hidden`, the element's `getClientRects()`
-    // would be empty.
+    // most importantly — still be paint-hit-testable at its bbox
+    // position. An absolute-positioned child at translate(-9999,-9999)
+    // bleeds outside any parent's clip box; if #root had
+    // `overflow:hidden`, two things would happen:
+    //   (1) getClientRects() / bbox still report the original
+    //       coordinates (rects aren't affected by clip), so a
+    //       rect-only check CANNOT detect clipping.
+    //   (2) document.elementFromPoint(centerX, centerY) would return
+    //       some other element (or null), because the clip hides the
+    //       paint at that coordinate.
+    // So we layer both: a rect check (proves mounting succeeded) and a
+    // hit-test check (proves visibility through any clip path).
     const probe = await page.evaluate(() => {
       const el = document.querySelector(
         '[data-testid="rdx-portal-sentinel"]',
@@ -177,7 +180,7 @@ test.describe('Scroll-bounds fix — #root must not clip React Portals', () => {
       const bbox = el.getBoundingClientRect();
       return {
         found: true,
-        inRoot: !!el.closest('#root'),
+        inRoot: !!el.closest("#root"),
         rectsCount: rects.length,
         firstRect:
           rects.length > 0
@@ -190,20 +193,56 @@ test.describe('Scroll-bounds fix — #root must not clip React Portals', () => {
 
     expect(
       probe,
-      'Sentinel element must exist in the DOM after the mount step',
+      `Sentinel element must exist in the DOM after the mount step (mode=${mount.mode})`,
     ).not.toBeNull();
     expect(probe!.found).toBe(true);
     expect(
       probe!.inRoot,
-      'Sentinel must be a descendant of #root — proves the Radix portal container was honoured',
+      "Sentinel must be a descendant of #root — proves the Radix portal container was honoured",
     ).toBe(true);
     expect(
       probe!.rectsCount,
-      `Sentinel must render ≥1 clientRect — empty clientRects() implies #root ` +
-        `now has overflow:hidden and is silently clipping the portal. ` +
+      `Sentinel must render ≥1 clientRect — empty clientRects() implies it never mounted. ` +
         `Mount mode: ${mount.mode}`,
     ).toBeGreaterThan(0);
     expect(probe!.bboxWidth).toBeGreaterThan(50);
     expect(probe!.bboxHeight).toBeGreaterThan(20);
+
+    // Paint-time hit test. elementFromPoint at the bbox centre must
+    // resolve to either the sentinel itself or one of its ancestors up
+    // to #root (Radix may wrap the Content). NOT some other element in
+    // #root (or null) that has clipped over its top via an
+    // `overflow:hidden` ancestor.
+    const hitOk = await page.evaluate(() => {
+      const el = document.querySelector(
+        '[data-testid="rdx-portal-sentinel"]',
+      ) as HTMLElement | null;
+      if (!el) return false;
+      const bbox = el.getBoundingClientRect();
+      const centerX = bbox.left + bbox.width / 2;
+      const centerY = bbox.top + bbox.height / 2;
+      const hit = document.elementFromPoint(centerX, centerY);
+      if (!hit) return false;
+      let cur: HTMLElement | null = hit as HTMLElement;
+      let depth = 0;
+      while (cur && depth < 6) {
+        if (cur === el) return true;
+        cur = cur.parentElement;
+        depth += 1;
+      }
+      return false;
+    });
+
+    expect(
+      hitOk,
+      `Sentinel must be the topmost element at its getBoundingClientRect centre. ` +
+        `If elementFromPoint(...) returns a different node, an ancestor of #root ` +
+        `now has overflow:hidden and is silently clipping the portal. ` +
+        `Mount mode: ${mount.mode}`,
+    ).toBe(true);
+
+    await expect(
+      page.locator('[data-testid="rdx-portal-sentinel"]'),
+    ).toBeAttached();
   });
 });

--- a/server.ts
+++ b/server.ts
@@ -12,6 +12,7 @@ import { mountOliveRoutes } from "./src/server/routes/olive.ts";
 import { mountArenaRoutes } from "./src/server/routes/arena.ts";
 import { probeTensorRtLoadable } from "./src/server/services/olive/tensorrt.ts";
 import { probeTensorRtRtxLoadable } from "./src/server/services/olive/tensorrt-rtx.ts";
+import { probeOpenVino } from "./src/server/services/olive/openvino.ts";
 import { staticServeRateLimit } from "./src/server/middleware/rateLimit.ts";
 
 // After imports: hydrate .env / .env.local / Windows User+Machine API keys into process.env.
@@ -98,6 +99,7 @@ const systemRouter = Router();
 const systemProbeOpts: SystemProbeOptions = {
   probeTensorRtLoadable,
   probeTensorRtRtxLoadable,
+  probeOpenVino,
 };
 mountSystemRoutes(systemRouter, systemProbeOpts);
 app.use("/api", systemRouter);

--- a/server.ts
+++ b/server.ts
@@ -2,6 +2,17 @@ import express, { Router } from "express";
 import path from "path";
 import { createServer as createViteServer } from "vite";
 import fs from "fs";
+
+/**
+ * Catch `.venv.bak`, `.venv.old`, `.venv-rename`, etc. in addition to the
+ * canonical `.venv`. Plain glob `'**' + '/.venv/' + '**'` only matches
+ * `.venv` as an exact path component, so renaming or backing up the venv
+ * directory reintroduces file-watch noise: pip writes inside the renamed
+ * folder used to fire reload events. This regex sits alongside the glob in
+ * the `ignored` array (chokidar accepts strings, RegExp, and functions
+ * mixed).
+ */
+const ANY_DOT_VENV_DIR = /(?:^|[\\/])\.venv(?:[._-][^\\/]+)?(?:[\\/]|$)/;
 import { loadStudioEnv } from "./src/server/loadStudioEnv.ts";
 import { mountSystemRoutes, type SystemProbeOptions } from "./src/server/routes/system.ts";
 import { mountGithubRoutes } from "./src/server/routes/github.ts";
@@ -159,7 +170,13 @@ async function startServer() {
       server: {
         middlewareMode: true,
         watch: {
-          ignored: ["**/.venv/**", "**/node_modules/**", "**/models/**", "**/.cache/**"],
+          ignored: [
+            "**/.venv/**",
+            ANY_DOT_VENV_DIR,
+            "**/node_modules/**",
+            "**/models/**",
+            "**/.cache/**",
+          ],
         },
       },
       appType: "spa",

--- a/server.ts
+++ b/server.ts
@@ -2,17 +2,8 @@ import express, { Router } from "express";
 import path from "path";
 import { createServer as createViteServer } from "vite";
 import fs from "fs";
+import { ANY_DOT_VENV_DIR } from "./src/server/shared/anyDotVenvDir.ts";
 
-/**
- * Catch `.venv.bak`, `.venv.old`, `.venv-rename`, etc. in addition to the
- * canonical `.venv`. Plain glob `'**' + '/.venv/' + '**'` only matches
- * `.venv` as an exact path component, so renaming or backing up the venv
- * directory reintroduces file-watch noise: pip writes inside the renamed
- * folder used to fire reload events. This regex sits alongside the glob in
- * the `ignored` array (chokidar accepts strings, RegExp, and functions
- * mixed).
- */
-const ANY_DOT_VENV_DIR = /(?:^|[\\/])\.venv(?:[._-][^\\/]+)?(?:[\\/]|$)/;
 import { loadStudioEnv } from "./src/server/loadStudioEnv.ts";
 import { mountSystemRoutes, type SystemProbeOptions } from "./src/server/routes/system.ts";
 import { mountGithubRoutes } from "./src/server/routes/github.ts";

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -101,7 +101,21 @@ function Dashboard() {
       if (isOliveRunning && id !== "execute" && id !== "playground") return;
       setActiveView(id);
       scrollingToRef.current = id;
-      document.getElementById(id)?.scrollIntoView({ behavior: "smooth", block: "start" });
+      const main = mainRef.current;
+      const target = document.getElementById(id);
+      if (!target) return;
+      // Resolve where we want to scroll to. `scroll-margin-top: 1rem` on
+      // each section gives us 16px of headroom above the section, so the
+      // ideal landing is `target.offsetTop - 16`. Browsers normally do this
+      // via `scrollIntoView({block:"start"})`, but they clamp to maxScroll
+      // and that leaves the *previous* section's tail visible above the
+      // targeted section's header when the target is short (Playground).
+      // The min-height on the last section keeps the target reachable, so
+      // we set `scrollTop` explicitly to honor the same offset without the
+      // pre-section bleed.
+      const top = target.offsetTop - 16;
+      const max = main ? main.scrollHeight - main.clientHeight : top;
+      main?.scrollTo({ top: Math.max(0, Math.min(top, max)), behavior: "smooth" });
       window.setTimeout(() => {
         if (scrollingToRef.current === id) scrollingToRef.current = null;
       }, 900);
@@ -258,21 +272,36 @@ function Dashboard() {
                     <span className="hidden sm:inline">Assistant</span>
                   </button>
                 </div>
-              </header>
-
-              <main
+              </header>                              <main
                 ref={mainRef}
                 id="main"
-                className="flex-1 overflow-y-auto overflow-x-hidden px-3 py-5 wide:px-6 wide:py-8 min-[1000px]:px-10 h-full min-w-0"
+                className="flex-1 overflow-x-hidden overflow-y-auto overscroll-contain px-3 py-5 wide:px-6 wide:py-8 min-[1000px]:px-10 h-full min-w-0"
               >
                 <h1 className="sr-only">Olive Studio recipe builder</h1>
-                <div className="mx-auto w-full max-w-5xl min-w-0 pb-16">
-                  {SECTIONS.map(({ id, step, label, desc }, index) => (
+                <div className="mx-auto w-full max-w-5xl min-w-0">
+                  {SECTIONS.map(({ id, step, label, desc }, index) => {
+                    const isLast = index === SECTIONS.length - 1;
+                    return (
                     <section
                       key={id}
                       id={id}
                       aria-labelledby={`${id}-heading`}
-                      className={cn("scroll-mt-4", index > 0 && "mt-12 pt-10 border-t border-slate-800")}
+                      data-pipeline-section={id}
+                      className={cn(
+                        "scroll-mt-4",
+                        index > 0 && "mt-12 pt-10 border-t border-slate-800",
+                        // The final pipeline section must be tall enough that
+                        // `scrollIntoView({block:"start"})` can land its top at
+                        // the scroll-container's top without being clamped to
+                        // `maxScroll`. Otherwise the user sees the tail of the
+                        // previous section (visible as empty gray) above the
+                        // playground header, which reads as "the app rolled
+                        // past the section". Height covers title bar + header
+                        // + post-section breathing room; uses the dynamic
+                        // viewport unit so browser chrome (URL bar, devtools)
+                        // does not leave the section short.
+                        isLast && "min-h-[calc(100dvh-3rem)] pb-16",
+                      )}
                     >
                       <header className="mb-5 pb-4 border-b border-slate-800/80">
                         <p className="text-xs text-electric-blue mb-1">{step}</p>
@@ -317,7 +346,8 @@ function Dashboard() {
                         </ErrorBoundary>
                       )}
                     </section>
-                  ))}
+                    );
+                  })}
                 </div>
               </main>
             </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -103,19 +103,14 @@ function Dashboard() {
       scrollingToRef.current = id;
       const main = mainRef.current;
       const target = document.getElementById(id);
-      if (!target) return;
-      // Resolve where we want to scroll to. `scroll-margin-top: 1rem` on
-      // each section gives us 16px of headroom above the section, so the
-      // ideal landing is `target.offsetTop - 16`. Browsers normally do this
-      // via `scrollIntoView({block:"start"})`, but they clamp to maxScroll
-      // and that leaves the *previous* section's tail visible above the
-      // targeted section's header when the target is short (Playground).
-      // The min-height on the last section keeps the target reachable, so
-      // we set `scrollTop` explicitly to honor the same offset without the
-      // pre-section bleed.
-      const top = target.offsetTop - 16;
-      const max = main ? main.scrollHeight - main.clientHeight : top;
-      main?.scrollTo({ top: Math.max(0, Math.min(top, max)), behavior: "smooth" });
+      if (!main || !target) return;
+      // Resolve the target position relative to the scroll container. Using
+      // offsetTop here would depend on the element's offsetParent.
+      const mainTop = main.getBoundingClientRect().top;
+      const targetTop = target.getBoundingClientRect().top;
+      const top = targetTop - mainTop + main.scrollTop - 16;
+      const max = main.scrollHeight - main.clientHeight;
+      main.scrollTo({ top: Math.max(0, Math.min(top, max)), behavior: "smooth" });
       window.setTimeout(() => {
         if (scrollingToRef.current === id) scrollingToRef.current = null;
       }, 900);

--- a/src/components/features/HardwareProviderCard.tsx
+++ b/src/components/features/HardwareProviderCard.tsx
@@ -1,0 +1,673 @@
+/**
+ * Single IHV provider selection card (conflicts, install CTAs, local detection).
+ * Extracted from IHVIntegrationPanel to keep that panel under CodeFactor complexity limits.
+ */
+import type { ReactNode } from "react";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui";
+import type { OpenVinoInstallState } from "@/components/features/useOpenVinoInstall";
+import {
+  applyProviderConflictAutofixes,
+  getProviderConflicts,
+  getProviderHardwareBlock,
+  prepareProviderChange,
+  type HardwareConflict,
+} from "@/lib/pipelineValidation";
+import {
+  isProviderDetectedLocally,
+  type HardwareProbeResult,
+} from "@/lib/hardwareProbe";
+import type { ProviderCatalogEntry } from "@/lib/providerCatalog";
+import {
+  OPEN_VINO_GPU_DRIVER_URL,
+  OPEN_VINO_NPU_DRIVER_URL,
+} from "@/lib/openvinoDeps";
+import type { IHVProvider, UIState } from "@/types";
+import {
+  AlertTriangle,
+  Wand2,
+  CheckCircle,
+  AlertCircle,
+  RefreshCw,
+  XCircle,
+  Globe,
+} from "lucide-react";
+
+export interface HardwareProviderCardProps {
+  provider: ProviderCatalogEntry;
+  state: UIState;
+  setState: (partial: Partial<UIState>) => void;
+  hardwareProbe: HardwareProbeResult | null;
+  probeLoading: boolean;
+  detectedProviders: IHVProvider[];
+  trtRtxNeedsInstall: boolean;
+  trtNeedsInstall: boolean;
+  openvinoNeedsInstall: boolean;
+  hardwareInstallBusy: boolean;
+  installingTrtRtx: boolean;
+  installTrtRtxError: string | null;
+  installTrtRtxLog: string[];
+  onInstallTensorRtRtx: () => void;
+  installingTrt: boolean;
+  installTrtError: string | null;
+  installTrtLog: string[];
+  onInstallTensorRt: () => void;
+  openvinoInstall: {
+    state: OpenVinoInstallState;
+    install: () => Promise<void>;
+  };
+}
+
+function resolveCardChrome(input: {
+  isSelected: boolean;
+  cardBlocked: boolean;
+  cardHardwareBlocked: boolean;
+  cardHasCritical: boolean;
+  cardHasWarning: boolean;
+  isWebGpuTarget: boolean;
+  detectedLocally: boolean;
+  probeLoading: boolean;
+  needsPluginInstall: boolean;
+}): {
+  cardClasses: string;
+  badgeText: string;
+  BadgeIcon: typeof CheckCircle | null;
+  badgeColor: string;
+} {
+  const base =
+    "relative flex flex-col rounded-xl border p-4.5 transition-all duration-200 cursor-pointer min-w-0 max-w-full overflow-hidden ";
+  const {
+    isSelected,
+    cardBlocked,
+    cardHardwareBlocked,
+    cardHasCritical,
+    cardHasWarning,
+    isWebGpuTarget,
+    detectedLocally,
+    probeLoading,
+    needsPluginInstall,
+  } = input;
+
+  if (isSelected) {
+    if (cardBlocked) {
+      return {
+        cardClasses: base + "border-rose-500 bg-rose-500/5",
+        badgeText: cardHardwareBlocked ? "Unavailable hardware" : "Critical Conflict",
+        BadgeIcon: XCircle,
+        badgeColor: "bg-rose-500/10 text-rose-400 border-rose-550/25",
+      };
+    }
+    if (cardHasWarning) {
+      return {
+        cardClasses: base + "border-amber-500 bg-amber-500/5",
+        badgeText: "Warning Conflict",
+        BadgeIcon: AlertTriangle,
+        badgeColor: "bg-amber-500/10 text-amber-400 border-amber-550/25",
+      };
+    }
+    return {
+      cardClasses: base + "border-electric-blue bg-electric-blue/5",
+      badgeText:
+        !detectedLocally && !probeLoading && !isWebGpuTarget
+          ? "Active (not local)"
+          : isWebGpuTarget
+            ? "Active (browser target)"
+            : "Active Target",
+      BadgeIcon: CheckCircle,
+      badgeColor: "bg-electric-blue/10 text-electric-blue border-electric-blue/20",
+    };
+  }
+
+  if (isWebGpuTarget) {
+    return {
+      cardClasses: base + "border-slate-800/80 bg-slate-900/40 hover:bg-slate-900 hover:border-slate-700",
+      badgeText: "Browser deploy target",
+      BadgeIcon: Globe,
+      badgeColor: "bg-slate-800/80 text-slate-300 border-slate-700/60",
+    };
+  }
+  if (cardHardwareBlocked) {
+    return {
+      cardClasses:
+        base + "border-rose-950/35 bg-zinc-950/40 opacity-55 hover:opacity-75 hover:border-slate-700",
+      badgeText: "Not on this system",
+      BadgeIcon: XCircle,
+      badgeColor: "bg-rose-500/5 text-rose-400/80 border-rose-550/15",
+    };
+  }
+  if (needsPluginInstall && detectedLocally) {
+    return {
+      cardClasses: base + "border-amber-900/40 bg-amber-950/10 opacity-95 hover:border-amber-500/40",
+      badgeText: "Plugin install needed",
+      BadgeIcon: AlertTriangle,
+      badgeColor: "bg-amber-500/10 text-amber-400 border-amber-500/20",
+    };
+  }
+  if (!detectedLocally && !probeLoading) {
+    return {
+      cardClasses:
+        base + "border-slate-850/60 bg-zinc-950/30 opacity-80 hover:opacity-100 hover:border-slate-700",
+      badgeText: "Not on this system",
+      BadgeIcon: AlertCircle,
+      badgeColor: "bg-slate-800/80 text-slate-500 border-slate-700/60",
+    };
+  }
+  if (cardHasCritical) {
+    return {
+      cardClasses:
+        base + "border-rose-950/35 bg-zinc-950/40 opacity-55 hover:opacity-100 hover:border-rose-500/40",
+      badgeText: "Incompatible",
+      BadgeIcon: XCircle,
+      badgeColor: "bg-rose-500/5 text-rose-400/80 border-rose-550/15",
+    };
+  }
+  if (cardHasWarning) {
+    return {
+      cardClasses:
+        base + "border-amber-950/35 bg-zinc-950/40 opacity-75 hover:opacity-100 hover:border-amber-500/40",
+      badgeText: "Needs Adjust",
+      BadgeIcon: AlertTriangle,
+      badgeColor: "bg-amber-500/5 text-amber-400/80 border-amber-550/15",
+    };
+  }
+  return {
+    cardClasses: base + "border-slate-800/80 bg-slate-900/40 hover:bg-slate-900 hover:border-slate-700",
+    badgeText: "Compatible with active passes",
+    BadgeIcon: CheckCircle,
+    badgeColor: "bg-emerald-500/10 text-emerald-400 border-emerald-500/15",
+  };
+}
+
+function hardwareDetailFor(
+  providerId: IHVProvider,
+  hardwareProbe: HardwareProbeResult | null,
+): string | null {
+  if (
+    providerId === "CUDAExecutionProvider" ||
+    providerId === "NvTensorRTRTXExecutionProvider" ||
+    providerId === "TensorrtExecutionProvider"
+  ) {
+    return hardwareProbe?.nvidia?.gpus.map((g) => g.name).join(", ") ?? null;
+  }
+  if (providerId === "ROCMExecutionProvider") {
+    return hardwareProbe?.rocm?.gpus.map((g) => g.name).join(", ") ?? null;
+  }
+  if (providerId === "OpenVINOExecutionProvider" && hardwareProbe?.openvino?.version) {
+    const devices = hardwareProbe.openvino.devices?.length
+      ? ` (${hardwareProbe.openvino.devices.join(", ")})`
+      : "";
+    return `OpenVINO ${hardwareProbe.openvino.version}${devices}`.trim();
+  }
+  if (providerId === "CPUExecutionProvider" && hardwareProbe) {
+    return hardwareProbe.platform.cpuModel;
+  }
+  return null;
+}
+
+function selectProvider(
+  providerId: IHVProvider,
+  state: UIState,
+  setState: (partial: Partial<UIState>) => void,
+  hardwareProbe: HardwareProbeResult | null,
+  detectedProviders: IHVProvider[],
+  pConflicts: HardwareConflict[],
+  isSelected: boolean,
+): void {
+  if (isSelected && pConflicts.length > 0) {
+    setState({ passes: applyProviderConflictAutofixes(providerId, state.passes) });
+    return;
+  }
+  const detected = detectedProviders.includes(providerId);
+  if (!detected) {
+    setState({ ihvProvider: providerId });
+    return;
+  }
+  const patch = prepareProviderChange(state, providerId, hardwareProbe);
+  if (patch) setState(patch);
+}
+
+function PluginInstallBlock({
+  description,
+  detail,
+  busy,
+  installing,
+  installLabel,
+  installingLabel,
+  onInstall,
+  error,
+  log,
+}: {
+  description: ReactNode;
+  detail?: string | null;
+  busy: boolean;
+  installing: boolean;
+  installLabel: string;
+  installingLabel: string;
+  onInstall: () => void;
+  error: string | null;
+  log: string[];
+}) {
+  return (
+    <div className="mt-2 space-y-1.5 min-w-0" onClick={(e) => e.stopPropagation()}>
+      <p className="text-[11px] text-amber-400/90 leading-relaxed">{description}</p>
+      {detail ? (
+        <p className="text-[10px] text-slate-500 font-mono break-all max-w-full" title={detail}>
+          {detail}
+        </p>
+      ) : null}
+      <button
+        type="button"
+        disabled={busy}
+        onClick={onInstall}
+        className="h-7 px-3 rounded border border-amber-500/40 text-amber-300 bg-amber-500/10 hover:bg-amber-500/20 text-[11px] font-bold disabled:opacity-50 flex items-center gap-1.5"
+      >
+        {installing ? (
+          <>
+            <RefreshCw className="h-3 w-3 animate-spin" />
+            {installingLabel}
+          </>
+        ) : (
+          installLabel
+        )}
+      </button>
+      {error ? <p className="text-[11px] text-rose-400 break-all">{error}</p> : null}
+      {log.length > 0 ? (
+        <pre className="text-[10px] text-slate-500 max-h-24 max-w-full overflow-auto font-mono whitespace-pre-wrap break-all">
+          {log.slice(-12).join("\n")}
+        </pre>
+      ) : null}
+    </div>
+  );
+}
+
+function ProviderPluginInstalls({
+  providerId,
+  hardwareProbe,
+  trtRtxNeedsInstall,
+  trtNeedsInstall,
+  openvinoNeedsInstall,
+  hardwareInstallBusy,
+  installingTrtRtx,
+  installTrtRtxError,
+  installTrtRtxLog,
+  onInstallTensorRtRtx,
+  installingTrt,
+  installTrtError,
+  installTrtLog,
+  onInstallTensorRt,
+  openvinoInstall,
+}: {
+  providerId: IHVProvider;
+  hardwareProbe: HardwareProbeResult | null;
+  trtRtxNeedsInstall: boolean;
+  trtNeedsInstall: boolean;
+  openvinoNeedsInstall: boolean;
+  hardwareInstallBusy: boolean;
+  installingTrtRtx: boolean;
+  installTrtRtxError: string | null;
+  installTrtRtxLog: string[];
+  onInstallTensorRtRtx: () => void;
+  installingTrt: boolean;
+  installTrtError: string | null;
+  installTrtLog: string[];
+  onInstallTensorRt: () => void;
+  openvinoInstall: HardwareProviderCardProps["openvinoInstall"];
+}) {
+  if (providerId === "NvTensorRTRTXExecutionProvider" && trtRtxNeedsInstall) {
+    return (
+      <PluginInstallBlock
+        description={
+          <>
+            GPU is compatible. The TensorRT RTX runtime is a separate package (not the full TensorRT
+            SDK). Install into the project <code className="text-slate-400">.venv</code> to enable
+            detection and runs.
+          </>
+        }
+        detail={hardwareProbe?.tensorRtRtx?.detail}
+        busy={hardwareInstallBusy}
+        installing={installingTrtRtx}
+        installLabel="Install tensorrt-rtx into .venv"
+        installingLabel="Installing tensorrt-rtx…"
+        onInstall={onInstallTensorRtRtx}
+        error={installTrtRtxError}
+        log={installTrtRtxLog}
+      />
+    );
+  }
+  if (providerId === "TensorrtExecutionProvider" && trtNeedsInstall) {
+    return (
+      <PluginInstallBlock
+        description={
+          <>
+            GPU is compatible (Turing / GeForce RTX 20xx+). Full TensorRT needs the{" "}
+            <code className="text-slate-400">nvinfer_10</code> SDK in the project{" "}
+            <code className="text-slate-400">.venv</code>. Prefer TensorRT RTX for a lighter consumer
+            install when that fits your recipe.
+          </>
+        }
+        detail={hardwareProbe?.tensorrt?.detail}
+        busy={hardwareInstallBusy}
+        installing={installingTrt}
+        installLabel="Install full TensorRT into .venv"
+        installingLabel="Installing tensorrt…"
+        onInstall={onInstallTensorRt}
+        error={installTrtError}
+        log={installTrtLog}
+      />
+    );
+  }
+  if (providerId === "OpenVINOExecutionProvider" && openvinoNeedsInstall) {
+    return (
+      <PluginInstallBlock
+        description={
+          <>
+            OpenVINOExecutionProvider not ready in the project{" "}
+            <code className="text-slate-400">.venv</code>. Install installs{" "}
+            <code className="text-slate-400">onnxruntime-openvino</code> (replaces{" "}
+            <code className="text-slate-400">onnxruntime-gpu</code> in this venv) plus OpenVINO and
+            Optimum-Intel.
+          </>
+        }
+        detail={hardwareProbe?.openvino?.detail}
+        busy={hardwareInstallBusy}
+        installing={openvinoInstall.state.installing}
+        installLabel="Install OpenVINO stack into .venv"
+        installingLabel="Installing OpenVINO stack…"
+        onInstall={() => void openvinoInstall.install()}
+        error={openvinoInstall.state.error}
+        log={openvinoInstall.state.log}
+      />
+    );
+  }
+  return null;
+}
+
+function OpenVinoDeviceHint({ hardwareProbe }: { hardwareProbe: HardwareProbeResult | null }) {
+  const devices = hardwareProbe?.openvino?.devices ?? [];
+  if (devices.length === 0 || devices.some((d) => /GPU|NPU/i.test(d))) return null;
+  return (
+    <p className="text-[11px] text-slate-500 mt-0.5 leading-relaxed">
+      Only CPU detected. For GPU/NPU inference, install Intel drivers:{" "}
+      <a
+        href={OPEN_VINO_GPU_DRIVER_URL}
+        target="_blank"
+        rel="noreferrer"
+        className="text-electric-blue hover:underline"
+        onClick={(e) => e.stopPropagation()}
+      >
+        GPU
+      </a>
+      {" / "}
+      <a
+        href={OPEN_VINO_NPU_DRIVER_URL}
+        target="_blank"
+        rel="noreferrer"
+        className="text-electric-blue hover:underline"
+        onClick={(e) => e.stopPropagation()}
+      >
+        NPU
+      </a>
+      .
+    </p>
+  );
+}
+
+function ProviderConflictAssist({
+  isSelected,
+  shortName,
+  cardHasCritical,
+  pConflicts,
+  onAssist,
+}: {
+  isSelected: boolean;
+  shortName: string;
+  cardHasCritical: boolean;
+  pConflicts: HardwareConflict[];
+  onAssist: () => void;
+}) {
+  return (
+    <div className="mt-3.5 pt-3.5 border-t border-slate-800/60 flex flex-col gap-2.5 animate-in fade-in duration-200">
+      <p className="text-xs text-slate-500 flex items-center gap-1.5">
+        <AlertTriangle className="h-3 w-3 text-amber-500 shrink-0" />
+        {isSelected ? "Passes to fix on this target" : "Adjustments needed to use this target"}
+      </p>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-2 pb-1">
+        {pConflicts.map((c, idx) => (
+          <div
+            key={idx}
+            className="bg-slate-950/60 p-2.5 rounded-lg border border-slate-900 flex items-start gap-2 text-xs"
+          >
+            <span
+              className={`inline-block h-1.5 w-1.5 rounded-full mt-1.5 shrink-0 ${
+                c.severity === "critical" ? "bg-rose-500" : "bg-amber-400"
+              }`}
+            />
+            <div className="leading-tight">
+              <span
+                className={`font-bold block text-[11px] mb-0.5 ${
+                  c.severity === "critical" ? "text-rose-300" : "text-amber-400"
+                }`}
+              >
+                {c.passName}
+              </span>
+              <span className="text-slate-450 text-[10.5px] font-medium leading-relaxed">{c.reason}</span>
+            </div>
+          </div>
+        ))}
+      </div>
+      <div className="flex justify-end pt-1">
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation();
+            onAssist();
+          }}
+          className={`text-[9.5px] uppercase tracking-wider font-extrabold px-3 py-1.5 rounded border transition-all cursor-pointer flex items-center gap-1.5 ${
+            cardHasCritical
+              ? "border-rose-550/30 text-rose-400 bg-rose-950/20 hover:text-white hover:bg-rose-500/20"
+              : "border-amber-500/30 text-amber-400 bg-amber-950/20 hover:text-white hover:bg-amber-550/20"
+          }`}
+        >
+          <Wand2 className="h-3.5 w-3.5" />
+          {isSelected ? "Fix passes for this target" : `Switch to ${shortName} (adjusts passes)`}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export function HardwareProviderCard({
+  provider: p,
+  state,
+  setState,
+  hardwareProbe,
+  probeLoading,
+  detectedProviders,
+  trtRtxNeedsInstall,
+  trtNeedsInstall,
+  openvinoNeedsInstall,
+  hardwareInstallBusy,
+  installingTrtRtx,
+  installTrtRtxError,
+  installTrtRtxLog,
+  onInstallTensorRtRtx,
+  installingTrt,
+  installTrtError,
+  installTrtLog,
+  onInstallTensorRt,
+  openvinoInstall,
+}: HardwareProviderCardProps) {
+  const isSelected = state.ihvProvider === p.id;
+  const Icon = p.icon;
+  const pConflicts = getProviderConflicts(p.id, state.passes);
+  const cardHasCritical = pConflicts.some((c) => c.severity === "critical");
+  const cardHardwareBlocked =
+    p.id !== "WebGpuExecutionProvider" &&
+    (Boolean(getProviderHardwareBlock(p.id, hardwareProbe)) ||
+      (p.id === "CPUExecutionProvider" && !hardwareProbe));
+  const cardBlocked = cardHasCritical || cardHardwareBlocked;
+  const cardHasWarning = pConflicts.some((c) => c.severity === "warning");
+  const showSwitchAssist = pConflicts.length > 0 && (isSelected || !cardBlocked);
+  const detectedLocally = isProviderDetectedLocally(p.id, hardwareProbe);
+  const isWebGpuTarget = p.id === "WebGpuExecutionProvider";
+  const needsPluginInstall =
+    (p.id === "NvTensorRTRTXExecutionProvider" && trtRtxNeedsInstall) ||
+    (p.id === "TensorrtExecutionProvider" && trtNeedsInstall) ||
+    (p.id === "OpenVINOExecutionProvider" && openvinoNeedsInstall);
+
+  const { cardClasses, badgeText, BadgeIcon, badgeColor } = resolveCardChrome({
+    isSelected,
+    cardBlocked,
+    cardHardwareBlocked,
+    cardHasCritical,
+    cardHasWarning,
+    isWebGpuTarget,
+    detectedLocally,
+    probeLoading,
+    needsPluginInstall,
+  });
+  const hardwareDetail = hardwareDetailFor(p.id, hardwareProbe);
+
+  const onSelect = () =>
+    selectProvider(p.id, state, setState, hardwareProbe, detectedProviders, pConflicts, isSelected);
+
+  return (
+    <div onClick={onSelect} className={cardClasses}>
+      <div className="flex items-start gap-4 min-w-0">
+        <div
+          className={`mt-0.5 shrink-0 rounded-xl p-2.5 transition-all ${
+            isSelected
+              ? cardHasCritical
+                ? "bg-rose-500/20 text-rose-400"
+                : cardHasWarning
+                  ? "bg-amber-500/20 text-amber-400"
+                  : "bg-electric-blue/20 text-electric-blue"
+              : "bg-slate-850 text-slate-400 group-hover:text-slate-300"
+          }`}
+        >
+          <Icon className="h-5 w-5" />
+        </div>
+
+        <div className="flex-1 min-w-0 space-y-1">
+          <div className="flex items-center gap-2">
+            <p className="font-semibold text-slate-200 text-sm md:text-base leading-none">{p.name}</p>
+            <span
+              className={`inline-flex items-center gap-1 text-[9px] font-mono uppercase tracking-wider font-extrabold px-2 py-0.5 rounded border ${badgeColor}`}
+            >
+              {BadgeIcon ? <BadgeIcon className="h-3 w-3" aria-hidden /> : null}
+              {badgeText}
+            </span>
+          </div>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <p className="text-xs text-slate-400 leading-relaxed pr-6 cursor-help border-b border-dashed border-slate-700 hover:border-slate-500 transition-colors">
+                {p.desc}
+              </p>
+            </TooltipTrigger>
+            <TooltipContent
+              side="bottom"
+              className="max-w-[360px] bg-slate-950 border border-slate-800 text-slate-300 p-4 shadow-2xl leading-relaxed z-50"
+            >
+              <div className="space-y-3">
+                <div className="border-b border-slate-900 pb-2">
+                  <p className="text-xs font-bold text-electric-blue uppercase tracking-wide">{p.name}</p>
+                </div>
+                <div>
+                  <p className="text-[10px] font-mono uppercase text-slate-500 mb-1">Requirements</p>
+                  <p className="text-[11px] text-slate-300 leading-relaxed">{p.tooltip.requirements}</p>
+                </div>
+                <div>
+                  <p className="text-[10px] font-mono uppercase text-slate-500 mb-1">Quantization Methods</p>
+                  <p className="text-[11px] text-slate-300 leading-relaxed">{p.tooltip.quantMethods}</p>
+                </div>
+                <div>
+                  <p className="text-[10px] font-mono uppercase text-slate-500 mb-1">Recommendation</p>
+                  <p className="text-[11px] text-emerald-400/90 leading-relaxed">{p.tooltip.recommendation}</p>
+                </div>
+              </div>
+            </TooltipContent>
+          </Tooltip>
+          {detectedLocally && hardwareDetail ? (
+            <p className="text-[11px] text-emerald-400/90 font-mono break-words">{hardwareDetail}</p>
+          ) : null}
+          <ProviderPluginInstalls
+            providerId={p.id}
+            hardwareProbe={hardwareProbe}
+            trtRtxNeedsInstall={trtRtxNeedsInstall}
+            trtNeedsInstall={trtNeedsInstall}
+            openvinoNeedsInstall={openvinoNeedsInstall}
+            hardwareInstallBusy={hardwareInstallBusy}
+            installingTrtRtx={installingTrtRtx}
+            installTrtRtxError={installTrtRtxError}
+            installTrtRtxLog={installTrtRtxLog}
+            onInstallTensorRtRtx={onInstallTensorRtRtx}
+            installingTrt={installingTrt}
+            installTrtError={installTrtError}
+            installTrtLog={installTrtLog}
+            onInstallTensorRt={onInstallTensorRt}
+            openvinoInstall={openvinoInstall}
+          />
+          {p.id === "OpenVINOExecutionProvider" ? (
+            <OpenVinoDeviceHint hardwareProbe={hardwareProbe} />
+          ) : null}
+          {isWebGpuTarget ? (
+            <p className="text-[11px] text-slate-500 mt-0.5 leading-relaxed">
+              Not a local Python EP. Select to build web-oriented recipes, then use{" "}
+              <span className="text-slate-400">Recipe &amp; run → Browser Test</span> / WebGPU benchmark in
+              Chrome or Edge 113+.
+            </p>
+          ) : null}
+          {!detectedLocally && !probeLoading && !isWebGpuTarget ? (
+            <p className="text-[11px] text-slate-600">
+              {p.id === "CPUExecutionProvider"
+                ? "Hardware detection unavailable — CPU status is unknown."
+                : "No matching hardware found locally — you can still select for remote/cross-compile targets."}
+            </p>
+          ) : null}
+        </div>
+
+        <div className="flex items-center justify-center shrink-0">
+          <div
+            className={`h-5 w-5 rounded-full border-2 flex items-center justify-center transition-colors ${
+              isSelected
+                ? cardHasCritical
+                  ? "border-rose-500 text-rose-500"
+                  : cardHasWarning
+                    ? "border-amber-500 text-amber-500"
+                    : "border-electric-blue text-electric-blue"
+                : "border-slate-700 hover:border-slate-500"
+            }`}
+          >
+            {isSelected ? (
+              <div
+                className={`h-2.5 w-2.5 rounded-full ${
+                  cardHasCritical ? "bg-rose-500" : cardHasWarning ? "bg-amber-500" : "bg-electric-blue"
+                }`}
+              />
+            ) : null}
+          </div>
+        </div>
+      </div>
+
+      {showSwitchAssist ? (
+        <ProviderConflictAssist
+          isSelected={isSelected}
+          shortName={p.shortName}
+          cardHasCritical={cardHasCritical}
+          pConflicts={pConflicts}
+          onAssist={onSelect}
+        />
+      ) : null}
+
+      {!isSelected && cardHasCritical && pConflicts.length > 0 ? (
+        <p className="mt-3 pt-3 border-t border-slate-800/60 text-[11px] text-slate-500 leading-relaxed">
+          Incompatible with your current passes. Change passes in Optimization or select a compatible target
+          above.
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/features/IHVIntegrationPanel.tsx
+++ b/src/components/features/IHVIntegrationPanel.tsx
@@ -326,7 +326,13 @@ export function IHVIntegrationPanel({
     Boolean(hardwareProbe?.nvidia?.gpus.length) && hardwareProbe?.tensorRtRtx?.loadable !== true;
   const trtNeedsInstall =
     Boolean(hardwareProbe?.nvidia?.gpus.length) && hardwareProbe?.tensorrt?.loadable !== true;
-  const tensorRtInstallBusy = installingTrt || installingTrtRtx;
+  // Single mutex covering all three pip install flows (TensorRT,
+  // TensorRT-RTX, onnxruntime-gpu). All three routes hit the same
+  // `.venv`, so any pair would step on each other's lock files if
+  // allowed to run concurrently. The individual `installingTrt | `
+  // Rtx | OrtGpu` booleans stay below so each button can keep its
+  // own per-flow spinner + error state, but the gate is shared.
+  const installInProgress = installingTrt || installingTrtRtx || installingOrtGpu;
 
   // CUDA install / toolkit-link gating. These mirror the TRT shape but
   // distinguish the four CUDA states:
@@ -345,7 +351,6 @@ export function IHVIntegrationPanel({
     nvidiaGpus.length > 0 && !isPreMaxwellBox && !cudaEpInVenv;
   const cudaToolkitMissing = hardwareProbe?.nvidia?.cudaToolkit?.available === false;
   const cudaToolkitMissingAndEpWorks = nvidiaGpus.length > 0 && !isPreMaxwellBox && cudaEpInVenv && cudaToolkitMissing;
-  const ortGpuInstallBusy = installingOrtGpu;
 
   const runNdjsonInstall = async (
     url: string,
@@ -402,7 +407,7 @@ export function IHVIntegrationPanel({
   };
 
   const handleInstallTensorRtRtx = async () => {
-    if (tensorRtInstallBusy) return;
+    if (installInProgress) return;
     setInstallingTrtRtx(true);
     setInstallTrtRtxError(null);
     setInstallTrtRtxLog([]);
@@ -422,7 +427,7 @@ export function IHVIntegrationPanel({
   };
 
   const handleInstallTensorRt = async () => {
-    if (tensorRtInstallBusy) return;
+    if (installInProgress) return;
     setInstallingTrt(true);
     setInstallTrtError(null);
     setInstallTrtLog([]);
@@ -442,7 +447,7 @@ export function IHVIntegrationPanel({
   };
 
   const handleInstallOrtGpu = async () => {
-    if (ortGpuInstallBusy || tensorRtInstallBusy) return;
+    if (installInProgress) return;
     setInstallingOrtGpu(true);
     setInstallOrtGpuError(null);
     setInstallOrtGpuLog([]);
@@ -922,7 +927,7 @@ export function IHVIntegrationPanel({
                               )}
                               <button
                                 type="button"
-                                disabled={tensorRtInstallBusy}
+                                disabled={installInProgress}
                                 onClick={() => void handleInstallTensorRtRtx()}
                                 className="h-7 px-3 rounded border border-amber-500/40 text-amber-300 bg-amber-500/10 hover:bg-amber-500/20 text-[11px] font-bold disabled:opacity-50 flex items-center gap-1.5"
                               >
@@ -963,7 +968,7 @@ export function IHVIntegrationPanel({
                               )}
                               <button
                                 type="button"
-                                disabled={tensorRtInstallBusy}
+                                disabled={installInProgress}
                                 onClick={() => void handleInstallTensorRt()}
                                 className="h-7 px-3 rounded border border-amber-500/40 text-amber-300 bg-amber-500/10 hover:bg-amber-500/20 text-[11px] font-bold disabled:opacity-50 flex items-center gap-1.5"
                               >
@@ -1025,7 +1030,7 @@ export function IHVIntegrationPanel({
                                   </p>
                                   <button
                                     type="button"
-                                    disabled={ortGpuInstallBusy || tensorRtInstallBusy}
+                                    disabled={installInProgress}
                                     onClick={() => void handleInstallOrtGpu()}
                                     className="h-7 px-3 rounded border border-amber-500/40 text-amber-300 bg-amber-500/10 hover:bg-amber-500/20 text-[11px] font-bold disabled:opacity-50 flex items-center gap-1.5"
                                   >

--- a/src/components/features/IHVIntegrationPanel.tsx
+++ b/src/components/features/IHVIntegrationPanel.tsx
@@ -955,9 +955,11 @@ export function IHVIntegrationPanel({
                           {p.id === "OpenVINOExecutionProvider" && openvinoNeedsInstall && (
                             <div className="mt-2 space-y-1.5 min-w-0" onClick={(e) => e.stopPropagation()}>
                               <p className="text-[11px] text-amber-400/90 leading-relaxed">
-                                OpenVINO stack not in the project{" "}
-                                <code className="text-slate-400">.venv</code>. Install to enable Intel CPU,
-                                GPU, and NPU targets.
+                                OpenVINOExecutionProvider not ready in the project{" "}
+                                <code className="text-slate-400">.venv</code>. Install installs{" "}
+                                <code className="text-slate-400">onnxruntime-openvino</code> (replaces{" "}
+                                <code className="text-slate-400">onnxruntime-gpu</code> in this venv) plus
+                                OpenVINO and Optimum-Intel.
                               </p>
                               {hardwareProbe?.openvino?.detail && (
                                 <p

--- a/src/components/features/IHVIntegrationPanel.tsx
+++ b/src/components/features/IHVIntegrationPanel.tsx
@@ -36,6 +36,7 @@ import { PROVIDER_CATALOG } from "@/lib/providerCatalog";
 import { VramEstimateBanner } from "@/components/features/VramEstimateBanner";
 import { HardwareProviderCard } from "@/components/features/HardwareProviderCard";
 import { useOpenVinoInstall } from "@/components/features/useOpenVinoInstall";
+import { runNdjsonInstall } from "@/lib/ndjsonInstall";
 import {
   Settings2,
   AlertTriangle,
@@ -348,60 +349,6 @@ export function IHVIntegrationPanel({
     isProviderDetectedLocally("OpenVINOExecutionProvider", hardwareProbe) &&
     hardwareProbe?.openvino?.loadable !== true;
   const hardwareInstallBusy = installingTrt || installingTrtRtx || openvinoInstall.state.installing;
-
-  const runNdjsonInstall = async (
-    url: string,
-    setLog: (updater: string[] | ((prev: string[]) => string[])) => void,
-  ): Promise<void> => {
-    const res = await fetch(url, { method: "POST" });
-    const contentType = res.headers.get("content-type") ?? "";
-
-    let ok = false;
-    let error: string | undefined;
-
-    if (contentType.includes("ndjson") && res.body) {
-      const reader = res.body.getReader();
-      const decoder = new TextDecoder();
-      let buffer = "";
-      while (true) {
-        const { done, value } = await reader.read();
-        if (done) break;
-        buffer += decoder.decode(value, { stream: true });
-        const parts = buffer.split("\n");
-        buffer = parts.pop() ?? "";
-        for (const line of parts) {
-          if (!line.trim()) continue;
-          let evt: { type?: string; message?: string; ok?: boolean; error?: string };
-          try {
-            evt = JSON.parse(line) as typeof evt;
-          } catch {
-            continue;
-          }
-          if (evt.type === "log" && evt.message) {
-            setLog((prev) => [...prev, evt.message!]);
-          } else if (evt.type === "done") {
-            ok = res.ok && evt.ok === true;
-            error = evt.error;
-          }
-        }
-      }
-    } else {
-      const data = (await res.json()) as {
-        ok?: boolean;
-        error?: string;
-        lines?: string[];
-        log?: string[];
-      };
-      const lines = data.lines ?? data.log;
-      if (Array.isArray(lines)) setLog(lines);
-      ok = res.ok && data.ok === true;
-      error = data.error;
-    }
-
-    if (!ok) {
-      throw new Error(error ?? `Install failed (HTTP ${res.status})`);
-    }
-  };
 
   const handleInstallTensorRtRtx = async () => {
     if (hardwareInstallBusy) return;

--- a/src/components/features/IHVIntegrationPanel.tsx
+++ b/src/components/features/IHVIntegrationPanel.tsx
@@ -33,6 +33,12 @@ import {
   isProviderDetectedLocally,
   type HardwareProbeResult,
 } from "@/lib/hardwareProbe";
+import {
+  CUDA_DOWNLOAD_LINKS,
+  CUDA_SM_FLOOR,
+  isPreMaxwellNvidiaBox,
+  pinnedOrtGpuInstallCommand,
+} from "@/lib/cudaDeps";
 import { PROVIDER_CATALOG } from "@/lib/providerCatalog";
 import { VramEstimateBanner } from "@/components/features/VramEstimateBanner";
 import {
@@ -52,6 +58,7 @@ import {
   HardDrive,
   XCircle,
   Globe,
+  ExternalLink,
 } from "lucide-react";
 
 export { getProviderConflicts };
@@ -309,6 +316,9 @@ export function IHVIntegrationPanel({
   const [installingTrt, setInstallingTrt] = useState(false);
   const [installTrtError, setInstallTrtError] = useState<string | null>(null);
   const [installTrtLog, setInstallTrtLog] = useState<string[]>([]);
+  const [installingOrtGpu, setInstallingOrtGpu] = useState(false);
+  const [installOrtGpuError, setInstallOrtGpuError] = useState<string | null>(null);
+  const [installOrtGpuLog, setInstallOrtGpuLog] = useState<string[]>([]);
 
   const hasAutoAppliedRef = useRef(false);
 
@@ -317,6 +327,26 @@ export function IHVIntegrationPanel({
   const trtNeedsInstall =
     Boolean(hardwareProbe?.nvidia?.gpus.length) && hardwareProbe?.tensorrt?.loadable !== true;
   const tensorRtInstallBusy = installingTrt || installingTrtRtx;
+
+  // CUDA install / toolkit-link gating. These mirror the TRT shape but
+  // distinguish the four CUDA states:
+  //   1. Pre-Maxwell GPU: don't offer an install button (cannot run modern CUDA).
+  //   2. NVIDIA + driver OK + onnxruntime-gpu CUDA EP missing in .venv: show
+  //      a pip install button for the pinned wheel.
+  //   3. NVIDIA + driver OK + CUDA EP registered + toolkit missing: show an
+  //      informational download link (toolkit optional for inference).
+  //   4. NVIDIA + driver OK + CUDA EP missing + toolkit missing: show BOTH
+  //      (the pip install is the actionable recovery; the download link is
+  //      informational for users who also want native builds).
+  const nvidiaGpus = hardwareProbe?.nvidia?.gpus ?? [];
+  const isPreMaxwellBox = isPreMaxwellNvidiaBox(nvidiaGpus);
+  const cudaEpInVenv =
+    hardwareProbe?.onnxRuntimeProviders?.includes("CUDAExecutionProvider") ?? false;
+  const cudaNeedsOrtGpuInstall =
+    nvidiaGpus.length > 0 && !isPreMaxwellBox && !cudaEpInVenv;
+  const cudaToolkitMissing = hardwareProbe?.nvidia?.cudaToolkit?.available === false;
+  const cudaToolkitMissingAndEpWorks = nvidiaGpus.length > 0 && !isPreMaxwellBox && cudaEpInVenv && cudaToolkitMissing;
+  const ortGpuInstallBusy = installingOrtGpu;
 
   const runNdjsonInstall = async (
     url: string,
@@ -409,6 +439,26 @@ export function IHVIntegrationPanel({
       );
     } finally {
       setInstallingTrt(false);
+    }
+  };
+
+  const handleInstallOrtGpu = async () => {
+    if (ortGpuInstallBusy || tensorRtInstallBusy) return;
+    setInstallingOrtGpu(true);
+    setInstallOrtGpuError(null);
+    setInstallOrtGpuLog([]);
+    try {
+      await runNdjsonInstall("/api/env/install-onnxruntime-gpu", setInstallOrtGpuLog);
+      await runHardwareProbe(true);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      setInstallOrtGpuError(
+        msg === "Failed to fetch"
+          ? "Could not reach the Olive Studio server (or the connection dropped during install). Keep pnpm dev running, then retry."
+          : msg,
+      );
+    } finally {
+      setInstallingOrtGpu(false);
     }
   };
 
@@ -934,6 +984,90 @@ export function IHVIntegrationPanel({
                                 <pre className="text-[10px] text-slate-500 max-h-24 max-w-full overflow-auto font-mono whitespace-pre-wrap break-all">
                                   {installTrtLog.slice(-12).join("\n")}
                                 </pre>
+                              )}
+                            </div>
+                          )}
+                          {/* CUDA install surface (mirrors TRT shape). Four cases:
+                              (a) pre-Maxwell GPU: rose-toned terminator, no install
+                                  button (cannot run modern CUDA on Kepler SM 3.x).
+                              (b) NVIDIA + driver OK + onnxruntime-gpu CUDA EP
+                                  missing: amber pip install button for the pinned
+                                  wheel. Reprobes after install.
+                              (c) NVIDIA + driver OK + CUDA EP registered + cuda
+                                  Toolkit missing: amber-ish informational
+                                  download link (toolkit is optional for inference).
+                              (d) NVIDIA + driver OK + both missing: both controls
+                                  stacked. The pip install is the actionable recovery. */}
+                          {p.id === "CUDAExecutionProvider" && isPreMaxwellBox && (
+                            <div className="mt-2 space-y-1.5 min-w-0" onClick={(e) => e.stopPropagation()}>
+                              <p className="text-[11px] text-rose-400/90 leading-relaxed">
+                                {nvidiaGpus.map((g) => g.name).join(", ")} predates the CUDA 12 toolkit
+                                floor (compute capability ≥ {CUDA_SM_FLOOR}, Maxwell / RTX 20xx+).
+                                Installing the toolkit or the CUDA wheel cannot recover this — these
+                                cards cannot execute modern CUDA. Use the CPU provider, or upgrade
+                                hardware.
+                              </p>
+                            </div>
+                          )}
+                          {p.id === "CUDAExecutionProvider" && (cudaNeedsOrtGpuInstall || cudaToolkitMissingAndEpWorks) && (
+                            <div className="mt-2 space-y-2 min-w-0" onClick={(e) => e.stopPropagation()}>
+                              {cudaNeedsOrtGpuInstall && (
+                                <>
+                                  <p className="text-[11px] text-amber-400/90 leading-relaxed">
+                                    {hardwareProbe?.onnxRuntimeProviders === undefined
+                                      ? "Onnxruntime-gpu isn't installed in the project "
+                                      : "Onnxruntime-gpu CUDA execution provider is not registered in the project "}
+                                    <code className="text-slate-400">.venv</code>. Click below
+                                    to pip-install the pinned wheel
+                                    (<code className="text-slate-400 font-mono break-all">
+                                      {pinnedOrtGpuInstallCommand()}
+                                    </code>
+                                    ); the panel re-probes after install.
+                                  </p>
+                                  <button
+                                    type="button"
+                                    disabled={ortGpuInstallBusy || tensorRtInstallBusy}
+                                    onClick={() => void handleInstallOrtGpu()}
+                                    className="h-7 px-3 rounded border border-amber-500/40 text-amber-300 bg-amber-500/10 hover:bg-amber-500/20 text-[11px] font-bold disabled:opacity-50 flex items-center gap-1.5"
+                                  >
+                                    {installingOrtGpu ? (
+                                      <>
+                                        <RefreshCw className="h-3 w-3 animate-spin" />
+                                        Installing onnxruntime-gpu…
+                                      </>
+                                    ) : (
+                                      "Install onnxruntime-gpu into .venv"
+                                    )}
+                                  </button>
+                                  {installOrtGpuError && (
+                                    <p className="text-[11px] text-rose-400 break-all">
+                                      {installOrtGpuError}
+                                    </p>
+                                  )}
+                                  {installOrtGpuLog.length > 0 && (
+                                    <pre className="text-[10px] text-slate-500 max-h-24 max-w-full overflow-auto font-mono whitespace-pre-wrap break-all">
+                                      {installOrtGpuLog.slice(-12).join("\n")}
+                                    </pre>
+                                  )}
+                                </>
+                              )}
+                              {cudaToolkitMissing && (
+                                <p className="text-[11px] text-amber-500/80 leading-relaxed">
+                                  NVIDIA driver + onnxruntime-gpu CUDA EP detected, but the CUDA
+                                  Toolkit (<code className="text-slate-400">nvcc</code>) is not
+                                  installed. Inference via OLIVE recipes does not need it; for
+                                  native CUDA builds, grab it from{" "}
+                                  <a
+                                    href={CUDA_DOWNLOAD_LINKS.archive}
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    className="text-electric-blue hover:text-white underline-offset-2 underline inline-flex items-center gap-1"
+                                  >
+                                    NVIDIA's CUDA Toolkit Archive
+                                    <ExternalLink className="h-3 w-3" />
+                                  </a>
+                                  .
+                                </p>
                               )}
                             </div>
                           )}

--- a/src/components/features/IHVIntegrationPanel.tsx
+++ b/src/components/features/IHVIntegrationPanel.tsx
@@ -1050,7 +1050,7 @@ export function IHVIntegrationPanel({
                                   )}
                                 </>
                               )}
-                              {cudaToolkitMissing && (
+                              {cudaToolkitMissing && cudaEpInVenv && (
                                 <p className="text-[11px] text-amber-500/80 leading-relaxed">
                                   NVIDIA driver + onnxruntime-gpu CUDA EP detected, but the CUDA
                                   Toolkit (<code className="text-slate-400">nvcc</code>) is not

--- a/src/components/features/IHVIntegrationPanel.tsx
+++ b/src/components/features/IHVIntegrationPanel.tsx
@@ -39,6 +39,7 @@ import {
   OPEN_VINO_NPU_DRIVER_URL,
 } from "@/lib/openvinoDeps";
 import { VramEstimateBanner } from "@/components/features/VramEstimateBanner";
+import { useOpenVinoInstall } from "@/components/features/useOpenVinoInstall";
 import {
   Settings2,
   AlertTriangle,
@@ -313,11 +314,36 @@ export function IHVIntegrationPanel({
   const [installingTrt, setInstallingTrt] = useState(false);
   const [installTrtError, setInstallTrtError] = useState<string | null>(null);
   const [installTrtLog, setInstallTrtLog] = useState<string[]>([]);
-  const [installingOpenvino, setInstallingOpenvino] = useState(false);
-  const [installOpenvinoError, setInstallOpenvinoError] = useState<string | null>(null);
-  const [installOpenvinoLog, setInstallOpenvinoLog] = useState<string[]>([]);
 
   const hasAutoAppliedRef = useRef(false);
+
+  const runHardwareProbe = useCallback(
+    async (refresh = false) => {
+      setProbeLoading(true);
+      setProbeError(null);
+      try {
+        const result = await fetchHardwareProbe(refresh);
+        setHardwareProbe(result);
+
+        // Auto-apply recommended provider on first probe completion
+        if (!hasAutoAppliedRef.current && result.recommendedProvider) {
+          hasAutoAppliedRef.current = true;
+          setState({ ihvProvider: result.recommendedProvider });
+        }
+      } catch (err) {
+        setProbeError(err instanceof Error ? err.message : "Hardware probe failed.");
+        setHardwareProbe(null);
+      } finally {
+        setProbeLoading(false);
+      }
+    },
+    [setState],
+  );
+
+  const openvinoInstall = useOpenVinoInstall({
+    onProbeRefresh: runHardwareProbe,
+    isInstallBusy: installingTrt || installingTrtRtx,
+  });
 
   const trtRtxNeedsInstall =
     Boolean(hardwareProbe?.nvidia?.gpus.length) && hardwareProbe?.tensorRtRtx?.loadable !== true;
@@ -326,8 +352,8 @@ export function IHVIntegrationPanel({
   const openvinoNeedsInstall =
     Boolean(hardwareProbe) &&
     isProviderDetectedLocally("OpenVINOExecutionProvider", hardwareProbe) &&
-    hardwareProbe?.openvino?.available !== true;
-  const hardwareInstallBusy = installingTrt || installingTrtRtx || installingOpenvino;
+    hardwareProbe?.openvino?.loadable !== true;
+  const hardwareInstallBusy = installingTrt || installingTrtRtx || openvinoInstall.state.installing;
 
   const runNdjsonInstall = async (
     url: string,
@@ -422,49 +448,6 @@ export function IHVIntegrationPanel({
       setInstallingTrt(false);
     }
   };
-
-  const handleInstallOpenVino = async () => {
-    if (hardwareInstallBusy) return;
-    setInstallingOpenvino(true);
-    setInstallOpenvinoError(null);
-    setInstallOpenvinoLog([]);
-    try {
-      await runNdjsonInstall("/api/env/install-openvino", setInstallOpenvinoLog);
-      await runHardwareProbe(true);
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      setInstallOpenvinoError(
-        msg === "Failed to fetch"
-          ? "Could not reach the Olive Studio server (or the connection dropped during install). Keep pnpm dev running, then retry."
-          : msg,
-      );
-    } finally {
-      setInstallingOpenvino(false);
-    }
-  };
-
-  const runHardwareProbe = useCallback(
-    async (refresh = false) => {
-      setProbeLoading(true);
-      setProbeError(null);
-      try {
-        const result = await fetchHardwareProbe(refresh);
-        setHardwareProbe(result);
-
-        // Auto-apply recommended provider on first probe completion
-        if (!hasAutoAppliedRef.current && result.recommendedProvider) {
-          hasAutoAppliedRef.current = true;
-          setState({ ihvProvider: result.recommendedProvider });
-        }
-      } catch (err) {
-        setProbeError(err instanceof Error ? err.message : "Hardware probe failed.");
-        setHardwareProbe(null);
-      } finally {
-        setProbeLoading(false);
-      }
-    },
-    [setState],
-  );
 
   useEffect(() => {
     void runHardwareProbe(false);
@@ -563,7 +546,7 @@ export function IHVIntegrationPanel({
                         </span>
                       </p>
                     ) : null}
-                    {hardwareProbe.openvino?.available ? (
+                    {hardwareProbe.openvino?.loadable ? (
                       <p>
                         <span className="text-slate-500">OpenVINO:</span>{" "}
                         <span className="text-slate-200">
@@ -786,8 +769,8 @@ export function IHVIntegrationPanel({
                       ? hardwareProbe?.nvidia?.gpus.map((g) => g.name).join(", ")
                       : p.id === "ROCMExecutionProvider"
                         ? hardwareProbe?.rocm?.gpus.map((g) => g.name).join(", ")
-                        : p.id === "OpenVINOExecutionProvider" && hardwareProbe?.openvino?.available
-                          ? `OpenVINO ${hardwareProbe.openvino.version ?? ""}${hardwareProbe.openvino.devices?.length ? ` (${hardwareProbe.openvino.devices.join(", ")})` : ""}`.trim()
+                        : p.id === "OpenVINOExecutionProvider" && hardwareProbe?.openvino?.version
+                          ? `OpenVINO ${hardwareProbe.openvino.version}${hardwareProbe.openvino.devices?.length ? ` (${hardwareProbe.openvino.devices.join(", ")})` : ""}`.trim()
                           : p.id === "CPUExecutionProvider" && hardwareProbe
                             ? hardwareProbe.platform.cpuModel
                             : null;
@@ -987,10 +970,10 @@ export function IHVIntegrationPanel({
                               <button
                                 type="button"
                                 disabled={hardwareInstallBusy}
-                                onClick={() => void handleInstallOpenVino()}
+                                onClick={() => void openvinoInstall.install()}
                                 className="h-7 px-3 rounded border border-amber-500/40 text-amber-300 bg-amber-500/10 hover:bg-amber-500/20 text-[11px] font-bold disabled:opacity-50 flex items-center gap-1.5"
                               >
-                                {installingOpenvino ? (
+                                {openvinoInstall.state.installing ? (
                                   <>
                                     <RefreshCw className="h-3 w-3 animate-spin" />
                                     Installing OpenVINO stack…
@@ -999,19 +982,19 @@ export function IHVIntegrationPanel({
                                   "Install OpenVINO stack into .venv"
                                 )}
                               </button>
-                              {installOpenvinoError && (
-                                <p className="text-[11px] text-rose-400 break-all">{installOpenvinoError}</p>
+                              {openvinoInstall.state.error && (
+                                <p className="text-[11px] text-rose-400 break-all">{openvinoInstall.state.error}</p>
                               )}
-                              {installOpenvinoLog.length > 0 && (
+                              {openvinoInstall.state.log.length > 0 && (
                                 <pre className="text-[10px] text-slate-500 max-h-24 max-w-full overflow-auto font-mono whitespace-pre-wrap break-all">
-                                  {installOpenvinoLog.slice(-12).join("\n")}
+                                  {openvinoInstall.state.log.slice(-12).join("\n")}
                                 </pre>
                               )}
                             </div>
                           )}
                           {p.id === "OpenVINOExecutionProvider" &&
-                            hardwareProbe?.openvino?.available &&
-                            !hardwareProbe.openvino.devices?.some((d) => /GPU|NPU/i.test(d)) && (
+                            hardwareProbe?.openvino?.devices?.length &&
+                            !hardwareProbe.openvino.devices.some((d) => /GPU|NPU/i.test(d)) && (
                               <p className="text-[11px] text-slate-500 mt-0.5 leading-relaxed">
                                 Only CPU detected. For GPU/NPU inference, install Intel drivers:{" "}
                                 <a

--- a/src/components/features/IHVIntegrationPanel.tsx
+++ b/src/components/features/IHVIntegrationPanel.tsx
@@ -16,7 +16,6 @@ import { usePipelineState } from "@/lib/stores/pipelineStore";
 import {
   applyProviderConflictAutofixes,
   getProviderConflicts,
-  getProviderHardwareBlock,
   getQuantMethodActivationBlock,
   isConversionFormatAllowed,
   isPeftAllowed,
@@ -34,11 +33,8 @@ import {
   type HardwareProbeResult,
 } from "@/lib/hardwareProbe";
 import { PROVIDER_CATALOG } from "@/lib/providerCatalog";
-import {
-  OPEN_VINO_GPU_DRIVER_URL,
-  OPEN_VINO_NPU_DRIVER_URL,
-} from "@/lib/openvinoDeps";
 import { VramEstimateBanner } from "@/components/features/VramEstimateBanner";
+import { HardwareProviderCard } from "@/components/features/HardwareProviderCard";
 import { useOpenVinoInstall } from "@/components/features/useOpenVinoInstall";
 import {
   Settings2,
@@ -55,8 +51,6 @@ import {
   List,
   RefreshCw,
   HardDrive,
-  XCircle,
-  Globe,
 } from "lucide-react";
 
 export { getProviderConflicts };
@@ -669,482 +663,30 @@ export function IHVIntegrationPanel({
               </div>
             ) : (
               <TooltipProvider delayDuration={200}>
-                {selectableProviders.map((p) => {
-                  const isSelected = state.ihvProvider === p.id;
-                  const Icon = p.icon;
-
-                  // Compute conflicts for this particular card to implement visual disabled indicators & warnings
-                  const pConflicts = getProviderConflicts(p.id, state.passes);
-                  const cardHasCritical = pConflicts.some((c) => c.severity === "critical");
-                  const cardHardwareBlocked =
-                    p.id !== "WebGpuExecutionProvider" &&
-                    (Boolean(getProviderHardwareBlock(p.id, hardwareProbe)) ||
-                      (p.id === "CPUExecutionProvider" && !hardwareProbe));
-                  const cardBlocked = cardHasCritical || cardHardwareBlocked;
-                  const cardHasWarning = pConflicts.some((c) => c.severity === "warning");
-                  const showSwitchAssist = pConflicts.length > 0 && (isSelected || !cardBlocked);
-                  const detectedLocally = isProviderDetectedLocally(p.id, hardwareProbe);
-                  const isWebGpuTarget = p.id === "WebGpuExecutionProvider";
-
-                  let cardClasses =
-                    "relative flex flex-col rounded-xl border p-4.5 transition-all duration-200 cursor-pointer min-w-0 max-w-full overflow-hidden ";
-                  let badgeText = "";
-                  let BadgeIcon: typeof CheckCircle | null = null;
-                  let badgeColor = "";
-
-                  if (isSelected) {
-                    if (cardBlocked) {
-                      cardClasses += "border-rose-500 bg-rose-500/5";
-                      badgeText = cardHardwareBlocked ? "Unavailable hardware" : "Critical Conflict";
-                      BadgeIcon = XCircle;
-                      badgeColor = "bg-rose-500/10 text-rose-400 border-rose-550/25";
-                    } else if (cardHasWarning) {
-                      cardClasses += "border-amber-500 bg-amber-500/5";
-                      badgeText = "Warning Conflict";
-                      BadgeIcon = AlertTriangle;
-                      badgeColor = "bg-amber-500/10 text-amber-400 border-amber-550/25";
-                    } else {
-                      cardClasses += "border-electric-blue bg-electric-blue/5";
-                      badgeText =
-                        !detectedLocally && !probeLoading && !isWebGpuTarget
-                          ? "Active (not local)"
-                          : isWebGpuTarget
-                            ? "Active (browser target)"
-                            : "Active Target";
-                      BadgeIcon = CheckCircle;
-                      badgeColor = "bg-electric-blue/10 text-electric-blue border-electric-blue/20";
-                    }
-                  } else if (isWebGpuTarget) {
-                    cardClasses +=
-                      "border-slate-800/80 bg-slate-900/40 hover:bg-slate-900 hover:border-slate-700";
-                    badgeText = "Browser deploy target";
-                    BadgeIcon = Globe;
-                    badgeColor = "bg-slate-800/80 text-slate-300 border-slate-700/60";
-                  } else if (cardHardwareBlocked) {
-                    cardClasses +=
-                      "border-rose-950/35 bg-zinc-950/40 opacity-55 hover:opacity-75 hover:border-slate-700";
-                    badgeText = "Not on this system";
-                    BadgeIcon = XCircle;
-                    badgeColor = "bg-rose-500/5 text-rose-400/80 border-rose-550/15";
-                  } else if (
-                    ((p.id === "NvTensorRTRTXExecutionProvider" && trtRtxNeedsInstall) ||
-                      (p.id === "TensorrtExecutionProvider" && trtNeedsInstall) ||
-                      (p.id === "OpenVINOExecutionProvider" && openvinoNeedsInstall)) &&
-                    detectedLocally
-                  ) {
-                    cardClasses += "border-amber-900/40 bg-amber-950/10 opacity-95 hover:border-amber-500/40";
-                    badgeText = "Plugin install needed";
-                    BadgeIcon = AlertTriangle;
-                    badgeColor = "bg-amber-500/10 text-amber-400 border-amber-500/20";
-                  } else if (!detectedLocally && !probeLoading) {
-                    cardClasses +=
-                      "border-slate-850/60 bg-zinc-950/30 opacity-80 hover:opacity-100 hover:border-slate-700";
-                    badgeText = "Not on this system";
-                    BadgeIcon = AlertCircle;
-                    badgeColor = "bg-slate-800/80 text-slate-500 border-slate-700/60";
-                  } else if (cardHasCritical) {
-                    cardClasses +=
-                      "border-rose-950/35 bg-zinc-950/40 opacity-55 hover:opacity-100 hover:border-rose-500/40";
-                    badgeText = "Incompatible";
-                    BadgeIcon = XCircle;
-                    badgeColor = "bg-rose-500/5 text-rose-400/80 border-rose-550/15";
-                  } else if (cardHasWarning) {
-                    cardClasses +=
-                      "border-amber-950/35 bg-zinc-950/40 opacity-75 hover:opacity-100 hover:border-amber-500/40";
-                    badgeText = "Needs Adjust";
-                    BadgeIcon = AlertTriangle;
-                    badgeColor = "bg-amber-500/5 text-amber-400/80 border-amber-550/15";
-                  } else {
-                    cardClasses +=
-                      "border-slate-800/80 bg-slate-900/40 hover:bg-slate-900 hover:border-slate-700";
-                    badgeText = "Compatible with active passes";
-                    BadgeIcon = CheckCircle;
-                    badgeColor = "bg-emerald-500/10 text-emerald-400 border-emerald-500/15";
-                  }
-
-                  const hardwareDetail =
-                    p.id === "CUDAExecutionProvider" ||
-                    p.id === "NvTensorRTRTXExecutionProvider" ||
-                    p.id === "TensorrtExecutionProvider"
-                      ? hardwareProbe?.nvidia?.gpus.map((g) => g.name).join(", ")
-                      : p.id === "ROCMExecutionProvider"
-                        ? hardwareProbe?.rocm?.gpus.map((g) => g.name).join(", ")
-                        : p.id === "OpenVINOExecutionProvider" && hardwareProbe?.openvino?.version
-                          ? `OpenVINO ${hardwareProbe.openvino.version}${hardwareProbe.openvino.devices?.length ? ` (${hardwareProbe.openvino.devices.join(", ")})` : ""}`.trim()
-                          : p.id === "CPUExecutionProvider" && hardwareProbe
-                            ? hardwareProbe.platform.cpuModel
-                            : null;
-
-                  return (
-                    <div
-                      key={p.id}
-                      onClick={() => {
-                        if (isSelected && pConflicts.length > 0) {
-                          setState({ passes: applyProviderConflictAutofixes(p.id, state.passes) });
-                          return;
-                        }
-                        // Allow selecting undetected providers for cross-compile / remote targets
-                        const detected = detectedProviders.includes(p.id);
-                        if (!detected) {
-                          setState({ ihvProvider: p.id });
-                          return;
-                        }
-                        const patch = prepareProviderChange(state, p.id, hardwareProbe);
-                        if (patch) {
-                          setState(patch);
-                        }
-                      }}
-                      className={cardClasses}
-                    >
-                      <div className="flex items-start gap-4 min-w-0">
-                        <div
-                          className={`mt-0.5 shrink-0 rounded-xl p-2.5 transition-all ${
-                            isSelected
-                              ? cardHasCritical
-                                ? "bg-rose-500/20 text-rose-400"
-                                : cardHasWarning
-                                  ? "bg-amber-500/20 text-amber-400"
-                                  : "bg-electric-blue/20 text-electric-blue"
-                              : "bg-slate-850 text-slate-400 group-hover:text-slate-300"
-                          }`}
-                        >
-                          <Icon className="h-5 w-5" />
-                        </div>
-
-                        <div className="flex-1 min-w-0 space-y-1">
-                          <div className="flex items-center gap-2">
-                            <p className="font-semibold text-slate-200 text-sm md:text-base leading-none">
-                              {p.name}
-                            </p>
-                            <span
-                              className={`inline-flex items-center gap-1 text-[9px] font-mono uppercase tracking-wider font-extrabold px-2 py-0.5 rounded border ${badgeColor}`}
-                            >
-                              {BadgeIcon ? <BadgeIcon className="h-3 w-3" aria-hidden /> : null}
-                              {badgeText}
-                            </span>
-                          </div>
-                          <Tooltip>
-                            <TooltipTrigger asChild>
-                              <p className="text-xs text-slate-400 leading-relaxed pr-6 cursor-help border-b border-dashed border-slate-700 hover:border-slate-500 transition-colors">
-                                {p.desc}
-                              </p>
-                            </TooltipTrigger>
-                            <TooltipContent
-                              side="bottom"
-                              className="max-w-[360px] bg-slate-950 border border-slate-800 text-slate-300 p-4 shadow-2xl leading-relaxed z-50"
-                            >
-                              <div className="space-y-3">
-                                <div className="border-b border-slate-900 pb-2">
-                                  <p className="text-xs font-bold text-electric-blue uppercase tracking-wide">
-                                    {p.name}
-                                  </p>
-                                </div>
-                                <div>
-                                  <p className="text-[10px] font-mono uppercase text-slate-500 mb-1">
-                                    Requirements
-                                  </p>
-                                  <p className="text-[11px] text-slate-300 leading-relaxed">
-                                    {p.tooltip.requirements}
-                                  </p>
-                                </div>
-                                <div>
-                                  <p className="text-[10px] font-mono uppercase text-slate-500 mb-1">
-                                    Quantization Methods
-                                  </p>
-                                  <p className="text-[11px] text-slate-300 leading-relaxed">
-                                    {p.tooltip.quantMethods}
-                                  </p>
-                                </div>
-                                <div>
-                                  <p className="text-[10px] font-mono uppercase text-slate-500 mb-1">
-                                    Recommendation
-                                  </p>
-                                  <p className="text-[11px] text-emerald-400/90 leading-relaxed">
-                                    {p.tooltip.recommendation}
-                                  </p>
-                                </div>
-                              </div>
-                            </TooltipContent>
-                          </Tooltip>
-                          {detectedLocally && hardwareDetail && (
-                            <p className="text-[11px] text-emerald-400/90 font-mono break-words">
-                              {hardwareDetail}
-                            </p>
-                          )}
-                          {p.id === "NvTensorRTRTXExecutionProvider" && trtRtxNeedsInstall && (
-                            <div className="mt-2 space-y-1.5 min-w-0" onClick={(e) => e.stopPropagation()}>
-                              <p className="text-[11px] text-amber-400/90 leading-relaxed">
-                                GPU is compatible. The TensorRT RTX runtime is a separate package (not the
-                                full TensorRT SDK). Install into the project{" "}
-                                <code className="text-slate-400">.venv</code> to enable detection and runs.
-                              </p>
-                              {hardwareProbe?.tensorRtRtx?.detail && (
-                                <p
-                                  className="text-[10px] text-slate-500 font-mono break-all max-w-full"
-                                  title={hardwareProbe.tensorRtRtx.detail}
-                                >
-                                  {hardwareProbe.tensorRtRtx.detail}
-                                </p>
-                              )}
-                              <button
-                                type="button"
-                                disabled={hardwareInstallBusy}
-                                onClick={() => void handleInstallTensorRtRtx()}
-                                className="h-7 px-3 rounded border border-amber-500/40 text-amber-300 bg-amber-500/10 hover:bg-amber-500/20 text-[11px] font-bold disabled:opacity-50 flex items-center gap-1.5"
-                              >
-                                {installingTrtRtx ? (
-                                  <>
-                                    <RefreshCw className="h-3 w-3 animate-spin" />
-                                    Installing tensorrt-rtx…
-                                  </>
-                                ) : (
-                                  "Install tensorrt-rtx into .venv"
-                                )}
-                              </button>
-                              {installTrtRtxError && (
-                                <p className="text-[11px] text-rose-400 break-all">{installTrtRtxError}</p>
-                              )}
-                              {installTrtRtxLog.length > 0 && (
-                                <pre className="text-[10px] text-slate-500 max-h-24 max-w-full overflow-auto font-mono whitespace-pre-wrap break-all">
-                                  {installTrtRtxLog.slice(-12).join("\n")}
-                                </pre>
-                              )}
-                            </div>
-                          )}
-                          {p.id === "TensorrtExecutionProvider" && trtNeedsInstall && (
-                            <div className="mt-2 space-y-1.5 min-w-0" onClick={(e) => e.stopPropagation()}>
-                              <p className="text-[11px] text-amber-400/90 leading-relaxed">
-                                GPU is compatible (Turing / GeForce RTX 20xx+). Full TensorRT needs the{" "}
-                                <code className="text-slate-400">nvinfer_10</code> SDK in the project{" "}
-                                <code className="text-slate-400">.venv</code>. Prefer TensorRT RTX for a
-                                lighter consumer install when that fits your recipe.
-                              </p>
-                              {hardwareProbe?.tensorrt?.detail && (
-                                <p
-                                  className="text-[10px] text-slate-500 font-mono break-all max-w-full"
-                                  title={hardwareProbe.tensorrt.detail}
-                                >
-                                  {hardwareProbe.tensorrt.detail}
-                                </p>
-                              )}
-                              <button
-                                type="button"
-                                disabled={hardwareInstallBusy}
-                                onClick={() => void handleInstallTensorRt()}
-                                className="h-7 px-3 rounded border border-amber-500/40 text-amber-300 bg-amber-500/10 hover:bg-amber-500/20 text-[11px] font-bold disabled:opacity-50 flex items-center gap-1.5"
-                              >
-                                {installingTrt ? (
-                                  <>
-                                    <RefreshCw className="h-3 w-3 animate-spin" />
-                                    Installing tensorrt…
-                                  </>
-                                ) : (
-                                  "Install full TensorRT into .venv"
-                                )}
-                              </button>
-                              {installTrtError && (
-                                <p className="text-[11px] text-rose-400 break-all">{installTrtError}</p>
-                              )}
-                              {installTrtLog.length > 0 && (
-                                <pre className="text-[10px] text-slate-500 max-h-24 max-w-full overflow-auto font-mono whitespace-pre-wrap break-all">
-                                  {installTrtLog.slice(-12).join("\n")}
-                                </pre>
-                              )}
-                            </div>
-                          )}
-                          {p.id === "OpenVINOExecutionProvider" && openvinoNeedsInstall && (
-                            <div className="mt-2 space-y-1.5 min-w-0" onClick={(e) => e.stopPropagation()}>
-                              <p className="text-[11px] text-amber-400/90 leading-relaxed">
-                                OpenVINOExecutionProvider not ready in the project{" "}
-                                <code className="text-slate-400">.venv</code>. Install installs{" "}
-                                <code className="text-slate-400">onnxruntime-openvino</code> (replaces{" "}
-                                <code className="text-slate-400">onnxruntime-gpu</code> in this venv) plus
-                                OpenVINO and Optimum-Intel.
-                              </p>
-                              {hardwareProbe?.openvino?.detail && (
-                                <p
-                                  className="text-[10px] text-slate-500 font-mono break-all max-w-full"
-                                  title={hardwareProbe.openvino.detail}
-                                >
-                                  {hardwareProbe.openvino.detail}
-                                </p>
-                              )}
-                              <button
-                                type="button"
-                                disabled={hardwareInstallBusy}
-                                onClick={() => void openvinoInstall.install()}
-                                className="h-7 px-3 rounded border border-amber-500/40 text-amber-300 bg-amber-500/10 hover:bg-amber-500/20 text-[11px] font-bold disabled:opacity-50 flex items-center gap-1.5"
-                              >
-                                {openvinoInstall.state.installing ? (
-                                  <>
-                                    <RefreshCw className="h-3 w-3 animate-spin" />
-                                    Installing OpenVINO stack…
-                                  </>
-                                ) : (
-                                  "Install OpenVINO stack into .venv"
-                                )}
-                              </button>
-                              {openvinoInstall.state.error && (
-                                <p className="text-[11px] text-rose-400 break-all">{openvinoInstall.state.error}</p>
-                              )}
-                              {openvinoInstall.state.log.length > 0 && (
-                                <pre className="text-[10px] text-slate-500 max-h-24 max-w-full overflow-auto font-mono whitespace-pre-wrap break-all">
-                                  {openvinoInstall.state.log.slice(-12).join("\n")}
-                                </pre>
-                              )}
-                            </div>
-                          )}
-                          {p.id === "OpenVINOExecutionProvider" &&
-                            (hardwareProbe?.openvino?.devices?.length ?? 0) > 0 &&
-                            !hardwareProbe!.openvino!.devices!.some((d) => /GPU|NPU/i.test(d)) && (
-                              <p className="text-[11px] text-slate-500 mt-0.5 leading-relaxed">
-                                Only CPU detected. For GPU/NPU inference, install Intel drivers:{" "}
-                                <a
-                                  href={OPEN_VINO_GPU_DRIVER_URL}
-                                  target="_blank"
-                                  rel="noreferrer"
-                                  className="text-electric-blue hover:underline"
-                                  onClick={(e) => e.stopPropagation()}
-                                >
-                                  GPU
-                                </a>
-                                {" / "}
-                                <a
-                                  href={OPEN_VINO_NPU_DRIVER_URL}
-                                  target="_blank"
-                                  rel="noreferrer"
-                                  className="text-electric-blue hover:underline"
-                                  onClick={(e) => e.stopPropagation()}
-                                >
-                                  NPU
-                                </a>
-                                .
-                              </p>
-                            )}
-                          {isWebGpuTarget && (
-                            <p className="text-[11px] text-slate-500 mt-0.5 leading-relaxed">
-                              Not a local Python EP. Select to build web-oriented recipes, then use{" "}
-                              <span className="text-slate-400">Recipe &amp; run → Browser Test</span> / WebGPU
-                              benchmark in Chrome or Edge 113+.
-                            </p>
-                          )}
-                          {!detectedLocally && !probeLoading && !isWebGpuTarget && (
-                            <p className="text-[11px] text-slate-600">
-                              {p.id === "CPUExecutionProvider"
-                                ? "Hardware detection unavailable — CPU status is unknown."
-                                : "No matching hardware found locally — you can still select for remote/cross-compile targets."}
-                            </p>
-                          )}
-                        </div>
-
-                        <div className="flex items-center justify-center shrink-0">
-                          <div
-                            className={`h-5 w-5 rounded-full border-2 flex items-center justify-center transition-colors ${
-                              isSelected
-                                ? cardHasCritical
-                                  ? "border-rose-500 text-rose-500"
-                                  : cardHasWarning
-                                    ? "border-amber-500 text-amber-500"
-                                    : "border-electric-blue text-electric-blue"
-                                : "border-slate-700 hover:border-slate-500"
-                            }`}
-                          >
-                            {isSelected && (
-                              <div
-                                className={`h-2.5 w-2.5 rounded-full ${
-                                  cardHasCritical
-                                    ? "bg-rose-500"
-                                    : cardHasWarning
-                                      ? "bg-amber-500"
-                                      : "bg-electric-blue"
-                                }`}
-                              />
-                            )}
-                          </div>
-                        </div>
-                      </div>
-
-                      {/* Conflicts on the active target, or adjustable warnings on other targets */}
-                      {showSwitchAssist && (
-                        <div className="mt-3.5 pt-3.5 border-t border-slate-800/60 flex flex-col gap-2.5 animate-in fade-in duration-200">
-                          <p className="text-xs text-slate-500 flex items-center gap-1.5">
-                            <AlertTriangle className="h-3 w-3 text-amber-500 shrink-0" />
-                            {isSelected
-                              ? "Passes to fix on this target"
-                              : "Adjustments needed to use this target"}
-                          </p>
-
-                          <div className="grid grid-cols-1 md:grid-cols-2 gap-2 pb-1">
-                            {pConflicts.map((c, idx) => (
-                              <div
-                                key={idx}
-                                className="bg-slate-950/60 p-2.5 rounded-lg border border-slate-900 flex items-start gap-2 text-xs"
-                              >
-                                <span
-                                  className={`inline-block h-1.5 w-1.5 rounded-full mt-1.5 shrink-0 ${
-                                    c.severity === "critical" ? "bg-rose-500" : "bg-amber-400"
-                                  }`}
-                                />
-                                <div className="leading-tight">
-                                  <span
-                                    className={`font-bold block text-[11px] mb-0.5 ${
-                                      c.severity === "critical" ? "text-rose-300" : "text-amber-400"
-                                    }`}
-                                  >
-                                    {c.passName}
-                                  </span>
-                                  <span className="text-slate-450 text-[10.5px] font-medium leading-relaxed">
-                                    {c.reason}
-                                  </span>
-                                </div>
-                              </div>
-                            ))}
-                          </div>
-
-                          <div className="flex justify-end pt-1">
-                            <button
-                              type="button"
-                              onClick={(e) => {
-                                e.stopPropagation();
-                                if (isSelected) {
-                                  setState({ passes: applyProviderConflictAutofixes(p.id, state.passes) });
-                                  return;
-                                }
-                                // Allow switching to undetected providers for cross-compile / remote targets
-                                const detected = detectedProviders.includes(p.id);
-                                if (!detected) {
-                                  setState({ ihvProvider: p.id });
-                                  return;
-                                }
-                                const patch = prepareProviderChange(state, p.id, hardwareProbe);
-                                if (patch) {
-                                  setState(patch);
-                                }
-                              }}
-                              className={`text-[9.5px] uppercase tracking-wider font-extrabold px-3 py-1.5 rounded border transition-all cursor-pointer flex items-center gap-1.5 ${
-                                cardHasCritical
-                                  ? "border-rose-550/30 text-rose-400 bg-rose-950/20 hover:text-white hover:bg-rose-500/20"
-                                  : "border-amber-500/30 text-amber-400 bg-amber-950/20 hover:text-white hover:bg-amber-550/20"
-                              }`}
-                            >
-                              <Wand2 className="h-3.5 w-3.5" />
-                              {isSelected
-                                ? "Fix passes for this target"
-                                : `Switch to ${p.shortName} (adjusts passes)`}
-                            </button>
-                          </div>
-                        </div>
-                      )}
-
-                      {!isSelected && cardHasCritical && pConflicts.length > 0 && (
-                        <p className="mt-3 pt-3 border-t border-slate-800/60 text-[11px] text-slate-500 leading-relaxed">
-                          Incompatible with your current passes. Change passes in Optimization or select a
-                          compatible target above.
-                        </p>
-                      )}
-                    </div>
-                  );
-                })}
+                {selectableProviders.map((p) => (
+                  <HardwareProviderCard
+                    key={p.id}
+                    provider={p}
+                    state={state}
+                    setState={setState}
+                    hardwareProbe={hardwareProbe}
+                    probeLoading={probeLoading}
+                    detectedProviders={detectedProviders}
+                    trtRtxNeedsInstall={trtRtxNeedsInstall}
+                    trtNeedsInstall={trtNeedsInstall}
+                    openvinoNeedsInstall={openvinoNeedsInstall}
+                    hardwareInstallBusy={hardwareInstallBusy}
+                    installingTrtRtx={installingTrtRtx}
+                    installTrtRtxError={installTrtRtxError}
+                    installTrtRtxLog={installTrtRtxLog}
+                    onInstallTensorRtRtx={() => void handleInstallTensorRtRtx()}
+                    installingTrt={installingTrt}
+                    installTrtError={installTrtError}
+                    installTrtLog={installTrtLog}
+                    onInstallTensorRt={() => void handleInstallTensorRt()}
+                    openvinoInstall={openvinoInstall}
+                  />
+                ))}
               </TooltipProvider>
             )}
           </div>

--- a/src/components/features/IHVIntegrationPanel.tsx
+++ b/src/components/features/IHVIntegrationPanel.tsx
@@ -340,8 +340,7 @@ export function IHVIntegrationPanel({
   //      informational for users who also want native builds).
   const nvidiaGpus = hardwareProbe?.nvidia?.gpus ?? [];
   const isPreMaxwellBox = isPreMaxwellNvidiaBox(nvidiaGpus);
-  const cudaEpInVenv =
-    hardwareProbe?.onnxRuntimeProviders?.includes("CUDAExecutionProvider") ?? false;
+  const cudaEpInVenv = hardwareProbe?.cuda?.loadable === true;
   const cudaNeedsOrtGpuInstall =
     nvidiaGpus.length > 0 && !isPreMaxwellBox && !cudaEpInVenv;
   const cudaToolkitMissing = hardwareProbe?.nvidia?.cudaToolkit?.available === false;

--- a/src/components/features/IHVIntegrationPanel.tsx
+++ b/src/components/features/IHVIntegrationPanel.tsx
@@ -34,6 +34,10 @@ import {
   type HardwareProbeResult,
 } from "@/lib/hardwareProbe";
 import { PROVIDER_CATALOG } from "@/lib/providerCatalog";
+import {
+  OPEN_VINO_GPU_DRIVER_URL,
+  OPEN_VINO_NPU_DRIVER_URL,
+} from "@/lib/openvinoDeps";
 import { VramEstimateBanner } from "@/components/features/VramEstimateBanner";
 import {
   Settings2,
@@ -309,6 +313,9 @@ export function IHVIntegrationPanel({
   const [installingTrt, setInstallingTrt] = useState(false);
   const [installTrtError, setInstallTrtError] = useState<string | null>(null);
   const [installTrtLog, setInstallTrtLog] = useState<string[]>([]);
+  const [installingOpenvino, setInstallingOpenvino] = useState(false);
+  const [installOpenvinoError, setInstallOpenvinoError] = useState<string | null>(null);
+  const [installOpenvinoLog, setInstallOpenvinoLog] = useState<string[]>([]);
 
   const hasAutoAppliedRef = useRef(false);
 
@@ -316,7 +323,11 @@ export function IHVIntegrationPanel({
     Boolean(hardwareProbe?.nvidia?.gpus.length) && hardwareProbe?.tensorRtRtx?.loadable !== true;
   const trtNeedsInstall =
     Boolean(hardwareProbe?.nvidia?.gpus.length) && hardwareProbe?.tensorrt?.loadable !== true;
-  const tensorRtInstallBusy = installingTrt || installingTrtRtx;
+  const openvinoNeedsInstall =
+    Boolean(hardwareProbe) &&
+    isProviderDetectedLocally("OpenVINOExecutionProvider", hardwareProbe) &&
+    hardwareProbe?.openvino?.available !== true;
+  const hardwareInstallBusy = installingTrt || installingTrtRtx || installingOpenvino;
 
   const runNdjsonInstall = async (
     url: string,
@@ -373,7 +384,7 @@ export function IHVIntegrationPanel({
   };
 
   const handleInstallTensorRtRtx = async () => {
-    if (tensorRtInstallBusy) return;
+    if (hardwareInstallBusy) return;
     setInstallingTrtRtx(true);
     setInstallTrtRtxError(null);
     setInstallTrtRtxLog([]);
@@ -393,7 +404,7 @@ export function IHVIntegrationPanel({
   };
 
   const handleInstallTensorRt = async () => {
-    if (tensorRtInstallBusy) return;
+    if (hardwareInstallBusy) return;
     setInstallingTrt(true);
     setInstallTrtError(null);
     setInstallTrtLog([]);
@@ -409,6 +420,26 @@ export function IHVIntegrationPanel({
       );
     } finally {
       setInstallingTrt(false);
+    }
+  };
+
+  const handleInstallOpenVino = async () => {
+    if (hardwareInstallBusy) return;
+    setInstallingOpenvino(true);
+    setInstallOpenvinoError(null);
+    setInstallOpenvinoLog([]);
+    try {
+      await runNdjsonInstall("/api/env/install-openvino", setInstallOpenvinoLog);
+      await runHardwareProbe(true);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      setInstallOpenvinoError(
+        msg === "Failed to fetch"
+          ? "Could not reach the Olive Studio server (or the connection dropped during install). Keep pnpm dev running, then retry."
+          : msg,
+      );
+    } finally {
+      setInstallingOpenvino(false);
     }
   };
 
@@ -714,7 +745,8 @@ export function IHVIntegrationPanel({
                     badgeColor = "bg-rose-500/5 text-rose-400/80 border-rose-550/15";
                   } else if (
                     ((p.id === "NvTensorRTRTXExecutionProvider" && trtRtxNeedsInstall) ||
-                      (p.id === "TensorrtExecutionProvider" && trtNeedsInstall)) &&
+                      (p.id === "TensorrtExecutionProvider" && trtNeedsInstall) ||
+                      (p.id === "OpenVINOExecutionProvider" && openvinoNeedsInstall)) &&
                     detectedLocally
                   ) {
                     cardClasses += "border-amber-900/40 bg-amber-950/10 opacity-95 hover:border-amber-500/40";
@@ -755,7 +787,7 @@ export function IHVIntegrationPanel({
                       : p.id === "ROCMExecutionProvider"
                         ? hardwareProbe?.rocm?.gpus.map((g) => g.name).join(", ")
                         : p.id === "OpenVINOExecutionProvider" && hardwareProbe?.openvino?.available
-                          ? `OpenVINO ${hardwareProbe.openvino.version ?? ""}`.trim()
+                          ? `OpenVINO ${hardwareProbe.openvino.version ?? ""}${hardwareProbe.openvino.devices?.length ? ` (${hardwareProbe.openvino.devices.join(", ")})` : ""}`.trim()
                           : p.id === "CPUExecutionProvider" && hardwareProbe
                             ? hardwareProbe.platform.cpuModel
                             : null;
@@ -873,7 +905,7 @@ export function IHVIntegrationPanel({
                               )}
                               <button
                                 type="button"
-                                disabled={tensorRtInstallBusy}
+                                disabled={hardwareInstallBusy}
                                 onClick={() => void handleInstallTensorRtRtx()}
                                 className="h-7 px-3 rounded border border-amber-500/40 text-amber-300 bg-amber-500/10 hover:bg-amber-500/20 text-[11px] font-bold disabled:opacity-50 flex items-center gap-1.5"
                               >
@@ -914,7 +946,7 @@ export function IHVIntegrationPanel({
                               )}
                               <button
                                 type="button"
-                                disabled={tensorRtInstallBusy}
+                                disabled={hardwareInstallBusy}
                                 onClick={() => void handleInstallTensorRt()}
                                 className="h-7 px-3 rounded border border-amber-500/40 text-amber-300 bg-amber-500/10 hover:bg-amber-500/20 text-[11px] font-bold disabled:opacity-50 flex items-center gap-1.5"
                               >
@@ -937,6 +969,73 @@ export function IHVIntegrationPanel({
                               )}
                             </div>
                           )}
+                          {p.id === "OpenVINOExecutionProvider" && openvinoNeedsInstall && (
+                            <div className="mt-2 space-y-1.5 min-w-0" onClick={(e) => e.stopPropagation()}>
+                              <p className="text-[11px] text-amber-400/90 leading-relaxed">
+                                OpenVINO stack not in the project{" "}
+                                <code className="text-slate-400">.venv</code>. Install to enable Intel CPU,
+                                GPU, and NPU targets.
+                              </p>
+                              {hardwareProbe?.openvino?.detail && (
+                                <p
+                                  className="text-[10px] text-slate-500 font-mono break-all max-w-full"
+                                  title={hardwareProbe.openvino.detail}
+                                >
+                                  {hardwareProbe.openvino.detail}
+                                </p>
+                              )}
+                              <button
+                                type="button"
+                                disabled={hardwareInstallBusy}
+                                onClick={() => void handleInstallOpenVino()}
+                                className="h-7 px-3 rounded border border-amber-500/40 text-amber-300 bg-amber-500/10 hover:bg-amber-500/20 text-[11px] font-bold disabled:opacity-50 flex items-center gap-1.5"
+                              >
+                                {installingOpenvino ? (
+                                  <>
+                                    <RefreshCw className="h-3 w-3 animate-spin" />
+                                    Installing OpenVINO stack…
+                                  </>
+                                ) : (
+                                  "Install OpenVINO stack into .venv"
+                                )}
+                              </button>
+                              {installOpenvinoError && (
+                                <p className="text-[11px] text-rose-400 break-all">{installOpenvinoError}</p>
+                              )}
+                              {installOpenvinoLog.length > 0 && (
+                                <pre className="text-[10px] text-slate-500 max-h-24 max-w-full overflow-auto font-mono whitespace-pre-wrap break-all">
+                                  {installOpenvinoLog.slice(-12).join("\n")}
+                                </pre>
+                              )}
+                            </div>
+                          )}
+                          {p.id === "OpenVINOExecutionProvider" &&
+                            hardwareProbe?.openvino?.available &&
+                            !hardwareProbe.openvino.devices?.some((d) => /GPU|NPU/i.test(d)) && (
+                              <p className="text-[11px] text-slate-500 mt-0.5 leading-relaxed">
+                                Only CPU detected. For GPU/NPU inference, install Intel drivers:{" "}
+                                <a
+                                  href={OPEN_VINO_GPU_DRIVER_URL}
+                                  target="_blank"
+                                  rel="noreferrer"
+                                  className="text-electric-blue hover:underline"
+                                  onClick={(e) => e.stopPropagation()}
+                                >
+                                  GPU
+                                </a>
+                                {" / "}
+                                <a
+                                  href={OPEN_VINO_NPU_DRIVER_URL}
+                                  target="_blank"
+                                  rel="noreferrer"
+                                  className="text-electric-blue hover:underline"
+                                  onClick={(e) => e.stopPropagation()}
+                                >
+                                  NPU
+                                </a>
+                                .
+                              </p>
+                            )}
                           {isWebGpuTarget && (
                             <p className="text-[11px] text-slate-500 mt-0.5 leading-relaxed">
                               Not a local Python EP. Select to build web-oriented recipes, then use{" "}

--- a/src/components/features/IHVIntegrationPanel.tsx
+++ b/src/components/features/IHVIntegrationPanel.tsx
@@ -995,8 +995,8 @@ export function IHVIntegrationPanel({
                             </div>
                           )}
                           {p.id === "OpenVINOExecutionProvider" &&
-                            hardwareProbe?.openvino?.devices?.length &&
-                            !hardwareProbe.openvino.devices.some((d) => /GPU|NPU/i.test(d)) && (
+                            (hardwareProbe?.openvino?.devices?.length ?? 0) > 0 &&
+                            !hardwareProbe!.openvino!.devices!.some((d) => /GPU|NPU/i.test(d)) && (
                               <p className="text-[11px] text-slate-500 mt-0.5 leading-relaxed">
                                 Only CPU detected. For GPU/NPU inference, install Intel drivers:{" "}
                                 <a

--- a/src/components/features/InputEnvironmentPanel.tsx
+++ b/src/components/features/InputEnvironmentPanel.tsx
@@ -39,10 +39,9 @@ import {
   assessRecipeHardwareCompatibility,
   summarizeRecipeHardwareCompatibility,
 } from "@/lib/recipeHardwareCompatibility";
-import { isNvTensorRtRtxCatalogPath, tensorrtRtxEpAbiLabel } from "@/lib/tensorrtRtxDeps";
+import { isNvTensorRtRtxCatalogPath } from "@/lib/tensorrtRtxDeps";
 import { fetchHardwareProbe, type HardwareProbeResult } from "@/lib/hardwareProbe";
 import { navigatePipeline } from "@/lib/pipelineNavigation";
-import { pinnedTensorRtLabel } from "@/lib/tensorrtDeps";
 import { estimateVramForCatalogPreset } from "@/lib/presetVramEstimate";
 import { CompatCountSummary, CompatStatusPill } from "@/components/features/CompatStatus";
 import {
@@ -1102,10 +1101,13 @@ export function InputEnvironmentPanel({
                                           <DownloadCloud className="h-3 w-3 text-amber-400 shrink-0 mt-0.5" />
                                           <div className="flex-1 min-w-0">
                                             <p className="text-[11px] text-amber-300/95 leading-snug">
-                                              {hardware.requiresInstall.kind === "tensorrt-rtx"
-                                                ? `${tensorrtRtxEpAbiLabel()} not in .venv yet — GPU is in the supported family.`
-                                                : `${pinnedTensorRtLabel()} not in .venv yet — GPU is in the supported family.`}
-                                              {" "}
+                                              {/* Use the hint directly so the label and
+                                                  install command always agree — the old
+                                                  code branched on `kind` and only swapped
+                                                  between two hardcoded labels, so the CUDA
+                                                  case silently printed the TensorRT label
+                                                  next to the onnxruntime install command. */}
+                                              {hardware.requiresInstall.hint}{" "}
                                               <button
                                                 type="button"
                                                 onClick={() => navigatePipeline("ihv")}

--- a/src/components/features/InputEnvironmentPanel.tsx
+++ b/src/components/features/InputEnvironmentPanel.tsx
@@ -39,8 +39,10 @@ import {
   assessRecipeHardwareCompatibility,
   summarizeRecipeHardwareCompatibility,
 } from "@/lib/recipeHardwareCompatibility";
-import { isNvTensorRtRtxCatalogPath } from "@/lib/tensorrtRtxDeps";
+import { isNvTensorRtRtxCatalogPath, tensorrtRtxEpAbiLabel } from "@/lib/tensorrtRtxDeps";
 import { fetchHardwareProbe, type HardwareProbeResult } from "@/lib/hardwareProbe";
+import { navigatePipeline } from "@/lib/pipelineNavigation";
+import { pinnedTensorRtLabel } from "@/lib/tensorrtDeps";
 import { estimateVramForCatalogPreset } from "@/lib/presetVramEstimate";
 import { CompatCountSummary, CompatStatusPill } from "@/components/features/CompatStatus";
 import {
@@ -1091,6 +1093,32 @@ export function InputEnvironmentPanel({
                                         <p className="text-[11px] text-amber-500/90 mt-0.5">
                                           {vramEst.fitHint}
                                         </p>
+                                      )}
+                                      {hardware.requiresInstall && (
+                                        <div
+                                          className="mt-1.5 flex items-start gap-1.5 rounded border border-amber-500/30 bg-amber-500/5 px-2 py-1.5"
+                                          title={hardware.requiresInstall.hint}
+                                        >
+                                          <DownloadCloud className="h-3 w-3 text-amber-400 shrink-0 mt-0.5" />
+                                          <div className="flex-1 min-w-0">
+                                            <p className="text-[11px] text-amber-300/95 leading-snug">
+                                              {hardware.requiresInstall.kind === "tensorrt-rtx"
+                                                ? `${tensorrtRtxEpAbiLabel()} not in .venv yet — GPU is in the supported family.`
+                                                : `${pinnedTensorRtLabel()} not in .venv yet — GPU is in the supported family.`}
+                                              {" "}
+                                              <button
+                                                type="button"
+                                                onClick={() => navigatePipeline("ihv")}
+                                                className="text-electric-blue hover:text-white underline underline-offset-2 cursor-pointer"
+                                              >
+                                                Install in Hardware (step 02) →
+                                              </button>
+                                            </p>
+                                            <p className="text-[10px] font-mono text-slate-500 mt-0.5 truncate">
+                                              {hardware.requiresInstall.installCommand}
+                                            </p>
+                                          </div>
+                                        </div>
                                       )}
                                       {hwBlocked && (
                                         <p className="text-[11px] text-rose-400/80 mt-0.5 line-clamp-1">

--- a/src/components/features/useOpenVinoInstall.test.ts
+++ b/src/components/features/useOpenVinoInstall.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it, vi, afterEach } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { useOpenVinoInstall } from "./useOpenVinoInstall";
+
+function ndjsonOk(): Response {
+  return new Response('{"type":"done","ok":true}\n', {
+    status: 200,
+    headers: { "content-type": "application/x-ndjson" },
+  });
+}
+
+describe("useOpenVinoInstall", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("guards against a concurrent second install", async () => {
+    let resolveFetch: ((value: Response) => void) | undefined;
+    const fetchPromise = new Promise<Response>((resolve) => {
+      resolveFetch = resolve;
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => fetchPromise),
+    );
+    const onProbeRefresh = vi.fn(async () => undefined);
+
+    const { result } = renderHook(() =>
+      useOpenVinoInstall({ onProbeRefresh, isInstallBusy: false }),
+    );
+
+    let first: Promise<void>;
+    act(() => {
+      first = result.current.install();
+    });
+    expect(result.current.state.installing).toBe(true);
+
+    await act(async () => {
+      await result.current.install();
+    });
+    expect(fetch).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolveFetch?.(ndjsonOk());
+      await first!;
+    });
+    expect(onProbeRefresh).toHaveBeenCalledTimes(1);
+  });
+
+  it('maps fetch rejection "Failed to fetch" to the user-facing server message', async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        throw new Error("Failed to fetch");
+      }),
+    );
+    const onProbeRefresh = vi.fn(async () => undefined);
+    const { result } = renderHook(() =>
+      useOpenVinoInstall({ onProbeRefresh, isInstallBusy: false }),
+    );
+
+    await act(async () => {
+      await result.current.install();
+    });
+
+    expect(result.current.state.error).toContain("Could not reach the Olive Studio server");
+    expect(onProbeRefresh).not.toHaveBeenCalled();
+  });
+
+  it("invokes onProbeRefresh(true) after a successful install", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ndjsonOk()),
+    );
+    const onProbeRefresh = vi.fn(async () => undefined);
+    const { result } = renderHook(() =>
+      useOpenVinoInstall({ onProbeRefresh, isInstallBusy: false }),
+    );
+
+    await act(async () => {
+      await result.current.install();
+    });
+
+    expect(onProbeRefresh).toHaveBeenCalledWith(true);
+    expect(result.current.state.error).toBeNull();
+    expect(result.current.state.installing).toBe(false);
+  });
+});

--- a/src/components/features/useOpenVinoInstall.ts
+++ b/src/components/features/useOpenVinoInstall.ts
@@ -1,0 +1,115 @@
+/**
+ * OpenVINO stack install hook for the Hardware panel.
+ *
+ * Streams NDJSON from POST /api/env/install-openvino and refreshes the
+ * hardware probe on success. Extracted from IHVIntegrationPanel so the
+ * panel stays thinner and the install path is unit-testable in isolation.
+ */
+import { useCallback, useState } from "react";
+
+export interface UseOpenVinoInstallOptions {
+  /** Called after a successful install (typically refresh=true hardware probe). */
+  onProbeRefresh: (refresh?: boolean) => Promise<void>;
+  /** True when another hardware install (TensorRT / TRT RTX) is already running. */
+  isInstallBusy: boolean;
+}
+
+export interface OpenVinoInstallState {
+  installing: boolean;
+  error: string | null;
+  log: string[];
+}
+
+async function runNdjsonInstall(
+  url: string,
+  setLog: (updater: string[] | ((prev: string[]) => string[])) => void,
+): Promise<void> {
+  const res = await fetch(url, { method: "POST" });
+  const contentType = res.headers.get("content-type") ?? "";
+
+  let ok = false;
+  let error: string | undefined;
+
+  if (contentType.includes("ndjson") && res.body) {
+    const reader = res.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = "";
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+      const parts = buffer.split("\n");
+      buffer = parts.pop() ?? "";
+      for (const line of parts) {
+        if (!line.trim()) continue;
+        let evt: { type?: string; message?: string; ok?: boolean; error?: string };
+        try {
+          evt = JSON.parse(line) as typeof evt;
+        } catch {
+          continue;
+        }
+        if (evt.type === "log" && evt.message) {
+          setLog((prev) => [...prev, evt.message!]);
+        } else if (evt.type === "done") {
+          ok = res.ok && evt.ok === true;
+          error = evt.error;
+        }
+      }
+    }
+  } else {
+    const data = (await res.json()) as {
+      ok?: boolean;
+      error?: string;
+      lines?: string[];
+      log?: string[];
+    };
+    const lines = data.lines ?? data.log;
+    if (Array.isArray(lines)) setLog(lines);
+    ok = res.ok && data.ok === true;
+    error = data.error;
+  }
+
+  if (!ok) {
+    throw new Error(error ?? `Install failed (HTTP ${res.status})`);
+  }
+}
+
+/**
+ * Manages OpenVINO stack installation UI state and the NDJSON install call.
+ */
+export function useOpenVinoInstall({
+  onProbeRefresh,
+  isInstallBusy,
+}: UseOpenVinoInstallOptions): {
+  state: OpenVinoInstallState;
+  install: () => Promise<void>;
+} {
+  const [installing, setInstalling] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [log, setLog] = useState<string[]>([]);
+
+  const install = useCallback(async () => {
+    if (isInstallBusy || installing) return;
+    setInstalling(true);
+    setError(null);
+    setLog([]);
+    try {
+      await runNdjsonInstall("/api/env/install-openvino", setLog);
+      await onProbeRefresh(true);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      setError(
+        msg === "Failed to fetch"
+          ? "Could not reach the Olive Studio server (or the connection dropped during install). Keep pnpm dev running, then retry."
+          : msg,
+      );
+    } finally {
+      setInstalling(false);
+    }
+  }, [isInstallBusy, installing, onProbeRefresh]);
+
+  return {
+    state: { installing, error, log },
+    install,
+  };
+}

--- a/src/components/features/useOpenVinoInstall.ts
+++ b/src/components/features/useOpenVinoInstall.ts
@@ -6,6 +6,7 @@
  * panel stays thinner and the install path is unit-testable in isolation.
  */
 import { useCallback, useState } from "react";
+import { runNdjsonInstall } from "@/lib/ndjsonInstall";
 
 export interface UseOpenVinoInstallOptions {
   /** Called after a successful install (typically refresh=true hardware probe). */
@@ -18,60 +19,6 @@ export interface OpenVinoInstallState {
   installing: boolean;
   error: string | null;
   log: string[];
-}
-
-async function runNdjsonInstall(
-  url: string,
-  setLog: (updater: string[] | ((prev: string[]) => string[])) => void,
-): Promise<void> {
-  const res = await fetch(url, { method: "POST" });
-  const contentType = res.headers.get("content-type") ?? "";
-
-  let ok = false;
-  let error: string | undefined;
-
-  if (contentType.includes("ndjson") && res.body) {
-    const reader = res.body.getReader();
-    const decoder = new TextDecoder();
-    let buffer = "";
-    while (true) {
-      const { done, value } = await reader.read();
-      if (done) break;
-      buffer += decoder.decode(value, { stream: true });
-      const parts = buffer.split("\n");
-      buffer = parts.pop() ?? "";
-      for (const line of parts) {
-        if (!line.trim()) continue;
-        let evt: { type?: string; message?: string; ok?: boolean; error?: string };
-        try {
-          evt = JSON.parse(line) as typeof evt;
-        } catch {
-          continue;
-        }
-        if (evt.type === "log" && evt.message) {
-          setLog((prev) => [...prev, evt.message!]);
-        } else if (evt.type === "done") {
-          ok = res.ok && evt.ok === true;
-          error = evt.error;
-        }
-      }
-    }
-  } else {
-    const data = (await res.json()) as {
-      ok?: boolean;
-      error?: string;
-      lines?: string[];
-      log?: string[];
-    };
-    const lines = data.lines ?? data.log;
-    if (Array.isArray(lines)) setLog(lines);
-    ok = res.ok && data.ok === true;
-    error = data.error;
-  }
-
-  if (!ok) {
-    throw new Error(error ?? `Install failed (HTTP ${res.status})`);
-  }
 }
 
 /**

--- a/src/index.css
+++ b/src/index.css
@@ -112,6 +112,33 @@
   :root {
     color-scheme: dark;
   }
+  /*
+   * Lock the document to the viewport so no descendant can push the body
+   * past the screen. Without this, sticky / fixed children or panels with a
+   * pixel-height such as `100vh` can briefly escape `overflow-hidden` on the
+   * React tree, leaving a tall empty band below the app and letting the
+   * browser/WKWebView scroll an empty page forever.
+   *
+   * `overscroll-behavior: none` silences the rubber-band bounce at the very
+   * top/bottom so scroll-chaining can't reach the body either.
+   *
+   * `#root` is intentionally NOT in this rule — React portals in this app
+   * target `document.body` (e.g. modals), and the inner App shell already
+   * clamps with `h-screen overflow-hidden`. Adding `overflow: hidden` on
+   * `#root` would silently clip any future portal that targets it.
+   */
+  html,
+  body {
+    height: 100%;
+    margin: 0;
+    padding: 0;
+    overflow: hidden;
+    overscroll-behavior: none;
+  }
+  html {
+    /* Belt-and-braces: prevent horizontal overscroll as well. */
+    overflow-x: hidden;
+  }
   body {
     @apply bg-slate-950 text-slate-300 font-sans antialiased selection:bg-electric-blue/30;
   }

--- a/src/lib/__tests__/providerCatalog.test.ts
+++ b/src/lib/__tests__/providerCatalog.test.ts
@@ -173,7 +173,7 @@ describe("TensorRT SM floor lockstep (catalog chip ↔ hardware probe)", () => {
     expect(trt.tooltip.requirements).toMatch(/Maxwell|Pascal|Kepler/i);
   });
 
-  it("full TensorRT chip and TRT-RTX chip share the SAME ${floor} string", () => {
+  it(`full TensorRT chip and TRT-RTX chip share the SAME ${floor} string`, () => {
     // Across-the-family lockstep: both halves of the family must cite the
     // exact same numeric constant so a future bump updates both halves
     // atomically. If only one chip gets a new floor, this test fails.

--- a/src/lib/__tests__/providerCatalog.test.ts
+++ b/src/lib/__tests__/providerCatalog.test.ts
@@ -1,0 +1,203 @@
+import { describe, expect, it } from "vitest";
+
+import { PROVIDER_CATALOG, getProviderCatalogEntry } from "@/lib/providerCatalog";
+import {
+  TENSORRT_FAMILY_MIN_COMPUTE_CAPABILITY,
+  getProviderAvailabilityBlock,
+  type HardwareProbeResult,
+} from "@/lib/hardwareProbe";
+
+/**
+ * Build a probe stub with `detectedProviders = ["CPUExecutionProvider"]` so
+ * `getProviderAvailabilityBlock` falls into the unavailable branch and
+ * surfaces the `undetectedProviderReason(...)` text the user sees for any
+ * non-CPU / non-WebGPU provider we ask about. This is exactly the path
+ * taken when a pre-Turing GPU is detected and `mergeDetectedProviders`
+ * strips the TensorRT-family EPs.
+ */
+function probeWithoutRecommendedProviders(): HardwareProbeResult {
+  return {
+    probedAt: new Date().toISOString(),
+    platform: { os: "win32 10.0", arch: "x64", cpuModel: "Test CPU", cpuCores: 8 },
+    nvidia: undefined,
+    rocm: undefined,
+    openvino: undefined,
+    tensorrt: undefined,
+    tensorRtRtx: undefined,
+    onnxRuntimeProviders: undefined,
+    detectedProviders: ["CPUExecutionProvider"],
+    recommendedProvider: "CPUExecutionProvider",
+    notes: [],
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Catalog structure
+// ─────────────────────────────────────────────────────────────────────────
+
+describe("PROVIDER_CATALOG", () => {
+  it("contains exactly one entry per known execution provider id", () => {
+    const ids = PROVIDER_CATALOG.map((p) => p.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    expect(ids).toContain("CUDAExecutionProvider");
+    expect(ids).toContain("TensorrtExecutionProvider");
+    expect(ids).toContain("NvTensorRTRTXExecutionProvider");
+    expect(ids).toContain("CPUExecutionProvider");
+    expect(ids).toContain("OpenVINOExecutionProvider");
+    expect(ids).toContain("ROCMExecutionProvider");
+    expect(ids).toContain("QNNExecutionProvider");
+    expect(ids).toContain("WebGpuExecutionProvider");
+  });
+
+  it("returns the matching entry from getProviderCatalogEntry", () => {
+    expect(getProviderCatalogEntry("TensorrtExecutionProvider")?.name).toBe("NVIDIA TensorRT");
+    expect(getProviderCatalogEntry("NvTensorRTRTXExecutionProvider")?.shortName).toBe("TRT RTX");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// SM 7.5 (Turing) floor lockstep — IMPORTANT DRIFT GUARD
+// ─────────────────────────────────────────────────────────────────────────
+//
+// `TENSORRT_FAMILY_MIN_COMPUTE_CAPABILITY` is the single source of truth in
+// `hardwareProbe.ts` for the floor required by both `TensorrtExecutionProvider`
+// AND `NvTensorRTRTXExecutionProvider`. Two user-facing surfaces tell the
+// user about this floor:
+//
+//   1. The catalog chip (desc + tooltip.requirements) in PROVIDER_CATALOG
+//      for NvTensorRTRTXExecutionProvider — surface A.
+//
+//   2. The `undetectedProviderReason('NvTensorRTRTXExecutionProvider')`
+//      text surfaced via `getProviderAvailabilityBlock` when a recipe
+//      provider is missing locally — surface B.
+//
+// When the floor changes, BOTH surfaces must change together. These tests
+// assert each surface contains the SAME numeric constant from
+// TENSORRT_FAMILY_MIN_COMPUTE_CAPABILITY so a one-sided edit can't slip
+// through.
+// ─────────────────────────────────────────────────────────────────────────
+
+describe("TensorRT-RTX SM floor lockstep (catalog chip ↔ hardware probe)", () => {
+  const rtx = getProviderCatalogEntry("NvTensorRTRTXExecutionProvider");
+  // Hard require — the catalog must carry a TRT-RTX entry.
+  if (!rtx) throw new Error("PROVIDER_CATALOG is missing NvTensorRTRTXExecutionProvider");
+
+  const floor = `${TENSORRT_FAMILY_MIN_COMPUTE_CAPABILITY.major}.${TENSORRT_FAMILY_MIN_COMPUTE_CAPABILITY.minor}`;
+
+  it("TRT-RTX chip tooltip.requirements states the SM floor numerically", () => {
+    expect(rtx.tooltip.requirements).toContain(floor);
+  });
+
+  it("TRT-RTX chip desc states the SM floor numerically", () => {
+    expect(rtx.desc).toContain(floor);
+  });
+
+  it("TRT-RTX chip tooltip mentions the Turing / RTX 20xx families by name", () => {
+    // The chip should name at least Turing + RTX 20xx so the user can map
+    // the floor onto a real product. The phrase is loose (allows
+    // "Turing" + "RTX 20xx" to appear separately) to keep the test stable
+    // against small wording tweaks.
+    expect(/Turing/i.test(rtx.tooltip.requirements)).toBe(true);
+    expect(/RTX\s*20xx?/i.test(rtx.tooltip.requirements)).toBe(true);
+  });
+
+  it("TRT-RTX chip tooltip calls out the pre-Turing cards that will never work", () => {
+    // The companion message to the floor — pre-Turing users must read this
+    // and understand that no install will recover them.
+    expect(rtx.tooltip.requirements).toMatch(/Maxwell|Pascal|Kepler/i);
+  });
+
+  it("hardware probe's unavailable reason for TRT-RTX carries the SAME SM floor constant", () => {
+    const block = getProviderAvailabilityBlock(
+      "NvTensorRTRTXExecutionProvider",
+      probeWithoutRecommendedProviders(),
+    );
+    expect(block).not.toBeNull();
+    expect(block?.reason).toContain(floor);
+  });
+
+  it("hardware probe's unavailable reason for full TensorRT carries the SAME SM floor constant", () => {
+    // Same drift guard for the OTHER half of the family. Both TRT and
+    // TRT-RTX share the same floor; both surfaces must reference it.
+    const block = getProviderAvailabilityBlock(
+      "TensorrtExecutionProvider",
+      probeWithoutRecommendedProviders(),
+    );
+    expect(block).not.toBeNull();
+    expect(block?.reason).toContain(floor);
+  });
+
+  it("does not regress to a misleading '30xx-only' requirement on the TRT-RTX chip", () => {
+    // The earlier chip said "GeForce RTX 30xx or newer (Ampere+)" which
+    // implied SM 8.0, contradicting the SM 7.5 floor. Make sure no future
+    // edit reintroduces that tighter (and incorrect) wording without
+    // bumping the gate too.
+    expect(rtx.tooltip.requirements).not.toMatch(/30xx or newer \(Ampere\+\)/);
+    expect(rtx.desc).not.toMatch(/GeForce 30xx\+/);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// Full TensorRT SM floor lockstep (catalog chip ↔ hardware probe)
+// ─────────────────────────────────────────────────────────────────────────
+//
+// Same drift guard as above but for the OTHER half of the family.
+// `TensorrtExecutionProvider` and `NvTensorRTRTXExecutionProvider` share
+// the same SM 7.5 floor (Turing / GeForce RTX 20xx+) — the catalog and
+// the hardware-probe reason for BOTH providers must cite the same
+// numeric constant. Previously the chip for full TensorRT said only
+// "Turing or newer (GeForce RTX 20xx+)" with no numeric anchor, so a
+// constant bump could silently desync the chip copy and the floor.
+// ─────────────────────────────────────────────────────────────────────────
+
+describe("TensorRT SM floor lockstep (catalog chip ↔ hardware probe)", () => {
+  const trt = getProviderCatalogEntry("TensorrtExecutionProvider");
+  if (!trt) throw new Error("PROVIDER_CATALOG is missing TensorrtExecutionProvider");
+
+  const floor = `${TENSORRT_FAMILY_MIN_COMPUTE_CAPABILITY.major}.${TENSORRT_FAMILY_MIN_COMPUTE_CAPABILITY.minor}`;
+
+  it("full TensorRT chip tooltip.requirements states the SM floor numerically", () => {
+    expect(trt.tooltip.requirements).toContain(floor);
+  });
+
+  it("full TensorRT chip desc states the SM floor numerically", () => {
+    expect(trt.desc).toContain(floor);
+  });
+
+  it("full TensorRT chip tooltip mentions Turing / RTX 20xx by name", () => {
+    expect(/Turing/i.test(trt.tooltip.requirements)).toBe(true);
+    expect(/RTX\s*20xx?/i.test(trt.tooltip.requirements)).toBe(true);
+  });
+
+  it("full TensorRT chip tooltip calls out pre-Turing cards that will never work", () => {
+    expect(trt.tooltip.requirements).toMatch(/Maxwell|Pascal|Kepler/i);
+  });
+
+  it("full TensorRT chip and TRT-RTX chip share the SAME ${floor} string", () => {
+    // Across-the-family lockstep: both halves of the family must cite the
+    // exact same numeric constant so a future bump updates both halves
+    // atomically. If only one chip gets a new floor, this test fails.
+    const rtx = getProviderCatalogEntry("NvTensorRTRTXExecutionProvider");
+    expect(rtx).toBeDefined();
+    expect(trt.tooltip.requirements).toContain(floor);
+    expect(rtx!.tooltip.requirements).toContain(floor);
+  });
+
+  it("hardware probe's unavailable reason for full TensorRT carries the SAME SM floor constant", () => {
+    const block = getProviderAvailabilityBlock(
+      "TensorrtExecutionProvider",
+      probeWithoutRecommendedProviders(),
+    );
+    expect(block).not.toBeNull();
+    expect(block?.reason).toContain(floor);
+  });
+
+  it("does not regress to a 'no numeric anchor' copy on the full TensorRT chip", () => {
+    // Earlier copy was "NVIDIA GPU Turing or newer (GeForce RTX 20xx+, Quadro,
+    // datacenter)" with no 7.5 anchor. A future edit that drops the numeric
+    // floor would leave the chip and the constant out of sync. Belt and
+    // braces: assert we never drop the numeric floor from the chip.
+    expect(trt.tooltip.requirements).toMatch(/\b\d+\.\d+\b/);
+    expect(trt.desc).toMatch(/\b\d+\.\d+\b/);
+  });
+});

--- a/src/lib/__tests__/recipeHardwareCompatibility.test.ts
+++ b/src/lib/__tests__/recipeHardwareCompatibility.test.ts
@@ -1,0 +1,481 @@
+import { describe, expect, it } from "vitest";
+import {
+  assessRecipeHardwareCompatibility,
+  summarizeRecipeHardwareCompatibility,
+  type RecipeHardwareCompatResult,
+} from "@/lib/recipeHardwareCompatibility";
+import {
+  TENSORRT_FAMILY_MIN_COMPUTE_CAPABILITY,
+  type HardwareProbeResult,
+} from "@/lib/hardwareProbe";
+import type { RecipeCatalogItem } from "@/lib/oliveRecipeHub";
+
+function makeProbe(overrides: Partial<HardwareProbeResult> = {}): HardwareProbeResult {
+  return {
+    probedAt: new Date().toISOString(),
+    platform: { os: "win32 10.0", arch: "x64", cpuModel: "Test CPU", cpuCores: 8 },
+    nvidia: undefined,
+    rocm: undefined,
+    openvino: undefined,
+    tensorrt: undefined,
+    tensorRtRtx: undefined,
+    onnxRuntimeProviders: undefined,
+    detectedProviders: ["CPUExecutionProvider"],
+    recommendedProvider: "CPUExecutionProvider",
+    notes: [],
+    ...overrides,
+  };
+}
+
+function tensorRtProbe(opts: {
+  nvidiaGpus?: Array<{ name: string; computeCapability?: string }>;
+  tensorrtLoadable?: boolean;
+  tensorrtDetail?: string;
+  tensorRtRtxLoadable?: boolean;
+  tensorRtRtxDetail?: string;
+  detectedProviders?: HardwareProbeResult["detectedProviders"];
+  onnxRuntimeProviders?: HardwareProbeResult["onnxRuntimeProviders"];
+}): HardwareProbeResult {
+  const result: Partial<HardwareProbeResult> = {
+    platform: { os: "win32 10.0", arch: "x64", cpuModel: "Test CPU", cpuCores: 8 },
+    nvidia: opts.nvidiaGpus
+      ? {
+          gpus: opts.nvidiaGpus,
+        }
+      : undefined,
+    tensorrt: {
+      loadable: opts.tensorrtLoadable ?? false,
+      detail: opts.tensorrtDetail,
+    },
+    tensorRtRtx: {
+      loadable: opts.tensorRtRtxLoadable ?? false,
+      detail: opts.tensorRtRtxDetail,
+    },
+    detectedProviders: opts.detectedProviders ?? ["CPUExecutionProvider"],
+    onnxRuntimeProviders: opts.onnxRuntimeProviders,
+    recommendedProvider: "CUDAExecutionProvider",
+  };
+  return makeProbe(result);
+}
+
+function makeCatalogItem(device: string, repoPath = "fake/recipe"): RecipeCatalogItem {
+  return {
+    repoPath,
+    name: `recipe (${device})`,
+    description: "",
+    device,
+    architecture: "Other",
+    metadataSource: "recipe",
+  } as RecipeCatalogItem;
+}
+
+describe("assessRecipeHardwareCompatibility — TensorRT install-needed fallback", () => {
+  it("returns 'compatible' with a tensorrt install hint when NVIDIA GPU is present but tensorrt deps aren't loaded", () => {
+    const probe = tensorRtProbe({
+      nvidiaGpus: [{ name: "NVIDIA GeForce RTX 5070" }],
+      tensorrtLoadable: false,
+      tensorrtDetail: "tensorrt not installed",
+      detectedProviders: ["CPUExecutionProvider", "CUDAExecutionProvider", "NvTensorRTRTXExecutionProvider"],
+    });
+
+    const result: RecipeHardwareCompatResult = assessRecipeHardwareCompatibility("TensorRT", probe);
+
+    expect(result.tier).toBe("compatible");
+    expect(result.requiredProvider).toBe("TensorrtExecutionProvider");
+    expect(result.requiresInstall).toBeDefined();
+    expect(result.requiresInstall?.kind).toBe("tensorrt");
+    expect(result.requiresInstall?.provider).toBe("TensorrtExecutionProvider");
+    // The install command MUST match what the project actually installs.
+    // No `--index-url` override (TRT 10.x is on PyPI) and version pinned.
+    expect(result.requiresInstall?.installCommand).toBe("pip install tensorrt==10.9.0.34");
+    expect(result.requiresInstall?.hint).toContain("RTX 5070");
+    expect(result.requiresInstall?.detail).toBe("tensorrt not installed");
+  });
+
+  it("returns plain 'compatible' (no install hint) when tensorrt deps are loaded", () => {
+    const probe = tensorRtProbe({
+      nvidiaGpus: [{ name: "NVIDIA GeForce RTX 5070" }],
+      tensorrtLoadable: true,
+      detectedProviders: [
+        "CPUExecutionProvider",
+        "CUDAExecutionProvider",
+        "TensorrtExecutionProvider",
+        "NvTensorRTRTXExecutionProvider",
+      ],
+    });
+
+    const result = assessRecipeHardwareCompatibility("TensorRT", probe);
+
+    expect(result.tier).toBe("compatible");
+    expect(result.requiredProvider).toBe("TensorrtExecutionProvider");
+    expect(result.requiresInstall).toBeUndefined();
+  });
+
+  it("still reports 'unavailable' when no NVIDIA GPU is present even if tensorrt deps were loaded", () => {
+    const probe = tensorRtProbe({
+      nvidiaGpus: undefined,
+      tensorrtLoadable: false,
+      detectedProviders: ["CPUExecutionProvider"],
+    });
+
+    const result = assessRecipeHardwareCompatibility("TensorRT", probe);
+
+    expect(result.tier).toBe("unavailable");
+    expect(result.requiresInstall).toBeUndefined();
+  });
+
+  it("returns 'compatible' with a tensorrt-rtx install hint when an NVIDIA GPU is present, RTX EP isn't in detectedProviders, and RTX deps aren't loaded", () => {
+    // Defensive fallback: as of this writing `mergeDetectedProviders` adds
+    // NvTensorRTRTXExecutionProvider unconditionally for any NVIDIA GPU, so
+    // this branch is unreachable in practice. The probe below strips RTX
+    // from detectedProviders to exercise the fallback anyway — it guards
+    // against future probes that report a more conservative detected list.
+    const probe = tensorRtProbe({
+      nvidiaGpus: [{ name: "NVIDIA GeForce RTX 5070" }],
+      tensorRtRtxLoadable: false,
+      tensorRtRtxDetail: "EP-ABI plugin missing",
+      detectedProviders: ["CPUExecutionProvider", "CUDAExecutionProvider"],
+    });
+
+    const result = assessRecipeHardwareCompatibility("TensorRT RTX", probe);
+
+    expect(result.tier).toBe("compatible");
+    expect(result.requiredProvider).toBe("NvTensorRTRTXExecutionProvider");
+    expect(result.requiresInstall).toBeDefined();
+    expect(result.requiresInstall?.kind).toBe("tensorrt-rtx");
+    // `--extra-index-url` (NOT `--index-url`) so other PyPI packages keep
+    // resolving from PyPI; matches `tensorrtRtxEpAbiInstallCommand()`.
+    expect(result.requiresInstall?.installCommand).toBe(
+      "pip install --extra-index-url https://pypi.nvidia.com onnxruntime-ep-nv-tensorrt-rtx-cu13==0.3.0",
+    );
+    expect(result.requiresInstall?.detail).toBe("EP-ABI plugin missing");
+  });
+
+  it("does not surface an install hint for non-TensorRT targets", () => {
+    const probe = tensorRtProbe({
+      nvidiaGpus: [{ name: "NVIDIA GeForce RTX 5070" }],
+      tensorrtLoadable: false,
+      detectedProviders: ["CPUExecutionProvider", "CUDAExecutionProvider"],
+    });
+
+    expect(assessRecipeHardwareCompatibility("CPU", probe).requiresInstall).toBeUndefined();
+    expect(assessRecipeHardwareCompatibility("CUDA", probe).requiresInstall).toBeUndefined();
+  });
+});
+
+describe("summarizeRecipeHardwareCompatibility — install-needed recipes count as compatible", () => {
+  it("rolls up install-needed TensorRT recipes under 'compatible', not 'unavailable'", () => {
+    const probe = tensorRtProbe({
+      nvidiaGpus: [{ name: "NVIDIA GeForce RTX 5070" }],
+      tensorrtLoadable: false,
+      detectedProviders: ["CPUExecutionProvider", "CUDAExecutionProvider", "NvTensorRTRTXExecutionProvider"],
+    });
+
+    const catalog: RecipeCatalogItem[] = [
+      makeCatalogItem("CPU"),
+      makeCatalogItem("CUDA"),
+      makeCatalogItem("TensorRT"),
+      makeCatalogItem("TensorRT RTX"),
+    ];
+
+    const summary = summarizeRecipeHardwareCompatibility(catalog, probe);
+
+    expect(summary.compatible).toBe(4);
+    expect(summary.unavailable).toBe(0);
+    expect(summary.unknown).toBe(0);
+  });
+});
+
+describe("assessRecipeHardwareCompatibility — pre-Turing NVIDIA boxes (SM < 7.5)", () => {
+  it("reports TensorRT 'unavailable' (no install hint) on a Pascal/Maxwell/Kepler GPU", () => {
+    const probe = tensorRtProbe({
+      // GTX 1080 = SM 6.1 (Pascal). Even when tensorrt.loadable is true
+      // (impossible in practice, but the test exercises the floor gate),
+      // the recipe must NOT be marked compatible.
+      nvidiaGpus: [{ name: "NVIDIA GeForce GTX 1080", computeCapability: "6.1" }],
+      tensorrtLoadable: false,
+      detectedProviders: ["CPUExecutionProvider", "CUDAExecutionProvider"],
+    });
+
+    const result = assessRecipeHardwareCompatibility("TensorRT", probe);
+
+    expect(result.tier).toBe("unavailable");
+    expect(result.requiredProvider).toBe("TensorrtExecutionProvider");
+    expect(result.requiresInstall).toBeUndefined();
+    expect(result.reason).toMatch(/compute capability/i);
+    expect(result.reason).toMatch(/GTX 1080/);
+    expect(result.reason).toMatch(/Turing/i);
+  });
+
+  it("reports TensorRT RTX 'unavailable' (no install hint) on a pre-Turing GPU", () => {
+    const probe = tensorRtProbe({
+      nvidiaGpus: [{ name: "NVIDIA GeForce GTX 980", computeCapability: "5.2" }],
+      tensorRtRtxLoadable: false,
+      detectedProviders: ["CPUExecutionProvider", "CUDAExecutionProvider"],
+    });
+
+    const result = assessRecipeHardwareCompatibility("TensorRT RTX", probe);
+
+    expect(result.tier).toBe("unavailable");
+    expect(result.requiredProvider).toBe("NvTensorRTRTXExecutionProvider");
+    expect(result.requiresInstall).toBeUndefined();
+    expect(result.reason).toMatch(/GTX 980/);
+    expect(result.reason).toMatch(/Maxwell\/Pascal\/Kepler/);
+  });
+
+  it("still falls through to the install-needed path on a Turing GPU at the floor boundary", () => {
+    // Boundary: SM 7.5 IS supported. If tensorrt deps aren't installed yet,
+    // we still want the green-banner-with-install-hint behavior.
+    const probe = tensorRtProbe({
+      nvidiaGpus: [{ name: "NVIDIA GeForce RTX 2080 Ti", computeCapability: "7.5" }],
+      tensorrtLoadable: false,
+      detectedProviders: ["CPUExecutionProvider", "CUDAExecutionProvider", "NvTensorRTRTXExecutionProvider"],
+    });
+
+    const result = assessRecipeHardwareCompatibility("TensorRT", probe);
+
+    expect(result.tier).toBe("compatible");
+    expect(result.requiresInstall).toBeDefined();
+    expect(result.requiresInstall?.kind).toBe("tensorrt");
+  });
+
+  it("treats missing compute capability as permissive (existing behavior preserved)", () => {
+    // No computeCapability reported (older driver). The pre-Turing gate
+    // must NOT silently downgrade — compatibility falls back to the existing
+    // install-needed path.
+    const probe = tensorRtProbe({
+      nvidiaGpus: [{ name: "NVIDIA GeForce RTX 5070" }],
+      tensorrtLoadable: false,
+      detectedProviders: ["CPUExecutionProvider", "CUDAExecutionProvider", "NvTensorRTRTXExecutionProvider"],
+    });
+
+    const result = assessRecipeHardwareCompatibility("TensorRT", probe);
+
+    expect(result.tier).toBe("compatible");
+    expect(result.requiresInstall?.kind).toBe("tensorrt");
+  });
+
+  it("mixed box (one pre-Turing, one Ampere) still reports TensorRT compatible", () => {
+    // The mergeDetectedProviders / isNvidiaGpuTensorRtFamily logic is true
+    // if AT LEAST ONE GPU meets the floor, since Olive picks one EP. A
+    // workstation with a GTX 1080 AND an RTX 3090 should still see TensorRT
+    // recipes as compatible / installable.
+    const probe = tensorRtProbe({
+      nvidiaGpus: [
+        { name: "NVIDIA GeForce GTX 1080", computeCapability: "6.1" },
+        { name: "NVIDIA GeForce RTX 3090", computeCapability: "8.6" },
+      ],
+      tensorrtLoadable: false,
+      detectedProviders: ["CPUExecutionProvider", "CUDAExecutionProvider", "NvTensorRTRTXExecutionProvider"],
+    });
+
+    const result = assessRecipeHardwareCompatibility("TensorRT", probe);
+
+    expect(result.tier).toBe("compatible");
+    expect(result.requiresInstall?.kind).toBe("tensorrt");
+  });
+
+  it("summary correctly counts pre-Tuning NVIDIA GPU as unavailable for TRTRTX recipes", () => {
+    const probe = tensorRtProbe({
+      nvidiaGpus: [{ name: "NVIDIA GeForce GTX 1060", computeCapability: "6.0" }],
+      detectedProviders: ["CPUExecutionProvider", "CUDAExecutionProvider"],
+    });
+
+    const catalog: RecipeCatalogItem[] = [
+      makeCatalogItem("CPU"),
+      makeCatalogItem("CUDA"),
+      makeCatalogItem("TensorRT"),
+      makeCatalogItem("TensorRT RTX"),
+    ];
+
+    const summary = summarizeRecipeHardwareCompatibility(catalog, probe);
+
+    expect(summary.compatible).toBe(2); // CPU + CUDA only
+    expect(summary.unavailable).toBe(2); // TensorRT + TensorRT RTX
+    expect(summary.unknown).toBe(0);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// CUDA — pre-Maxwell SM 5.0 short-circuit + onnxruntime-gpu install hint
+// ─────────────────────────────────────────────────────────────────────────
+
+describe("assessRecipeHardwareCompatibility — CUDA pre-Maxwell (SM < 5.0)", () => {
+  it("reports CUDA 'unavailable' (no install hint) on a Kepler SM 3.0 GPU", () => {
+    // Mirror what the real route produces: when CUDA cannot run on this
+    // hardware, `mergeDetectedProviders` strips the EP from the detected
+    // list — so this probe uses `["CPUExecutionProvider"]` only.
+    const probe = tensorRtProbe({
+      // GTX 680 = SM 3.0 (Kepler). Modern CUDA 12 wheels / toolkit cannot
+      // run on this card even when onnxruntime-gpu is installed.
+      nvidiaGpus: [{ name: "NVIDIA GeForce GTX 680", computeCapability: "3.0" }],
+      // `mergeDetectedProviders` keeps CUDA EP for any NVIDIA card; the
+      // pre-Maxwell short-circuit is what protects the user.
+      detectedProviders: ["CPUExecutionProvider"],
+    });
+
+    const result = assessRecipeHardwareCompatibility("CUDA", probe);
+
+    expect(result.tier).toBe("unavailable");
+    expect(result.requiredProvider).toBe("CUDAExecutionProvider");
+    expect(result.requiresInstall).toBeUndefined();
+    expect(result.reason).toMatch(/compute capability/i);
+    expect(result.reason).toMatch(/GTX 680/);
+    expect(result.reason).toMatch(/5\.0|Maxwell/);
+    expect(result.reason).toMatch(/Kepler/);
+  });
+
+  it("returns plain 'compatible' for CUDA recipes on a Maxwell boundary SM 5.0 card when EP is loaded", () => {
+    const probe = tensorRtProbe({
+      nvidiaGpus: [{ name: "NVIDIA GeForce GTX 750 Ti", computeCapability: "5.0" }],
+      detectedProviders: ["CPUExecutionProvider", "CUDAExecutionProvider"],
+      onnxRuntimeProviders: ["CPUExecutionProvider", "CUDAExecutionProvider"],
+    });
+
+    const result = assessRecipeHardwareCompatibility("CUDA", probe);
+    expect(result.tier).toBe("compatible");
+    expect(result.requiresInstall).toBeUndefined();
+  });
+
+  it("still falls through to install-needed on a SM 5.0 boundary card when onnxruntime-gpu missing", () => {
+    // Mirror what `mergeDetectedProviders` would produce when the ORT CUDA
+    // probe reports `cudaLoadable: false` — CUDA stripped from the detected
+    // list, so the install-needed branch is reachable.
+    const probe = tensorRtProbe({
+      nvidiaGpus: [{ name: "NVIDIA GeForce GTX 750 Ti", computeCapability: "5.0" }],
+      detectedProviders: ["CPUExecutionProvider"],
+    });
+
+    const result = assessRecipeHardwareCompatibility("CUDA", probe);
+    expect(result.tier).toBe("compatible");
+    expect(result.requiresInstall).toBeDefined();
+    expect(result.requiresInstall?.kind).toBe("onnxruntime-gpu");
+  });
+
+  it("mixed box (one Kepler SM 3.x + one Ampere SM 8.x) still reports CUDA compatible with install hint", () => {
+    // `isPreMaxwellNvidiaBox` is true only if every card is below the
+    // floor. A workstation with a GTX 680 AND an RTX 3090 should NOT
+    // hit the terminator — the user can run CUDA recipes on the RTX.
+    const probe = tensorRtProbe({
+      nvidiaGpus: [
+        { name: "NVIDIA GeForce GTX 680", computeCapability: "3.0" },
+        { name: "NVIDIA GeForce RTX 3090", computeCapability: "8.6" },
+      ],
+      detectedProviders: ["CPUExecutionProvider"],
+    });
+
+    const result = assessRecipeHardwareCompatibility("CUDA", probe);
+    expect(result.tier).toBe("compatible");
+    expect(result.requiredProvider).toBe("CUDAExecutionProvider");
+    expect(result.requiresInstall?.kind).toBe("onnxruntime-gpu");
+  });
+
+  it("locks the install command to the pinned onnxruntime-gpu==1.26.0", () => {
+    const probe = tensorRtProbe({
+      nvidiaGpus: [{ name: "NVIDIA GeForce RTX 5070", computeCapability: "12.0" }],
+      detectedProviders: ["CPUExecutionProvider"],
+    });
+
+    const result = assessRecipeHardwareCompatibility("CUDA", probe);
+    expect(result.requiresInstall?.installCommand).toBe("pip install onnxruntime-gpu==1.26.0");
+  });
+
+  it("locks the SM 5.0 floor in the pre-Maxwell reason text", () => {
+    // Drift-guard: parallel to the hardwareProbe.test.ts pre-Turing lock
+    // and the catalog chip SM 7.5 lock — future rewording can't drop 5.0.
+    const probe = tensorRtProbe({
+      nvidiaGpus: [{ name: "NVIDIA GeForce GT 730 Kepler", computeCapability: "3.5" }],
+      detectedProviders: ["CPUExecutionProvider"],
+    });
+
+    const reason = assessRecipeHardwareCompatibility("CUDA", probe).reason;
+    expect(reason).toMatch(/compute capability ≥ 5\.0/);
+    expect(reason.toLowerCase()).toMatch(/maxwell|pascal|kepler/);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// Drift-guard: pre-Turing SM floor in recipe-compat reason
+// ─────────────────────────────────────────────────────────────────────────
+//
+// Mirrors the providerCatalog.test.ts and hardwareProbe.test.ts drift
+// guards. Bumping TENSORRT_FAMILY_MIN_COMPUTE_CAPABILITY (e.g. 7.5 → 8.6
+// when Triton/Blackwell drops late-Turing support) must update THREE
+// places atomically: the catalog chip copy, the hardwareProbe
+// undetected-reason wording, and this recipe-compat reason. These tests
+// fail CI if any of them drifts out of lockstep with the constant.
+
+describe("assessRecipeHardwareCompatibility — pre-Turing drift-guard (recipe-compat reason)", () => {
+  const smFloor = `${TENSORRT_FAMILY_MIN_COMPUTE_CAPABILITY.major}.${TENSORRT_FAMILY_MIN_COMPUTE_CAPABILITY.minor}`;
+
+  it("the SM-floor constant is exactly 7.5 today (catches accidental constant typos)", () => {
+    expect(TENSORRT_FAMILY_MIN_COMPUTE_CAPABILITY).toEqual({ major: 7, minor: 5 });
+    expect(smFloor).toBe("7.5");
+  });
+
+  it("the pre-Turing reason for classic TensorRT pins SM ≥ 7.5 + Turing + Maxwell/Pascal/Kepler", () => {
+    const probe = tensorRtProbe({
+      nvidiaGpus: [{ name: "NVIDIA GeForce GTX 1080", computeCapability: "6.1" }],
+      detectedProviders: ["CPUExecutionProvider", "CUDAExecutionProvider"],
+    });
+
+    const reason = assessRecipeHardwareCompatibility("TensorRT", probe).reason;
+    // The reason must literally interpolate the constant — caught if the
+    // template switches to a hardcoded "7.5" string literal.
+    expect(reason).toContain(`compute capability ≥ ${smFloor}`);
+    // Floor name + floor-as-hardware delineation. Maxwell/Pascal/Kepler
+    // names the families that can NEVER run this EP — protects against a
+    // generic "no compatible GPU" copy that drops the actionable callout.
+    expect(reason.toLowerCase()).toContain("turing");
+    expect(reason.toLowerCase()).toMatch(/maxwell|pascal|kepler/);
+    // The GPU name must be quoted so the user knows which of their cards
+    // is the offender.
+    expect(reason).toContain("GTX 1080");
+  });
+
+  it("the pre-Turing reason for TensorRT RTX pins SM ≥ 7.5 + Turing + Maxwell/Pascal/Kepler", () => {
+    const probe = tensorRtProbe({
+      nvidiaGpus: [{ name: "NVIDIA GeForce GTX 980", computeCapability: "5.2" }],
+      detectedProviders: ["CPUExecutionProvider", "CUDAExecutionProvider"],
+    });
+
+    const reason = assessRecipeHardwareCompatibility("TensorRT RTX", probe).reason;
+    expect(reason).toContain(`compute capability ≥ ${smFloor}`);
+    expect(reason.toLowerCase()).toContain("turing");
+    expect(reason.toLowerCase()).toMatch(/maxwell|pascal|kepler/);
+    expect(reason).toContain("GTX 980");
+  });
+
+  it("locks the classical 'Turing / RTX 20xx+' tie-in phrase so the floor name stays exact", () => {
+    // The recipe-compat reason uses the copy pattern
+    // "≥ X.Y (Turing / RTX 20xx+)" — if a future change drops the
+    // "RTX 20xx+" tie-in (which is the consumer-friendly anchor of
+    // "Turing = which cards?"), the user can't tell what to upgrade to.
+    const probe = tensorRtProbe({
+      nvidiaGpus: [{ name: "NVIDIA GeForce GTX 1660", computeCapability: "6.1" }],
+      detectedProviders: ["CPUExecutionProvider", "CUDAExecutionProvider"],
+    });
+
+    const reason = assessRecipeHardwareCompatibility("TensorRT", probe).reason;
+    expect(reason).toMatch(/turing\s*\/\s*rtx 20xx\+?/i);
+  });
+
+  it("locks the 'cannot execute on Maxwell/Pascal/Kepler' terminator phrasing — install hint must NEVER appear here", () => {
+    // If a future change re-introduces a pip-install hint on a pre-Turing
+    // box, the user gets a one-click install that cannot succeed. The
+    // drift-guard asserts both the negative (no install hint) and the
+    // positive (the families that can never run this EP are named).
+    const probe = tensorRtProbe({
+      nvidiaGpus: [{ name: "NVIDIA GeForce GT 1030", computeCapability: "6.0" }],
+      detectedProviders: ["CPUExecutionProvider", "CUDAExecutionProvider"],
+    });
+
+    const trt = assessRecipeHardwareCompatibility("TensorRT", probe);
+    expect(trt.requiresInstall).toBeUndefined();
+    expect(trt.reason.toLowerCase()).toMatch(/maxwell\/pascal\/kepler/);
+
+    const rtx = assessRecipeHardwareCompatibility("TensorRT RTX", probe);
+    expect(rtx.requiresInstall).toBeUndefined();
+    expect(rtx.reason.toLowerCase()).toMatch(/maxwell\/pascal\/kepler/);
+  });
+});

--- a/src/lib/cudaDeps.test.ts
+++ b/src/lib/cudaDeps.test.ts
@@ -56,14 +56,22 @@ describe("isPreMaxwellNvidiaBox", () => {
   });
 
   it("returns false when every card is at or above the floor", () => {
+    // Both cards meet SM ≥ 5.0; the box is fully CUDA-toolkit-supported.
+    expect(
+      isPreMaxwellNvidiaBox([
+        { name: "GTX 750 Ti Maxwell", computeCapability: "5.0" }, // boundary — supported
+        { name: "RTX 3090", computeCapability: "8.6" },
+      ]),
+    ).toBe(false);
+  });
+
+  it("returns true when every card is strictly below the floor", () => {
+    // All Kepler SM 3.x: nothing runs modern CUDA even after install.
     expect(
       isPreMaxwellNvidiaBox([
         { name: "GTX 680", computeCapability: "3.0" },
-        { name: "GTX 750 Ti Maxwell", computeCapability: "5.0" }, // boundary — supported
+        { name: "GT 730", computeCapability: "3.5" },
       ]),
-    ).toBe(false);
-    expect(
-      isPreMaxwellNvidiaBox([{ name: "GT 730", computeCapability: "3.5" }]),
     ).toBe(true);
   });
 
@@ -83,12 +91,29 @@ describe("cudaDownloadUrlForOs", () => {
     expect(cudaDownloadUrlForOs("Windows 11")).toBe(CUDA_DOWNLOAD_LINKS.windows);
   });
 
+  it("does not misroute darwin to the Windows URL via the substring 'win'", () => {
+    // 'darwin' contains the substring 'win' — a loose substring check
+    // previously sent macOS users to the Windows toolkit installer.
+    // Verify the word-boundary regex keeps darwin on its own path.
+    expect(cudaDownloadUrlForOs("darwin 23.4.0")).not.toBe(CUDA_DOWNLOAD_LINKS.windows);
+    expect(cudaDownloadUrlForOs("Darwin arm64")).not.toBe(CUDA_DOWNLOAD_LINKS.windows);
+  });
+
   it("returns the WSL-specific URL when the OS string mentions wsl", () => {
     expect(cudaDownloadUrlForOs("linux wsl2")).toBe(CUDA_DOWNLOAD_LINKS.wsl);
   });
 
   it("returns the Linux-specific URL when the OS string mentions linux (but not wsl)", () => {
     expect(cudaDownloadUrlForOs("linux 5.15.0-91-generic")).toBe(CUDA_DOWNLOAD_LINKS.linux);
+  });
+
+  it("routes macOS (darwin) to the archive landing page instead of Linux", () => {
+    // Apple dropped CUDA toolkit support after CUDA 11.6 (2022); macOS
+    // no longer has a path forward. Sending darwin to the Linux
+    // installer silently misleads users — route to the archive so they
+    // can read that the toolkit is unsupported on their platform.
+    expect(cudaDownloadUrlForOs("darwin 23.4.0")).toBe(CUDA_DOWNLOAD_LINKS.archive);
+    expect(cudaDownloadUrlForOs("Darwin arm64")).toBe(CUDA_DOWNLOAD_LINKS.archive);
   });
 
   it("falls back to the archive landing page for unrecognized / missing OS", () => {

--- a/src/lib/cudaDeps.test.ts
+++ b/src/lib/cudaDeps.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  CUDA_DOWNLOAD_LINKS,
+  CUDA_SM_FLOOR,
+  CUDA_TOOLKIT_MIN_COMPUTE_CAPABILITY,
+  cudaDownloadUrlForOs,
+  isNvidiaGpuCudaToolkitFamily,
+  isPreMaxwellNvidiaBox,
+  pinnedOrtGpuInstallArgs,
+  pinnedOrtGpuInstallCommand,
+  pinnedOrtGpuLabel,
+} from "@/lib/cudaDeps";
+
+describe("CUDA_TOOLKIT_MIN_COMPUTE_CAPABILITY", () => {
+  it("is locked at SM 5.0 (Maxwell floor for CUDA 12)", () => {
+    expect(CUDA_TOOLKIT_MIN_COMPUTE_CAPABILITY).toEqual({ major: 5, minor: 0 });
+    expect(CUDA_SM_FLOOR).toBe("5.0");
+  });
+});
+
+describe("isNvidiaGpuCudaToolkitFamily", () => {
+  it("accepts Maxwell SM 5.0 (the boundary)", () => {
+    expect(isNvidiaGpuCudaToolkitFamily({ name: "GTX 750 Ti", computeCapability: "5.0" })).toBe(true);
+  });
+
+  it("accepts Pascal SM 6.0 / 6.1 and Volta SM 7.0", () => {
+    expect(isNvidiaGpuCudaToolkitFamily({ name: "GTX 1060", computeCapability: "6.1" })).toBe(true);
+    expect(isNvidiaGpuCudaToolkitFamily({ name: "Tesla V100", computeCapability: "7.0" })).toBe(true);
+  });
+
+  it("accepts Turing / Ampere / Ada / Hopper / Blackwell", () => {
+    expect(isNvidiaGpuCudaToolkitFamily({ name: "RTX 2080 Ti", computeCapability: "7.5" })).toBe(true);
+    expect(isNvidiaGpuCudaToolkitFamily({ name: "RTX 3090", computeCapability: "8.6" })).toBe(true);
+    expect(isNvidiaGpuCudaToolkitFamily({ name: "RTX 4090", computeCapability: "8.9" })).toBe(true);
+    expect(isNvidiaGpuCudaToolkitFamily({ name: "RTX 5070", computeCapability: "12.0" })).toBe(true);
+  });
+
+  it("rejects Kepler SM 3.x (below the CUDA 12 floor)", () => {
+    expect(isNvidiaGpuCudaToolkitFamily({ name: "GTX 680", computeCapability: "3.0" })).toBe(false);
+    expect(isNvidiaGpuCudaToolkitFamily({ name: "GT 730", computeCapability: "3.5" })).toBe(false);
+  });
+
+  it("treats '0.0' as below floor (older driver / parse glitch)", () => {
+    expect(isNvidiaGpuCudaToolkitFamily({ name: "Unidentified", computeCapability: "0.0" })).toBe(false);
+  });
+
+  it("treats missing compute capability as permissive", () => {
+    expect(isNvidiaGpuCudaToolkitFamily({ name: "Some NVIDIA" })).toBe(true);
+  });
+});
+
+describe("isPreMaxwellNvidiaBox", () => {
+  it("returns false when no GPUs are listed", () => {
+    expect(isPreMaxwellNvidiaBox([])).toBe(false);
+  });
+
+  it("returns false when every card is at or above the floor", () => {
+    expect(
+      isPreMaxwellNvidiaBox([
+        { name: "GTX 680", computeCapability: "3.0" },
+        { name: "GTX 750 Ti Maxwell", computeCapability: "5.0" }, // boundary — supported
+      ]),
+    ).toBe(false);
+    expect(
+      isPreMaxwellNvidiaBox([{ name: "GT 730", computeCapability: "3.5" }]),
+    ).toBe(true);
+  });
+
+  it("returns false when at least one card meets the floor (mixed box)", () => {
+    expect(
+      isPreMaxwellNvidiaBox([
+        { name: "GTX 680", computeCapability: "3.0" },
+        { name: "RTX 3090", computeCapability: "8.6" },
+      ]),
+    ).toBe(false);
+  });
+});
+
+describe("cudaDownloadUrlForOs", () => {
+  it("returns the Windows-specific URL when the OS string mentions win", () => {
+    expect(cudaDownloadUrlForOs("win32 10.0.19041")).toBe(CUDA_DOWNLOAD_LINKS.windows);
+    expect(cudaDownloadUrlForOs("Windows 11")).toBe(CUDA_DOWNLOAD_LINKS.windows);
+  });
+
+  it("returns the WSL-specific URL when the OS string mentions wsl", () => {
+    expect(cudaDownloadUrlForOs("linux wsl2")).toBe(CUDA_DOWNLOAD_LINKS.wsl);
+  });
+
+  it("returns the Linux-specific URL when the OS string mentions linux (but not wsl)", () => {
+    expect(cudaDownloadUrlForOs("linux 5.15.0-91-generic")).toBe(CUDA_DOWNLOAD_LINKS.linux);
+  });
+
+  it("falls back to the archive landing page for unrecognized / missing OS", () => {
+    expect(cudaDownloadUrlForOs(undefined)).toBe(CUDA_DOWNLOAD_LINKS.archive);
+    expect(cudaDownloadUrlForOs(null)).toBe(CUDA_DOWNLOAD_LINKS.archive);
+    expect(cudaDownloadUrlForOs("freebsd")).toBe(CUDA_DOWNLOAD_LINKS.archive);
+    expect(cudaDownloadUrlForOs("")).toBe(CUDA_DOWNLOAD_LINKS.archive);
+  });
+
+  it("constant URLs are HTTPS and live under developer.nvidia.com", () => {
+    for (const url of Object.values(CUDA_DOWNLOAD_LINKS)) {
+      expect(url.startsWith("https://developer.nvidia.com/")).toBe(true);
+    }
+  });
+});
+
+describe("pinnedOrtGpu* — pinned onnxruntime-gpu install command", () => {
+  it("pinnedOrtGpuInstallArgs carries the wheel + version pin from oliveGpuRuntime", () => {
+    expect(pinnedOrtGpuInstallArgs()).toEqual(["onnxruntime-gpu==1.26.0"]);
+  });
+
+  it("pinnedOrtGpuInstallCommand is a paste-ready pip command", () => {
+    expect(pinnedOrtGpuInstallCommand()).toBe("pip install onnxruntime-gpu==1.26.0");
+  });
+
+  it("pinnedOrtGpuLabel names the package + the pinned version", () => {
+    expect(pinnedOrtGpuLabel()).toBe("onnxruntime-gpu (1.26.0)");
+  });
+});

--- a/src/lib/cudaDeps.ts
+++ b/src/lib/cudaDeps.ts
@@ -1,0 +1,123 @@
+import { parseComputeCapability, type GpuInfo } from "@/lib/hardwareProbe";
+import {
+  pinnedOrtGpuInstallArgs as _pinnedOrtGpuInstallArgs,
+  pinnedOrtGpuLabel as _pinnedOrtGpuLabel,
+} from "@/lib/oliveGpuRuntime";
+
+// NOTE: this file imports primitives from `@/lib/hardwareProbe` (the SM
+// parser + GPU info type) AND hardwareProbe.ts imports the CUDA floor
+// constants + `isPreMaxwellNvidiaBox` from us. The cycle resolves because
+// every cross-reference sits inside a function body — module-init never
+// reads across the boundary. If you add a module-level `const x =
+// parseComputeCapability(...)` here or `const y = isPreMaxwellNvidiaBox(...)`
+// in hardwareProbe.ts the cycle breaks. The next refactor that needs an
+// early-init usage should split `parseComputeCapability` + `GpuInfo` into a
+// leaf module and have both sides depend on it.
+
+/**
+ * Minimum NVIDIA compute capability the CUDA 12.x toolkit / runtime can run on.
+ *
+ * CUDA 12 dropped all SM 3.x (Kepler) support — Maxwell SM 5.0 is the new
+ * floor for cuobjdump'd code, and onnxruntime-gpu 1.26 / CUDA 12.x wheels
+ * are built accordingly. Pascal SM 6.x and above all run cleanly.
+ *
+ * Cards below 5.0 (Kepler GK110 / GK208 family — e.g. GTX 680, GT 730
+ * Kepler) cannot execute modern CUDA at all; installing the toolkit cannot
+ * recover this. Centralizing the number avoids drift between the device
+ * probe, the recipe-compat layer, the install-needed hint, and the
+ * missing-EP reason text.
+ *
+ * Compare numerically (e.g. 7.5 ≥ 5.0).
+ */
+export const CUDA_TOOLKIT_MIN_COMPUTE_CAPABILITY = { major: 5, minor: 0 } as const;
+
+export const CUDA_SM_FLOOR = `${CUDA_TOOLKIT_MIN_COMPUTE_CAPABILITY.major}.${CUDA_TOOLKIT_MIN_COMPUTE_CAPABILITY.minor}` as const;
+
+/**
+ * Does the GPU's compute capability meet or exceed the CUDA 12 toolkit floor?
+ *
+ * `undefined` compute capability is treated as supported so a probe glitch
+ * does not silently mark an otherwise supported GPU as incompatible — the
+ * same permissive-to-unknown convention used by `isNvidiaGpuTensorRtFamily`.
+ *
+ * Both "0.0" (older drivers / parse glitch) and explicit pre-floor values
+ * resolve to `false`: we only return `true` when we have NO reason to
+ * suspect the GPU is below the floor.
+ */
+export function isNvidiaGpuCudaToolkitFamily(gpu: GpuInfo): boolean {
+  const cap = parseComputeCapability(gpu.computeCapability);
+  if (!cap) return true;
+  if (cap.major !== CUDA_TOOLKIT_MIN_COMPUTE_CAPABILITY.major) {
+    return cap.major > CUDA_TOOLKIT_MIN_COMPUTE_CAPABILITY.major;
+  }
+  return cap.minor >= CUDA_TOOLKIT_MIN_COMPUTE_CAPABILITY.minor;
+}
+
+/**
+ * True only when at least one NVIDIA GPU is detected AND every card is
+ * strictly below the CUDA 12 toolkit floor (SM < 5.0). Such a workstation
+ * cannot run modern Olive recipes — listing the install buttons would just
+ * point the user at a one-click install that cannot possibly succeed.
+ *
+ * On a mixed box (one Kepler + one RTX), the helper returns `false` and
+ * the install hint stays available.
+ */
+export function isPreMaxwellNvidiaBox(gpus: GpuInfo[]): boolean {
+  if (gpus.length === 0) return false;
+  return gpus.every((g) => !isNvidiaGpuCudaToolkitFamily(g));
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Install points
+// ─────────────────────────────────────────────────────────────────────────
+
+/**
+ * The CUDA Toolkit is a system-level install (~3 GB) and Olive Studio
+ * cannot pip-install it. Instead, the UI surfaces a deep link to NVIDIA's
+ * archive page so the user can grab the matching toolkit for their
+ * driver + OS in one click.
+ *
+ * The `archive` URL is the canonical landing page; the `windows` / `linux`
+ * / `wsl` entries deep-link into the CUDA 12.8 wizard (the highest tag
+ * `RESOLVABLE_CUDA_TAGS` in oliveGpuRuntime resolves today).
+ */
+export const CUDA_DOWNLOAD_LINKS = {
+  archive: "https://developer.nvidia.com/cuda-toolkit-archive",
+  windows: "https://developer.nvidia.com/cuda-12-8-0-download-archive?target_os=Windows",
+  linux: "https://developer.nvidia.com/cuda-12-8-0-download-archive?target_os=Linux",
+  wsl: "https://developer.nvidia.com/cuda-12-8-0-download-archive?target_os=Windows&target_arch=x86_64&target_distro=WSL",
+} as const;
+
+/**
+ * Returns the most appropriate NVIDIA CUDA Toolkit download URL for the
+ * running OS. Defaults to the archive landing page so the user can pick
+ * any toolkit if we don't recognize the OS string.
+ */
+export function cudaDownloadUrlForOs(os: string | undefined | null): string {
+  const text = (os ?? "").toLowerCase();
+  if (text.includes("wsl")) return CUDA_DOWNLOAD_LINKS.wsl;
+  if (text.includes("win")) return CUDA_DOWNLOAD_LINKS.windows;
+  if (text.includes("linux") || text.includes("darwin")) return CUDA_DOWNLOAD_LINKS.linux;
+  return CUDA_DOWNLOAD_LINKS.archive;
+}
+
+/**
+ * Pip-installable command for the pinned onnxruntime-gpu into the project's
+ * `.venv`. Re-exports the version pin from oliveGpuRuntime so the CUDA /
+ * TensorRT / TensorRT-RTX install paths all stay on the same wheel set.
+ */
+export function pinnedOrtGpuInstallCommand(): string {
+  return `pip install ${_pinnedOrtGpuInstallArgs().join(" ")}`;
+}
+
+/**
+ * Read-only copy of the pinned install args — useful for the install
+ * route that needs to pipe them straight into `pip install`.
+ */
+export function pinnedOrtGpuInstallArgs(): string[] {
+  return _pinnedOrtGpuInstallArgs();
+}
+
+export function pinnedOrtGpuLabel(): string {
+  return _pinnedOrtGpuLabel();
+}

--- a/src/lib/cudaDeps.ts
+++ b/src/lib/cudaDeps.ts
@@ -95,8 +95,14 @@ export const CUDA_DOWNLOAD_LINKS = {
  */
 export function cudaDownloadUrlForOs(os: string | undefined | null): string {
   const text = (os ?? "").toLowerCase();
+  // Word-boundary matches prevent `"darwin"` from accidentally hitting
+  // the Windows branch — `"darwin"` contains the substring `"win"`,
+  // which the naive loose substring check silently matched. macOS has
+  // no NVIDIA + no path forward on modern CUDA after 11.6, so it always
+  // falls to the archive landing page.
+  if (/\bdarwin\b/.test(text)) return CUDA_DOWNLOAD_LINKS.archive;
   if (text.includes("wsl")) return CUDA_DOWNLOAD_LINKS.wsl;
-  if (text.includes("win")) return CUDA_DOWNLOAD_LINKS.windows;
+  if (/\bwin(?:32|dows)?\b/.test(text)) return CUDA_DOWNLOAD_LINKS.windows;
   if (text.includes("linux")) return CUDA_DOWNLOAD_LINKS.linux;
   return CUDA_DOWNLOAD_LINKS.archive;
 }

--- a/src/lib/cudaDeps.ts
+++ b/src/lib/cudaDeps.ts
@@ -97,7 +97,7 @@ export function cudaDownloadUrlForOs(os: string | undefined | null): string {
   const text = (os ?? "").toLowerCase();
   if (text.includes("wsl")) return CUDA_DOWNLOAD_LINKS.wsl;
   if (text.includes("win")) return CUDA_DOWNLOAD_LINKS.windows;
-  if (text.includes("linux") || text.includes("darwin")) return CUDA_DOWNLOAD_LINKS.linux;
+  if (text.includes("linux")) return CUDA_DOWNLOAD_LINKS.linux;
   return CUDA_DOWNLOAD_LINKS.archive;
 }
 

--- a/src/lib/hardwareProbe.test.ts
+++ b/src/lib/hardwareProbe.test.ts
@@ -338,17 +338,35 @@ describe("getProviderAvailabilityBlock — CUDA 4-state branching", () => {
     expect(block?.reason).toMatch(/developer\.nvidia\.com/);
   });
 
-  it("4) reports driver/wheel mismatch when NVIDIA + driver + toolkit OK but EP not registered", () => {
+  it("4) reports state-4 driver/wheel mismatch when NVIDIA + ORT + toolkit OK but EP stripped from detectedProviders", () => {
+    // State 4: NVIDIA + driver + toolkit + onnxruntime-gpu CUDA EP all
+    // detected — but the EP is NOT in detectedProviders (because the
+    // route's mergeDetectedProviders stripped it via cudaLoadable=false,
+    // e.g. a CUDA 13 wheel against a CUDA 11 driver). `detectedProviders`
+    // set explicitly here mirrors what /api/system/hardware-probe would
+    // surface so getProviderAvailabilityBlock reaches the state-4
+    // reason branch instead of the install-hint branch.
     const probe = makeProbe({
       nvidia: {
         gpus: [{ name: "NVIDIA GeForce RTX 5070", computeCapability: "12.0" }],
         cudaVersion: "12.8",
         cudaToolkit: { available: true, version: "12.8" },
       },
-      onnxRuntimeProviders: ["CPUExecutionProvider"], // CUDA EP not registered
+      // state-4 fixture: NVIDIA + driver + toolkit all healthy AND
+      // probe.cuda.loadable === true (so the state-3 install-hint branch
+      // is bypassed), but detectedProviders was post-processed to drop
+      // CUDAExecutionProvider (e.g. a downstream merge only kept EP
+      // strings whose .loadable flag was true at probe time, and the EP
+      // fell out). This exercises the cascade through state 3 -> state
+      // 4 and surfaces the driver/wheel mismatch reason rather than the
+      // 'install onnxruntime-gpu' advice.
+      cuda: { loadable: true },
+      onnxRuntimeProviders: ["CPUExecutionProvider", "CUDAExecutionProvider"],
+      detectedProviders: ["CPUExecutionProvider"],
     });
     const block = getProviderAvailabilityBlock("CUDAExecutionProvider", probe);
-    expect(block?.reason).toMatch(/driver.*wheel|driver.*version|mismatch/i);
+    expect(block?.reason).toMatch(/driver\/wheel version mismatch/i);
+    expect(block?.reason).not.toMatch(/pip install onnxruntime-gpu/);
   });
 
   it("returns null block when CUDA is in detectedProviders (already working)", () => {

--- a/src/lib/hardwareProbe.test.ts
+++ b/src/lib/hardwareProbe.test.ts
@@ -52,3 +52,45 @@ describe("mergeDetectedProviders TensorRT", () => {
     );
   });
 });
+
+describe("mergeDetectedProviders OpenVINO", () => {
+  it("detects OpenVINO when hasOpenVinoCompatibleHardware is true (Intel CPU)", () => {
+    const detected = mergeDetectedProviders({
+      hasNvidiaGpu: false,
+      hasRocmGpu: false,
+      hasOpenVino: false,
+      hasOpenVinoCompatibleHardware: true,
+    });
+    expect(detected).toContain("OpenVINOExecutionProvider");
+  });
+
+  it("detects OpenVINO when hasOpenVino is true (runtime installed)", () => {
+    const detected = mergeDetectedProviders({
+      hasNvidiaGpu: false,
+      hasRocmGpu: false,
+      hasOpenVino: true,
+      hasOpenVinoCompatibleHardware: false,
+    });
+    expect(detected).toContain("OpenVINOExecutionProvider");
+  });
+
+  it("detects OpenVINO with AMD CPU + Intel Arc GPU scenario", () => {
+    const detected = mergeDetectedProviders({
+      hasNvidiaGpu: false,
+      hasRocmGpu: false,
+      hasOpenVino: false,
+      hasOpenVinoCompatibleHardware: true, // Set by Arc GPU detection
+    });
+    expect(detected).toContain("OpenVINOExecutionProvider");
+  });
+
+  it("does not detect OpenVINO without compatible hardware or runtime", () => {
+    const detected = mergeDetectedProviders({
+      hasNvidiaGpu: false,
+      hasRocmGpu: false,
+      hasOpenVino: false,
+      hasOpenVinoCompatibleHardware: false,
+    });
+    expect(detected).not.toContain("OpenVINOExecutionProvider");
+  });
+});

--- a/src/lib/hardwareProbe.test.ts
+++ b/src/lib/hardwareProbe.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { mergeDetectedProviders, pickRecommendedProvider } from "@/lib/hardwareProbe";
+import {
+  computeOpenVinoCompatibleHardware,
+  mergeDetectedProviders,
+  pickRecommendedProvider,
+} from "@/lib/hardwareProbe";
 
 describe("mergeDetectedProviders TensorRT", () => {
   it("does not infer classic TensorRT until the runtime probe succeeds", () => {
@@ -53,6 +57,47 @@ describe("mergeDetectedProviders TensorRT", () => {
   });
 });
 
+describe("computeOpenVinoCompatibleHardware", () => {
+  it("detects Intel CPU by vendor qualifiers", () => {
+    expect(
+      computeOpenVinoCompatibleHardware({
+        cpuModel: "Intel(R) Core(TM) i9-13900K",
+      }),
+    ).toBe(true);
+    expect(
+      computeOpenVinoCompatibleHardware({
+        cpuModel: "Intel(R) Xeon(R) Platinum 8480+",
+      }),
+    ).toBe(true);
+  });
+
+  it("does not treat AMD N-Core Processor strings as Intel", () => {
+    expect(
+      computeOpenVinoCompatibleHardware({
+        cpuModel: "AMD Ryzen 9 7950X 16-Core Processor",
+      }),
+    ).toBe(false);
+  });
+
+  it("detects AMD CPU + Intel Arc GPU as OpenVINO-compatible", () => {
+    expect(
+      computeOpenVinoCompatibleHardware({
+        cpuModel: "AMD Ryzen 7 5800X 8-Core Processor",
+        intelGpuNames: ["Intel(R) Arc(TM) A770 Graphics"],
+      }),
+    ).toBe(true);
+  });
+
+  it("detects OpenVINO GPU/NPU devices even without Intel CPU/GPU names", () => {
+    expect(
+      computeOpenVinoCompatibleHardware({
+        cpuModel: "AMD Ryzen 9 7950X 16-Core Processor",
+        openvinoDevices: ["CPU", "GPU.0"],
+      }),
+    ).toBe(true);
+  });
+});
+
 describe("mergeDetectedProviders OpenVINO", () => {
   it("detects OpenVINO when hasOpenVinoCompatibleHardware is true (Intel CPU)", () => {
     const detected = mergeDetectedProviders({
@@ -74,13 +119,18 @@ describe("mergeDetectedProviders OpenVINO", () => {
     expect(detected).toContain("OpenVINOExecutionProvider");
   });
 
-  it("detects OpenVINO with AMD CPU + Intel Arc GPU scenario", () => {
+  it("propagates Arc-compatible hardware flag into detected providers", () => {
+    const compatible = computeOpenVinoCompatibleHardware({
+      cpuModel: "AMD Ryzen 7 5800X 8-Core Processor",
+      intelGpuNames: ["Intel(R) Arc(TM) A770 Graphics"],
+    });
     const detected = mergeDetectedProviders({
       hasNvidiaGpu: false,
       hasRocmGpu: false,
       hasOpenVino: false,
-      hasOpenVinoCompatibleHardware: true, // Set by Arc GPU detection
+      hasOpenVinoCompatibleHardware: compatible,
     });
+    expect(compatible).toBe(true);
     expect(detected).toContain("OpenVINOExecutionProvider");
   });
 

--- a/src/lib/hardwareProbe.test.ts
+++ b/src/lib/hardwareProbe.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, it } from "vitest";
-import { mergeDetectedProviders, pickRecommendedProvider } from "@/lib/hardwareProbe";
+import {
+  getProviderAvailabilityBlock,
+  isNvidiaGpuTensorRtFamily,
+  mergeDetectedProviders,
+  parseComputeCapability,
+  pickRecommendedProvider,
+  TENSORRT_FAMILY_MIN_COMPUTE_CAPABILITY,
+  type HardwareProbeResult,
+} from "@/lib/hardwareProbe";
 
 describe("mergeDetectedProviders TensorRT", () => {
   it("does not infer classic TensorRT until the runtime probe succeeds", () => {
@@ -50,5 +58,326 @@ describe("mergeDetectedProviders TensorRT", () => {
     expect(pickRecommendedProvider(detected, { tensorRtRtxLoadable: true, tensorRtLoadable: false })).toBe(
       "NvTensorRTRTXExecutionProvider",
     );
+  });
+
+  it("treats an unknown compute capability as permissive (does not silently downgrade)", () => {
+    // Older nvidia-smi drivers or parse hiccups can drop compute_cap.
+    // mergeDetectedProviders must NOT use that absence as an excuse to hide
+    // RTX-family EPs — the user already sees a separate "loadable" probe
+    // for the runtime side. Missing SM data == we don't know == assume yes.
+    const detected = mergeDetectedProviders({
+      hasNvidiaGpu: true,
+      hasRocmGpu: false,
+      hasOpenVino: false,
+      tensorRtLoadable: true,
+      tensorRtRtxLoadable: true,
+      nvidiaTensorRtFamilyCapable: undefined,
+    });
+    expect(detected).toContain("TensorrtExecutionProvider");
+    expect(detected).toContain("NvTensorRTRTXExecutionProvider");
+  });
+});
+
+describe("parseComputeCapability", () => {
+  it("parses a well-formed '8.9' into a comparable pair", () => {
+    expect(parseComputeCapability("8.9")).toEqual({ major: 8, minor: 9 });
+    expect(parseComputeCapability("7.5")).toEqual({ major: 7, minor: 5 });
+    expect(parseComputeCapability("12.0")).toEqual({ major: 12, minor: 0 });
+  });
+
+  it("treats undefined / malformed input as 'unknown'", () => {
+    expect(parseComputeCapability(undefined)).toBeUndefined();
+    expect(parseComputeCapability("")).toBeUndefined();
+    expect(parseComputeCapability("8")).toBeUndefined();
+    expect(parseComputeCapability("8.x")).toBeUndefined();
+    expect(parseComputeCapability("0.0")).toEqual({ major: 0, minor: 0 });
+  });
+});
+
+describe("isNvidiaGpuTensorRtFamily", () => {
+  it("accepts Turing (7.5) as the boundary case", () => {
+    expect(isNvidiaGpuTensorRtFamily({ name: "RTX 2080 Ti", computeCapability: "7.5" })).toBe(true);
+  });
+
+  it("accepts cards at or above the floor", () => {
+    expect(isNvidiaGpuTensorRtFamily({ name: "RTX 3080", computeCapability: "8.6" })).toBe(true);
+    expect(isNvidiaGpuTensorRtFamily({ name: "RTX 4090", computeCapability: "8.9" })).toBe(true);
+    expect(isNvidiaGpuTensorRtFamily({ name: "RTX 5070", computeCapability: "10.0" })).toBe(true);
+  });
+
+  it("rejects pre-Turing cards (Maxwell, Pascal, Kepler)", () => {
+    expect(isNvidiaGpuTensorRtFamily({ name: "GTX 1080", computeCapability: "6.1" })).toBe(false);
+    expect(isNvidiaGpuTensorRtFamily({ name: "GTX 980", computeCapability: "5.2" })).toBe(false);
+    expect(isNvidiaGpuTensorRtFamily({ name: "GT 1030", computeCapability: "6.0" })).toBe(false);
+    // Older drivers report '0.0' which must be treated as below floor,
+    // not as 'unknown', so pre-Turing cards never silently downgrade.
+    expect(isNvidiaGpuTensorRtFamily({ name: "Unidentified", computeCapability: "0.0" })).toBe(false);
+  });
+
+  it("treats missing compute capability as 'we don't know -> permissive'", () => {
+    expect(isNvidiaGpuTensorRtFamily({ name: "GTX 1080" })).toBe(true);
+  });
+
+  it("exports the constant matching the actual minimum", () => {
+    expect(TENSORRT_FAMILY_MIN_COMPUTE_CAPABILITY).toEqual({ major: 7, minor: 5 });
+  });
+});
+
+describe("mergeDetectedProviders — CUDA cudaLoadable gating", () => {
+  it("strips CUDAExecutionProvider when cudaLoadable is explicitly false", () => {
+    // Mirrors the RTX/TRT pattern: when the ORT probe reports the EP
+    // isn't loadable (wheel missing or driver mismatch), we must NOT
+    // advertise it as detected — otherwise the recipe-compatibility
+    // layer can't gate on `isProviderDetectedLocally`.
+    const detected = mergeDetectedProviders({
+      hasNvidiaGpu: true,
+      hasRocmGpu: false,
+      hasOpenVino: false,
+      cudaLoadable: false,
+    });
+    expect(detected).not.toContain("CUDAExecutionProvider");
+  });
+
+  it("strips CUDAExecutionProvider from a reported ORT list when cudaLoadable is false", () => {
+    const detected = mergeDetectedProviders({
+      hasNvidiaGpu: true,
+      hasRocmGpu: false,
+      hasOpenVino: false,
+      onnxRuntimeProviders: ["CPUExecutionProvider", "CUDAExecutionProvider"],
+      cudaLoadable: false,
+    });
+    expect(detected).toContain("CPUExecutionProvider");
+    expect(detected).not.toContain("CUDAExecutionProvider");
+  });
+
+  it("keeps CUDAExecutionProvider when cudaLoadable is true (or undefined, permissive default)", () => {
+    expect(
+      mergeDetectedProviders({
+        hasNvidiaGpu: true,
+        hasRocmGpu: false,
+        hasOpenVino: false,
+        cudaLoadable: true,
+      }).includes("CUDAExecutionProvider"),
+    ).toBe(true);
+    expect(
+      mergeDetectedProviders({
+        hasNvidiaGpu: true,
+        hasRocmGpu: false,
+        hasOpenVino: false,
+        // cudaLoadable undefined → permissive
+      }).includes("CUDAExecutionProvider"),
+    ).toBe(true);
+  });
+});
+
+describe("mergeDetectedProviders — pre-Turing (SM < 7.5) gating", () => {
+  it("hides classic TensorRT and TensorRT-RTX when every NVIDIA GPU is below the floor", () => {
+    const detected = mergeDetectedProviders({
+      hasNvidiaGpu: true,
+      hasRocmGpu: false,
+      hasOpenVino: false,
+      tensorRtLoadable: true, // SDK installed; doesn't matter — GPU can't run it
+      tensorRtRtxLoadable: true,
+      nvidiaTensorRtFamilyCapable: false,
+    });
+    expect(detected).toContain("CUDAExecutionProvider");
+    expect(detected).not.toContain("TensorrtExecutionProvider");
+    expect(detected).not.toContain("NvTensorRTRTXExecutionProvider");
+  });
+
+  it("keeps TensorRT family when at least one GPU meets the floor (mixed box)", () => {
+    const detected = mergeDetectedProviders({
+      hasNvidiaGpu: true,
+      hasRocmGpu: false,
+      hasOpenVino: false,
+      tensorRtLoadable: true,
+      tensorRtRtxLoadable: true,
+      nvidiaTensorRtFamilyCapable: true,
+    });
+    expect(detected).toContain("NvTensorRTRTXExecutionProvider");
+    expect(detected).toContain("TensorrtExecutionProvider");
+  });
+
+  it("strips the RTX-family EPs from a reported ORT list when the GPU is pre-Turing", () => {
+    // Belt-and-braces: even if onnxruntime reports CUDA/CPU only, an ORT
+    // build that ALSO reports TensorrtExecutionProvider must still be filtered
+    // when the GPU is below floor. The probe-aware caller passes the flag;
+    // we mirror the same gate for the ORT branch.
+    const detected = mergeDetectedProviders({
+      hasNvidiaGpu: true,
+      hasRocmGpu: false,
+      hasOpenVino: false,
+      onnxRuntimeProviders: [
+        "CPUExecutionProvider",
+        "CUDAExecutionProvider",
+        "TensorrtExecutionProvider",
+        "NvTensorRTRTXExecutionProvider",
+      ],
+      tensorRtLoadable: true,
+      tensorRtRtxLoadable: true,
+      nvidiaTensorRtFamilyCapable: false,
+    });
+    expect(detected).toContain("CUDAExecutionProvider");
+    expect(detected).not.toContain("TensorrtExecutionProvider");
+    expect(detected).not.toContain("NvTensorRTRTXExecutionProvider");
+  });
+});
+
+describe("getProviderAvailabilityBlock — pre-Turing messaging", () => {
+  // Lock the user-facing wording so future rewording can't drop the
+  // SM 7.5 floor or the Maxwell/Pascal/Kepler callout — those are the
+  // three pieces the user needs to understand the EP is unavailable
+  // even after a fresh install.
+  const smFloor = `${TENSORRT_FAMILY_MIN_COMPUTE_CAPABILITY.major}.${TENSORRT_FAMILY_MIN_COMPUTE_CAPABILITY.minor}`;
+  const preTuringProbe = {
+    probedAt: new Date().toISOString(),
+    platform: { os: "win32 10.0", arch: "x64", cpuModel: "Test CPU", cpuCores: 8 },
+    nvidia: { gpus: [{ name: "NVIDIA GeForce GTX 1080", computeCapability: "6.1" }] },
+    detectedProviders: ["CPUExecutionProvider", "CUDAExecutionProvider"],
+    recommendedProvider: "CUDAExecutionProvider",
+    notes: [],
+  } as HardwareProbeResult;
+
+  it("explains the SM 7.5 floor when classic TensorRT is unavailable on a pre-Turing GPU", () => {
+    const block = getProviderAvailabilityBlock("TensorrtExecutionProvider", preTuringProbe);
+    expect(block?.reason).toContain(smFloor);
+    expect(block?.reason.toLowerCase()).toContain("turing");
+    expect(block?.reason.toLowerCase()).toMatch(/maxwell|pascal|kepler/);
+  });
+
+  it("explains the SM 7.5 floor when TensorRT RTX is unavailable on a pre-Turing GPU", () => {
+    const block = getProviderAvailabilityBlock("NvTensorRTRTXExecutionProvider", preTuringProbe);
+    expect(block?.reason).toContain(smFloor);
+    expect(block?.reason.toLowerCase()).toContain("turing");
+    expect(block?.reason.toLowerCase()).toMatch(/maxwell|pascal|kepler/);
+  });
+
+  it("returns null for missing providers that are not gated by SM (CPU)", () => {
+    expect(getProviderAvailabilityBlock("CPUExecutionProvider", preTuringProbe)).toBeNull();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// CUDA: 4-state unavailable-reason branching
+// ─────────────────────────────────────────────────────────────────────────
+
+describe("getProviderAvailabilityBlock — CUDA 4-state branching", () => {
+  const cudaSmFloor = "5.0";
+
+  function makeProbe(overrides: Partial<HardwareProbeResult>): HardwareProbeResult {
+    return {
+      probedAt: new Date().toISOString(),
+      platform: { os: "win32 10.0", arch: "x64", cpuModel: "Test CPU", cpuCores: 8 },
+      nvidia: undefined,
+      rocm: undefined,
+      openvino: undefined,
+      tensorrt: undefined,
+      tensorRtRtx: undefined,
+      onnxRuntimeProviders: undefined,
+      detectedProviders: ["CPUExecutionProvider"],
+      recommendedProvider: "CPUExecutionProvider",
+      notes: [],
+      ...overrides,
+    };
+  }
+
+  it("1) reports 'no GPU' wording for a CPU-only box (no nvidia field)", () => {
+    const block = getProviderAvailabilityBlock(
+      "CUDAExecutionProvider",
+      makeProbe({ detectedProviders: ["CPUExecutionProvider"] }),
+    );
+    expect(block?.reason).toMatch(/No NVIDIA GPU|nvidia-smi/);
+  });
+
+  it("2) reports 'pre-Maxwell' wording when every NVIDIA GPU is below SM 5.0", () => {
+    const probe = makeProbe({
+      nvidia: {
+        gpus: [{ name: "NVIDIA GeForce GTX 680", computeCapability: "3.0" }],
+      },
+      onnxRuntimeProviders: ["CPUExecutionProvider"],
+    });
+    const block = getProviderAvailabilityBlock("CUDAExecutionProvider", probe);
+    expect(block?.reason).toContain(cudaSmFloor);
+    // Names at least one of the pre-floor families for clarity.
+    expect(block?.reason.toLowerCase()).toMatch(/maxwell|pascal|kepler/);
+    // Must not advertise a one-click install that cannot succeed.
+    expect(block?.reason).not.toMatch(/pip install/);
+  });
+
+  it("3) reports pip install hint when NVIDIA driver is fine but onnxruntime-gpu missing", () => {
+    const probe = makeProbe({
+      nvidia: {
+        gpus: [{ name: "NVIDIA GeForce RTX 5070", computeCapability: "12.0" }],
+        cudaVersion: "12.8",
+        cudaToolkit: { available: true, version: "12.8" },
+      },
+    });
+    const block = getProviderAvailabilityBlock("CUDAExecutionProvider", probe);
+    expect(block?.reason).toMatch(/pip install onnxruntime-gpu/);
+    expect(block?.reason).toContain("RTX 5070");
+  });
+
+  it("3b) pip install hint references the pinned wheel version 1.26.0", () => {
+    const probe = makeProbe({
+      nvidia: {
+        gpus: [{ name: "NVIDIA GeForce RTX 5070", computeCapability: "12.0" }],
+      },
+    });
+    const block = getProviderAvailabilityBlock("CUDAExecutionProvider", probe);
+    expect(block?.reason).toContain("onnxruntime-gpu==1.26.0");
+  });
+
+  it("3c) mentions NVIDIA Toolkit archive link when toolkit is also missing", () => {
+    const probe = makeProbe({
+      nvidia: {
+        gpus: [{ name: "NVIDIA GeForce RTX 5070", computeCapability: "12.0" }],
+        cudaToolkit: { available: false },
+      },
+    });
+    const block = getProviderAvailabilityBlock("CUDAExecutionProvider", probe);
+    expect(block?.reason).toMatch(/developer\.nvidia\.com/);
+  });
+
+  it("4) reports driver/wheel mismatch when NVIDIA + driver + toolkit OK but EP not registered", () => {
+    const probe = makeProbe({
+      nvidia: {
+        gpus: [{ name: "NVIDIA GeForce RTX 5070", computeCapability: "12.0" }],
+        cudaVersion: "12.8",
+        cudaToolkit: { available: true, version: "12.8" },
+      },
+      onnxRuntimeProviders: ["CPUExecutionProvider"], // CUDA EP not registered
+    });
+    const block = getProviderAvailabilityBlock("CUDAExecutionProvider", probe);
+    expect(block?.reason).toMatch(/driver.*wheel|driver.*version|mismatch/i);
+  });
+
+  it("returns null block when CUDA is in detectedProviders (already working)", () => {
+    const probe = makeProbe({
+      nvidia: {
+        gpus: [{ name: "NVIDIA GeForce RTX 5070", computeCapability: "12.0" }],
+        cudaToolkit: { available: true, version: "12.8" },
+      },
+      onnxRuntimeProviders: ["CPUExecutionProvider", "CUDAExecutionProvider"],
+      detectedProviders: ["CPUExecutionProvider", "CUDAExecutionProvider"],
+    });
+    expect(getProviderAvailabilityBlock("CUDAExecutionProvider", probe)).toBeNull();
+  });
+
+  it("CUDA reason always names the SM 5.0 floor when NVIDIA is present but pre-Maxwell", () => {
+    // Use a pure pre-Maxwell box so the pre-Maxwell terminator branch
+    // fires (mixed boxes hit the install-needed path, which doesn't pin
+    // the SM floor). The terminator message must lock the 5.0 floor in
+    // user-facing copy so a future rewording can't drift away from it.
+    const probe = makeProbe({
+      nvidia: {
+        gpus: [
+          { name: "GTX 680", computeCapability: "3.0" },
+          { name: "GT 730 Kepler", computeCapability: "3.5" },
+        ],
+      },
+      detectedProviders: ["CPUExecutionProvider"],
+    });
+    const block = getProviderAvailabilityBlock("CUDAExecutionProvider", probe);
+    expect(block?.reason).toContain(cudaSmFloor);
   });
 });

--- a/src/lib/hardwareProbe.ts
+++ b/src/lib/hardwareProbe.ts
@@ -179,8 +179,7 @@ export function mergeDetectedProviders(input: {
   // Only an explicit `false` from the ORT probe removes the EP from the
   // detected list, unlocking the install-needed branch in the recipe
   // compat layer. Same permissive-to-unknown convention as the RTX gate.
-  const cudaOk =
-    input.cudaLoadable === undefined ? true : input.cudaLoadable === true;
+  const cudaOk = input.cudaLoadable !== false;
   // Default true: callers without compute-cap data must not silently hide
   // the RTX-family EPs (pre-Turing downgrades only fire when we KNOW the SM).
   const tensorRtFamilyCapable = input.nvidiaTensorRtFamilyCapable ?? true;
@@ -307,7 +306,7 @@ function undetectedProviderReason(
       // 2. Pre-Maxwell box: install cannot recover
       if (isPreMaxwellNvidiaBox(gpus)) {
         const names = gpus.map((g) => g.name).join(", ");
-        return `NVIDIA GPU detected (${names}) but every card predates the CUDA 12 toolkit floor (compute capability ≥ ${CUDA_SM_FLOOR}, Maxwell / GeForce RTX 20xx+). Upgrading the toolkit cannot recover this — these cards (Kepler SM 3.x) cannot execute modern CUDA. Use the CPU provider, or upgrade hardware.`;
+        return `NVIDIA GPU detected (${names}) but every card predates the CUDA 12 toolkit floor (compute capability ≥ ${CUDA_SM_FLOOR}, Maxwell / GeForce GTX 750 Ti or GTX 9xx series). Upgrading the toolkit cannot recover this — these cards (Kepler SM 3.x) cannot execute modern CUDA. Use the CPU provider, or upgrade hardware.`;
       }
       // 3. NVIDIA driver OK but onnxruntime-gpu missing in .venv
       const cudaEpUsable = probe.cuda?.loadable === true;

--- a/src/lib/hardwareProbe.ts
+++ b/src/lib/hardwareProbe.ts
@@ -310,7 +310,7 @@ function undetectedProviderReason(
         return `NVIDIA GPU detected (${names}) but every card predates the CUDA 12 toolkit floor (compute capability ≥ ${CUDA_SM_FLOOR}, Maxwell / GeForce RTX 20xx+). Upgrading the toolkit cannot recover this — these cards (Kepler SM 3.x) cannot execute modern CUDA. Use the CPU provider, or upgrade hardware.`;
       }
       // 3. NVIDIA driver OK but onnxruntime-gpu missing in .venv
-      const cudaEpInVenv = probe.onnxRuntimeProviders?.includes("CUDAExecutionProvider") ?? false;
+      const cudaEpUsable = probe.cuda?.loadable === true;
       const toolkit = nvidia?.cudaToolkit;
       const toolTip =
         toolkit?.available === true
@@ -319,7 +319,7 @@ function undetectedProviderReason(
           : toolkit?.available === false
             ? "toolkit (nvcc) not installed"
             : "toolkit status unknown";
-      if (!cudaEpInVenv) {
+      if (!cudaEpUsable) {
         return `NVIDIA driver detected on ${gpus.map((g) => g.name).join(", ")}; ${toolTip}. The CUDA execution provider is not registered by onnxruntime-gpu in the project .venv — install the pinned wheel with \`${pinnedOrtGpuInstallCommand()}\` (you can also click "Install onnxruntime-gpu" in the Hardware panel).${
           toolkit?.available === false
             ? ` CUDA toolkit is also missing; for native builds grab it from ${CUDA_DOWNLOAD_LINKS.archive}.`

--- a/src/lib/hardwareProbe.ts
+++ b/src/lib/hardwareProbe.ts
@@ -18,6 +18,8 @@ export interface OpenVinoProbeResult {
     version?: string;
     detail?: string;
   };
+  /** True when onnxruntime reports OpenVINOExecutionProvider. */
+  openvinoExecutionProvider?: boolean;
   detail?: string;
 }
 

--- a/src/lib/hardwareProbe.ts
+++ b/src/lib/hardwareProbe.ts
@@ -1,9 +1,59 @@
 import { IHVProvider } from "@/types";
+import {
+  CUDA_SM_FLOOR,
+  CUDA_DOWNLOAD_LINKS,
+  isPreMaxwellNvidiaBox,
+  pinnedOrtGpuInstallCommand,
+} from "@/lib/cudaDeps";
 
+/**
+ * Compute capability is reported as `"<major>.<minor>"` (e.g. `"8.9"` for
+ * Ada Lovelace, `"7.5"` for Turing). `undefined` means we could not read it
+ * (older drivers, parsing failure) — callers must treat absence as permissive
+ * so a probe hiccup never falsely downgrades an otherwise supported GPU.
+ */
 export interface GpuInfo {
   name: string;
   vramMb?: number;
   driver?: string;
+  computeCapability?: string;
+}
+
+/**
+ * Minimum NVIDIA compute capability TensorRT 10.x and TensorRT-RTX can run on.
+ * Turing (SM 7.5) is the floor; Maxwell/Pascal/Kepler cannot execute either
+ * EP even when the SDK/runtime are installed. Centralizing this number avoids
+ * drift between the detection (nvidia-smi), the recipe-compatibility check,
+ * the install-needed hint, and the missing-provider reason.
+ *
+ * Format: `{ major, minor }`. Compare numerically; e.g. 8.9 ≥ 7.5.
+ */
+export const TENSORRT_FAMILY_MIN_COMPUTE_CAPABILITY = { major: 7, minor: 5 } as const;
+
+/**
+ * Parse a `"<major>.<minor>"` string (e.g. `"8.9"`, `"7.5"`, `"12.0"`) into
+ * a comparable pair. Returns `undefined` on any malformed/empty input so
+ * "I don't know" never downgrades compat silently.
+ */
+export function parseComputeCapability(value: string | undefined): { major: number; minor: number } | undefined {
+  if (!value) return undefined;
+  const m = value.trim().match(/^(\d+)\.(\d+)$/);
+  if (!m) return undefined;
+  return { major: parseInt(m[1], 10), minor: parseInt(m[2], 10) };
+}
+
+/**
+ * Does the GPU's compute capability meet or exceed the TensorRT 10.x / RTX floor?
+ * `undefined` compute capability is treated as supported so a probe glitch
+ * does not silently mark a real RTX card as incompatible.
+ */
+export function isNvidiaGpuTensorRtFamily(gpu: GpuInfo): boolean {
+  const cap = parseComputeCapability(gpu.computeCapability);
+  if (!cap) return true;
+  if (cap.major !== TENSORRT_FAMILY_MIN_COMPUTE_CAPABILITY.major) {
+    return cap.major > TENSORRT_FAMILY_MIN_COMPUTE_CAPABILITY.major;
+  }
+  return cap.minor >= TENSORRT_FAMILY_MIN_COMPUTE_CAPABILITY.minor;
 }
 
 export interface HardwareProbeResult {
@@ -19,6 +69,20 @@ export interface HardwareProbeResult {
     gpus: GpuInfo[];
     cudaVersion?: string;
     cudaTag?: string;
+    /**
+     * True when `nvcc --version` succeeded. The toolkit is only required
+     * for native CUDA compilation — Olive Studio inference only needs the
+     * driver + CUDA runtime libraries (which ship inside the
+     * `onnxruntime-gpu` wheel). Surfacing this separately lets the IHV
+     * panel decide whether to offer a download link.
+     *
+     * `undefined` means the probe didn't run or didn't yield a clear answer
+     * (no nvcc in PATH, fresh installer, etc.).
+     */
+    cudaToolkit?: {
+      available: boolean;
+      version?: string;
+    };
   };
   rocm?: {
     gpus: GpuInfo[];
@@ -35,6 +99,19 @@ export interface HardwareProbeResult {
     loadable: boolean;
     detail?: string;
     version?: string;
+  };
+  /**
+   * Whether the CUDA execution provider is actually loadable by ORT in this
+   * environment. Distinct from NVIDIA GPU detection (nvidia-smi) — the EP can
+   * be missing because `onnxruntime-gpu` wheel isn't installed, the CUDA
+   * runtime libs aren't on PATH, or the driver/ORT ABI versions don't match.
+   * Mirrors the `tensorrt` / `tensorRtRtx` shape so `mergeDetectedProviders`
+   * can strip CUDA from the detected list when it isn't loadable and the
+   * recipe-compat layer can surface a one-click install hint.
+   */
+  cuda?: {
+    loadable: boolean;
+    detail?: string;
   };
   /** Providers reported by onnxruntime.get_available_providers() when probed. */
   onnxRuntimeProviders?: string[];
@@ -77,10 +154,36 @@ export function mergeDetectedProviders(input: {
   hasOpenVino: boolean;
   tensorRtLoadable?: boolean;
   tensorRtRtxLoadable?: boolean;
+  /**
+   * Pre-computed by the route handler from `nvidia.gpus[].computeCapability`.
+   * When `true`, at least one NVIDIA GPU meets the TensorRT-family floor
+   * (SM 7.5 / Turing+). Defaults to `true` for backwards compatibility with
+   * callers that did not supply the GPU detail; routes that have it should
+   * always pass it explicitly.
+   */
+  nvidiaTensorRtFamilyCapable?: boolean;
+  /**
+   * Pre-computed from the ORT CUDA EP probe (`ORT_GPU_PROBE_SCRIPT`).
+   * When explicitly `false`, the CUDA execution provider is not loadable in
+   * this environment (e.g. onnxruntime-gpu wheel missing, driver/wheel
+   * mismatch) and `mergeDetectedProviders` strips `CUDAExecutionProvider`
+   * from the detected list. Defaults to `true` for callers that don't probe
+   * the EP — same permissive-to-unknown convention as TensorRT.
+   */
+  cudaLoadable?: boolean;
 }): IHVProvider[] {
   const detected = new Set<IHVProvider>(["CPUExecutionProvider"]);
   const tensorRtOk = input.tensorRtLoadable === true;
   const tensorRtRtxOk = input.tensorRtRtxLoadable === true;
+  // Treat `undefined` as "we don't know yet" → permissive (don't strip CUDA).
+  // Only an explicit `false` from the ORT probe removes the EP from the
+  // detected list, unlocking the install-needed branch in the recipe
+  // compat layer. Same permissive-to-unknown convention as the RTX gate.
+  const cudaOk =
+    input.cudaLoadable === undefined ? true : input.cudaLoadable === true;
+  // Default true: callers without compute-cap data must not silently hide
+  // the RTX-family EPs (pre-Turing downgrades only fire when we KNOW the SM).
+  const tensorRtFamilyCapable = input.nvidiaTensorRtFamilyCapable ?? true;
 
   if (input.onnxRuntimeProviders?.length) {
     for (const provider of mapOrtProvidersToIhv(input.onnxRuntimeProviders)) {
@@ -90,16 +193,34 @@ export function mergeDetectedProviders(input: {
       if (provider === "NvTensorRTRTXExecutionProvider" && !tensorRtRtxOk) {
         continue;
       }
+      // Gate RTX-family EPs even when ORT reports them — nvidia-smi SM ≥ 7.5
+      // is the real floor; without it the EP load is a lie.
+      if (provider === "TensorrtExecutionProvider" || provider === "NvTensorRTRTXExecutionProvider") {
+        if (!tensorRtFamilyCapable) continue;
+      }
+      // Mirror the RTX gate: if the CUDA EP is not actually loadable in
+      // this environment, strip it from ORT's reported list even when ORT
+      // reports it (e.g. wheel installed but EP failed to register).
+      if (provider === "CUDAExecutionProvider" && !cudaOk) {
+        continue;
+      }
       detected.add(provider);
     }
   }
 
   // nvidia-smi / rocm-smi / openvino fill gaps when the installed ORT wheel lacks GPU EPs.
   if (input.hasNvidiaGpu) {
-    detected.add("CUDAExecutionProvider");
-    detected.add("NvTensorRTRTXExecutionProvider");
-    if (tensorRtOk) {
-      detected.add("TensorrtExecutionProvider");
+    // Only fill CUDA from nvidia-smi when the ORT probe confirms the EP loads.
+    // Falls back to the onnxRuntimeProviders branch when probe hasn't run yet
+    // (caller didn't pass cudaLoadable, defaults to permissive).
+    if (cudaOk) {
+      detected.add("CUDAExecutionProvider");
+    }
+    if (tensorRtFamilyCapable) {
+      detected.add("NvTensorRTRTXExecutionProvider");
+      if (tensorRtOk) {
+        detected.add("TensorrtExecutionProvider");
+      }
     }
   }
   if (input.hasRocmGpu) {
@@ -144,10 +265,28 @@ export function pickRecommendedProvider(
 /**
  * Provides the user-facing reason an execution provider is unavailable.
  *
+ * The CUDA branch consults the latest probe fields to give a precise
+ * explanation:
+ *
+ *   1. No NVIDIA GPU at all → pick the CPU provider instead.
+ *   2. NVIDIA GPU present but every card predates the CUDA 12 toolkit
+ *      floor (SM < 5.0 / Maxwell) → toolkits cannot help this hardware.
+ *   3. NVIDIA GPU + driver detected but `onnxruntime-gpu` is missing from
+ *      `.venv` → pip install the wheel.
+ *   4. NVIDIA GPU + driver + toolkit installed but the CUDA EP failed to
+ *      register → driver or wheel mismatch.
+ *
+ * The "Install onnxruntime-gpu" hint includes the exact pinned install
+ * command so the user can paste it without digging through Hardware.
+ *
  * @param provider - The execution provider to describe
+ * @param probe - Optional hardware probe result for path-specific messaging
  * @returns An availability message, or an empty string for the CPU provider
  */
-function undetectedProviderReason(provider: IHVProvider): string {
+function undetectedProviderReason(
+  provider: IHVProvider,
+  probe?: HardwareProbeResult | null,
+): string {
   switch (provider) {
     case "QNNExecutionProvider":
       return "Qualcomm QNN requires Snapdragon / Hexagon NPU hardware on this machine.";
@@ -155,12 +294,51 @@ function undetectedProviderReason(provider: IHVProvider): string {
       return "AMD ROCm was not detected (no ROCm GPU or ROCm runtime on this machine).";
     case "OpenVINOExecutionProvider":
       return "Intel OpenVINO was not detected (OpenVINO runtime not installed locally).";
-    case "CUDAExecutionProvider":
-      return "NVIDIA CUDA was not detected (no NVIDIA GPU or CUDA execution provider on this machine).";
-    case "TensorrtExecutionProvider":
-      return "Full TensorRT needs an NVIDIA GPU (Turing / GeForce RTX 20xx or newer). Install the TensorRT SDK into .venv from Hardware, or it installs on first TensorRT run.";
-    case "NvTensorRTRTXExecutionProvider":
-      return "TensorRT RTX needs an NVIDIA GPU. On GeForce RTX, install tensorrt-rtx from Hardware (or it installs on first run). This is not the same as full TensorRT.";
+    case "CUDAExecutionProvider": {
+      if (!probe) {
+        return "NVIDIA CUDA was not detected (no NVIDIA GPU or CUDA execution provider on this machine).";
+      }
+      const nvidia = probe.nvidia;
+      const gpus = nvidia?.gpus ?? [];
+      // 1. CPU-only box
+      if (gpus.length === 0) {
+        return "No NVIDIA GPU detected on this machine (nvidia-smi returned no devices). Use the CPU provider for OLIVE recipes.";
+      }
+      // 2. Pre-Maxwell box: install cannot recover
+      if (isPreMaxwellNvidiaBox(gpus)) {
+        const names = gpus.map((g) => g.name).join(", ");
+        return `NVIDIA GPU detected (${names}) but every card predates the CUDA 12 toolkit floor (compute capability ≥ ${CUDA_SM_FLOOR}, Maxwell / GeForce RTX 20xx+). Upgrading the toolkit cannot recover this — these cards (Kepler SM 3.x) cannot execute modern CUDA. Use the CPU provider, or upgrade hardware.`;
+      }
+      // 3. NVIDIA driver OK but onnxruntime-gpu missing in .venv
+      const cudaEpInVenv = probe.onnxRuntimeProviders?.includes("CUDAExecutionProvider") ?? false;
+      const toolkit = nvidia?.cudaToolkit;
+      const toolTip =
+        toolkit?.available === true
+          ? `toolkit ${toolkit.version ?? "available"}` +
+            (nvidia?.cudaVersion ? ` on driver CUDA ${nvidia.cudaVersion}` : "")
+          : toolkit?.available === false
+            ? "toolkit (nvcc) not installed"
+            : "toolkit status unknown";
+      if (!cudaEpInVenv) {
+        return `NVIDIA driver detected on ${gpus.map((g) => g.name).join(", ")}; ${toolTip}. The CUDA execution provider is not registered by onnxruntime-gpu in the project .venv — install the pinned wheel with \`${pinnedOrtGpuInstallCommand()}\` (you can also click "Install onnxruntime-gpu" in the Hardware panel).${
+          toolkit?.available === false
+            ? ` CUDA toolkit is also missing; for native builds grab it from ${CUDA_DOWNLOAD_LINKS.archive}.`
+            : ""
+        }`;
+      }
+      // 4. Toolkit + driver + ORT installed but the CUDA EP isn't in
+      // detectedProviders — likely driver/wheel mismatch (e.g. CUDA 13
+      // wheel against CUDA 11 driver).
+      return `NVIDIA CUDA driver + toolkit installed, but the CUDA execution provider is not selectable in this environment (likely driver/wheel version mismatch — refresh the probe after fixing the install).`;
+    }
+    case "TensorrtExecutionProvider": {
+      const min = `${TENSORRT_FAMILY_MIN_COMPUTE_CAPABILITY.major}.${TENSORRT_FAMILY_MIN_COMPUTE_CAPABILITY.minor}`;
+      return `Full TensorRT needs an NVIDIA GPU with compute capability ≥ ${min} (Turing / GeForce RTX 20xx, Quadro, datacenter). Pre-Turing cards (Maxwell/Pascal/Kepler) cannot run TensorRT 10.x even after install. On a supported GPU, install the TensorRT SDK into .venv from Hardware — it installs on first TensorRT run otherwise.`;
+    }
+    case "NvTensorRTRTXExecutionProvider": {
+      const min = `${TENSORRT_FAMILY_MIN_COMPUTE_CAPABILITY.major}.${TENSORRT_FAMILY_MIN_COMPUTE_CAPABILITY.minor}`;
+      return `TensorRT RTX needs an NVIDIA GPU with compute capability ≥ ${min} (Turing / GeForce RTX 20xx or newer). Pre-Turing cards (Maxwell/Pascal/Kepler) cannot run the EP. On a supported GeForce RTX, install tensorrt-rtx from Hardware (or it installs on first run). This is not the same as full TensorRT.`;
+    }
     case "WebGpuExecutionProvider":
       return "WebGPU is a browser deploy target (ONNX Runtime Web), not a local Python EP. Select it to build web-oriented recipes, then run Browser Test / WebGPU benchmark in Recipe & run (Chrome 113+ / Edge 113+).";
     case "CPUExecutionProvider":
@@ -198,7 +376,7 @@ export function getProviderAvailabilityBlock(
     };
   }
   if (!probe.detectedProviders.includes(provider)) {
-    return { reason: undetectedProviderReason(provider) };
+    return { reason: undetectedProviderReason(provider, probe) };
   }
   return null;
 }

--- a/src/lib/hardwareProbe.ts
+++ b/src/lib/hardwareProbe.ts
@@ -6,6 +6,19 @@ export interface GpuInfo {
   driver?: string;
 }
 
+export interface OpenVinoProbeResult {
+  available: boolean;
+  version?: string;
+  /** Devices reported by openvino.Core().available_devices (e.g. CPU, GPU, NPU, AUTO). */
+  devices?: string[];
+  optimumIntel?: {
+    available: boolean;
+    version?: string;
+    detail?: string;
+  };
+  detail?: string;
+}
+
 export interface HardwareProbeResult {
   probedAt: string;
   platform: {
@@ -23,10 +36,7 @@ export interface HardwareProbeResult {
   rocm?: {
     gpus: GpuInfo[];
   };
-  openvino?: {
-    available: boolean;
-    version?: string;
-  };
+  openvino?: OpenVinoProbeResult;
   tensorrt?: {
     loadable: boolean;
     detail?: string;
@@ -75,6 +85,8 @@ export function mergeDetectedProviders(input: {
   hasNvidiaGpu: boolean;
   hasRocmGpu: boolean;
   hasOpenVino: boolean;
+  /** True when the local CPU/platform can run the OpenVINO runtime, even if not yet installed. */
+  hasOpenVinoCompatibleHardware?: boolean;
   tensorRtLoadable?: boolean;
   tensorRtRtxLoadable?: boolean;
 }): IHVProvider[] {
@@ -105,7 +117,7 @@ export function mergeDetectedProviders(input: {
   if (input.hasRocmGpu) {
     detected.add("ROCMExecutionProvider");
   }
-  if (input.hasOpenVino) {
+  if (input.hasOpenVino || input.hasOpenVinoCompatibleHardware) {
     detected.add("OpenVINOExecutionProvider");
   }
 
@@ -121,7 +133,7 @@ export function mergeDetectedProviders(input: {
  */
 export function pickRecommendedProvider(
   detected: IHVProvider[],
-  opts?: { tensorRtRtxLoadable?: boolean; tensorRtLoadable?: boolean },
+  opts?: { tensorRtRtxLoadable?: boolean; tensorRtLoadable?: boolean; openvinoLoadable?: boolean },
 ): IHVProvider {
   // Prefer installed acceleration stacks; otherwise CUDA is the safe NVIDIA default.
   const priority: IHVProvider[] = [
@@ -131,7 +143,7 @@ export function pickRecommendedProvider(
     "NvTensorRTRTXExecutionProvider",
     "TensorrtExecutionProvider",
     "ROCMExecutionProvider",
-    "OpenVINOExecutionProvider",
+    ...(opts?.openvinoLoadable ? (["OpenVINOExecutionProvider"] as const) : []),
     "WebGpuExecutionProvider",
     "CPUExecutionProvider",
   ];

--- a/src/lib/hardwareProbe.ts
+++ b/src/lib/hardwareProbe.ts
@@ -8,6 +8,8 @@ export interface GpuInfo {
 
 export interface OpenVinoProbeResult {
   available: boolean;
+  /** True when OpenVINO EP is loadable in the .venv (matches tensorrt.loadable pattern). */
+  loadable?: boolean;
   version?: string;
   /** Devices reported by openvino.Core().available_devices (e.g. CPU, GPU, NPU, AUTO). */
   devices?: string[];

--- a/src/lib/hardwareProbe.ts
+++ b/src/lib/hardwareProbe.ts
@@ -79,6 +79,26 @@ export function mapOrtProvidersToIhv(providers: string[]): IHVProvider[] {
 }
 
 /**
+ * Whether local hardware can usefully run OpenVINO acceleration.
+ *
+ * Requires an Intel CPU (vendor-qualified), an Intel GPU/NPU name from host
+ * enumeration, or OpenVINO already reporting GPU/NPU devices. Does not use
+ * NVIDIA GPU lists (Arc never appears there) and does not match AMD
+ * "N-Core Processor" strings via a bare `Core` token.
+ */
+export function computeOpenVinoCompatibleHardware(input: {
+  cpuModel: string;
+  intelGpuNames?: string[];
+  openvinoDevices?: string[];
+}): boolean {
+  const hasIntelCpu = /\bIntel\b|\bXeon\b/i.test(input.cpuModel);
+  const hasIntelGpu = (input.intelGpuNames ?? []).some((name) => /Intel/i.test(name));
+  const hasIntelOpenVinoDevices =
+    (input.openvinoDevices ?? []).some((device) => /GPU|NPU/i.test(device));
+  return hasIntelCpu || hasIntelGpu || hasIntelOpenVinoDevices;
+}
+
+/**
  * Combines ONNX Runtime providers and hardware probe results into the locally detected provider list.
  *
  * @param input - Provider and hardware detection results, including runtime loadability for TensorRT variants

--- a/src/lib/ndjsonInstall.test.ts
+++ b/src/lib/ndjsonInstall.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { runNdjsonInstall } from "./ndjsonInstall.ts";
+
+function ndjsonResponse(frames: string[], status = 200): Response {
+  const body = frames.join("");
+  return new Response(body, {
+    status,
+    headers: { "content-type": "application/x-ndjson" },
+  });
+}
+
+describe("runNdjsonInstall", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("parses log and done frames", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        ndjsonResponse([
+          '{"type":"log","message":"step 1"}\n',
+          '{"type":"done","ok":true}\n',
+        ]),
+      ),
+    );
+    const log: string[] = [];
+    await runNdjsonInstall("/api/env/install-openvino", (u) => {
+      const next = typeof u === "function" ? u(log) : u;
+      log.splice(0, log.length, ...next);
+    });
+    expect(log).toEqual(["step 1"]);
+  });
+
+  it("flushes a final unterminated frame after the reader completes", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        ndjsonResponse(['{"type":"log","message":"partial"}\n', '{"type":"done","ok":true}']),
+      ),
+    );
+    const log: string[] = [];
+    await runNdjsonInstall("/api/env/install-openvino", (u) => {
+      const next = typeof u === "function" ? u(log) : u;
+      log.splice(0, log.length, ...next);
+    });
+    expect(log).toEqual(["partial"]);
+  });
+
+  it("throws when done reports failure", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        ndjsonResponse(['{"type":"done","ok":false,"error":"pip failed"}\n'], 500),
+      ),
+    );
+    await expect(runNdjsonInstall("/api/env/x", () => undefined)).rejects.toThrow("pip failed");
+  });
+});

--- a/src/lib/ndjsonInstall.ts
+++ b/src/lib/ndjsonInstall.ts
@@ -1,0 +1,87 @@
+/**
+ * Shared NDJSON install stream reader for Hardware panel package installs.
+ *
+ * Used by TensorRT / TensorRT RTX / OpenVINO install flows that POST to
+ * `/api/env/install-*` and stream `{type:"log"|"done"}` frames.
+ */
+
+export type NdjsonLogSetter = (updater: string[] | ((prev: string[]) => string[])) => void;
+
+type InstallEvent = { type?: string; message?: string; ok?: boolean; error?: string };
+
+function applyInstallEvent(
+  evt: InstallEvent,
+  resOk: boolean,
+  setLog: NdjsonLogSetter,
+  state: { ok: boolean; error?: string },
+): void {
+  if (evt.type === "log" && evt.message) {
+    setLog((prev) => [...prev, evt.message!]);
+    return;
+  }
+  if (evt.type === "done") {
+    state.ok = resOk && evt.ok === true;
+    state.error = evt.error;
+  }
+}
+
+function parseAndApplyLine(
+  line: string,
+  resOk: boolean,
+  setLog: NdjsonLogSetter,
+  state: { ok: boolean; error?: string },
+): void {
+  if (!line.trim()) return;
+  let evt: InstallEvent;
+  try {
+    evt = JSON.parse(line) as InstallEvent;
+  } catch {
+    return;
+  }
+  applyInstallEvent(evt, resOk, setLog, state);
+}
+
+/**
+ * POSTs to an install endpoint and consumes either an NDJSON body or a JSON fallback.
+ * Flushes any residual unterminated frame after the reader completes.
+ */
+export async function runNdjsonInstall(url: string, setLog: NdjsonLogSetter): Promise<void> {
+  const res = await fetch(url, { method: "POST" });
+  const contentType = res.headers.get("content-type") ?? "";
+  const state = { ok: false, error: undefined as string | undefined };
+
+  if (contentType.includes("ndjson") && res.body) {
+    const reader = res.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = "";
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+      const parts = buffer.split("\n");
+      buffer = parts.pop() ?? "";
+      for (const line of parts) {
+        parseAndApplyLine(line, res.ok, setLog, state);
+      }
+    }
+    buffer += decoder.decode();
+    if (buffer.trim()) {
+      parseAndApplyLine(buffer, res.ok, setLog, state);
+    }
+  } else {
+    const data = (await res.json()) as {
+      ok?: boolean;
+      error?: string;
+      lines?: string[];
+      log?: string[];
+    };
+    const lines = data.lines ?? data.log;
+    if (Array.isArray(lines)) setLog(lines);
+    state.ok = res.ok && data.ok === true;
+    state.error = data.error;
+  }
+
+  if (!state.ok) {
+    throw new Error(state.error ?? `Install failed (HTTP ${res.status})`);
+  }
+}

--- a/src/lib/openvinoDeps.test.ts
+++ b/src/lib/openvinoDeps.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import {
+  OPEN_VINO_PIP_PACKAGE,
+  OPTIMUM_INTEL_OPEN_VINO_PIP_PACKAGE,
+  openvinoStackInstallArgs,
+  openvinoStackLabel,
+} from "./openvinoDeps.ts";
+
+describe("openvinoStackInstallArgs", () => {
+  it("includes --upgrade-strategy eager and both packages", () => {
+    const args = openvinoStackInstallArgs();
+    expect(args).toContain("--upgrade-strategy");
+    expect(args).toContain("eager");
+    expect(args).toContain(OPEN_VINO_PIP_PACKAGE);
+    expect(args).toContain(OPTIMUM_INTEL_OPEN_VINO_PIP_PACKAGE);
+  });
+
+  it("does not split the bracketed extra into a bare token", () => {
+    const args = openvinoStackInstallArgs();
+    expect(args.some((a) => a.startsWith("["))).toBe(false);
+    expect(args).toContain(`${OPEN_VINO_PIP_PACKAGE}`);
+    expect(args).toContain(OPTIMUM_INTEL_OPEN_VINO_PIP_PACKAGE);
+  });
+
+  it("labels the stack for UI/logs", () => {
+    expect(openvinoStackLabel()).toContain(OPEN_VINO_PIP_PACKAGE);
+    expect(openvinoStackLabel()).toContain(OPTIMUM_INTEL_OPEN_VINO_PIP_PACKAGE);
+  });
+});

--- a/src/lib/openvinoDeps.test.ts
+++ b/src/lib/openvinoDeps.test.ts
@@ -1,18 +1,21 @@
 import { describe, expect, it } from "vitest";
 import {
+  ONNXRUNTIME_OPENVINO_PIP_PACKAGE,
   OPEN_VINO_PIP_PACKAGE,
+  OPENVINO_CONFLICTING_ORT_PACKAGES,
   OPTIMUM_INTEL_OPEN_VINO_PIP_PACKAGE,
   openvinoStackInstallArgs,
   openvinoStackLabel,
 } from "./openvinoDeps.ts";
 
 describe("openvinoStackInstallArgs", () => {
-  it("includes --upgrade-strategy eager and both packages", () => {
+  it("includes --upgrade-strategy eager and all OpenVINO stack packages", () => {
     const args = openvinoStackInstallArgs();
     expect(args).toContain("--upgrade-strategy");
     expect(args).toContain("eager");
     expect(args).toContain(OPEN_VINO_PIP_PACKAGE);
     expect(args).toContain(OPTIMUM_INTEL_OPEN_VINO_PIP_PACKAGE);
+    expect(args).toContain(ONNXRUNTIME_OPENVINO_PIP_PACKAGE);
   });
 
   it("does not split the bracketed extra into a bare token", () => {
@@ -22,8 +25,15 @@ describe("openvinoStackInstallArgs", () => {
     expect(args).toContain(OPTIMUM_INTEL_OPEN_VINO_PIP_PACKAGE);
   });
 
-  it("labels the stack for UI/logs", () => {
+  it("labels the stack for UI/logs including the ORT OpenVINO EP wheel", () => {
     expect(openvinoStackLabel()).toContain(OPEN_VINO_PIP_PACKAGE);
     expect(openvinoStackLabel()).toContain(OPTIMUM_INTEL_OPEN_VINO_PIP_PACKAGE);
+    expect(openvinoStackLabel()).toContain(ONNXRUNTIME_OPENVINO_PIP_PACKAGE);
+  });
+
+  it("lists ORT wheels that must be removed before installing onnxruntime-openvino", () => {
+    expect(OPENVINO_CONFLICTING_ORT_PACKAGES).toContain("onnxruntime");
+    expect(OPENVINO_CONFLICTING_ORT_PACKAGES).toContain("onnxruntime-gpu");
+    expect(OPENVINO_CONFLICTING_ORT_PACKAGES).toContain("onnxruntime-directml");
   });
 });

--- a/src/lib/openvinoDeps.test.ts
+++ b/src/lib/openvinoDeps.test.ts
@@ -9,13 +9,15 @@ import {
 } from "./openvinoDeps.ts";
 
 describe("openvinoStackInstallArgs", () => {
-  it("includes --upgrade-strategy eager and all OpenVINO stack packages", () => {
-    const args = openvinoStackInstallArgs();
-    expect(args).toContain("--upgrade-strategy");
-    expect(args).toContain("eager");
-    expect(args).toContain(OPEN_VINO_PIP_PACKAGE);
-    expect(args).toContain(OPTIMUM_INTEL_OPEN_VINO_PIP_PACKAGE);
-    expect(args).toContain(ONNXRUNTIME_OPENVINO_PIP_PACKAGE);
+  it("returns the exact pip args contract including --upgrade and eager strategy", () => {
+    expect(openvinoStackInstallArgs()).toEqual([
+      "--upgrade",
+      "--upgrade-strategy",
+      "eager",
+      OPEN_VINO_PIP_PACKAGE,
+      OPTIMUM_INTEL_OPEN_VINO_PIP_PACKAGE,
+      ONNXRUNTIME_OPENVINO_PIP_PACKAGE,
+    ]);
   });
 
   it("does not split the bracketed extra into a bare token", () => {

--- a/src/lib/openvinoDeps.ts
+++ b/src/lib/openvinoDeps.ts
@@ -1,0 +1,31 @@
+/**
+ * OpenVINO + Optimum-Intel stack installation metadata.
+ *
+ * Installs the PyPI OpenVINO runtime and the Hugging Face Optimum-Intel bridge
+ * (openvino extra) into the project .venv. Used by the Hardware panel install
+ * button and by recipe-required-package inference.
+ */
+export const OPEN_VINO_PIP_PACKAGE = "openvino";
+export const OPTIMUM_INTEL_OPEN_VINO_PIP_PACKAGE = "optimum-intel[openvino]";
+
+/** Intel GPU driver setup docs for OpenVINO. */
+export const OPEN_VINO_GPU_DRIVER_URL =
+  "https://docs.openvino.ai/2026/get-started/install-openvino/configurations/configurations-intel-gpu.html";
+
+/** Intel NPU driver setup docs for OpenVINO. */
+export const OPEN_VINO_NPU_DRIVER_URL =
+  "https://docs.openvino.ai/2026/get-started/install-openvino/configurations/configurations-intel-npu.html";
+
+/**
+ * Returns the pip install arguments for the OpenVINO stack.
+ *
+ * Uses --upgrade-strategy eager so OpenVINO upgrades cleanly even when optimum-intel
+ * transitively pins an older runtime.
+ */
+export function openvinoStackInstallArgs(): string[] {
+  return ["--upgrade-strategy", "eager", OPEN_VINO_PIP_PACKAGE, OPTIMUM_INTEL_OPEN_VINO_PIP_PACKAGE];
+}
+
+export function openvinoStackLabel(): string {
+  return `${OPEN_VINO_PIP_PACKAGE} + ${OPTIMUM_INTEL_OPEN_VINO_PIP_PACKAGE}`;
+}

--- a/src/lib/openvinoDeps.ts
+++ b/src/lib/openvinoDeps.ts
@@ -1,12 +1,29 @@
 /**
- * OpenVINO + Optimum-Intel stack installation metadata.
+ * OpenVINO + Optimum-Intel + ORT OpenVINO EP installation metadata.
  *
- * Installs the PyPI OpenVINO runtime and the Hugging Face Optimum-Intel bridge
- * (openvino extra) into the project .venv. Used by the Hardware panel install
- * button and by recipe-required-package inference.
+ * Installs the PyPI OpenVINO runtime, the Hugging Face Optimum-Intel bridge
+ * (openvino extra), and `onnxruntime-openvino` (supplies OpenVINOExecutionProvider)
+ * into the project .venv. Used by the Hardware panel install button and by
+ * recipe-required-package inference.
+ *
+ * Olive maps OpenVINOExecutionProvider → onnxruntime-openvino
+ * (see microsoft/Olive olive/hardware/constants.py). Plain `openvino` /
+ * `optimum-intel` alone do not register the ORT execution provider.
  */
 export const OPEN_VINO_PIP_PACKAGE = "openvino";
 export const OPTIMUM_INTEL_OPEN_VINO_PIP_PACKAGE = "optimum-intel[openvino]";
+/** ORT wheel that bundles OpenVINOExecutionProvider (mutually exclusive with onnxruntime-gpu). */
+export const ONNXRUNTIME_OPENVINO_PIP_PACKAGE = "onnxruntime-openvino";
+
+/**
+ * ORT distributions that conflict with `onnxruntime-openvino` on the same
+ * import path. Uninstall these before installing the OpenVINO ORT wheel.
+ */
+export const OPENVINO_CONFLICTING_ORT_PACKAGES = [
+  "onnxruntime",
+  "onnxruntime-gpu",
+  "onnxruntime-directml",
+] as const;
 
 /** Intel GPU driver setup docs for OpenVINO. */
 export const OPEN_VINO_GPU_DRIVER_URL =
@@ -23,9 +40,15 @@ export const OPEN_VINO_NPU_DRIVER_URL =
  * transitively pins an older runtime.
  */
 export function openvinoStackInstallArgs(): string[] {
-  return ["--upgrade-strategy", "eager", OPEN_VINO_PIP_PACKAGE, OPTIMUM_INTEL_OPEN_VINO_PIP_PACKAGE];
+  return [
+    "--upgrade-strategy",
+    "eager",
+    OPEN_VINO_PIP_PACKAGE,
+    OPTIMUM_INTEL_OPEN_VINO_PIP_PACKAGE,
+    ONNXRUNTIME_OPENVINO_PIP_PACKAGE,
+  ];
 }
 
 export function openvinoStackLabel(): string {
-  return `${OPEN_VINO_PIP_PACKAGE} + ${OPTIMUM_INTEL_OPEN_VINO_PIP_PACKAGE}`;
+  return `${OPEN_VINO_PIP_PACKAGE} + ${OPTIMUM_INTEL_OPEN_VINO_PIP_PACKAGE} + ${ONNXRUNTIME_OPENVINO_PIP_PACKAGE}`;
 }

--- a/src/lib/openvinoDeps.ts
+++ b/src/lib/openvinoDeps.ts
@@ -36,11 +36,13 @@ export const OPEN_VINO_NPU_DRIVER_URL =
 /**
  * Returns the pip install arguments for the OpenVINO stack.
  *
- * Uses --upgrade-strategy eager so OpenVINO upgrades cleanly even when optimum-intel
- * transitively pins an older runtime.
+ * `--upgrade` is required for `--upgrade-strategy eager` to take effect so
+ * already-installed OpenVINO packages (and their deps) are upgraded when
+ * optimum-intel transitively pins an older runtime.
  */
 export function openvinoStackInstallArgs(): string[] {
   return [
+    "--upgrade",
     "--upgrade-strategy",
     "eager",
     OPEN_VINO_PIP_PACKAGE,

--- a/src/lib/providerCatalog.ts
+++ b/src/lib/providerCatalog.ts
@@ -51,13 +51,18 @@ export const PROVIDER_CATALOG: ProviderCatalogEntry[] = [
   },
   {
     id: "NvTensorRTRTXExecutionProvider",
+    // The SM 7.5 (Turing) floor mirrors `TENSORRT_FAMILY_MIN_COMPUTE_CAPABILITY`
+    // in `src/lib/hardwareProbe.ts`. Keep this wording in lockstep with the
+    // `undetectedProviderReason('NvTensorRTRTXExecutionProvider')` text so the
+    // chip and the unavailable reason can't drift apart; the
+    // providerCatalog.test.ts guard test enforces this.
     name: "NVIDIA TensorRT RTX",
     shortName: "TRT RTX",
-    desc: "Consumer RTX GPUs (GeForce 30xx+). JIT TensorRT engines via tensorrt-rtx — no full SDK.",
+    desc: "JIT TensorRT engines via tensorrt-rtx — no full SDK. Runs on NVIDIA GPUs with compute capability ≥ 7.5 (Turing / GeForce RTX 20xx or newer; primary target Ampere/Ada/Blackwell consumer RTX).",
     icon: Layers,
     tooltip: {
       requirements:
-        "NVIDIA GeForce RTX 30xx or newer (Ampere+). Uses tensorrt-rtx runtime — no full TensorRT SDK needed.",
+        "NVIDIA GPU with compute capability ≥ 7.5 (Turing / GeForce RTX 20xx or newer). Targets consumer RTX (Ampere/Ada/Blackwell) via tensorrt-rtx runtime — no full TensorRT SDK needed. Pre-Turing cards (Maxwell/Pascal/Kepler) cannot run this EP even after install.",
       quantMethods: "AWQ INT4 (strongly recommended), GPTQ INT4. Avoid PTQ INT8 (requires QDQ nodes).",
       recommendation:
         "AWQ INT4 is optimal for consumer RTX GPUs — reduces VRAM and provides fast inference. PTQ INT8 requires QDQ format which tensorrt-rtx does not generate.",
@@ -65,13 +70,22 @@ export const PROVIDER_CATALOG: ProviderCatalogEntry[] = [
   },
   {
     id: "TensorrtExecutionProvider",
+    // The SM 7.5 (Turing) floor mirrors `TENSORRT_FAMILY_MIN_COMPUTE_CAPABILITY`
+    // in `src/lib/hardwareProbe.ts`. Keep this wording in lockstep with the
+    // catalog chip for `NvTensorRTRTXExecutionProvider` (same family, same
+    // floor, separate install path) and with the
+    // `undetectedProviderReason('TensorrtExecutionProvider')` text so the
+    // chip, the unavailable reason, and the TRT-RTX chip can't drift apart.
+    // The providerCatalog.test.ts guard test enforces this across all four
+    // surfaces.
     name: "NVIDIA TensorRT",
     shortName: "TensorRT",
-    desc: "Full TensorRT SDK (nvinfer_10) for maximum throughput on NVIDIA GPUs.",
+    desc: "Full TensorRT 10.x SDK (nvinfer_10) for maximum throughput on NVIDIA GPUs ≥ compute capability 7.5 (Turing / GeForce RTX 20xx or newer; also Quadro, Datacenter, H100/B100).",
     icon: Layers,
     tooltip: {
       requirements:
-        "NVIDIA GPU Turing or newer (GeForce RTX 20xx+, Quadro, datacenter). Requires full TensorRT 10.x SDK (nvinfer_10) in .venv — installable from Hardware. For a lighter consumer path, prefer TensorRT RTX.",
+        "NVIDIA GPU with compute capability ≥ 7.5 (Turing / GeForce RTX 20xx or newer; also Quadro, Datacenter, H100/B100). Requires full TensorRT 10.x SDK (nvinfer_10) in .venv — installable from Hardware. Pre-Turing cards (Maxwell/Pascal/Kepler) cannot run this EP even after install. For a lighter consumer path on the same floor, prefer TensorRT RTX.",
+
       quantMethods: "AWQ INT4 (recommended), GPTQ INT4. INT8 requires QDQ-format ONNX graph.",
       recommendation:
         "AWQ INT4 skips TensorRT calibration and provides the fastest build times. Use for maximum throughput in production.",

--- a/src/lib/recipeHardwareCompatibility.ts
+++ b/src/lib/recipeHardwareCompatibility.ts
@@ -1,9 +1,41 @@
-import { isNvTensorRtRtxCatalogPath } from "@/lib/tensorrtRtxDeps";
+import {
+  isNvTensorRtRtxCatalogPath,
+  tensorrtRtxEpAbiInstallCommand,
+} from "@/lib/tensorrtRtxDeps";
+import { pinnedTensorRtInstallCommand } from "@/lib/tensorrtDeps";
 import { getCatalogDeviceFromRecipe, type RecipeCatalogItem } from "@/lib/oliveRecipeHub";
-import { type HardwareProbeResult, isProviderDetectedLocally } from "@/lib/hardwareProbe";
+import {
+  isNvidiaGpuTensorRtFamily,
+  TENSORRT_FAMILY_MIN_COMPUTE_CAPABILITY,
+  type HardwareProbeResult,
+  isProviderDetectedLocally,
+} from "@/lib/hardwareProbe";
+import {
+  CUDA_TOOLKIT_MIN_COMPUTE_CAPABILITY,
+  isPreMaxwellNvidiaBox,
+  pinnedOrtGpuInstallCommand,
+} from "@/lib/cudaDeps";
 import type { IHVProvider } from "@/types";
 
 export type RecipeHardwareCompatTier = "compatible" | "unavailable" | "unknown";
+
+/**
+ * When a recipe's target EP is GPU-capable on the current machine but the
+ * Python runtime deps for that EP haven't been installed yet, surface a
+ * targeted install hint instead of hiding the recipe. The recipe still
+ * counts as hardware-compatible so `hideIncompatibleRecipes` does not drop it.
+ */
+export interface RecipeInstallHint {
+  kind: "tensorrt" | "tensorrt-rtx" | "onnxruntime-gpu";
+  /** Provider the recipe expects once deps land. */
+  provider: IHVProvider;
+  /** Underlying detail string from the probe (may be empty). */
+  detail?: string;
+  /** Human-friendly hint shown next to the recipe card. */
+  hint: string;
+  /** Ready-to-paste pip command for the install. */
+  installCommand: string;
+}
 
 export interface RecipeHardwareCompatResult {
   tier: RecipeHardwareCompatTier;
@@ -11,10 +43,41 @@ export interface RecipeHardwareCompatResult {
   reason: string;
   /** Primary EP this recipe expects on this machine. */
   requiredProvider?: IHVProvider;
+  /**
+   * Set when this machine has the correct GPU but the runtime deps for the
+   * recipe's EP aren't installed in `.venv` yet. UI shows an inline install
+   * hint; recipe is still counted as `tier: "compatible"`.
+   */
+  requiresInstall?: RecipeInstallHint;
 }
 
 function isWindowsProbe(probe: HardwareProbeResult): boolean {
   return probe.platform.os.toLowerCase().includes("win");
+}
+
+/**
+ * Builds an install hint for a TensorRT-family EP on a GPU that supports it
+ * but where the matching Python runtime isn't loaded in `.venv` yet.
+ */
+function tensorRtInstallHint(args: {
+  probe: HardwareProbeResult;
+  requiredProvider: IHVProvider;
+  kind: "tensorrt" | "tensorrt-rtx";
+  detailKey: "tensorrt" | "tensorRtRtx";
+  depLabel: string;
+  installCommand: string;
+}): RecipeInstallHint {
+  const gpuHint = args.probe.nvidia?.gpus[0]?.name ?? args.probe.platform.cpuModel;
+  const detail = args.probe[args.detailKey]?.detail;
+  return {
+    kind: args.kind,
+    provider: args.requiredProvider,
+    detail,
+    hint: detail
+      ? `${args.depLabel} not in .venv (${detail}). GPU is in the supported family (${gpuHint}) — install in Hardware then retry.`
+      : `${args.depLabel} not in .venv yet. GPU is in the supported family (${gpuHint}) — install in Hardware (step 02) to run this recipe.`,
+    installCommand: args.installCommand,
+  };
 }
 
 function catalogDeviceToProvider(device: string): IHVProvider | undefined {
@@ -105,13 +168,144 @@ export function assessRecipeHardwareCompatibility(
     };
   }
 
+  const hasNvidia = Boolean(probe.nvidia?.gpus.length);
+  const gpuHint = probe.nvidia?.gpus[0]?.name ?? probe.rocm?.gpus[0]?.name ?? probe.platform.cpuModel;
+  // Pre-Turing NVIDIA GPUs (Maxwell/Pascal/Kepler, SM < 7.5) cannot execute
+  // TensorRT 10.x or TensorRT-RTX — installing the SDK does not change that.
+  // Surface as unavailable with no install hint so the user does not waste
+  // time on a one-click install that cannot possibly succeed. Mixed-GPU
+  // boxes (one pre-Turing, one modern) are still treated as supported —
+  // `isNvidiaGpuTensorRtFamily` is true if at least one GPU meets the floor.
+  const isPreTuringNvidiaBox =
+    hasNvidia &&
+    Boolean(probe.nvidia) &&
+    !probe.nvidia!.gpus.some((g) => isNvidiaGpuTensorRtFamily(g));
+  const smFloor = `${TENSORRT_FAMILY_MIN_COMPUTE_CAPABILITY.major}.${TENSORRT_FAMILY_MIN_COMPUTE_CAPABILITY.minor}`;
+  // Pre-Maxwell NVIDIA GPUs (Kepler SM 3.x, sm < 5.0) cannot execute modern
+  // CUDA 12 builds — the toolkit floor dropped SM 3.x with CUDA 12.0.
+  // Mirror the pre-Turing short-circuit: the install hint would point the
+  // user at a one-click install that cannot possibly succeed.
+  const isPreMaxwellBox =
+    hasNvidia && Boolean(probe.nvidia) && isPreMaxwellNvidiaBox(probe.nvidia!.gpus);
+  const cudaSmFloor = `${CUDA_TOOLKIT_MIN_COMPUTE_CAPABILITY.major}.${CUDA_TOOLKIT_MIN_COMPUTE_CAPABILITY.minor}`;
+
   if (isProviderDetectedLocally(requiredProvider, probe)) {
-    const gpuHint = probe.nvidia?.gpus[0]?.name ?? probe.rocm?.gpus[0]?.name ?? probe.platform.cpuModel;
     return {
       tier: "compatible",
       targetDevice,
       reason: `${targetDevice} backend available (${gpuHint}).`,
       requiredProvider,
+    };
+  }
+
+  if (isPreTuringNvidiaBox && (requiredProvider === "TensorrtExecutionProvider" || requiredProvider === "NvTensorRTRTXExecutionProvider")) {
+    return {
+      tier: "unavailable",
+      targetDevice,
+      reason: `${targetDevice} requires NVIDIA compute capability ≥ ${smFloor} (Turing / RTX 20xx+); ${gpuHint} is below that floor. TensorRT 10.x and TensorRT-RTX cannot execute on Maxwell/Pascal/Kepler.`,
+      requiredProvider,
+    };
+  }
+
+  // Pre-Maxwell NVIDIA short-circuit for CUDA recipes. Every detected NVIDIA
+  // GPU is below the CUDA 12 toolkit floor (SM 5.0 / Maxwell) and cannot
+  // execute modern CUDA — surfacing as unavailable prevents the user from
+  // chasing one-click installs that cannot succeed.
+  if (
+    isPreMaxwellBox &&
+    targetDevice === "CUDA" &&
+    requiredProvider === "CUDAExecutionProvider"
+  ) {
+    return {
+      tier: "unavailable",
+      targetDevice,
+      reason: `CUDA requires NVIDIA compute capability ≥ ${cudaSmFloor} (Maxwell / GeForce RTX 20xx+); ${gpuHint} is below that floor. The CUDA 12 toolkit drops SM 3.x (Kepler) support and modern Olive recipes cannot run on those cards. Use the CPU provider, or upgrade hardware.`,
+      requiredProvider,
+    };
+  }
+
+  // 🟢 Hardware-compatible fallback: the GPU on this machine is in the
+  // TensorRT-supported family (NVIDIA, SM 7.5+ for TRT 10.x / RTX 30xx+
+  // for TRT-RTX), but the Python deps for the recipe's EP haven't landed in
+  // .venv yet. Treat the recipe as compatible so `hideIncompatibleRecipes`
+  // doesn't drop it, but expose an install hint so the user knows one click
+  // in Hardware (step 02) will close the gap.
+  // Pre-Turing NVIDIA boxes skip this fallback (see isPreTuringNvidiaBox)
+  // so the hint is never shown for cards that cannot run the EP at all.
+  if (
+    !isPreTuringNvidiaBox &&
+    requiredProvider === "TensorrtExecutionProvider" &&
+    hasNvidia &&
+    probe.tensorrt?.loadable === false
+  ) {
+    return {
+      tier: "compatible",
+      targetDevice,
+      reason: `TensorRT backend available on ${gpuHint} after installing tensorrt in .venv.`,
+      requiredProvider,
+      requiresInstall: tensorRtInstallHint({
+        probe,
+        requiredProvider,
+        kind: "tensorrt",
+        detailKey: "tensorrt",
+        depLabel: "tensorrt SDK (nvinfer_10)",
+        installCommand: pinnedTensorRtInstallCommand(),
+      }),
+    };
+  }
+  if (
+    !isPreTuringNvidiaBox &&
+    requiredProvider === "NvTensorRTRTXExecutionProvider" &&
+    hasNvidia &&
+    probe.tensorRtRtx?.loadable === false
+  ) {
+    // (Pre-Turing check above already short-circuits to unavailable; this branch
+    // is only reached for SM ≥ 7.5 GPUs with EP-ABI plugin not yet installed.)
+    return {
+      tier: "compatible",
+      targetDevice,
+      reason: `TensorRT RTX backend available on ${gpuHint} after installing tensorrt-rtx in .venv.`,
+      requiredProvider,
+      requiresInstall: tensorRtInstallHint({
+        probe,
+        requiredProvider,
+        kind: "tensorrt-rtx",
+        detailKey: "tensorRtRtx",
+        depLabel: "tensorrt-rtx (NVIDIA EP-ABI plugin)",
+        installCommand: tensorrtRtxEpAbiInstallCommand(),
+      }),
+    };
+  }
+
+  // 🟢 Hardware-compatible fallback: NVIDIA driver + compute capability are
+  // fine, but `onnxruntime-gpu` isn't installed (or the CUDA EP failed to
+  // register) in `.venv` yet. Surface the recipe as compatible so
+  // `hideIncompatibleRecipes` does not drop it, but expose the install
+  // hint so the user knows one click in Hardware (step 02) closes the gap.
+  // Pre-Maxwell boxes skip this fallback (see isPreMaxwellBox) so the hint
+  // is never shown for cards that cannot run the EP at all.
+  //
+  // We use `isProviderDetectedLocally` (not a direct `onnxRuntimeProviders`
+  // check) because the route handler strips `CUDAExecutionProvider` from
+  // `detectedProviders` when `mergeDetectedProviders(...)` is given
+  // `cudaLoadable: false` — so this gate fires in lockstep with the UI.
+  if (
+    !isPreMaxwellBox &&
+    requiredProvider === "CUDAExecutionProvider" &&
+    hasNvidia &&
+    !isProviderDetectedLocally("CUDAExecutionProvider", probe)
+  ) {
+    return {
+      tier: "compatible",
+      targetDevice,
+      reason: `CUDA backend available on ${gpuHint} after installing onnxruntime-gpu in .venv.`,
+      requiredProvider,
+      requiresInstall: {
+        kind: "onnxruntime-gpu",
+        provider: "CUDAExecutionProvider",
+        hint: `onnxruntime-gpu CUDA EP is not registered in the project .venv. NVIDIA driver + GPU are in the supported family (${gpuHint}) — install in Hardware (step 02) or run \`${pinnedOrtGpuInstallCommand()}\` to run this recipe.`,
+        installCommand: pinnedOrtGpuInstallCommand(),
+      },
     };
   }
 

--- a/src/lib/recipeHardwareCompatibility.ts
+++ b/src/lib/recipeHardwareCompatibility.ts
@@ -56,14 +56,18 @@ function isWindowsProbe(probe: HardwareProbeResult): boolean {
 }
 
 /**
- * Builds an install hint for a TensorRT-family EP on a GPU that supports it
- * but where the matching Python runtime isn't loaded in `.venv` yet.
+ * Builds an install hint for an execution provider on a GPU that supports it
+ * but where the matching Python runtime isn't loaded in `.venv` yet. Used
+ * for the TensorRT family (kind: "tensorrt" / "tensorrt-rtx") and now also
+ * for the CUDA case (kind: "onnxruntime-gpu") — the CUDA branch used to
+ * inline this object and dropped the probe's `detail` string, so a real
+ * "driver/wheel mismatch" message never made it back to the UI.
  */
-function tensorRtInstallHint(args: {
+function ePInstallHint(args: {
   probe: HardwareProbeResult;
   requiredProvider: IHVProvider;
-  kind: "tensorrt" | "tensorrt-rtx";
-  detailKey: "tensorrt" | "tensorRtRtx";
+  kind: RecipeInstallHint["kind"];
+  detailKey: "tensorrt" | "tensorRtRtx" | "cuda";
   depLabel: string;
   installCommand: string;
 }): RecipeInstallHint {
@@ -219,7 +223,12 @@ export function assessRecipeHardwareCompatibility(
     return {
       tier: "unavailable",
       targetDevice,
-      reason: `CUDA requires NVIDIA compute capability ≥ ${cudaSmFloor} (Maxwell / GeForce RTX 20xx+); ${gpuHint} is below that floor. The CUDA 12 toolkit drops SM 3.x (Kepler) support and modern Olive recipes cannot run on those cards. Use the CPU provider, or upgrade hardware.`,
+      // CUDA-floor copy must track Maxwell SM 5.0: GTX 750 Ti / GTX 9xx
+      // are the canonical Maxwell product IDs; the previous wording
+      // borrowed "GeForce RTX 20xx+" from the pre-Turing branch (RTX 20xx
+      // is Turing SM 7.5, the floor above) and would have told a Pascal
+      // SM 6.x owner their supported card is unsupported.
+      reason: `CUDA requires NVIDIA compute capability ≥ ${cudaSmFloor} (Maxwell / GeForce GTX 750 Ti or GTX 9xx series and newer); ${gpuHint} is below that floor. The CUDA 12 toolkit drops SM 3.x (Kepler) support and modern Olive recipes cannot run on those cards. Use the CPU provider, or upgrade hardware.`,
       requiredProvider,
     };
   }
@@ -243,7 +252,7 @@ export function assessRecipeHardwareCompatibility(
       targetDevice,
       reason: `TensorRT backend available on ${gpuHint} after installing tensorrt in .venv.`,
       requiredProvider,
-      requiresInstall: tensorRtInstallHint({
+      requiresInstall: ePInstallHint({
         probe,
         requiredProvider,
         kind: "tensorrt",
@@ -266,7 +275,7 @@ export function assessRecipeHardwareCompatibility(
       targetDevice,
       reason: `TensorRT RTX backend available on ${gpuHint} after installing tensorrt-rtx in .venv.`,
       requiredProvider,
-      requiresInstall: tensorRtInstallHint({
+      requiresInstall: ePInstallHint({
         probe,
         requiredProvider,
         kind: "tensorrt-rtx",
@@ -300,12 +309,14 @@ export function assessRecipeHardwareCompatibility(
       targetDevice,
       reason: `CUDA backend available on ${gpuHint} after installing onnxruntime-gpu in .venv.`,
       requiredProvider,
-      requiresInstall: {
+      requiresInstall: ePInstallHint({
+        probe,
+        requiredProvider,
         kind: "onnxruntime-gpu",
-        provider: "CUDAExecutionProvider",
-        hint: `onnxruntime-gpu CUDA EP is not registered in the project .venv. NVIDIA driver + GPU are in the supported family (${gpuHint}) — install in Hardware (step 02) or run \`${pinnedOrtGpuInstallCommand()}\` to run this recipe.`,
+        detailKey: "cuda",
+        depLabel: "onnxruntime-gpu (CUDA EP wheel)",
         installCommand: pinnedOrtGpuInstallCommand(),
-      },
+      }),
     };
   }
 

--- a/src/lib/tensorrtDeps.test.ts
+++ b/src/lib/tensorrtDeps.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { PINNED_TENSORRT_VERSION, pinnedTensorRtInstallArgs, pinnedTensorRtLabel } from "./tensorrtDeps.ts";
+import {
+  PINNED_TENSORRT_VERSION,
+  pinnedTensorRtInstallArgs,
+  pinnedTensorRtInstallCommand,
+  pinnedTensorRtLabel,
+} from "./tensorrtDeps.ts";
 
 describe("pinnedTensorRtInstallArgs", () => {
   it("passes a single pip requirement (package==version)", () => {
@@ -14,5 +19,15 @@ describe("pinnedTensorRtInstallArgs", () => {
 
   it("labels the pin for UI/logs", () => {
     expect(pinnedTensorRtLabel()).toContain(PINNED_TENSORRT_VERSION);
+  });
+});
+
+describe("pinnedTensorRtInstallCommand", () => {
+  it("renders a paste-able pip install command with the pinned version and no extra index", () => {
+    expect(pinnedTensorRtInstallCommand()).toBe(`pip install tensorrt==${PINNED_TENSORRT_VERSION}`);
+  });
+
+  it("does not override PyPI with --index-url (TRT 10.x is published on PyPI)", () => {
+    expect(pinnedTensorRtInstallCommand()).not.toContain("--index-url");
   });
 });

--- a/src/lib/tensorrtDeps.ts
+++ b/src/lib/tensorrtDeps.ts
@@ -25,6 +25,19 @@ export function pinnedTensorRtLabel(): string {
   return `tensorrt (${PINNED_TENSORRT_VERSION})`;
 }
 
+/**
+ * Copy-pasteable pip command that installs the classic TensorRT SDK at the
+ * pinned version. NVIDIA publishes TRT 10.x on PyPI.org, so we deliberately
+ * avoid `--index-url` here — that flag would override the project's index
+ * resolution and could break other packages. Use this helper anywhere a
+ * user-facing hint needs the exact install invocation so the hint stays in
+ * lockstep with the version `ensureTensorRt` actually installs.
+ */
+export function pinnedTensorRtInstallCommand(): string {
+  const args = pinnedTensorRtInstallArgs();
+  return `pip install ${args.join(" ")}`;
+}
+
 /** ORT TensorrtExecutionProvider in stable wheels is built against TensorRT 10.x (nvinfer_10). */
 export function isCompatibleTensorRtVersion(version: string): boolean {
   const major = Number.parseInt(version.split(".")[0] ?? "", 10);

--- a/src/lib/tensorrtRtxDeps.test.ts
+++ b/src/lib/tensorrtRtxDeps.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+import {
+  PINNED_TENSORRT_VERSION, pinnedTensorRtInstallArgs, pinnedTensorRtLabel,
+} from "./tensorrtDeps.ts";
+import {
+  TENSORRT_RTX_EP_ABI_PACKAGE,
+  TENSORRT_RTX_EP_ABI_VERSION,
+  TENSORRT_RTX_NVIDIA_INDEX_URL,
+  TENSORRT_RTX_PIP_PACKAGE,
+  isNvTensorRtRtxCatalogPath,
+  isNvTensorRtRtxProvider,
+  tensorrtRtxEpAbiInstallArgs,
+  tensorrtRtxEpAbiInstallCommand,
+  tensorrtRtxEpAbiLabel,
+  tensorrtRtxInstallArgs,
+  tensorrtRtxLabel,
+} from "./tensorrtRtxDeps.ts";
+
+/**
+ * The PyPI `tensorrt-rtx` package alone does not register
+ * NvTensorRTRTXExecutionProvider with onnxruntime. Registration only
+ * happens after the NVIDIA EP-ABI plugin package
+ * (`onnxruntime-ep-nv-tensorrt-rtx-cu13`) is installed and its op-library
+ * DLL is registered with `onnxruntime.register_execution_provider_library`.
+ * Tests here lock down the install-args shape, the label, the discovery
+ * script, and provider/catalog recognition.
+ */
+describe("tensorrt-rtx deps", () => {
+  it("keeps the PyPI py-name and Surface label for the runtime package", () => {
+    expect(TENSORRT_RTX_PIP_PACKAGE).toBe("tensorrt-rtx");
+    expect(tensorrtRtxInstallArgs()).toEqual(["tensorrt-rtx"]);
+    expect(tensorrtRtxLabel()).toBe("tensorrt-rtx");
+  });
+
+  it("pins the NVIDIA EP-ABI plugin package name and version", () => {
+    expect(TENSORRT_RTX_EP_ABI_PACKAGE).toBe("onnxruntime-ep-nv-tensorrt-rtx-cu13");
+    expect(TENSORRT_RTX_EP_ABI_VERSION).toBe("0.3.0");
+    expect(TENSORRT_RTX_NVIDIA_INDEX_URL).toBe("https://pypi.nvidia.com");
+  });
+
+  it("returns pip install args that include the NVIDIA extra-index-url", () => {
+    const args = tensorrtRtxEpAbiInstallArgs();
+    expect(args).toContain("--extra-index-url");
+    expect(args).toContain(TENSORRT_RTX_NVIDIA_INDEX_URL);
+    expect(args).toContain(`${TENSORRT_RTX_EP_ABI_PACKAGE}==${TENSORRT_RTX_EP_ABI_VERSION}`);
+    // Pass a single requirement token (never split into a bare ==version).
+    expect(args.filter((a) => a.startsWith("=="))).toEqual([]);
+  });
+
+  it("labels the EP-ABI plugin like the runtime package does", () => {
+    expect(tensorrtRtxEpAbiLabel()).toBe(
+      `${TENSORRT_RTX_EP_ABI_PACKAGE} (${TENSORRT_RTX_EP_ABI_VERSION})`,
+    );
+  });
+
+  it("returns a copy-pasteable pip install command in the manual-install hint", () => {
+    expect(tensorrtRtxEpAbiInstallCommand()).toBe(
+      `pip install --extra-index-url ${TENSORRT_RTX_NVIDIA_INDEX_URL} ` +
+        `${TENSORRT_RTX_EP_ABI_PACKAGE}==${TENSORRT_RTX_EP_ABI_VERSION}`,
+    );
+    // The hint must contain a parseable package==version spec, not the
+    // human-readable label "(0.3.0)" form.
+    expect(tensorrtRtxEpAbiInstallCommand()).not.toContain(" (");
+    expect(tensorrtRtxEpAbiInstallCommand()).toMatch(/==\d+\.\d+\.\d+/);
+  });
+
+  it("matches the canonical provider name only", () => {
+    expect(isNvTensorRtRtxProvider("NvTensorRTRTXExecutionProvider")).toBe(true);
+    for (const wrong of [
+      "TensorrtExecutionProvider",
+      "nvtensorrtrtxexecutionprovider".toLowerCase(),
+      "CUDAExecutionProvider",
+      "CPUExecutionProvider",
+      "",
+    ]) {
+      expect(isNvTensorRtRtxProvider(wrong)).toBe(false);
+    }
+  });
+
+  it("recognises catalog paths that mention the RTX EP", () => {
+    expect(isNvTensorRtRtxCatalogPath("NvTensorRtRtx_DeepSeek_R1_distill")).toBe(true);
+    expect(isNvTensorRtRtxCatalogPath("recipe.NvTensorRTRTXConversion")).toBe(true);
+    expect(isNvTensorRtRtxCatalogPath("recipes/NvTensorRtRtx_model_builder_int4")).toBe(true);
+    expect(isNvTensorRtRtxCatalogPath("TensorrtExecutionProvider")).toBe(false);
+    expect(isNvTensorRtRtxCatalogPath("cuda_and_tensorrt_decision")).toBe(false);
+  });
+});
+
+// sanity check: classic TensorRT pin still pinned independently — the two
+// paths must not collapse onto one another.
+describe("tensorrt (classic) pin does not bleed into rtx deps", () => {
+  it("keeps the classic tensorrt pin", () => {
+    expect(PINNED_TENSORRT_VERSION).toMatch(/^10\./);
+    const args = pinnedTensorRtInstallArgs();
+    expect(args).toContain(`tensorrt==${PINNED_TENSORRT_VERSION}`);
+  });
+  it("does not include an NVIDIA-index-url for the classic path", () => {
+    expect(pinnedTensorRtInstallArgs()).not.toContain("--extra-index-url");
+  });
+  it("does not duplicate the RTX surface label", () => {
+    expect(pinnedTensorRtLabel()).not.toMatch(/tensorrt-rtx|RTX/i);
+    expect(pinnedTensorRtLabel()).toMatch(/^tensorrt \(/);
+  });
+});

--- a/src/lib/tensorrtRtxDeps.ts
+++ b/src/lib/tensorrtRtxDeps.ts
@@ -1,12 +1,58 @@
 /** Pip metapackage for NVIDIA TensorRT RTX (consumer GeForce 30xx+). Olive v0.9.1+. */
 export const TENSORRT_RTX_PIP_PACKAGE = "tensorrt-rtx";
 
+/**
+ * NVIDIA standalone TensorRT-RTX EP-ABI plugin package, hosted on NVIDIA's
+ * PyPI index (not on PyPI.org). Installing this package is what actually
+ * registers the `NvTensorRTRTXExecutionProvider` symbol with ONNX Runtime
+ * via `register_execution_provider_library`. Without it, ONNX Runtime
+ * (including the pinned `onnxruntime-gpu`) reports the EP as missing
+ * even though the `tensorrt-rtx` PyPI package is installed.
+ *
+ * The Python module that ships in this distribution is
+ * `onnxruntime_ep_nv_tensorrt_rtx`; the wheel itself bundles the
+ * `onnxruntime_providers_nv_tensorrt_rtx.dll` op library plus the
+ * TensorRT-RTX runtime (`tensorrt_rtx_1_5.dll`) and CUDA-13 runtime.
+ */
+export const TENSORRT_RTX_EP_ABI_PACKAGE = "onnxruntime-ep-nv-tensorrt-rtx-cu13";
+export const TENSORRT_RTX_EP_ABI_VERSION = "0.3.0";
+export const TENSORRT_RTX_NVIDIA_INDEX_URL = "https://pypi.nvidia.com";
+
 export function tensorrtRtxInstallArgs(): string[] {
   return [TENSORRT_RTX_PIP_PACKAGE];
 }
 
 export function tensorrtRtxLabel(): string {
   return TENSORRT_RTX_PIP_PACKAGE;
+}
+
+/**
+ * Pip args for installing the NVIDIA EP-ABI plugin. The package is only
+ * hosted on NVIDIA's PyPI index, so the install passes the index URL as
+ * an *extra* index (not the system index) so other PyPI packages keep
+ * resolving normally.
+ */
+export function tensorrtRtxEpAbiInstallArgs(): string[] {
+  return [
+    "--extra-index-url",
+    TENSORRT_RTX_NVIDIA_INDEX_URL,
+    `${TENSORRT_RTX_EP_ABI_PACKAGE}==${TENSORRT_RTX_EP_ABI_VERSION}`,
+  ];
+}
+
+export function tensorrtRtxEpAbiLabel(): string {
+  return `${TENSORRT_RTX_EP_ABI_PACKAGE} (${TENSORRT_RTX_EP_ABI_VERSION})`;
+}
+
+/**
+ * Copy-pasteable pip command that installs the EP-ABI plugin (for the
+ * fallback hint surfaced to users when the in-app install path fails).
+ * Uses `pip install --extra-index-url` so the NVIDIA-only package is
+ * fetched from the NVIDIA index while other packages keep coming from
+ * PyPI.
+ */
+export function tensorrtRtxEpAbiInstallCommand(): string {
+  return `pip install --extra-index-url ${TENSORRT_RTX_NVIDIA_INDEX_URL} ${TENSORRT_RTX_EP_ABI_PACKAGE}==${TENSORRT_RTX_EP_ABI_VERSION}`;
 }
 
 export function isNvTensorRtRtxProvider(provider: string): boolean {

--- a/src/lib/tensorrtRtxDeps.ts
+++ b/src/lib/tensorrtRtxDeps.ts
@@ -47,12 +47,14 @@ export function tensorrtRtxEpAbiLabel(): string {
 /**
  * Copy-pasteable pip command that installs the EP-ABI plugin (for the
  * fallback hint surfaced to users when the in-app install path fails).
- * Uses `pip install --extra-index-url` so the NVIDIA-only package is
- * fetched from the NVIDIA index while other packages keep coming from
- * PyPI.
+ * Uses `pip install <args>` so the manual command mirrors exactly the
+ * argument string the install route actually passes to `pip install`
+ * (see `tensorrtRtxEpAbiInstallArgs`). Single source of truth = the
+ * args list, so a version/index bump updates both in lockstep without
+ * any drift.
  */
 export function tensorrtRtxEpAbiInstallCommand(): string {
-  return `pip install --extra-index-url ${TENSORRT_RTX_NVIDIA_INDEX_URL} ${TENSORRT_RTX_EP_ABI_PACKAGE}==${TENSORRT_RTX_EP_ABI_VERSION}`;
+  return `pip install ${tensorrtRtxEpAbiInstallArgs().join(" ")}`;
 }
 
 export function isNvTensorRtRtxProvider(provider: string): boolean {

--- a/src/server/routes/env.ts
+++ b/src/server/routes/env.ts
@@ -13,11 +13,15 @@ import {
 import { writeStudioConfig, addVenvToUserPath } from "../services/venv/config.ts";
 import { setRuntimeHfToken, getRuntimeHfToken } from "../services/olive/state.ts";
 import { ensureTensorRtRtx, ensureTensorRt } from "./tensorrt.ts";
+import { ensureOpenVino } from "./openvino.ts";
 import { fsWriteRateLimit } from "../middleware/rateLimit.ts";
 import { resolveAllowedPythonFile } from "../services/venv/pythonGuard.ts";
 
 /** Serialize TensorRT + TensorRT RTX installs (shared venv / pip). */
 let tensorrtInstallChain: Promise<unknown> = Promise.resolve();
+
+/** Serialize OpenVINO installs (shared venv / pip). */
+let openvinoInstallChain: Promise<unknown> = Promise.resolve();
 
 /**
  * Serializes TensorRT installation operations so that only one runs at a time.
@@ -35,14 +39,29 @@ function withTensorrtInstallMutex<T>(fn: () => Promise<T>): Promise<T> {
 }
 
 /**
+ * Serializes OpenVINO installation operations so that only one runs at a time.
+ *
+ * @param fn - The asynchronous OpenVINO installation operation to run
+ * @returns The result of the installation operation
+ */
+function withOpenvinoInstallMutex<T>(fn: () => Promise<T>): Promise<T> {
+  const run = openvinoInstallChain.then(fn, fn);
+  openvinoInstallChain = run.then(
+    () => undefined,
+    () => undefined,
+  );
+  return run;
+}
+
+/**
  * Streams installation log messages and a final result as newline-delimited JSON.
  *
  * @param res - The response used to send progress and completion records.
  * @param run - The installation operation that receives a callback for progress lines.
  */
-function streamNdjsonInstall(
+function streamNdjsonInstall<T extends { ok: boolean; error?: string }>(
   res: Response,
-  run: (onLine: (line: string) => void) => Promise<{ ok: boolean; error?: string; libsDir?: string | null }>,
+  run: (onLine: (line: string) => void) => Promise<T>,
 ) {
   res.setHeader("Content-Type", "application/x-ndjson; charset=utf-8");
   res.setHeader("Cache-Control", "no-cache, no-transform");
@@ -105,6 +124,10 @@ export function mountEnvRoutes(router: Router): void {
 
   router.post("/env/install-tensorrt", async (_req, res) => {
     await withTensorrtInstallMutex(() => streamNdjsonInstall(res, ensureTensorRt));
+  });
+
+  router.post("/env/install-openvino", async (_req, res) => {
+    await withOpenvinoInstallMutex(() => streamNdjsonInstall(res, ensureOpenVino));
   });
 
   // ─── Runtime Status ───────────────────────────────────────────────────

--- a/src/server/routes/env.ts
+++ b/src/server/routes/env.ts
@@ -13,7 +13,7 @@ import {
 import { writeStudioConfig, addVenvToUserPath } from "../services/venv/config.ts";
 import { setRuntimeHfToken, getRuntimeHfToken } from "../services/olive/state.ts";
 import { ensureTensorRtRtx, ensureTensorRt } from "./tensorrt.ts";
-import { ensureOpenVino } from "./openvino.ts";
+import { ensureOpenVino } from "../services/olive/openvino.ts";
 import { fsWriteRateLimit, heavyCommandRateLimit } from "../middleware/rateLimit.ts";
 import { resolveAllowedPythonFile } from "../services/venv/pythonGuard.ts";
 

--- a/src/server/routes/env.ts
+++ b/src/server/routes/env.ts
@@ -13,6 +13,7 @@ import {
 import { writeStudioConfig, addVenvToUserPath } from "../services/venv/config.ts";
 import { setRuntimeHfToken, getRuntimeHfToken } from "../services/olive/state.ts";
 import { ensureTensorRtRtx, ensureTensorRt } from "./tensorrt.ts";
+import { ensureOnnxRuntimeGpu } from "../services/olive/cuda.ts";
 import { fsWriteRateLimit } from "../middleware/rateLimit.ts";
 import { resolveAllowedPythonFile } from "../services/venv/pythonGuard.ts";
 
@@ -105,6 +106,14 @@ export function mountEnvRoutes(router: Router): void {
 
   router.post("/env/install-tensorrt", async (_req, res) => {
     await withTensorrtInstallMutex(() => streamNdjsonInstall(res, ensureTensorRt));
+  });
+
+  // Pip-installs the pinned onnxruntime-gpu wheel into `.venv` and verifies
+  // the CUDA execution provider registers. Mirrors the TRT install route
+  // shape (NDJSON stream of [deps] log lines + final { ok } marker) so the
+  // IHV panel can stream the existing UI log viewer into this handler.
+  router.post("/env/install-onnxruntime-gpu", async (_req, res) => {
+    await withTensorrtInstallMutex(() => streamNdjsonInstall(res, ensureOnnxRuntimeGpu));
   });
 
   // ─── Runtime Status ───────────────────────────────────────────────────

--- a/src/server/routes/env.ts
+++ b/src/server/routes/env.ts
@@ -14,39 +14,16 @@ import { writeStudioConfig, addVenvToUserPath } from "../services/venv/config.ts
 import { setRuntimeHfToken, getRuntimeHfToken } from "../services/olive/state.ts";
 import { ensureTensorRtRtx, ensureTensorRt } from "./tensorrt.ts";
 import { ensureOpenVino } from "./openvino.ts";
-import { fsWriteRateLimit } from "../middleware/rateLimit.ts";
+import { fsWriteRateLimit, heavyCommandRateLimit } from "../middleware/rateLimit.ts";
 import { resolveAllowedPythonFile } from "../services/venv/pythonGuard.ts";
 
-/** Serialize TensorRT + TensorRT RTX installs (shared venv / pip). */
-let tensorrtInstallChain: Promise<unknown> = Promise.resolve();
+/** Serialize all stack installs that mutate the shared venv via pip. */
+let venvPipInstallChain: Promise<unknown> = Promise.resolve();
 
-/** Serialize OpenVINO installs (shared venv / pip). */
-let openvinoInstallChain: Promise<unknown> = Promise.resolve();
-
-/**
- * Serializes TensorRT installation operations so that only one runs at a time.
- *
- * @param fn - The asynchronous TensorRT installation operation to run
- * @returns The result of the installation operation
- */
-function withTensorrtInstallMutex<T>(fn: () => Promise<T>): Promise<T> {
-  const run = tensorrtInstallChain.then(fn, fn);
-  tensorrtInstallChain = run.then(
-    () => undefined,
-    () => undefined,
-  );
-  return run;
-}
-
-/**
- * Serializes OpenVINO installation operations so that only one runs at a time.
- *
- * @param fn - The asynchronous OpenVINO installation operation to run
- * @returns The result of the installation operation
- */
-function withOpenvinoInstallMutex<T>(fn: () => Promise<T>): Promise<T> {
-  const run = openvinoInstallChain.then(fn, fn);
-  openvinoInstallChain = run.then(
+/** Serialize stack installation operations so that only one shared-venv pip run occurs at a time. */
+function withVenvPipInstallMutex<T>(fn: () => Promise<T>): Promise<T> {
+  const run = venvPipInstallChain.then(fn, fn);
+  venvPipInstallChain = run.then(
     () => undefined,
     () => undefined,
   );
@@ -119,15 +96,15 @@ export function mountEnvRoutes(router: Router): void {
 
   // ─── TensorRT installs (NDJSON stream; creates .venv if needed) ────────
   router.post("/env/install-tensorrt-rtx", async (_req, res) => {
-    await withTensorrtInstallMutex(() => streamNdjsonInstall(res, ensureTensorRtRtx));
+    await withVenvPipInstallMutex(() => streamNdjsonInstall(res, ensureTensorRtRtx));
   });
 
   router.post("/env/install-tensorrt", async (_req, res) => {
-    await withTensorrtInstallMutex(() => streamNdjsonInstall(res, ensureTensorRt));
+    await withVenvPipInstallMutex(() => streamNdjsonInstall(res, ensureTensorRt));
   });
 
-  router.post("/env/install-openvino", async (_req, res) => {
-    await withOpenvinoInstallMutex(() => streamNdjsonInstall(res, ensureOpenVino));
+  router.post("/env/install-openvino", heavyCommandRateLimit, async (_req, res) => {
+    await withVenvPipInstallMutex(() => streamNdjsonInstall(res, ensureOpenVino));
   });
 
   // ─── Runtime Status ───────────────────────────────────────────────────

--- a/src/server/routes/env.ts
+++ b/src/server/routes/env.ts
@@ -14,7 +14,7 @@ import { writeStudioConfig, addVenvToUserPath } from "../services/venv/config.ts
 import { setRuntimeHfToken, getRuntimeHfToken } from "../services/olive/state.ts";
 import { ensureTensorRtRtx, ensureTensorRt } from "./tensorrt.ts";
 import { ensureOpenVino } from "./openvino.ts";
-import { fsWriteRateLimit } from "../middleware/rateLimit.ts";
+import { fsWriteRateLimit, heavyCommandRateLimit } from "../middleware/rateLimit.ts";
 import { resolveAllowedPythonFile } from "../services/venv/pythonGuard.ts";
 
 /** Serialize TensorRT + TensorRT RTX installs (shared venv / pip). */
@@ -118,15 +118,15 @@ export function mountEnvRoutes(router: Router): void {
   });
 
   // ─── TensorRT installs (NDJSON stream; creates .venv if needed) ────────
-  router.post("/env/install-tensorrt-rtx", async (_req, res) => {
+  router.post("/env/install-tensorrt-rtx", heavyCommandRateLimit, async (_req, res) => {
     await withTensorrtInstallMutex(() => streamNdjsonInstall(res, ensureTensorRtRtx));
   });
 
-  router.post("/env/install-tensorrt", async (_req, res) => {
+  router.post("/env/install-tensorrt", heavyCommandRateLimit, async (_req, res) => {
     await withTensorrtInstallMutex(() => streamNdjsonInstall(res, ensureTensorRt));
   });
 
-  router.post("/env/install-openvino", async (_req, res) => {
+  router.post("/env/install-openvino", heavyCommandRateLimit, async (_req, res) => {
     await withOpenvinoInstallMutex(() => streamNdjsonInstall(res, ensureOpenVino));
   });
 

--- a/src/server/routes/openvino.ts
+++ b/src/server/routes/openvino.ts
@@ -1,0 +1,7 @@
+/**
+ * OpenVINO route shim — re-exports from the canonical service module.
+ *
+ * Used by env routes (POST /api/env/install-openvino) and by the
+ * hardware probe (SystemProbeOptions DI).
+ */
+export { probeOpenVino, ensureOpenVino } from "../services/olive/openvino.ts";

--- a/src/server/routes/openvino.ts
+++ b/src/server/routes/openvino.ts
@@ -1,7 +1,0 @@
-/**
- * OpenVINO route shim — re-exports from the canonical service module.
- *
- * Used by env routes (POST /api/env/install-openvino) and by the
- * hardware probe (SystemProbeOptions DI).
- */
-export { probeOpenVino, ensureOpenVino } from "../services/olive/openvino.ts";

--- a/src/server/routes/system.ts
+++ b/src/server/routes/system.ts
@@ -17,6 +17,7 @@ import {
   mergeDetectedProviders,
   pickRecommendedProvider,
   type HardwareProbeResult,
+  type OpenVinoProbeResult,
 } from "../../lib/hardwareProbe.ts";
 
 const execFileAsync = promisify(execFile);
@@ -85,16 +86,8 @@ async function probeRocmGpus(): Promise<HardwareProbeResult["rocm"] | undefined>
 
 async function probePythonRuntime(
   python: string,
-): Promise<Pick<HardwareProbeResult, "openvino" | "onnxRuntimeProviders">> {
-  const result: Pick<HardwareProbeResult, "openvino" | "onnxRuntimeProviders"> = {};
-
-  try {
-    const { stdout } = await execFileAsync(python, ["-c", "import openvino; print(openvino.__version__)"]);
-    const version = stdout.trim();
-    if (version) result.openvino = { available: true, version };
-  } catch {
-    result.openvino = { available: false };
-  }
+): Promise<Pick<HardwareProbeResult, "onnxRuntimeProviders">> {
+  const result: Pick<HardwareProbeResult, "onnxRuntimeProviders"> = {};
 
   try {
     const { stdout } = await execFileAsync(python, [
@@ -125,6 +118,7 @@ export interface SystemProbeOptions {
   probeTensorRtRtxLoadable: (
     python: string,
   ) => Promise<{ loadable: boolean; detail?: string; version?: string }>;
+  probeOpenVino: (python: string) => Promise<OpenVinoProbeResult>;
 }
 
 /**
@@ -146,7 +140,8 @@ async function probeSystemHardware(opts: SystemProbeOptions): Promise<HardwarePr
 
   const [nvidia, rocm] = await Promise.all([probeNvidiaGpus(), probeRocmGpus()]);
 
-  let openvino: HardwareProbeResult["openvino"];
+  let openvino: OpenVinoProbeResult | undefined;
+  let openvinoVenvAvailable = false;
   let onnxRuntimeProviders: string[] | undefined;
   let tensorrt: HardwareProbeResult["tensorrt"];
   let tensorRtRtx: HardwareProbeResult["tensorRtRtx"];
@@ -161,15 +156,23 @@ async function probeSystemHardware(opts: SystemProbeOptions): Promise<HardwarePr
 
   for (const python of pythonCandidates) {
     const pyResult = await probePythonRuntime(python);
-    if (pyResult.openvino?.available && !openvino?.available) {
-      openvino = pyResult.openvino;
-    }
     if (pyResult.onnxRuntimeProviders?.length && !onnxRuntimeProviders?.length) {
       onnxRuntimeProviders = pyResult.onnxRuntimeProviders;
       notes.push(
         `ONNX Runtime providers probed via ${python === venvPython ? ".venv Python" : "system Python"}.`,
       );
     }
+
+    const ov = await opts.probeOpenVino(python);
+    if (ov.available) {
+      if (python === venvPython) {
+        openvino = ov;
+        openvinoVenvAvailable = true;
+      } else if (!openvino) {
+        openvino = ov;
+      }
+    }
+
     if (!tensorrt?.loadable) {
       const trt = await opts.probeTensorRtLoadable(python);
       if (python === venvPython && trt.loadable) {
@@ -223,14 +226,27 @@ async function probeSystemHardware(opts: SystemProbeOptions): Promise<HardwarePr
 
   if (!nvidia) notes.push("No NVIDIA GPU detected (nvidia-smi unavailable or returned no devices).");
   if (!rocm) notes.push("No AMD ROCm GPU detected.");
-  if (!openvino?.available) notes.push("OpenVINO Python package not found locally.");
+  if (openvinoVenvAvailable) {
+    const deviceMsg = openvino?.devices?.length ? ` [${openvino.devices.join(", ")}]` : "";
+    notes.push(`OpenVINO stack verified${openvino?.version ? ` (${openvino.version})` : ""}${deviceMsg}.`);
+  } else if (openvino?.available) {
+    notes.push(`OpenVINO stack found on system Python but not in .venv — use Install in Hardware.`);
+  } else {
+    notes.push("OpenVINO Python package not found locally.");
+  }
   notes.push("QNN requires Snapdragon/Hexagon dev hardware — not probed on desktop.");
+
+  const hasOpenVinoCompatibleHardware =
+    /Intel|Xeon|Core|Arc|Ultra/i.test(platform.cpuModel) ||
+    platform.arch === "x64" ||
+    platform.arch === "arm64";
 
   const detectedProviders = mergeDetectedProviders({
     onnxRuntimeProviders,
     hasNvidiaGpu: Boolean(nvidia?.gpus.length),
     hasRocmGpu: Boolean(rocm?.gpus.length),
     hasOpenVino: Boolean(openvino?.available),
+    hasOpenVinoCompatibleHardware,
     tensorRtLoadable: tensorRtVenvLoadable,
     tensorRtRtxLoadable: tensorRtRtxVenvLoadable,
   });
@@ -240,7 +256,7 @@ async function probeSystemHardware(opts: SystemProbeOptions): Promise<HardwarePr
     platform,
     nvidia,
     rocm,
-    openvino,
+    openvino: openvino ? { ...openvino, available: openvinoVenvAvailable } : undefined,
     // UI consumers (IHV panel) read `.loadable`; keep it aligned with .venv readiness.
     tensorrt: tensorrt ? { ...tensorrt, loadable: tensorRtVenvLoadable } : tensorrt,
     tensorRtRtx: tensorRtRtx ? { ...tensorRtRtx, loadable: tensorRtRtxVenvLoadable } : tensorRtRtx,
@@ -249,6 +265,7 @@ async function probeSystemHardware(opts: SystemProbeOptions): Promise<HardwarePr
     recommendedProvider: pickRecommendedProvider(detectedProviders, {
       tensorRtRtxLoadable: tensorRtRtxVenvLoadable,
       tensorRtLoadable: tensorRtVenvLoadable,
+      openvinoLoadable: openvinoVenvAvailable,
     }),
     notes,
   };

--- a/src/server/routes/system.ts
+++ b/src/server/routes/system.ts
@@ -227,7 +227,11 @@ async function probeSystemHardware(opts: SystemProbeOptions): Promise<HardwarePr
   }
   notes.push("QNN requires Snapdragon/Hexagon dev hardware — not probed on desktop.");
 
-  const hasOpenVinoCompatibleHardware = /Intel|Xeon|Core|Arc|Ultra/i.test(platform.cpuModel);
+  // Probe Intel-compatible hardware: Intel CPU OR Intel Arc GPU OR detected OpenVINO devices (GPU/NPU).
+  const hasIntelCpu = /Intel|Xeon|Core|Ultra/i.test(platform.cpuModel);
+  const hasIntelArcGpu = nvidia?.gpus.some((g) => /Arc/i.test(g.name)) ?? false;
+  const hasIntelOpenVinoDevices = openvino?.devices?.some((d) => /GPU|NPU/i.test(d)) ?? false;
+  const hasOpenVinoCompatibleHardware = hasIntelCpu || hasIntelArcGpu || hasIntelOpenVinoDevices;
 
   const detectedProviders = mergeDetectedProviders({
     onnxRuntimeProviders,
@@ -244,7 +248,7 @@ async function probeSystemHardware(opts: SystemProbeOptions): Promise<HardwarePr
     platform,
     nvidia,
     rocm,
-    openvino: openvino ? { ...openvino, available: openvinoVenvAvailable } : undefined,
+    openvino: openvino ? { ...openvino, available: openvinoVenvAvailable, loadable: openvinoVenvAvailable } : undefined,
     // UI consumers (IHV panel) read `.loadable`; keep it aligned with .venv readiness.
     tensorrt: tensorrt ? { ...tensorrt, loadable: tensorRtVenvLoadable } : tensorrt,
     tensorRtRtx: tensorRtRtx ? { ...tensorRtRtx, loadable: tensorRtRtxVenvLoadable } : tensorRtRtx,

--- a/src/server/routes/system.ts
+++ b/src/server/routes/system.ts
@@ -14,10 +14,17 @@ import { getVenvPython } from "../services/venv/paths.ts";
 import { findSystemPython } from "../services/venv/index.ts";
 import { parseCudaVersionFromNvidiaSmi } from "../services/olive/cuda.ts";
 import {
+  isNvidiaGpuTensorRtFamily,
   mergeDetectedProviders,
   pickRecommendedProvider,
+  TENSORRT_FAMILY_MIN_COMPUTE_CAPABILITY,
   type HardwareProbeResult,
 } from "../../lib/hardwareProbe.ts";
+import { isPreMaxwellNvidiaBox, CUDA_SM_FLOOR } from "../../lib/cudaDeps.ts";
+import {
+  ORT_GPU_PROBE_SCRIPT,
+  parseOrtGpuProbe,
+} from "../../lib/oliveGpuRuntime.ts";
 
 const execFileAsync = promisify(execFile);
 
@@ -25,8 +32,10 @@ const execFileAsync = promisify(execFile);
 
 async function probeNvidiaGpus(): Promise<HardwareProbeResult["nvidia"] | undefined> {
   try {
+    // compute_cap lets us gate TensorRT-family EPs on the SM ≥ 7.5 (Turing)
+    // floor so pre-Turing cards are not falsely reported as compatible.
     const { stdout } = await execFileAsync("nvidia-smi", [
-      "--query-gpu=name,driver_version,memory.total",
+      "--query-gpu=name,driver_version,memory.total,compute_cap",
       "--format=csv,noheader",
     ]);
     const gpus = stdout
@@ -39,12 +48,17 @@ async function probeNvidiaGpus(): Promise<HardwareProbeResult["nvidia"] | undefi
         const name = parts[0] ?? "Unknown GPU";
         const driver = parts[1];
         const memStr = parts[2];
+        // compute_cap is reported as e.g. "8.9" — leave as-is so callers can
+        // compare via parseComputeCapability. Older drivers may emit "0.0" or
+        // be missing; `undefined` means "we couldn't tell", which our
+        // compat logic treats as permissive (no silent downgrade).
+        const computeCapability = parts[3]?.match(/^\d+\.\d+$/) ? parts[3] : undefined;
         let vramMb: number | undefined;
         if (memStr) {
           const m = memStr.match(/(\d+)/);
           if (m) vramMb = parseInt(m[1], 10);
         }
-        return { name, driver, vramMb };
+        return { name, driver, vramMb, computeCapability };
       });
 
     if (gpus.length === 0) return undefined;
@@ -62,7 +76,22 @@ async function probeNvidiaGpus(): Promise<HardwareProbeResult["nvidia"] | undefi
       /* ignore */
     }
 
-    return { gpus, cudaVersion, cudaTag };
+    // Probe for the CUDA Toolkit (`nvcc`). Pure inference via onnxruntime-gpu
+    // does NOT need the toolkit (it ships its own runtime libs), so a missing
+    // toolkit is benign for OLIVE recipes — but the IHV panel still wants
+    // to know so it can surface a download link when the user kicks off a
+    // native build. `available` is `undefined` when we couldn't even tell.
+    type NvidiaToolkit = NonNullable<HardwareProbeResult["nvidia"]>["cudaToolkit"];
+    let cudaToolkit: NvidiaToolkit;
+    try {
+      const { stdout: nvccOut } = await execFileAsync("nvcc", ["--version"]);
+      const m = nvccOut.match(/release\s+(\d+\.\d+)/i);
+      cudaToolkit = { available: true, version: m?.[1] };
+    } catch {
+      cudaToolkit = { available: false };
+    }
+
+    return { gpus, cudaVersion, cudaTag, cudaToolkit };
   } catch {
     return undefined;
   }
@@ -150,8 +179,10 @@ async function probeSystemHardware(opts: SystemProbeOptions): Promise<HardwarePr
   let onnxRuntimeProviders: string[] | undefined;
   let tensorrt: HardwareProbeResult["tensorrt"];
   let tensorRtRtx: HardwareProbeResult["tensorRtRtx"];
+  let cuda: HardwareProbeResult["cuda"] | undefined;
   let tensorRtVenvLoadable = false;
   let tensorRtRtxVenvLoadable = false;
+  let cudaVenvLoadable = false;
 
   const venvPython = getVenvPython();
   const pythonCandidates: string[] = [];
@@ -169,6 +200,35 @@ async function probeSystemHardware(opts: SystemProbeOptions): Promise<HardwarePr
       notes.push(
         `ONNX Runtime providers probed via ${python === venvPython ? ".venv Python" : "system Python"}.`,
       );
+    }
+    // Probe whether the CUDA execution provider actually loads in this
+    // python environment. Distinct from `onnxRuntimeProviders` (which just
+    // reports what ORT sees) — this checks the pinned wheel version AND the
+    // CUDA EP usability, so a driver/wheel mismatch surfaces as not-loadable
+    // with the right error detail. Mirrors how `tensorRtVenvLoadable` is
+    // tracked in this same loop.
+    if (!cuda) {
+      try {
+        const { stdout } = await execFileAsync(python, ["-c", ORT_GPU_PROBE_SCRIPT]);
+        const probe = parseOrtGpuProbe(stdout);
+        if (python === venvPython && probe.ok) cudaVenvLoadable = true;
+        cuda = {
+          loadable: probe.ok,
+          detail: probe.ok
+            ? undefined
+            : probe.cudaUsable === false
+              ? `onnxruntime-gpu CUDA EP not registered (driver/wheel mismatch — got dist ${probe.distVersion ?? "?"} / ort ${probe.ortVersion ?? "?"})`
+              : `onnxruntime-gpu not at pinned version ${probe.distVersion ?? probe.ortVersion ?? "?"} (required 1.26.0)`,
+        };
+      } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : String(err);
+        cuda = {
+          loadable: false,
+          detail: /No module named ['"]onnxruntime['"]/i.test(msg)
+            ? "onnxruntime (CPU/GPU) not installed in .venv"
+            : `onnxruntime-gpu probe failed: ${msg.split(/\r?\n/, 1)[0] ?? msg}`,
+        };
+      }
     }
     if (!tensorrt?.loadable) {
       const trt = await opts.probeTensorRtLoadable(python);
@@ -210,6 +270,16 @@ async function probeSystemHardware(opts: SystemProbeOptions): Promise<HardwarePr
     );
   }
 
+  if (cudaVenvLoadable) {
+    notes.push("CUDA execution provider load verified.");
+  } else if (nvidia?.gpus.length) {
+    notes.push(
+      cuda?.detail
+        ? `${cuda.detail}. GPU is compatible — click "Install onnxruntime-gpu" in Hardware (step 02) or run \`pip install onnxruntime-gpu==1.26.0\` to enable CUDA EP.`
+        : "onnxruntime-gpu not in .venv yet. GPU is compatible — click \"Install onnxruntime-gpu\" in Hardware (step 02) or it installs on first CUDA run.",
+    );
+  }
+
   if (onnxRuntimeProviders?.length) {
     notes.push(`ORT execution providers: ${onnxRuntimeProviders.join(", ")}`);
     if (nvidia && !onnxRuntimeProviders.includes("CUDAExecutionProvider")) {
@@ -226,6 +296,37 @@ async function probeSystemHardware(opts: SystemProbeOptions): Promise<HardwarePr
   if (!openvino?.available) notes.push("OpenVINO Python package not found locally.");
   notes.push("QNN requires Snapdragon/Hexagon dev hardware — not probed on desktop.");
 
+  // Surface pre-Maxwell NVIDIA boxes (every detected GPU below the CUDA 12
+  // toolkit floor) so the IHV panel / recipe compat layer can suppress the
+  // install hints (no install can recover Kepler SM 3.x). Mirrors the
+  // pre-Turing TensorRT short-circuit a few lines above.
+  if (nvidia?.gpus.length && isPreMaxwellNvidiaBox(nvidia.gpus)) {
+    notes.push(
+      `NVIDIA GPU(s) below CUDA 12 toolkit floor (compute capability < ${CUDA_SM_FLOOR}); modern CUDA cannot run on Maxwell/Pascal/Kepler cards.`,
+    );
+  } else if (nvidia?.cudaToolkit?.available === false) {
+    notes.push(
+      "CUDA driver detected but the CUDA Toolkit (nvcc) is not installed. Inference via onnxruntime-gpu does not need it; get it from NVIDIA's CUDA Toolkit Archive for native builds.",
+    );
+  }
+
+  // Gate TensorRT-family EPs on the SM ≥ 7.5 (Turing) floor.
+  // `hasNvidiaGpu` alone is not enough: pre-Turing cards return CUDA from
+  // ONNX Runtime but cannot execute TensorRT 10.x or TensorRT-RTX, so we
+  // must strip those EPs from the detected list (and from the install-needed
+  // hint path) before reporting compat.
+  const nvidiaTensorRtFamilyCapable = nvidia
+    ? nvidia.gpus.some((g) => isNvidiaGpuTensorRtFamily(g))
+    : false;
+  // Only warn when there are *actual* GPUs below the floor — `[].some(...)`
+  // returning false for an empty GPU list would otherwise print a misleading
+  // "all NVIDIA GPUs below TensorRT floor" note on machines with zero GPUs.
+  if (nvidiaTensorRtFamilyCapable === false && (nvidia?.gpus.length ?? 0) > 0) {
+    notes.push(
+      `NVIDIA GPU(s) below TensorRT 10.x floor (compute capability < ${TENSORRT_FAMILY_MIN_COMPUTE_CAPABILITY.major}.${TENSORRT_FAMILY_MIN_COMPUTE_CAPABILITY.minor}); TensorRT / TensorRT-RTX EPs hidden.`,
+    );
+  }
+
   const detectedProviders = mergeDetectedProviders({
     onnxRuntimeProviders,
     hasNvidiaGpu: Boolean(nvidia?.gpus.length),
@@ -233,6 +334,8 @@ async function probeSystemHardware(opts: SystemProbeOptions): Promise<HardwarePr
     hasOpenVino: Boolean(openvino?.available),
     tensorRtLoadable: tensorRtVenvLoadable,
     tensorRtRtxLoadable: tensorRtRtxVenvLoadable,
+    nvidiaTensorRtFamilyCapable,
+    cudaLoadable: cudaVenvLoadable,
   });
 
   return {
@@ -244,6 +347,7 @@ async function probeSystemHardware(opts: SystemProbeOptions): Promise<HardwarePr
     // UI consumers (IHV panel) read `.loadable`; keep it aligned with .venv readiness.
     tensorrt: tensorrt ? { ...tensorrt, loadable: tensorRtVenvLoadable } : tensorrt,
     tensorRtRtx: tensorRtRtx ? { ...tensorRtRtx, loadable: tensorRtRtxVenvLoadable } : tensorRtRtx,
+    cuda: cuda ? { ...cuda, loadable: cudaVenvLoadable } : cuda,
     onnxRuntimeProviders,
     detectedProviders,
     recommendedProvider: pickRecommendedProvider(detectedProviders, {

--- a/src/server/routes/system.ts
+++ b/src/server/routes/system.ts
@@ -20,13 +20,20 @@ import {
   TENSORRT_FAMILY_MIN_COMPUTE_CAPABILITY,
   type HardwareProbeResult,
 } from "../../lib/hardwareProbe.ts";
-import { isPreMaxwellNvidiaBox, CUDA_SM_FLOOR } from "../../lib/cudaDeps.ts";
+import {
+  isPreMaxwellNvidiaBox,
+  CUDA_SM_FLOOR,
+  pinnedOrtGpuInstallCommand,
+  pinnedOrtGpuLabel,
+} from "../../lib/cudaDeps.ts";
 import {
   ORT_GPU_PROBE_SCRIPT,
   parseOrtGpuProbe,
 } from "../../lib/oliveGpuRuntime.ts";
 
 const execFileAsync = promisify(execFile);
+
+const ORT_PROBE_TIMEOUT_MS = 30_000;
 
 // ─── GPU probes ────────────────────────────────────────────────────────────
 
@@ -209,16 +216,31 @@ async function probeSystemHardware(opts: SystemProbeOptions): Promise<HardwarePr
     // tracked in this same loop.
     if (!cuda) {
       try {
-        const { stdout } = await execFileAsync(python, ["-c", ORT_GPU_PROBE_SCRIPT]);
+        // Bound the onnxruntime import probe against a hung driver
+        // loader. On any modern dev box the probe finishes in well
+        // under 5 s; a 30 s ceiling still gives slow CI/turbo-boost-down
+        // boxes headroom while keeping the route from stalling the UI
+        // on a broken driver install. On timeout, the existing catch
+        // branch records `cuda.loadable: false` with the probe-failure
+        // detail.
+        const { stdout } = await execFileAsync(python, ["-c", ORT_GPU_PROBE_SCRIPT], {
+          timeout: ORT_PROBE_TIMEOUT_MS,
+        });
         const probe = parseOrtGpuProbe(stdout);
         if (python === venvPython && probe.ok) cudaVenvLoadable = true;
+        // Use the canonical pinned-version string from `pinnedOrtGpuLabel`
+        // instead of hardcoding "1.26.0". A bump to `oliveGpuRuntime.ts`
+        // then propagates here and to the install hint without drift.
+        const pinnedLabel = pinnedOrtGpuLabel();
+        const requiredVersionMatch = pinnedLabel.match(/==\s*([\d.]+[^\s]*)/);
+        const pinnedVersion = requiredVersionMatch?.[1] ?? pinnedLabel;
         cuda = {
           loadable: probe.ok,
           detail: probe.ok
             ? undefined
             : probe.cudaUsable === false
               ? `onnxruntime-gpu CUDA EP not registered (driver/wheel mismatch — got dist ${probe.distVersion ?? "?"} / ort ${probe.ortVersion ?? "?"})`
-              : `onnxruntime-gpu not at pinned version ${probe.distVersion ?? probe.ortVersion ?? "?"} (required 1.26.0)`,
+              : `onnxruntime-gpu not at pinned version ${probe.distVersion ?? probe.ortVersion ?? "?"} (required ${pinnedVersion})`,
         };
       } catch (err: unknown) {
         const msg = err instanceof Error ? err.message : String(err);
@@ -273,10 +295,14 @@ async function probeSystemHardware(opts: SystemProbeOptions): Promise<HardwarePr
   if (cudaVenvLoadable) {
     notes.push("CUDA execution provider load verified.");
   } else if (nvidia?.gpus.length) {
+    // Derive the install command from the pinned args so a wheel-pin
+    // bump updates this hint and the probe-detail string above in
+    // lockstep.
+    const ortGpuCmd = pinnedOrtGpuInstallCommand();
     notes.push(
       cuda?.detail
-        ? `${cuda.detail}. GPU is compatible — click "Install onnxruntime-gpu" in Hardware (step 02) or run \`pip install onnxruntime-gpu==1.26.0\` to enable CUDA EP.`
-        : "onnxruntime-gpu not in .venv yet. GPU is compatible — click \"Install onnxruntime-gpu\" in Hardware (step 02) or it installs on first CUDA run.",
+        ? `${cuda.detail}. GPU is compatible — click "Install onnxruntime-gpu" in Hardware (step 02) or run \`${ortGpuCmd}\` to enable CUDA EP.`
+        : `${ortGpuCmd} not yet run in .venv. GPU is compatible — click "Install onnxruntime-gpu" in Hardware (step 02) or it installs on first CUDA run.`,
     );
   }
 

--- a/src/server/routes/system.ts
+++ b/src/server/routes/system.ts
@@ -155,7 +155,12 @@ async function probeSystemHardware(opts: SystemProbeOptions): Promise<HardwarePr
   if (systemPython) pythonCandidates.push(systemPython);
 
   for (const python of pythonCandidates) {
-    const pyResult = await probePythonRuntime(python);
+    const [pyResult, ov, trt, rtx] = await Promise.all([
+      probePythonRuntime(python),
+      opts.probeOpenVino(python),
+      opts.probeTensorRtLoadable(python),
+      opts.probeTensorRtRtxLoadable(python),
+    ]);
     if (pyResult.onnxRuntimeProviders?.length && !onnxRuntimeProviders?.length) {
       onnxRuntimeProviders = pyResult.onnxRuntimeProviders;
       notes.push(
@@ -163,34 +168,20 @@ async function probeSystemHardware(opts: SystemProbeOptions): Promise<HardwarePr
       );
     }
 
-    const ov = await opts.probeOpenVino(python);
-    if (ov.available) {
+    const hasOpenVinoSignal = Boolean(ov.version || ov.devices?.length || ov.optimumIntel || ov.detail);
+    if (hasOpenVinoSignal || ov.available) {
       if (python === venvPython) {
         openvino = ov;
-        openvinoVenvAvailable = true;
+        openvinoVenvAvailable = ov.available;
       } else if (!openvino) {
         openvino = ov;
       }
     }
 
-    if (!tensorrt?.loadable) {
-      const trt = await opts.probeTensorRtLoadable(python);
-      if (python === venvPython && trt.loadable) {
-        tensorRtVenvLoadable = true;
-      }
-      if (trt.loadable || !tensorrt) {
-        tensorrt = trt;
-      }
-    }
-    if (!tensorRtRtx?.loadable) {
-      const rtx = await opts.probeTensorRtRtxLoadable(python);
-      if (python === venvPython && rtx.loadable) {
-        tensorRtRtxVenvLoadable = true;
-      }
-      if (rtx.loadable || !tensorRtRtx) {
-        tensorRtRtx = rtx;
-      }
-    }
+    if (python === venvPython && trt.loadable) tensorRtVenvLoadable = true;
+    if (trt.loadable || !tensorrt) tensorrt = trt;
+    if (python === venvPython && rtx.loadable) tensorRtRtxVenvLoadable = true;
+    if (rtx.loadable || !tensorRtRtx) tensorRtRtx = rtx;
   }
 
   if (tensorRtRtxVenvLoadable) {
@@ -229,8 +220,8 @@ async function probeSystemHardware(opts: SystemProbeOptions): Promise<HardwarePr
   if (openvinoVenvAvailable) {
     const deviceMsg = openvino?.devices?.length ? ` [${openvino.devices.join(", ")}]` : "";
     notes.push(`OpenVINO stack verified${openvino?.version ? ` (${openvino.version})` : ""}${deviceMsg}.`);
-  } else if (openvino?.available) {
-    notes.push(`OpenVINO stack found on system Python but not in .venv — use Install in Hardware.`);
+  } else if (openvino?.version || openvino?.devices?.length || openvino?.optimumIntel) {
+    notes.push("OpenVINO is present but the complete .venv stack is not ready — use Install in Hardware.");
   } else {
     notes.push("OpenVINO Python package not found locally.");
   }

--- a/src/server/routes/system.ts
+++ b/src/server/routes/system.ts
@@ -14,6 +14,7 @@ import { getVenvPython } from "../services/venv/paths.ts";
 import { findSystemPython } from "../services/venv/index.ts";
 import { parseCudaVersionFromNvidiaSmi } from "../services/olive/cuda.ts";
 import {
+  computeOpenVinoCompatibleHardware,
   mergeDetectedProviders,
   pickRecommendedProvider,
   type HardwareProbeResult,
@@ -84,6 +85,40 @@ async function probeRocmGpus(): Promise<HardwareProbeResult["rocm"] | undefined>
   }
 }
 
+/**
+ * Enumerates Intel display / compute adapters (iGPU, Arc, Xe) independently of nvidia-smi.
+ * Returns adapter name strings used for OpenVINO-compatible hardware detection.
+ */
+async function probeIntelGpuNames(): Promise<string[]> {
+  if (process.platform === "linux") {
+    try {
+      const { stdout } = await execFileAsync("lspci", ["-nn"]);
+      return stdout
+        .split("\n")
+        .map((line) => line.trim())
+        .filter((line) => /VGA|3D|Display/i.test(line) && /Intel/i.test(line));
+    } catch {
+      return [];
+    }
+  }
+  if (process.platform === "win32") {
+    try {
+      const { stdout } = await execFileAsync("powershell.exe", [
+        "-NoProfile",
+        "-Command",
+        "Get-CimInstance Win32_VideoController | Select-Object -ExpandProperty Name",
+      ]);
+      return stdout
+        .split(/\r?\n/)
+        .map((line) => line.trim())
+        .filter((name) => name.length > 0 && /Intel/i.test(name));
+    } catch {
+      return [];
+    }
+  }
+  return [];
+}
+
 async function probePythonRuntime(
   python: string,
 ): Promise<Pick<HardwareProbeResult, "onnxRuntimeProviders">> {
@@ -138,7 +173,11 @@ async function probeSystemHardware(opts: SystemProbeOptions): Promise<HardwarePr
     systemRamGb: Math.round((os.totalmem() / 1024 ** 3) * 10) / 10,
   };
 
-  const [nvidia, rocm] = await Promise.all([probeNvidiaGpus(), probeRocmGpus()]);
+  const [nvidia, rocm, intelGpuNames] = await Promise.all([
+    probeNvidiaGpus(),
+    probeRocmGpus(),
+    probeIntelGpuNames(),
+  ]);
 
   let openvino: OpenVinoProbeResult | undefined;
   let openvinoVenvAvailable = false;
@@ -233,11 +272,12 @@ async function probeSystemHardware(opts: SystemProbeOptions): Promise<HardwarePr
   }
   notes.push("QNN requires Snapdragon/Hexagon dev hardware — not probed on desktop.");
 
-  // Probe Intel-compatible hardware: Intel CPU OR Intel Arc GPU OR detected OpenVINO devices (GPU/NPU).
-  const hasIntelCpu = /Intel|Xeon|Core|Ultra/i.test(platform.cpuModel);
-  const hasIntelArcGpu = nvidia?.gpus.some((g) => /Arc/i.test(g.name)) ?? false;
-  const hasIntelOpenVinoDevices = openvino?.devices?.some((d) => /GPU|NPU/i.test(d)) ?? false;
-  const hasOpenVinoCompatibleHardware = hasIntelCpu || hasIntelArcGpu || hasIntelOpenVinoDevices;
+  // Probe Intel-compatible hardware: Intel CPU OR Intel GPU/NPU OR OpenVINO GPU/NPU devices.
+  const hasOpenVinoCompatibleHardware = computeOpenVinoCompatibleHardware({
+    cpuModel: platform.cpuModel,
+    intelGpuNames,
+    openvinoDevices: openvino?.devices,
+  });
 
   const detectedProviders = mergeDetectedProviders({
     onnxRuntimeProviders,

--- a/src/server/routes/system.ts
+++ b/src/server/routes/system.ts
@@ -219,11 +219,17 @@ async function probeSystemHardware(opts: SystemProbeOptions): Promise<HardwarePr
   if (!rocm) notes.push("No AMD ROCm GPU detected.");
   if (openvinoVenvAvailable) {
     const deviceMsg = openvino?.devices?.length ? ` [${openvino.devices.join(", ")}]` : "";
-    notes.push(`OpenVINO stack verified${openvino?.version ? ` (${openvino.version})` : ""}${deviceMsg}.`);
-  } else if (openvino?.version || openvino?.devices?.length || openvino?.optimumIntel) {
-    notes.push("OpenVINO is present but the complete .venv stack is not ready — use Install in Hardware.");
+    notes.push(
+      `OpenVINO stack verified${openvino?.version ? ` (${openvino.version})` : ""}${deviceMsg} (OpenVINOExecutionProvider).`,
+    );
+  } else if (openvino?.version || openvino?.devices?.length || openvino?.optimumIntel || openvino?.openvinoExecutionProvider === false) {
+    notes.push(
+      openvino?.detail
+        ? `OpenVINO stack not ready (${openvino.detail}). Use Install in Hardware (installs onnxruntime-openvino).`
+        : "OpenVINO is present but OpenVINOExecutionProvider is not ready — use Install in Hardware.",
+    );
   } else {
-    notes.push("OpenVINO Python package not found locally.");
+    notes.push("OpenVINO Python stack not found locally (needs openvino + onnxruntime-openvino).");
   }
   notes.push("QNN requires Snapdragon/Hexagon dev hardware — not probed on desktop.");
 

--- a/src/server/routes/system.ts
+++ b/src/server/routes/system.ts
@@ -236,10 +236,7 @@ async function probeSystemHardware(opts: SystemProbeOptions): Promise<HardwarePr
   }
   notes.push("QNN requires Snapdragon/Hexagon dev hardware — not probed on desktop.");
 
-  const hasOpenVinoCompatibleHardware =
-    /Intel|Xeon|Core|Arc|Ultra/i.test(platform.cpuModel) ||
-    platform.arch === "x64" ||
-    platform.arch === "arm64";
+  const hasOpenVinoCompatibleHardware = /Intel|Xeon|Core|Arc|Ultra/i.test(platform.cpuModel);
 
   const detectedProviders = mergeDetectedProviders({
     onnxRuntimeProviders,

--- a/src/server/services/olive/cuda.ts
+++ b/src/server/services/olive/cuda.ts
@@ -4,9 +4,19 @@
  * parseCudaVersionFromNvidiaSmi and pickCudaTag are the canonical implementations.
  * routes/system.ts was duplicating them — it should import from here instead.
  */
-import { isResolvableCudaTag } from "../../../lib/oliveGpuRuntime.ts";
+import { spawn } from "child_process";
+import {
+  ORT_GPU_PROBE_SCRIPT,
+  parseOrtGpuProbe,
+  pinnedOrtGpuInstallArgs,
+  pinnedOrtGpuLabel,
+  PINNED_ORT_GPU_VERSION,
+  isResolvableCudaTag,
+} from "../../../lib/oliveGpuRuntime.ts";
 import { execFileAsync } from "../shared/exec.ts";
-import { getVenvPython } from "../venv/paths.ts";
+import { getVenvPython, getVenvPip } from "../venv/paths.ts";
+import { ensureVenv } from "../venv/index.ts";
+import fs from "fs";
 
 /** Parse CUDA version from nvidia-smi output. */
 export function parseCudaVersionFromNvidiaSmi(
@@ -95,4 +105,115 @@ export async function detectCudaTag(preferred: string, onLine: (line: string) =>
 
   onLine(`[deps] No GPU detected → CPU torch`);
   return "cpu";
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// onnxruntime-gpu install path (mirrors TRT install UX in tensorrt.ts)
+// ─────────────────────────────────────────────────────────────────────────
+
+/**
+ * Runs `pip install` and forwards output line-by-line to the provided callback,
+ * prepending each line with `[deps]`. Mirrors the helper in tensorrt.ts so the
+ * NDJSON stream the UI receives has the same shape across all install paths.
+ */
+async function pipInstall(
+  pip: string,
+  args: string[],
+  onLine: (line: string) => void,
+): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const proc = spawn(pip, ["install", ...args], { stdio: "pipe" });
+    proc.stdout.on("data", (d: Buffer) => onLine("[deps] " + d.toString().trim()));
+    proc.stderr.on("data", (d: Buffer) => onLine("[deps] " + d.toString().trim()));
+    proc.on("error", (err: Error) =>
+      reject(
+        new Error(
+          `Failed to launch ${pip}: ${err.message}. Create the project .venv via Setup runtime first.`,
+        ),
+      ),
+    );
+    proc.on("close", (code: number | null) =>
+      code === 0
+        ? resolve()
+        : reject(new Error(`pip install ${args.join(" ")} failed (exit ${code})`)),
+    );
+  });
+}
+
+/**
+ * Ensures the project virtual environment has the pinned onnxruntime-gpu
+ * wheel with a usable CUDA execution provider. The probe script
+ * `ORT_GPU_PROBE_SCRIPT` checks both the wheel version AND that the CUDA EP
+ * is actually registered, so a successful run means the user can pick
+ * CUDA as their IHV provider without further config.
+ *
+ * Returns `{ ok, error? }`; on success, `libsDir` carries the path the
+ * caller can prepend so subsequent `pip install` invocations find cuBLAS /
+ * cuDNN shared libs.
+ *
+ * @param onLine - Receives install + verification messages for the NDJSON stream
+ */
+export async function ensureOnnxRuntimeGpu(
+  onLine: (line: string) => void,
+): Promise<{ ok: boolean; error?: string; libsDir?: string | null }> {
+  const venvResult = await ensureVenv(onLine);
+  if (!venvResult.ok) {
+    return {
+      ok: false,
+      error: venvResult.error ?? "Failed to create or prepare the project .venv",
+    };
+  }
+  const venvPython = getVenvPython();
+  const pip = getVenvPip();
+  if (!fs.existsSync(venvPython) || !fs.existsSync(pip)) {
+    return {
+      ok: false,
+      error: `Project .venv is incomplete (missing ${!fs.existsSync(pip) ? "pip" : "python"}). Use Setup runtime, then retry.`,
+    };
+  }
+
+  try {
+    const { stdout } = await execFileAsync(venvPython, ["-c", ORT_GPU_PROBE_SCRIPT]);
+    const probe = parseOrtGpuProbe(stdout);
+    if (probe.ok) {
+      onLine("[deps] onnxruntime-gpu already installed and CUDA EP registered ✓");
+      return { ok: true };
+    }
+    if (probe.distVersion || probe.ortVersion) {
+      onLine(
+        probe.cudaUsable === false
+          ? `[deps] onnxruntime-gpu ${probe.distVersion ?? probe.ortVersion} installed but CUDA EP not registered — reinstalling pinned wheel...`
+          : `[deps] onnxruntime-gpu ${probe.distVersion ?? probe.ortVersion} installed but need ${PINNED_ORT_GPU_VERSION}, reinstalling...`,
+      );
+    }
+  } catch {
+    /* install below */
+  }
+
+  onLine(`[deps] Installing ${pinnedOrtGpuLabel()} (required for CUDA EP)...`);
+  await pipInstall(pip, pinnedOrtGpuInstallArgs(), onLine);
+  onLine(`[deps] ${pinnedOrtGpuLabel()} installed ✓`);
+
+  // Verify after install — surfaces driver/wheel mismatch as a real error.
+  try {
+    const { stdout } = await execFileAsync(venvPython, ["-c", ORT_GPU_PROBE_SCRIPT]);
+    const probe = parseOrtGpuProbe(stdout);
+    if (probe.ok) {
+      onLine("[deps] CUDA execution provider load verified after install ✓");
+      return { ok: true };
+    }
+    return {
+      ok: false,
+      error:
+        probe.cudaUsable === false
+          ? `${pinnedOrtGpuLabel()} installed but the onnxruntime CUDA EP did not register — likely a driver / CUDA-version mismatch (probe reported: ${probe.distVersion ?? "?"} / ort ${probe.ortVersion ?? "?"}). Refresh the hardware probe and check the NVIDIA driver.`
+          : `${pinnedOrtGpuLabel()} is not at the pinned version ${PINNED_ORT_GPU_VERSION} after install (got ${probe.distVersion ?? "?"} / ort ${probe.ortVersion ?? "?"}).`,
+    };
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return {
+      ok: false,
+      error: `CUDA EP probe failed after install: ${msg}. Refresh the hardware probe and check the Python venv.`,
+    };
+  }
 }

--- a/src/server/services/olive/cuda.ts
+++ b/src/server/services/olive/cuda.ts
@@ -4,7 +4,6 @@
  * parseCudaVersionFromNvidiaSmi and pickCudaTag are the canonical implementations.
  * routes/system.ts was duplicating them — it should import from here instead.
  */
-import { spawn } from "child_process";
 import {
   ORT_GPU_PROBE_SCRIPT,
   parseOrtGpuProbe,
@@ -14,6 +13,7 @@ import {
   isResolvableCudaTag,
 } from "../../../lib/oliveGpuRuntime.ts";
 import { execFileAsync } from "../shared/exec.ts";
+import { pipInstall } from "../shared/pipInstall.ts";
 import { getVenvPython, getVenvPip } from "../venv/paths.ts";
 import { ensureVenv } from "../venv/index.ts";
 import fs from "fs";
@@ -111,34 +111,9 @@ export async function detectCudaTag(preferred: string, onLine: (line: string) =>
 // onnxruntime-gpu install path (mirrors TRT install UX in tensorrt.ts)
 // ─────────────────────────────────────────────────────────────────────────
 
-/**
- * Runs `pip install` and forwards output line-by-line to the provided callback,
- * prepending each line with `[deps]`. Mirrors the helper in tensorrt.ts so the
- * NDJSON stream the UI receives has the same shape across all install paths.
- */
-async function pipInstall(
-  pip: string,
-  args: string[],
-  onLine: (line: string) => void,
-): Promise<void> {
-  await new Promise<void>((resolve, reject) => {
-    const proc = spawn(pip, ["install", ...args], { stdio: "pipe" });
-    proc.stdout.on("data", (d: Buffer) => onLine("[deps] " + d.toString().trim()));
-    proc.stderr.on("data", (d: Buffer) => onLine("[deps] " + d.toString().trim()));
-    proc.on("error", (err: Error) =>
-      reject(
-        new Error(
-          `Failed to launch ${pip}: ${err.message}. Create the project .venv via Setup runtime first.`,
-        ),
-      ),
-    );
-    proc.on("close", (code: number | null) =>
-      code === 0
-        ? resolve()
-        : reject(new Error(`pip install ${args.join(" ")} failed (exit ${code})`)),
-    );
-  });
-}
+// `pipInstall` is imported from `../shared/pipInstall.ts` so the same NDJSON
+// line shape + error contract is used by every install route. The local
+// duplicate copy was deleted when this was extracted.
 
 /**
  * Ensures the project virtual environment has the pinned onnxruntime-gpu
@@ -176,8 +151,15 @@ export async function ensureOnnxRuntimeGpu(
     const { stdout } = await execFileAsync(venvPython, ["-c", ORT_GPU_PROBE_SCRIPT]);
     const probe = parseOrtGpuProbe(stdout);
     if (probe.ok) {
-      onLine("[deps] onnxruntime-gpu already installed and CUDA EP registered ✓");
-      return { ok: true };
+      onLine("[deps] onnxruntime-gpu already installed and CUDA EP registered");
+      // The `libsDir` field in the return type carries the path the
+      // caller can prepend to find cuBLAS / cuDNN shared libs for
+      // non-venv subprocesses. We don't compute that here (the
+      // install runs inside .venv where the wheel already shipped its
+      // DLLs alongside the Python module), so explicitly return
+      // `null` rather than leave the field undefined — the caller
+      // distinguishes "ready" from "unknown".
+      return { ok: true, libsDir: null };
     }
     if (probe.distVersion || probe.ortVersion) {
       onLine(
@@ -192,18 +174,19 @@ export async function ensureOnnxRuntimeGpu(
 
   onLine(`[deps] Installing ${pinnedOrtGpuLabel()} (required for CUDA EP)...`);
   await pipInstall(pip, pinnedOrtGpuInstallArgs(), onLine);
-  onLine(`[deps] ${pinnedOrtGpuLabel()} installed ✓`);
+  onLine(`[deps] ${pinnedOrtGpuLabel()} installed`);
 
   // Verify after install — surfaces driver/wheel mismatch as a real error.
   try {
     const { stdout } = await execFileAsync(venvPython, ["-c", ORT_GPU_PROBE_SCRIPT]);
     const probe = parseOrtGpuProbe(stdout);
     if (probe.ok) {
-      onLine("[deps] CUDA execution provider load verified after install ✓");
-      return { ok: true };
+      onLine("[deps] CUDA execution provider load verified after install");
+      return { ok: true, libsDir: null };
     }
     return {
       ok: false,
+      libsDir: null,
       error:
         probe.cudaUsable === false
           ? `${pinnedOrtGpuLabel()} installed but the onnxruntime CUDA EP did not register — likely a driver / CUDA-version mismatch (probe reported: ${probe.distVersion ?? "?"} / ort ${probe.ortVersion ?? "?"}). Refresh the hardware probe and check the NVIDIA driver.`
@@ -213,6 +196,7 @@ export async function ensureOnnxRuntimeGpu(
     const msg = err instanceof Error ? err.message : String(err);
     return {
       ok: false,
+      libsDir: null,
       error: `CUDA EP probe failed after install: ${msg}. Refresh the hardware probe and check the Python venv.`,
     };
   }

--- a/src/server/services/olive/openvino.ts
+++ b/src/server/services/olive/openvino.ts
@@ -108,7 +108,7 @@ export async function probeOpenVino(python: string): Promise<OpenVinoProbeResult
   try {
     const { stdout, stderr } = await execFileAsync(python, ["-c", buildProbeScript()]);
     const acc = parseProbeOutput(`${stdout}\n${stderr}`);
-    const available = Boolean(acc.version) && Boolean(acc.optimumIntel?.available);
+    const available = Boolean(acc.version) && acc.devices !== undefined && Boolean(acc.optimumIntel?.available);
     return {
       available,
       version: acc.version,

--- a/src/server/services/olive/openvino.ts
+++ b/src/server/services/olive/openvino.ts
@@ -2,7 +2,8 @@
  * OpenVINO probe, install, and dependency helpers.
  *
  * Mirrors the TensorRT / TensorRT RTX flow: ensure .venv, probe the OpenVINO
- * runtime + Optimum-Intel bridge, pip install the stack if missing, then re-probe.
+ * runtime + Optimum-Intel bridge + OpenVINOExecutionProvider, pip install the
+ * stack if missing, then re-probe.
  */
 import { spawn } from "child_process";
 import fs from "fs";
@@ -11,6 +12,7 @@ import { execFileAsync } from "../shared/exec.ts";
 import { ensureVenv } from "../venv/index.ts";
 import { getVenvPython, getVenvPip } from "../venv/paths.ts";
 import {
+  OPENVINO_CONFLICTING_ORT_PACKAGES,
   openvinoStackInstallArgs,
   openvinoStackLabel,
 } from "../../../lib/openvinoDeps.ts";
@@ -20,7 +22,7 @@ const OV_MARK = "OLIVE_OV:";
 
 /**
  * Build the one-shot Python script used to interrogate a Python interpreter
- * for the OpenVINO runtime and the Optimum-Intel bridge.
+ * for the OpenVINO runtime, Optimum-Intel bridge, and ORT OpenVINO EP.
  */
 function buildProbeScript(): string {
   return `
@@ -32,6 +34,12 @@ def emit(key, value):
 try:
     import openvino
     emit("version", openvino.__version__)
+    try:
+        import openvino.utils as ov_utils
+        if hasattr(ov_utils, "add_openvino_libs_to_path"):
+            ov_utils.add_openvino_libs_to_path()
+    except Exception:
+        pass
     from openvino import Core
     devices = Core().available_devices
     emit("devices", ",".join(devices))
@@ -44,6 +52,19 @@ try:
     emit("optimum_intel_version", getattr(optimum.intel, "__version__", "unknown"))
 except Exception as exc:
     emit("optimum_intel_error", str(exc).replace(chr(10), " "))
+
+try:
+    import onnxruntime as ort
+    providers = ort.get_available_providers()
+    emit("ort_providers", ",".join(providers))
+    if "OpenVINOExecutionProvider" in providers:
+        emit("openvino_ep", "1")
+    else:
+        emit("openvino_ep", "0")
+        emit("openvino_ep_error", "OpenVINOExecutionProvider missing from onnxruntime (need onnxruntime-openvino)")
+except Exception as exc:
+    emit("openvino_ep", "0")
+    emit("openvino_ep_error", str(exc).replace(chr(10), " "))
 `.trim();
 }
 
@@ -51,6 +72,7 @@ interface ProbeAccumulator {
   version?: string;
   devices?: string[];
   optimumIntel?: OpenVinoProbeResult["optimumIntel"];
+  openvinoExecutionProvider?: boolean;
   detail?: string;
 }
 
@@ -78,6 +100,16 @@ function parseProbeOutput(out: string): ProbeAccumulator {
       acc.optimumIntel = { available: false, detail: value || "optimum.intel import failed" };
       if (!acc.detail) acc.detail = value || "optimum.intel import failed";
     },
+    openvino_ep: (value) => {
+      acc.openvinoExecutionProvider = value === "1";
+    },
+    openvino_ep_error: (value) => {
+      acc.openvinoExecutionProvider = false;
+      if (!acc.detail) acc.detail = value || "OpenVINOExecutionProvider not available";
+    },
+    ort_providers: () => {
+      /* diagnostic only; openvino_ep drives availability */
+    },
     error: (value) => {
       acc.detail = value || "OpenVINO probe failed";
     },
@@ -98,28 +130,48 @@ function parseProbeOutput(out: string): ProbeAccumulator {
 }
 
 /**
- * Probes a Python environment for the OpenVINO runtime, available devices, and
- * the Optimum-Intel bridge.
+ * Probes a Python environment for the OpenVINO runtime, available devices,
+ * Optimum-Intel, and OpenVINOExecutionProvider.
  *
  * @param python - Path to the Python interpreter to probe
- * @returns Availability, version, device list, and Optimum-Intel status
+ * @returns Availability, version, device list, Optimum-Intel and EP status
  */
 export async function probeOpenVino(python: string): Promise<OpenVinoProbeResult> {
   try {
     const { stdout, stderr } = await execFileAsync(python, ["-c", buildProbeScript()]);
     const acc = parseProbeOutput(`${stdout}\n${stderr}`);
-    const available = Boolean(acc.version) && acc.devices !== undefined && Boolean(acc.optimumIntel?.available);
+    const openvinoRuntimeOk = Boolean(acc.version) && acc.devices !== undefined;
+    const openvinoEpOk = Boolean(acc.openvinoExecutionProvider);
+    const available = openvinoRuntimeOk && openvinoEpOk;
+    let detail: string | undefined;
+    if (!available) {
+      if (!openvinoRuntimeOk) {
+        detail = acc.detail ?? "OpenVINO runtime not available";
+      } else if (!openvinoEpOk) {
+        detail =
+          acc.detail ??
+          "OpenVINOExecutionProvider missing — install onnxruntime-openvino (conflicts with onnxruntime-gpu)";
+      }
+    }
     return {
       available,
       version: acc.version,
       devices: acc.devices,
       optimumIntel: acc.optimumIntel,
-      detail: available ? undefined : (acc.detail ?? "OpenVINO stack not available"),
+      openvinoExecutionProvider: acc.openvinoExecutionProvider,
+      detail,
     };
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : String(err);
     if (/No module named ['"]openvino['"]/i.test(message)) {
       return { available: false, detail: "openvino is not installed in this Python environment" };
+    }
+    if (/No module named ['"]onnxruntime['"]/i.test(message)) {
+      return {
+        available: false,
+        openvinoExecutionProvider: false,
+        detail: "onnxruntime-openvino is not installed in this Python environment",
+      };
     }
     return { available: false, detail: message };
   }
@@ -139,9 +191,25 @@ async function pipInstall(pip: string, args: string[], onLine: (line: string) =>
   });
 }
 
+async function pipUninstall(pip: string, packages: readonly string[], onLine: (line: string) => void): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const proc = spawn(pip, ["uninstall", "-y", ...packages], { stdio: "pipe" });
+    proc.stdout.on("data", (d: Buffer) => onLine("[deps] " + d.toString().trim()));
+    proc.stderr.on("data", (d: Buffer) => onLine("[deps] " + d.toString().trim()));
+    proc.on("error", (err: Error) =>
+      reject(new Error(`Failed to launch ${pip}: ${err.message}. Create the project .venv via Setup runtime first.`)),
+    );
+    // Missing packages still exit 0 with -y; non-zero is a real failure.
+    proc.on("close", (code: number | null) =>
+      code === 0 ? resolve() : reject(new Error(`pip uninstall ${packages.join(" ")} failed (exit ${code})`)),
+    );
+  });
+}
+
 /**
  * Ensures the project virtual environment contains a loadable OpenVINO stack
- * (openvino + optimum-intel[openvino]) and reports available devices.
+ * (openvino + optimum-intel[openvino] + onnxruntime-openvino) with
+ * OpenVINOExecutionProvider registered.
  *
  * @param onLine - Receives progress messages during environment preparation and installation.
  * @returns Success flag and the probe result when available.
@@ -176,12 +244,20 @@ export async function ensureOpenVino(
 
   if (!probe.version) {
     onLine(`[deps] Installing ${openvinoStackLabel()} for OpenVINO EP (may take a few minutes)...`);
+  } else if (!probe.openvinoExecutionProvider) {
+    onLine(
+      `[deps] OpenVINO runtime present but OpenVINOExecutionProvider missing — installing ${openvinoStackLabel()}...`,
+    );
   } else if (!probe.optimumIntel?.available) {
     onLine(`[deps] OpenVINO present but Optimum-Intel bridge missing — installing ${openvinoStackLabel()}...`);
   } else {
     onLine(`[deps] OpenVINO stack present but not loadable — reinstalling ${openvinoStackLabel()}...`);
   }
 
+  onLine(
+    `[deps] Warning: onnxruntime-openvino replaces other ORT wheels in this .venv (${OPENVINO_CONFLICTING_ORT_PACKAGES.join(", ")}). CUDA/TensorRT EPs will be unavailable until you reinstall onnxruntime-gpu.`,
+  );
+  await pipUninstall(pip, OPENVINO_CONFLICTING_ORT_PACKAGES, onLine);
   await pipInstall(pip, openvinoStackInstallArgs(), onLine);
   onLine(`[deps] ${openvinoStackLabel()} installed ✓`);
 
@@ -194,6 +270,6 @@ export async function ensureOpenVino(
 
   return {
     ok: false,
-    error: retry.detail ?? "OpenVINO stack not loadable after install",
+    error: retry.detail ?? "OpenVINO stack not loadable after install (OpenVINOExecutionProvider missing)",
   };
 }

--- a/src/server/services/olive/openvino.ts
+++ b/src/server/services/olive/openvino.ts
@@ -19,14 +19,11 @@ import type { OpenVinoProbeResult } from "../../../lib/hardwareProbe.ts";
 const OV_MARK = "OLIVE_OV:";
 
 /**
- * Probes a Python environment for the OpenVINO runtime, available devices, and
- * the Optimum-Intel bridge.
- *
- * @param python - Path to the Python interpreter to probe
- * @returns Availability, version, device list, and Optimum-Intel status
+ * Build the one-shot Python script used to interrogate a Python interpreter
+ * for the OpenVINO runtime and the Optimum-Intel bridge.
  */
-export async function probeOpenVino(python: string): Promise<OpenVinoProbeResult> {
-  const script = `
+function buildProbeScript(): string {
+  return `
 import sys
 
 def emit(key, value):
@@ -48,60 +45,83 @@ try:
 except Exception as exc:
     emit("optimum_intel_error", str(exc).replace(chr(10), " "))
 `.trim();
+}
 
-  let version: string | undefined;
-  let devices: string[] | undefined;
-  let optimumIntel: OpenVinoProbeResult["optimumIntel"] | undefined;
-  let detail: string | undefined;
+interface ProbeAccumulator {
+  version?: string;
+  devices?: string[];
+  optimumIntel?: OpenVinoProbeResult["optimumIntel"];
+  detail?: string;
+}
 
+function parseProbeOutput(out: string): ProbeAccumulator {
+  const acc: ProbeAccumulator = {};
+
+  const handlers: Record<string, (value: string) => void> = {
+    version: (value) => {
+      if (value) acc.version = value;
+    },
+    devices: (value) => {
+      acc.devices = value ? value.split(",").filter(Boolean) : [];
+    },
+    optimum_intel_available: () => {
+      acc.optimumIntel = { available: true, ...(acc.optimumIntel?.version ? { version: acc.optimumIntel.version } : {}) };
+    },
+    optimum_intel_version: (value) => {
+      acc.optimumIntel = {
+        ...(acc.optimumIntel ?? { available: false }),
+        available: acc.optimumIntel?.available ?? false,
+        version: value || undefined,
+      };
+    },
+    optimum_intel_error: (value) => {
+      acc.optimumIntel = { available: false, detail: value || "optimum.intel import failed" };
+    },
+    error: (value) => {
+      acc.detail = value || "OpenVINO probe failed";
+    },
+  };
+
+  for (const line of out.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed.startsWith(OV_MARK)) continue;
+    const payload = trimmed.slice(OV_MARK.length);
+    const idx = payload.indexOf("=");
+    if (idx < 0) continue;
+    const key = payload.slice(0, idx);
+    const value = payload.slice(idx + 1).trim();
+    handlers[key]?.(value);
+  }
+
+  return acc;
+}
+
+/**
+ * Probes a Python environment for the OpenVINO runtime, available devices, and
+ * the Optimum-Intel bridge.
+ *
+ * @param python - Path to the Python interpreter to probe
+ * @returns Availability, version, device list, and Optimum-Intel status
+ */
+export async function probeOpenVino(python: string): Promise<OpenVinoProbeResult> {
   try {
-    const { stdout, stderr } = await execFileAsync(python, ["-c", script]);
-    const out = `${stdout}\n${stderr}`;
-    for (const line of out.split(/\r?\n/)) {
-      const trimmed = line.trim();
-      if (!trimmed.startsWith(OV_MARK)) continue;
-      const payload = trimmed.slice(OV_MARK.length);
-      const idx = payload.indexOf("=");
-      if (idx < 0) continue;
-      const key = payload.slice(0, idx);
-      const value = payload.slice(idx + 1).trim();
-      switch (key) {
-        case "version":
-          version = value || undefined;
-          break;
-        case "devices":
-          devices = value ? value.split(",").filter(Boolean) : [];
-          break;
-        case "optimum_intel_available":
-          optimumIntel = { available: true, ...(optimumIntel?.version ? { version: optimumIntel.version } : {}) };
-          break;
-        case "optimum_intel_version":
-          optimumIntel = { ...(optimumIntel ?? { available: false }), available: optimumIntel?.available ?? false, version: value || undefined };
-          break;
-        case "optimum_intel_error":
-          optimumIntel = { available: false, detail: value || "optimum.intel import failed" };
-          break;
-        case "error":
-          detail = value || "OpenVINO probe failed";
-          break;
-      }
-    }
+    const { stdout, stderr } = await execFileAsync(python, ["-c", buildProbeScript()]);
+    const acc = parseProbeOutput(`${stdout}\n${stderr}`);
+    const available = Boolean(acc.version) && Boolean(acc.optimumIntel?.available);
+    return {
+      available,
+      version: acc.version,
+      devices: acc.devices,
+      optimumIntel: acc.optimumIntel,
+      detail: available ? undefined : (acc.detail ?? "OpenVINO stack not available"),
+    };
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : String(err);
     if (/No module named ['"]openvino['"]/i.test(message)) {
       return { available: false, detail: "openvino is not installed in .venv" };
     }
-    detail = message;
+    return { available: false, detail: message };
   }
-
-  const available = Boolean(version) && Boolean(optimumIntel?.available);
-  return {
-    available,
-    version,
-    devices,
-    optimumIntel,
-    detail: available ? undefined : (detail ?? "OpenVINO stack not available"),
-  };
 }
 
 async function pipInstall(pip: string, args: string[], onLine: (line: string) => void): Promise<void> {
@@ -139,9 +159,10 @@ export async function ensureOpenVino(
   const venvPython = getVenvPython();
   const pip = getVenvPip();
   if (!fs.existsSync(venvPython) || !fs.existsSync(pip)) {
+    const missing = !fs.existsSync(pip) ? "pip" : "python";
     return {
       ok: false,
-      error: `Project .venv is incomplete (missing ${!fs.existsSync(pip) ? "pip" : "python"}). Use Setup runtime, then retry.`,
+      error: `Project .venv is incomplete (missing ${missing}). Use Setup runtime, then retry.`,
     };
   }
 

--- a/src/server/services/olive/openvino.ts
+++ b/src/server/services/olive/openvino.ts
@@ -76,6 +76,7 @@ function parseProbeOutput(out: string): ProbeAccumulator {
     },
     optimum_intel_error: (value) => {
       acc.optimumIntel = { available: false, detail: value || "optimum.intel import failed" };
+      if (!acc.detail) acc.detail = value || "optimum.intel import failed";
     },
     error: (value) => {
       acc.detail = value || "OpenVINO probe failed";

--- a/src/server/services/olive/openvino.ts
+++ b/src/server/services/olive/openvino.ts
@@ -1,0 +1,177 @@
+/**
+ * OpenVINO probe, install, and dependency helpers.
+ *
+ * Mirrors the TensorRT / TensorRT RTX flow: ensure .venv, probe the OpenVINO
+ * runtime + Optimum-Intel bridge, pip install the stack if missing, then re-probe.
+ */
+import { spawn } from "child_process";
+import fs from "fs";
+
+import { execFileAsync } from "../shared/exec.ts";
+import { ensureVenv } from "../venv/index.ts";
+import { getVenvPython, getVenvPip } from "../venv/paths.ts";
+import {
+  openvinoStackInstallArgs,
+  openvinoStackLabel,
+} from "../../../lib/openvinoDeps.ts";
+import type { OpenVinoProbeResult } from "../../../lib/hardwareProbe.ts";
+
+const OV_MARK = "OLIVE_OV:";
+
+/**
+ * Probes a Python environment for the OpenVINO runtime, available devices, and
+ * the Optimum-Intel bridge.
+ *
+ * @param python - Path to the Python interpreter to probe
+ * @returns Availability, version, device list, and Optimum-Intel status
+ */
+export async function probeOpenVino(python: string): Promise<OpenVinoProbeResult> {
+  const script = `
+import sys
+
+def emit(key, value):
+    print(${JSON.stringify(OV_MARK)} + key + "=" + str(value).replace(chr(10), " "))
+
+try:
+    import openvino
+    emit("version", openvino.__version__)
+    from openvino import Core
+    devices = Core().available_devices
+    emit("devices", ",".join(devices))
+except Exception as exc:
+    emit("error", str(exc).replace(chr(10), " "))
+
+try:
+    import optimum.intel
+    emit("optimum_intel_available", "1")
+    emit("optimum_intel_version", getattr(optimum.intel, "__version__", "unknown"))
+except Exception as exc:
+    emit("optimum_intel_error", str(exc).replace(chr(10), " "))
+`.trim();
+
+  let version: string | undefined;
+  let devices: string[] | undefined;
+  let optimumIntel: OpenVinoProbeResult["optimumIntel"] | undefined;
+  let detail: string | undefined;
+
+  try {
+    const { stdout, stderr } = await execFileAsync(python, ["-c", script]);
+    const out = `${stdout}\n${stderr}`;
+    for (const line of out.split(/\r?\n/)) {
+      const trimmed = line.trim();
+      if (!trimmed.startsWith(OV_MARK)) continue;
+      const payload = trimmed.slice(OV_MARK.length);
+      const idx = payload.indexOf("=");
+      if (idx < 0) continue;
+      const key = payload.slice(0, idx);
+      const value = payload.slice(idx + 1).trim();
+      switch (key) {
+        case "version":
+          version = value || undefined;
+          break;
+        case "devices":
+          devices = value ? value.split(",").filter(Boolean) : [];
+          break;
+        case "optimum_intel_available":
+          optimumIntel = { available: true, ...(optimumIntel?.version ? { version: optimumIntel.version } : {}) };
+          break;
+        case "optimum_intel_version":
+          optimumIntel = { ...(optimumIntel ?? { available: false }), available: optimumIntel?.available ?? false, version: value || undefined };
+          break;
+        case "optimum_intel_error":
+          optimumIntel = { available: false, detail: value || "optimum.intel import failed" };
+          break;
+        case "error":
+          detail = value || "OpenVINO probe failed";
+          break;
+      }
+    }
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    if (/No module named ['"]openvino['"]/i.test(message)) {
+      return { available: false, detail: "openvino is not installed in .venv" };
+    }
+    detail = message;
+  }
+
+  const available = Boolean(version) && Boolean(optimumIntel?.available);
+  return {
+    available,
+    version,
+    devices,
+    optimumIntel,
+    detail: available ? undefined : (detail ?? "OpenVINO stack not available"),
+  };
+}
+
+async function pipInstall(pip: string, args: string[], onLine: (line: string) => void): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const proc = spawn(pip, ["install", ...args], { stdio: "pipe" });
+    proc.stdout.on("data", (d: Buffer) => onLine("[deps] " + d.toString().trim()));
+    proc.stderr.on("data", (d: Buffer) => onLine("[deps] " + d.toString().trim()));
+    proc.on("error", (err: Error) =>
+      reject(new Error(`Failed to launch ${pip}: ${err.message}. Create the project .venv via Setup runtime first.`)),
+    );
+    proc.on("close", (code: number | null) =>
+      code === 0 ? resolve() : reject(new Error(`pip install ${args.join(" ")} failed (exit ${code})`)),
+    );
+  });
+}
+
+/**
+ * Ensures the project virtual environment contains a loadable OpenVINO stack
+ * (openvino + optimum-intel[openvino]) and reports available devices.
+ *
+ * @param onLine - Receives progress messages during environment preparation and installation.
+ * @returns Success flag and the probe result when available.
+ */
+export async function ensureOpenVino(
+  onLine: (line: string) => void,
+): Promise<{ ok: boolean; error?: string; probe?: OpenVinoProbeResult }> {
+  const venvResult = await ensureVenv(onLine);
+  if (!venvResult.ok) {
+    return {
+      ok: false,
+      error: venvResult.error ?? "Failed to create or prepare the project .venv",
+    };
+  }
+
+  const venvPython = getVenvPython();
+  const pip = getVenvPip();
+  if (!fs.existsSync(venvPython) || !fs.existsSync(pip)) {
+    return {
+      ok: false,
+      error: `Project .venv is incomplete (missing ${!fs.existsSync(pip) ? "pip" : "python"}). Use Setup runtime, then retry.`,
+    };
+  }
+
+  const probe = await probeOpenVino(venvPython);
+  if (probe.available) {
+    const deviceMsg = probe.devices?.length ? ` [${probe.devices.join(", ")}]` : "";
+    onLine(`[deps] OpenVINO stack verified${probe.version ? ` (${probe.version})` : ""}${deviceMsg} ✓`);
+    return { ok: true, probe };
+  }
+
+  if (!probe.version) {
+    onLine(`[deps] Installing ${openvinoStackLabel()} for OpenVINO EP (may take a few minutes)...`);
+  } else if (!probe.optimumIntel?.available) {
+    onLine(`[deps] OpenVINO present but Optimum-Intel bridge missing — installing ${openvinoStackLabel()}...`);
+  } else {
+    onLine(`[deps] OpenVINO stack present but not loadable — reinstalling ${openvinoStackLabel()}...`);
+  }
+
+  await pipInstall(pip, openvinoStackInstallArgs(), onLine);
+  onLine(`[deps] ${openvinoStackLabel()} installed ✓`);
+
+  const retry = await probeOpenVino(venvPython);
+  if (retry.available) {
+    const deviceMsg = retry.devices?.length ? ` [${retry.devices.join(", ")}]` : "";
+    onLine(`[deps] OpenVINO stack verified after install${retry.version ? ` (${retry.version})` : ""}${deviceMsg} ✓`);
+    return { ok: true, probe: retry };
+  }
+
+  return {
+    ok: false,
+    error: retry.detail ?? "OpenVINO stack not loadable after install",
+  };
+}

--- a/src/server/services/olive/openvino.ts
+++ b/src/server/services/olive/openvino.ts
@@ -254,11 +254,30 @@ export async function ensureOpenVino(
     onLine(`[deps] OpenVINO stack present but not loadable — reinstalling ${openvinoStackLabel()}...`);
   }
 
+  const needsOrtSwap = !probe.openvinoExecutionProvider;
   onLine(
-    `[deps] Warning: onnxruntime-openvino replaces other ORT wheels in this .venv (${OPENVINO_CONFLICTING_ORT_PACKAGES.join(", ")}). CUDA/TensorRT EPs will be unavailable until you reinstall onnxruntime-gpu.`,
+    needsOrtSwap
+      ? `[deps] Warning: onnxruntime-openvino replaces other ORT wheels in this .venv (${OPENVINO_CONFLICTING_ORT_PACKAGES.join(", ")}). CUDA/TensorRT EPs will be unavailable until you reinstall onnxruntime-gpu.`
+      : `[deps] Installing remaining OpenVINO packages without swapping ORT wheels (OpenVINOExecutionProvider already present).`,
   );
-  await pipUninstall(pip, OPENVINO_CONFLICTING_ORT_PACKAGES, onLine);
-  await pipInstall(pip, openvinoStackInstallArgs(), onLine);
+
+  let didOrtSwap = false;
+  if (needsOrtSwap) {
+    await pipUninstall(pip, OPENVINO_CONFLICTING_ORT_PACKAGES, onLine);
+    didOrtSwap = true;
+  }
+
+  try {
+    await pipInstall(pip, openvinoStackInstallArgs(), onLine);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return {
+      ok: false,
+      error: didOrtSwap
+        ? `${msg}. Conflicting ORT wheels were removed for onnxruntime-openvino; reinstall onnxruntime-gpu if you need CUDA/TensorRT again.`
+        : msg,
+    };
+  }
   onLine(`[deps] ${openvinoStackLabel()} installed ✓`);
 
   const retry = await probeOpenVino(venvPython);

--- a/src/server/services/olive/openvino.ts
+++ b/src/server/services/olive/openvino.ts
@@ -119,7 +119,7 @@ export async function probeOpenVino(python: string): Promise<OpenVinoProbeResult
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : String(err);
     if (/No module named ['"]openvino['"]/i.test(message)) {
-      return { available: false, detail: "openvino is not installed in .venv" };
+      return { available: false, detail: "openvino is not installed in this Python environment" };
     }
     return { available: false, detail: message };
   }

--- a/src/server/services/olive/recipe.ts
+++ b/src/server/services/olive/recipe.ts
@@ -122,10 +122,15 @@ export function inferRequiredPackages(recipe: OliveRecipe, cudaTag: string): Pkg
     }
   }
 
-  // OpenVINO runtime + Optimum-Intel bridge (single install action)
+  // OpenVINO runtime + Optimum-Intel bridge
   if (passTypes.some((t) => t.includes("OpenVINO"))) {
     pkgs.push({
       importName: "openvino",
+      installArgs: openvinoStackInstallArgs(),
+      label: openvinoStackLabel(),
+    });
+    pkgs.push({
+      importName: "optimum.intel",
       installArgs: openvinoStackInstallArgs(),
       label: openvinoStackLabel(),
     });

--- a/src/server/services/olive/recipe.ts
+++ b/src/server/services/olive/recipe.ts
@@ -99,31 +99,41 @@ export function inferRequiredPackages(recipe: OliveRecipe, cudaTag: string): Pkg
         },
   );
 
-  // ONNX Runtime — pin CUDA 12 build via resolveCudaTag
-  if (passTypes.some((t) => t.includes("Onnx") || t.includes("ORT") || t.includes("Transformers"))) {
-    pkgs.push(
-      isGpu && resolved
-        ? {
-            importName: "onnxruntime",
-            installArgs: resolved.ortInstallArgs,
-            label: resolved.ortLabel,
-          }
-        : {
-            importName: "onnxruntime",
-            installArgs: ["onnxruntime"],
-            label: "onnxruntime",
-          },
-    );
+  const wantsOpenVinoEp =
+    getRecipeIhvProvider(recipe) === "OpenVINOExecutionProvider" ||
+    passTypes.some((t) => t.includes("OpenVINO"));
+
+  // ONNX Runtime — OpenVINO EP needs onnxruntime-openvino (not the CUDA wheel).
+  if (passTypes.some((t) => t.includes("Onnx") || t.includes("ORT") || t.includes("Transformers")) || wantsOpenVinoEp) {
+    if (wantsOpenVinoEp) {
+      pkgs.push({
+        importName: "onnxruntime",
+        installArgs: openvinoStackInstallArgs(),
+        label: openvinoStackLabel(),
+      });
+    } else if (isGpu && resolved) {
+      pkgs.push({
+        importName: "onnxruntime",
+        installArgs: resolved.ortInstallArgs,
+        label: resolved.ortLabel,
+      });
+    } else {
+      pkgs.push({
+        importName: "onnxruntime",
+        installArgs: ["onnxruntime"],
+        label: "onnxruntime",
+      });
+    }
   }
 
-  if (isGpu && resolved) {
+  if (isGpu && resolved && !wantsOpenVinoEp) {
     for (const pkg of resolved.runtimePackages) {
       pkgs.push(pkg);
     }
   }
 
-  // OpenVINO runtime + Optimum-Intel bridge
-  if (passTypes.some((t) => t.includes("OpenVINO"))) {
+  // OpenVINO runtime + Optimum-Intel bridge (+ ORT OpenVINO EP via stack args)
+  if (wantsOpenVinoEp) {
     pkgs.push({
       importName: "openvino",
       installArgs: openvinoStackInstallArgs(),

--- a/src/server/services/olive/recipe.ts
+++ b/src/server/services/olive/recipe.ts
@@ -6,6 +6,7 @@ import type { IHVProvider } from "../../../types.ts";
 import { recipeUsesMemoryOffload } from "../../../lib/memoryOffload.ts";
 import { resolveCudaTag, RESOLVABLE_CUDA_TAGS } from "../../../lib/oliveGpuRuntime.ts";
 import { tensorrtRtxInstallArgs, tensorrtRtxLabel } from "../../../lib/tensorrtRtxDeps.ts";
+import { openvinoStackInstallArgs, openvinoStackLabel } from "../../../lib/openvinoDeps.ts";
 
 /** Olive recipe shape (subset needed for inference). */
 export interface OliveRecipe {
@@ -121,17 +122,12 @@ export function inferRequiredPackages(recipe: OliveRecipe, cudaTag: string): Pkg
     }
   }
 
-  // OpenVINO
+  // OpenVINO runtime + Optimum-Intel bridge (single install action)
   if (passTypes.some((t) => t.includes("OpenVINO"))) {
     pkgs.push({
       importName: "openvino",
-      installArgs: ["openvino"],
-      label: "openvino",
-    });
-    pkgs.push({
-      importName: "optimum",
-      installArgs: ["optimum[openvino]"],
-      label: "optimum[openvino]",
+      installArgs: openvinoStackInstallArgs(),
+      label: openvinoStackLabel(),
     });
   }
 

--- a/src/server/services/olive/tensorrt-rtx.ts
+++ b/src/server/services/olive/tensorrt-rtx.ts
@@ -17,10 +17,10 @@
  *
  * For classic TensorRT (datacenter), see `tensorrt.ts`.
  */
-import { spawn } from "child_process";
 import fs from "fs";
 
 import { execFileAsync } from "../shared/exec.ts";
+import { pipInstall } from "../shared/pipInstall.ts";
 import { ensureVenv } from "../venv/index.ts";
 import { getVenvPython, getVenvPip } from "../venv/paths.ts";
 import {
@@ -30,13 +30,7 @@ import {
   tensorrtRtxInstallArgs,
   tensorrtRtxLabel,
 } from "../../../lib/tensorrtRtxDeps.ts";
-import {
-  ORT_GPU_PROBE_SCRIPT,
-  parseOrtGpuProbe,
-  pinnedOrtGpuInstallArgs,
-  pinnedOrtGpuLabel,
-  PINNED_ORT_GPU_VERSION,
-} from "../../../lib/oliveGpuRuntime.ts";
+import { ensureOnnxRuntimeGpu } from "./cuda.ts";
 
 /**
  * Retrieves the installed TensorRT RTX package version.
@@ -108,7 +102,18 @@ def _register_rtx_ep():
     except Exception as exc:
         return None
     pkg_dir = os.path.dirname(_plug.__file__)
-    dll = os.path.join(pkg_dir, "onnxruntime_providers_nv_tensorrt_rtx.dll")
+    # Pick the platform-appropriate extension: .dll on Windows, .so on
+    # Linux, .dylib on macOS. A hardcoded ".dll" hides the real reason
+    # an import fails on Linux/macOS.
+    import sys
+    if sys.platform == "win32":
+        _ext = ".dll"
+        _libname = "onnxruntime_providers_nv_tensorrt_rtx" + _ext
+    elif sys.platform == "darwin":
+        _libname = "libonnxruntime_providers_nv_tensorrt_rtx.dylib"
+    else:
+        _libname = "libonnxruntime_providers_nv_tensorrt_rtx.so"
+    dll = os.path.join(pkg_dir, _libname)
     if not os.path.isfile(dll):
         return None
     try:
@@ -173,56 +178,14 @@ print("ok:" + tensorrt_rtx.__version__)
   }
 }
 
-/**
- * Installs Python packages with pip and reports process output line by line.
- *
- * @param pip - Path to the pip executable
- * @param args - Arguments specifying the packages and installation options
- * @param onLine - Callback for each captured output line
- * @throws If pip cannot be launched or the installation exits unsuccessfully
- */
-async function pipInstall(pip: string, args: string[], onLine: (line: string) => void): Promise<void> {
-  await new Promise<void>((resolve, reject) => {
-    const proc = spawn(pip, ["install", ...args], { stdio: "pipe" });
-    proc.stdout.on("data", (d: Buffer) => onLine("[deps] " + d.toString().trim()));
-    proc.stderr.on("data", (d: Buffer) => onLine("[deps] " + d.toString().trim()));
-    proc.on("error", (err: Error) =>
-      reject(
-        new Error(
-          `Failed to launch ${pip}: ${err.message}. Create the project .venv via Setup runtime first.`,
-        ),
-      ),
-    );
-    proc.on("close", (code: number | null) =>
-      code === 0 ? resolve() : reject(new Error(`pip install ${args.join(" ")} failed (exit ${code})`)),
-    );
-  });
-}
-
-async function ensureOnnxRuntimeGpu(
-  python: string,
-  pip: string,
-  onLine: (line: string) => void,
-): Promise<void> {
-  try {
-    const { stdout } = await execFileAsync(python, ["-c", ORT_GPU_PROBE_SCRIPT]);
-    const probe = parseOrtGpuProbe(stdout);
-    if (probe.ok) {
-      onLine("[deps] onnxruntime-gpu already installed ✓");
-      return;
-    }
-    if (probe.distVersion || probe.ortVersion) {
-      onLine(
-        `[deps] onnxruntime-gpu ${probe.distVersion ?? probe.ortVersion} installed — need ${PINNED_ORT_GPU_VERSION}, reinstalling...`,
-      );
-    }
-  } catch {
-    /* install below */
-  }
-  onLine(`[deps] Installing ${pinnedOrtGpuLabel()} (required to detect TensorRT RTX)...`);
-  await pipInstall(pip, pinnedOrtGpuInstallArgs(), onLine);
-  onLine(`[deps] ${pinnedOrtGpuLabel()} installed ✓`);
-}
+// `pipInstall` is imported from `../shared/pipInstall.ts` so the same
+// NDJSON line shape + error contract is used by every install route.
+// The local copy was deleted when this was extracted.
+//
+// `ensureOnnxRuntimeGpu` is imported from `./cuda.ts` so the RTX and
+// CUDA paths share one probe-then-install-retry loop; the previous
+// private copy in this file was drifting in subtle ways from the
+// CUDA path's version.
 
 /**
  * Installs the NVIDIA standalone TensorRT-RTX EP-ABI plugin (CUDA-13) from
@@ -265,7 +228,14 @@ export async function ensureTensorRtRtx(
     };
   }
 
-  await ensureOnnxRuntimeGpu(venvPython, pip, onLine);
+  // Reuse the shared CUDA install helper — it probes
+  // `onnxRuntimeProviders` and, on mismatch, pip-installs the pinned
+  // wheel into the same .venv. The .venv-prep work above is idempotent
+  // and fast on a warm venv.
+  const ortGpu = await ensureOnnxRuntimeGpu(onLine);
+  if (!ortGpu.ok) {
+    return { ok: false, error: ortGpu.error };
+  }
 
   const probe = await probeTensorRtRtxLoadable(venvPython);
   if (probe.loadable) {

--- a/src/server/services/olive/tensorrt-rtx.ts
+++ b/src/server/services/olive/tensorrt-rtx.ts
@@ -4,6 +4,17 @@
  * probeTensorRtRtxLoadable and ensureTensorRtRtx cover the RTX path for
  * consumer GPUs that use NvTensorRTRTXExecutionProvider.
  *
+ * Two packages must be present in the venv for the EP to be detectable:
+ *
+ *   1. `tensorrt-rtx` (PyPI) — must match the runtime ABI indirectly, but
+ *      by itself does NOT register the EP with ONNX Runtime.
+ *   2. `onnxruntime-ep-nv-tensorrt-rtx-cu13` 0.3.0 (NVIDIA PyPI index) —
+ *      ships the ORT op-library DLL that exports `CreateEpFactories` and
+ *      `tensorrt_rtx_*` runtime libs. Calling
+ *      `onnxruntime.register_execution_provider_library` against this
+ *      DLL is what causes `NvTensorRTRTXExecutionProvider` to appear in
+ *      `onnxruntime.get_available_providers()`.
+ *
  * For classic TensorRT (datacenter), see `tensorrt.ts`.
  */
 import { spawn } from "child_process";
@@ -12,7 +23,13 @@ import fs from "fs";
 import { execFileAsync } from "../shared/exec.ts";
 import { ensureVenv } from "../venv/index.ts";
 import { getVenvPython, getVenvPip } from "../venv/paths.ts";
-import { tensorrtRtxInstallArgs, tensorrtRtxLabel } from "../../../lib/tensorrtRtxDeps.ts";
+import {
+  tensorrtRtxEpAbiInstallArgs,
+  tensorrtRtxEpAbiInstallCommand,
+  tensorrtRtxEpAbiLabel,
+  tensorrtRtxInstallArgs,
+  tensorrtRtxLabel,
+} from "../../../lib/tensorrtRtxDeps.ts";
 import {
   ORT_GPU_PROBE_SCRIPT,
   parseOrtGpuProbe,
@@ -55,19 +72,64 @@ export async function getTensorRtRtxLibsDir(python: string): Promise<string | nu
 /**
  * Checks whether TensorRT RTX loads successfully and provides the required ONNX Runtime execution provider.
  *
+ * Steps: import the NVIDIA EP-ABI plugin package (if installed), register
+ * `NvTensorRTRTXExecutionProvider` against the bundled op-library DLL, then
+ * check `onnxruntime.get_available_providers()`. If either the ABI package
+ * is missing or the registration fails, the probe falls through to a
+ * descriptive failure detail so the install path can act.
+ *
  * @param python - Path to the Python interpreter to probe
  * @returns The load status, with the detected version when successful or an error detail when unsuccessful
  */
 export async function probeTensorRtRtxLoadable(
   python: string,
 ): Promise<{ loadable: boolean; detail?: string; version?: string }> {
+  // Self-diagnostics: every failure case ends in `fail:<detail>` so the
+  // outer catch can keep treating missing modules uniformly. We deliberately
+  // check ABI-plugin presence BEFORE importing onnxruntime so a missing
+  // plugin reports a clean "plugin not installed" message instead of a
+  // ForeignFunction failure deep in ORT's symbol-resolution path.
   const probeScript = `
-import tensorrt_rtx
-import onnxruntime as ort
+import os, sys
+try:
+    import tensorrt_rtx
+except Exception as exc:
+    print("fail:tensorrt_rtx is not installed in .venv")
+    sys.exit(0)
+try:
+    import onnxruntime as ort
+except Exception as exc:
+    print("fail:onnxruntime is not installed in .venv (required for TensorRT RTX detection)")
+    sys.exit(0)
+
+def _register_rtx_ep():
+    try:
+        import onnxruntime_ep_nv_tensorrt_rtx as _plug
+    except Exception as exc:
+        return None
+    pkg_dir = os.path.dirname(_plug.__file__)
+    dll = os.path.join(pkg_dir, "onnxruntime_providers_nv_tensorrt_rtx.dll")
+    if not os.path.isfile(dll):
+        return None
+    try:
+        ort.register_execution_provider_library("NvTensorRTRTXExecutionProvider", dll)
+        return dll
+    except Exception as exc:
+        return exc
+
+_dll_or_err = _register_rtx_ep()
+if _dll_or_err is None:
+    print("fail:onnxruntime-ep-nv-tensorrt-rtx-cu13 is not installed in .venv (NvTensorRTRTXExecutionProvider requires its ORT op-library)")
+    sys.exit(0)
+if isinstance(_dll_or_err, Exception):
+    print("fail:TensorRT RTX op-library failed to register with onnxruntime: " + str(_dll_or_err).split(chr(10))[0][:200])
+    sys.exit(0)
+
 if "NvTensorRTRTXExecutionProvider" not in ort.get_available_providers():
-    print("fail:NvTensorRTRTXExecutionProvider missing from onnxruntime-gpu")
-else:
-    print("ok:" + tensorrt_rtx.__version__)
+    print("fail:NvTensorRTRTXExecutionProvider not exposed by onnxruntime after plugin registration")
+    sys.exit(0)
+
+print("ok:" + tensorrt_rtx.__version__)
 `.trim();
   try {
     const { stdout } = await execFileAsync(python, ["-c", probeScript]);
@@ -163,6 +225,21 @@ async function ensureOnnxRuntimeGpu(
 }
 
 /**
+ * Installs the NVIDIA standalone TensorRT-RTX EP-ABI plugin (CUDA-13) from
+ * NVIDIA's PyPI index. This is the package that ships the ORT op-library
+ * DLL (`onnxruntime_providers_nv_tensorrt_rtx.dll`) which registers the
+ * `NvTensorRTRTXExecutionProvider` symbol with onnxruntime.
+ */
+async function ensureTensorRtRtxEpAbi(
+  pip: string,
+  onLine: (line: string) => void,
+): Promise<void> {
+  onLine(`[deps] Installing ${tensorrtRtxEpAbiLabel()} (NVIDIA EP-ABI plugin)...`);
+  await pipInstall(pip, tensorrtRtxEpAbiInstallArgs(), onLine);
+  onLine(`[deps] ${tensorrtRtxEpAbiLabel()} installed ✓`);
+}
+
+/**
  * Ensures the project virtual environment contains a loadable TensorRT RTX runtime.
  *
  * @param onLine - Receives progress messages during environment preparation and installation.
@@ -201,13 +278,31 @@ export async function ensureTensorRtRtx(
 
   const installed = await getInstalledTensorRtRtxVersion(venvPython);
   if (!installed) {
-    onLine(`[deps] Installing ${tensorrtRtxLabel()} for TensorRT RTX EP (may take a few minutes)...`);
+    onLine(`[deps] Installing ${tensorrtRtxLabel()} for TensorRT RTX runtime (may take a few minutes)...`);
+    await pipInstall(pip, tensorrtRtxInstallArgs(), onLine);
+    onLine(`[deps] ${tensorrtRtxLabel()} installed ✓`);
   } else {
-    onLine(`[deps] ${tensorrtRtxLabel()} present but runtime not loadable — reinstalling...`);
+    onLine(
+      `[deps] ${tensorrtRtxLabel()} present but EP not loaded by onnxruntime — installing NVIDIA EP-ABI plugin...`,
+    );
   }
 
-  await pipInstall(pip, tensorrtRtxInstallArgs(), onLine);
-  onLine(`[deps] ${tensorrtRtxLabel()} installed ✓`);
+  // Always run the EP-ABI install when the probe failed. pip reinstalls
+  // an already-present package as a no-op "already satisfied" — so this
+  // stays cheap when both `tensorrt-rtx` AND the ABI plugin were already
+  // present, but it also catches the case where the ABI plugin is missing
+  // regardless of the specific failure message from `probeTensorRtRtxLoadable`.
+  try {
+    await ensureTensorRtRtxEpAbi(pip, onLine);
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return {
+      ok: false,
+      error:
+        `${tensorrtRtxEpAbiLabel()} install failed: ${msg}. ` +
+        `Install it manually with: ${tensorrtRtxEpAbiInstallCommand()}`,
+    };
+  }
 
   const retry = await probeTensorRtRtxLoadable(venvPython);
   if (retry.loadable) {
@@ -220,6 +315,8 @@ export async function ensureTensorRtRtx(
 
   return {
     ok: false,
-    error: retry.detail ?? "TensorRT RTX not loadable after install",
+    error:
+      retry.detail ??
+      `TensorRT RTX not loadable after installing ${tensorrtRtxLabel()} + ${tensorrtRtxEpAbiLabel()}`,
   };
 }

--- a/src/server/services/olive/tensorrt.ts
+++ b/src/server/services/olive/tensorrt.ts
@@ -27,6 +27,10 @@ import {
   pinnedOrtGpuLabel,
   PINNED_ORT_GPU_VERSION,
 } from "../../../lib/oliveGpuRuntime.ts";
+import {
+  tensorrtRtxEpAbiInstallArgs,
+  tensorrtRtxEpAbiLabel,
+} from "../../../lib/tensorrtRtxDeps.ts";
 import { probeTensorRtRtxLoadable } from "./tensorrt-rtx.ts";
 import type { PkgDef } from "./recipe.ts";
 
@@ -356,6 +360,30 @@ export async function ensureDeps(
         onLine(`[deps] ${pkg.label} already installed (${probe.version ?? "ok"}) ✓`);
         continue;
       }
+      // The PyPI `tensorrt-rtx` package alone does NOT make
+      // `NvTensorRTRTXExecutionProvider` appear in
+      // `onnxruntime.get_available_providers()`. The NVIDIA
+      // `onnxruntime-ep-nv-tensorrt-rtx-cu13` plugin package on NVIDIA's
+      // PyPI index ships the ORT op-library DLL that actually registers
+      // the EP. Install it inline so recipes requiring tensorrt_rtx also
+      // get a working EP at runtime, not just a Python module.
+      onLine(
+        `[deps] ${pkg.label} present but EP not loaded by onnxruntime — installing ${tensorrtRtxEpAbiLabel()}...`,
+      );
+      await pipInstall(pip, tensorrtRtxEpAbiInstallArgs(), onLine);
+      const rtProbe = await probeTensorRtRtxLoadable(venvPython);
+      if (rtProbe.loadable) {
+        onLine(`[deps] ${tensorrtRtxEpAbiLabel()} installed — TensorRT RTX EP loadable ✓`);
+        continue;
+      }
+      // ABI plugin installed but the EP still didn't register (driver
+      // mismatch, transform/version mismatch in ORT ABI, etc.). Surface
+      // the detail so the user can diagnose; the surrounding loop will
+      // still install the PyPI `tensorrt-rtx` package below for the
+      // recipe's `import tensorrt_rtx` use case.
+      onLine(
+        `[deps] ${tensorrtRtxEpAbiLabel()} installed but EP still not loadable — ${rtProbe.detail ?? "unknown reason"}`,
+      );
     } else if (pkg.importName.startsWith("nvidia.")) {
       try {
         await execFileAsync(venvPython, [

--- a/src/server/services/olive/tensorrt.ts
+++ b/src/server/services/olive/tensorrt.ts
@@ -5,11 +5,11 @@
  * install-on-demand via ensureTensorRt matches the TensorRT RTX flow.
  * RTX-specific path is in tensorrt-rtx.ts.
  */
-import { spawn } from "child_process";
 import fs from "fs";
 import path from "path";
 
 import { execFileAsync } from "../shared/exec.ts";
+import { pipInstall } from "../shared/pipInstall.ts";
 import { ensureVenv } from "../venv/index.ts";
 import { getVenvPython, getVenvPip } from "../venv/paths.ts";
 import { getNativeGpuLibPaths } from "../venv/gpu.ts";
@@ -79,30 +79,10 @@ function extractTrtFailDetail(text: string): string | undefined {
   return text.slice(idx + TRT_FAIL_MARK.length).trim() || undefined;
 }
 
-/**
- * Installs packages with pip and reports output through the provided callback.
- *
- * @param pip - The pip executable to run
- * @param args - Arguments passed to `pip install`
- * @param onLine - Callback invoked for each output chunk
- */
-async function pipInstall(pip: string, args: string[], onLine: (line: string) => void): Promise<void> {
-  await new Promise<void>((resolve, reject) => {
-    const proc = spawn(pip, ["install", ...args], { stdio: "pipe" });
-    proc.stdout.on("data", (d: Buffer) => onLine("[deps] " + d.toString().trim()));
-    proc.stderr.on("data", (d: Buffer) => onLine("[deps] " + d.toString().trim()));
-    proc.on("error", (err: Error) =>
-      reject(
-        new Error(
-          `Failed to launch ${pip}: ${err.message}. Create the project .venv via Setup runtime first.`,
-        ),
-      ),
-    );
-    proc.on("close", (code: number | null) =>
-      code === 0 ? resolve() : reject(new Error(`pip install ${args.join(" ")} failed (exit ${code})`)),
-    );
-  });
-}
+// `pipInstall` is imported from `../shared/pipInstall.ts` so all three
+// install routes (this file, `cuda.ts`, `tensorrt-rtx.ts`) share the
+// same NDJSON line shape + error contract. The local copy that lived
+// here was deleted when the helper was extracted.
 
 /**
  * Ensures the pinned ONNX Runtime GPU package is installed for TensorRT execution.
@@ -426,18 +406,8 @@ export async function ensureDeps(
     }
 
     onLine(`[deps] Installing ${pkg.label}...`);
-    await new Promise<void>((resolve, reject) => {
-      const proc = spawn(pip, ["install", ...pkg.installArgs], {
-        stdio: "pipe",
-      });
-      proc.stdout.on("data", (d: Buffer) => onLine("[deps] " + d.toString().trim()));
-      proc.stderr.on("data", (d: Buffer) => onLine("[deps] " + d.toString().trim()));
-      proc.on("error", (err: Error) => reject(new Error(`Failed to launch ${pip}: ${err.message}`)));
-      proc.on("close", (code: number | null) =>
-        code === 0 ? resolve() : reject(new Error(`pip install ${pkg.label} failed (exit ${code})`)),
-      );
-    });
-    onLine(`[deps] ${pkg.label} installed ✓`);
+    await pipInstall(pip, pkg.installArgs, onLine);
+    onLine(`[deps] ${pkg.label} installed`);
   }
 
   return { ok: true };

--- a/src/server/services/shared/pipInstall.ts
+++ b/src/server/services/shared/pipInstall.ts
@@ -1,0 +1,42 @@
+/**
+ * Shared `pip install` helper used by every service that streams install
+ * progress back to the UI as NDJSON (`/api/env/install-*` routes). Keeping
+ * the helper in one place ensures three things stay equal across paths:
+ *
+ *   1. Line prefix — every line is prepended with `[deps]` so the UI
+ *      recognizes the output regardless of which install route produced it.
+ *   2. Error shape — `pip` launch failures and `pip install` exit non-zero
+ *      produce the same `Error` class with the same prefix, so the UI
+ *      can show a uniform error message.
+ *   3. Stdout/stderr handling — both pipes are forwarded so `pip`'s
+ *      progress bars and warnings are visible instead of being swallowed.
+ *
+ * Replaces the per-service copies that lived in `cuda.ts`, `tensorrt.ts`,
+ * and `tensorrt-rtx.ts` before the helper was extracted; behavior is
+ * unchanged.
+ */
+import { spawn } from "child_process";
+
+export async function pipInstall(
+  pip: string,
+  args: string[],
+  onLine: (line: string) => void,
+): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const proc = spawn(pip, ["install", ...args], { stdio: "pipe" });
+    proc.stdout.on("data", (d: Buffer) => onLine("[deps] " + d.toString().trim()));
+    proc.stderr.on("data", (d: Buffer) => onLine("[deps] " + d.toString().trim()));
+    proc.on("error", (err: Error) =>
+      reject(
+        new Error(
+          `Failed to launch ${pip}: ${err.message}. Create the project .venv via Setup runtime first.`,
+        ),
+      ),
+    );
+    proc.on("close", (code: number | null) =>
+      code === 0
+        ? resolve()
+        : reject(new Error(`pip install ${args.join(" ")} failed (exit ${code})`)),
+    );
+  });
+}

--- a/src/server/shared/anyDotVenvDir.ts
+++ b/src/server/shared/anyDotVenvDir.ts
@@ -1,0 +1,13 @@
+/**
+ * Regex matching any `.venv*` directory variant. Both `vite.config.ts`
+ * (which configures the development middleware HMR file watcher) and
+ * `server.ts` (which configures Vite's middleware watch for the same
+ * reason) add this to their chokidar `ignored` list, so the regex must
+ * live in a single place — otherwise a rename/back-up of the venv
+ * reintroduces file-watch noise on whichever side forgot to update.
+ *
+ * Handles `.venv`, `.venv.bak`, `.venv.old`, `.venv-rename`, etc.
+ * Anchored to a path separator on either side (or string start/end)
+ * so it doesn't match unrelated folders such as `notavenv`.
+ */
+export const ANY_DOT_VENV_DIR = /(?:^|[\\/])\.venv(?:[._-][^\\/]+)?(?:[\\/]|$)/;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,16 +5,15 @@ import path from 'path';
 import { defineConfig } from 'vite';
 import { visualizer } from 'rollup-plugin-visualizer';
 import compression from 'vite-plugin-compression';
+import { ANY_DOT_VENV_DIR } from './src/server/shared/anyDotVenvDir';
 
 /**
- * Catch `.venv.bak`, `.venv.old`, `.venv-rename`, etc. in addition to the
- * canonical `.venv`. The plain glob only matches `.venv` as an exact path
- * component, so renaming or backing up the venv directory reintroduces
- * file-watch noise: pip writes inside the renamed folder used to fire
- * reload events. This regex sits alongside the glob in the `ignored` array
- * (chokidar accepts strings, RegExp, and functions mixed in one list).
+ * The shared regex from `src/server/shared/anyDotVenvDir.ts` matches both
+ * here and in `server.ts` so a rename/back-up of the venv directory
+ * (`.venv.bak`, `.venv.old`, `.venv-rename`) is filtered out by both
+ * Vite watchlists in lockstep.
  */
-const ANY_DOT_VENV_DIR = /(?:^|[\\/])\.venv(?:[._-][^\\/]+)?(?:[\\/]|$)/;
+void ANY_DOT_VENV_DIR;
 
 export default defineConfig(() => {
   return {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,6 +6,16 @@ import { defineConfig } from 'vite';
 import { visualizer } from 'rollup-plugin-visualizer';
 import compression from 'vite-plugin-compression';
 
+/**
+ * Catch `.venv.bak`, `.venv.old`, `.venv-rename`, etc. in addition to the
+ * canonical `.venv`. The plain glob only matches `.venv` as an exact path
+ * component, so renaming or backing up the venv directory reintroduces
+ * file-watch noise: pip writes inside the renamed folder used to fire
+ * reload events. This regex sits alongside the glob in the `ignored` array
+ * (chokidar accepts strings, RegExp, and functions mixed in one list).
+ */
+const ANY_DOT_VENV_DIR = /(?:^|[\\/])\.venv(?:[._-][^\\/]+)?(?:[\\/]|$)/;
+
 export default defineConfig(() => {
   return {
     plugins: [
@@ -64,6 +74,7 @@ export default defineConfig(() => {
         : {
             ignored: [
               '**/.venv/**',
+              ANY_DOT_VENV_DIR,
               '**/node_modules/**',
               '**/models/**',
               '**/.cache/**',


### PR DESCRIPTION
## Summary
Adds a single **Install OpenVINO stack** button in the Hardware panel that pip-installs `openvino` and `optimum-intel[openvino]` into the project `.venv`, then re-probes — matching the existing TensorRT NDJSON install flow.

## What changed
- **New `POST /api/env/install-openvino`** (`src/server/routes/env.ts`)
  - Serialized with a dedicated mutex (`withOpenvinoInstallMutex`).
  - Streams NDJSON progress/completion, reusing `streamNdjsonInstall` (now generic over `{ ok, error?, ... }`).
- **New OpenVINO service** (`src/server/services/olive/openvino.ts`)
  - `probeOpenVino(python)` reads `openvino.__version__`, `Core().available_devices`, and `optimum.intel` availability.
  - `ensureOpenVino(onLine)` ensures `.venv` exists, probes, runs `pip install --upgrade-strategy eager openvino "optimum-intel[openvino]"`, and re-probes.
- **Hardware probe integration** (`src/server/routes/system.ts`)
  - `SystemProbeOptions` now accepts `probeOpenVino` (injected from `server.ts`).
  - `HardwareProbeResult.openvino` now carries `version`, `devices`, `optimumIntel`, and `detail`.
  - `mergeDetectedProviders` / `pickRecommendedProvider` treat OpenVINO as detected when compatible hardware is present, and recommended only when the stack actually loads.
- **UI** (`src/components/features/IHVIntegrationPanel.tsx`)
  - Adds `openvinoNeedsInstall` badge and an inline **Install OpenVINO stack into .venv** button with logs/error affordances, paralleling the TensorRT cards.
  - When OpenVINO is available but only `CPU` is reported, shows driver-doc links for Intel GPU/NPU.
- **Recipe inference** (`src/server/services/olive/recipe.ts`)
  - OpenVINO pass recipes now request the single `openvino + optimum-intel[openvino]` install args.
- **Metadata** (`src/lib/openvinoDeps.ts`)
  - Centralizes install args/labels and Intel driver documentation URLs.
- **Tests**
  - Added `src/lib/openvinoDeps.test.ts` covering install args and labeling.

## Verification
- `pnpm lint` passes (only pre-existing warnings remain).
- `pnpm build` succeeds for both Vite client and esbuild server bundles.
- `pnpm test:server` passes all server tests except one pre-existing `arenaOliveOutputs.test.ts` temp-dir teardown flake.
- `pnpm test` runs 611 unit tests; two jsdom/undici worker-start errors are unrelated to this change (existing Node 24/jsdom compatibility).
- Targeted `vitest run src/lib/openvinoDeps.test.ts src/lib/hardwareProbe.test.ts` passes.

## Notes / open follow-up
- OpenVINO is intentionally **not pinned** unless Optimum/Olive break on a yearly release, since OpenVINO rarely needs the hard nvinfer-style pin TensorRT requires.
- GPU/NPU driver installation is out-of-band; the UI only links to Intel docs.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tonythethompson/Olive-Studio/pull/108?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

