### PR TITLE
feat: QNN 2.x plugin EP parity (.venvs/qnn)

### DIFF
--- a/docs/hardware/qnn.md
+++ b/docs/hardware/qnn.md
@@ -1,0 +1,45 @@
+# Qualcomm QNN execution provider (plugin 2.x)
+
+Olive Studio isolates QNN in `.venvs/qnn` with:
+
+- `onnxruntime==1.26.0` (standard wheel, not DirectML/GPU/OpenVINO)
+- `onnxruntime-qnn==2.4.0` (plugin beside ORT)
+- Tested NumPy pins per CPython minor (3.11–3.13)
+
+`onnxruntime-qnn` is **not** an `OrtDistributionName`. It must not be treated as a conflicting ORT flavor.
+
+## Host modes (Windows-first)
+
+| Host | Mode |
+|------|------|
+| Windows ARM64 Snapdragon | Local QNN NPU **inference** (after NPU EpDevice + release gate) |
+| Windows x64 | Plugin **preparation / AOT** only (not local HTP inference) |
+| Other | Out of Windows-first release scope |
+
+## Capabilities
+
+- **Preparation:** plugin registered and any `QNNExecutionProvider` EpDevice appears
+- **Inference:** Windows ARM64 + `OrtHardwareDeviceType.NPU` (CPU/emulator devices do not count)
+- **Verified “QNN NPU ready”:** Snapdragon release gate + cached fail-closed HTP diagnostic
+
+Until the Snapdragon release gate passes, the UI says **QNN runtime installed** (plus accurate prep/device wording), never **QNN NPU ready**.
+
+## Olive session path
+
+Production registration uses Olive’s native EP library path (`maybe_register_ep_libraries` / plugin import). Studio does **not** ship `sitecustomize` or `InferenceSession` monkeypatches.
+
+## Fail-closed execution
+
+QNN failures do not auto-fallback to DirectML or CPU. Use explicit **Retry with DirectML** or **Retry with CPU**.
+
+## SDK-backed Olive passes
+
+Plugin install alone does **not** enable every Olive QNN pass. Passes that still need `QNN_SDK_ROOT` / QAIRT (for example `QNNConversion`, model libgen, SDK context binaries) stay separately gated. Advanced QAIRT docs:
+
+https://docs.qualcomm.com/bundle/publicresource/topics/80-63442-10/introduction.html
+
+## Install
+
+Hardware panel → QNN → **Install QNN runtime** (`POST /api/env/install-qnn`).
+
+Optional ARM64 diagnostic: **Test QNN NPU** (`POST /api/env/test-qnn-npu`). Cached under `.olive-studio/qnn-htp-diagnostic.json`; never run on every status refresh.

--- a/server.ts
+++ b/server.ts
@@ -15,6 +15,7 @@ import { mountArenaRoutes } from "./src/server/routes/arena.ts";
 import { probeTensorRtLoadable } from "./src/server/services/olive/tensorrt.ts";
 import { probeTensorRtRtxLoadable } from "./src/server/services/olive/tensorrt-rtx.ts";
 import { probeOpenVino } from "./src/server/services/olive/openvino.ts";
+import { probeQnn } from "./src/server/services/olive/qnn.ts";
 import { staticServeRateLimit } from "./src/server/middleware/rateLimit.ts";
 
 // After imports: hydrate .env / .env.local / Windows User+Machine API keys into process.env.
@@ -102,6 +103,7 @@ const systemProbeOpts: SystemProbeOptions = {
   probeTensorRtLoadable,
   probeTensorRtRtxLoadable,
   probeOpenVino,
+  probeQnn,
 };
 mountSystemRoutes(systemRouter, systemProbeOpts);
 app.use("/api", systemRouter);

--- a/src/components/features/ExecutionWorkspace.tsx
+++ b/src/components/features/ExecutionWorkspace.tsx
@@ -57,6 +57,7 @@ import { cn } from "@/lib/utils";
 import { buildRecipeFromState, buildRecipeJsonFromState } from "@/lib/recipePipeline";
 import { buildOwrConfigs } from "@/lib/owrExportConfigs";
 import { fetchHardwareProbe, type HardwareProbeResult } from "@/lib/hardwareProbe";
+import { qnnExplicitRetryProviders } from "@/lib/qnnReadiness";
 import { VramEstimateBanner } from "@/components/features/VramEstimateBanner";
 import { GpuMetricsBar } from "@/components/features/GpuMetricsBar";
 import { parseGpuMetrics, type GpuMetrics } from "@/lib/gpuMetrics";
@@ -1562,6 +1563,25 @@ ${owrPlatform === "web"
                         <Bug className="h-3 w-3" /> Report
                       </button>
                     )}
+                    {executionStatus === "failed" &&
+                      state.ihvProvider === "QNNExecutionProvider" &&
+                      qnnExplicitRetryProviders().map((provider) => (
+                        <button
+                          key={provider}
+                          type="button"
+                          onClick={() => {
+                            setState({ ihvProvider: provider });
+                            setExecutionLogs((prev) => [
+                              ...prev,
+                              `[INFO] Switched target to ${provider} (explicit retry — QNN does not auto-fallback). Rebuild/refresh the recipe, then Execute Live again.`,
+                            ]);
+                          }}
+                          title={`Explicit retry with ${provider} (no automatic EP fallback)`}
+                          className="flex items-center gap-1 px-2 py-1 text-[11px] font-semibold rounded border border-slate-600/50 bg-slate-800/60 text-slate-300 hover:bg-slate-700/60 transition-all cursor-pointer"
+                        >
+                          Retry with {provider === "DmlExecutionProvider" ? "DirectML" : "CPU"}
+                        </button>
+                      ))}
                   </div>
                 </div>
               )}

--- a/src/components/features/ExecutionWorkspace.tsx
+++ b/src/components/features/ExecutionWorkspace.tsx
@@ -58,6 +58,7 @@ import { buildRecipeFromState, buildRecipeJsonFromState } from "@/lib/recipePipe
 import { buildOwrConfigs } from "@/lib/owrExportConfigs";
 import { fetchHardwareProbe, type HardwareProbeResult } from "@/lib/hardwareProbe";
 import { qnnExplicitRetryProviders } from "@/lib/qnnReadiness";
+import { prepareProviderChange } from "@/lib/pipelineValidation";
 import { VramEstimateBanner } from "@/components/features/VramEstimateBanner";
 import { GpuMetricsBar } from "@/components/features/GpuMetricsBar";
 import { parseGpuMetrics, type GpuMetrics } from "@/lib/gpuMetrics";
@@ -1570,7 +1571,10 @@ ${owrPlatform === "web"
                           key={provider}
                           type="button"
                           onClick={() => {
-                            setState({ ihvProvider: provider });
+                            const patch = prepareProviderChange(state, provider, hardwareProbe, {
+                              skipHardwareBlock: true,
+                            });
+                            setState(patch ?? { ihvProvider: provider });
                             setExecutionLogs((prev) => [
                               ...prev,
                               `[INFO] Switched target to ${provider} (explicit retry — QNN does not auto-fallback). Rebuild/refresh the recipe, then Execute Live again.`,

--- a/src/components/features/HardwareProviderCard.tsx
+++ b/src/components/features/HardwareProviderCard.tsx
@@ -25,6 +25,7 @@ import {
 } from "@/lib/pipelineValidation";
 import {
   isProviderDetectedLocally,
+  computeDirectMlHardwareReady,
   type GpuInfo,
   type HardwareProbeResult,
 } from "@/lib/hardwareProbe";
@@ -462,7 +463,7 @@ function ProviderPluginInstalls({
     hardwareProbe?.qnn?.hostMode === "local-inference" &&
     hardwareProbe?.qnn?.loadable === true;
   const directMlNeedsInstall =
-    /^win(?:32|64)?$/i.test(hardwareProbe?.platform.os.trim() ?? "") &&
+    computeDirectMlHardwareReady({ os: hardwareProbe?.platform.os ?? "" }) &&
     Boolean(hardwareProbe) &&
     !isProviderDetectedLocally("DmlExecutionProvider", hardwareProbe);
 
@@ -756,7 +757,7 @@ export function HardwareProviderCard({
     isProviderDetectedLocally("QNNExecutionProvider", hardwareProbe) &&
     hardwareProbe?.qnn?.loadable !== true;
   const directMlNeedsInstall =
-    /^win(?:32|64)?$/i.test(hardwareProbe?.platform.os.trim() ?? "") &&
+    computeDirectMlHardwareReady({ os: hardwareProbe?.platform.os ?? "" }) &&
     Boolean(hardwareProbe) &&
     !isProviderDetectedLocally("DmlExecutionProvider", hardwareProbe);
   const needsPluginInstall =

--- a/src/components/features/HardwareProviderCard.tsx
+++ b/src/components/features/HardwareProviderCard.tsx
@@ -457,40 +457,46 @@ function ProviderPluginInstalls({
     Boolean(hardwareProbe) &&
     isProviderDetectedLocally("QNNExecutionProvider", hardwareProbe) &&
     hardwareProbe?.qnn?.loadable !== true;
+  const qnnShowTestNpu =
+    providerId === "QNNExecutionProvider" &&
+    hardwareProbe?.qnn?.hostMode === "local-inference" &&
+    hardwareProbe?.qnn?.loadable === true;
   const directMlNeedsInstall =
     /^win(?:32|64)?$/i.test(hardwareProbe?.platform.os.trim() ?? "") &&
     Boolean(hardwareProbe) &&
     !isProviderDetectedLocally("DmlExecutionProvider", hardwareProbe);
 
-  if (providerId === "QNNExecutionProvider" && qnnNeedsInstall) {
+  if (providerId === "QNNExecutionProvider" && (qnnNeedsInstall || qnnShowTestNpu)) {
     const mode = hardwareProbe?.qnn?.hostMode;
     const prepOnly = mode === "preparation";
     return (
       <div className="mt-2 space-y-1.5 min-w-0" onClick={(e) => e.stopPropagation()}>
-        <PluginInstallBlock
-          description={
-            <>
-              Install prepares isolated <code className="text-slate-400">.venvs/qnn</code> with{" "}
-              <code className="text-slate-400">onnxruntime==1.26.0</code> +{" "}
-              <code className="text-slate-400">onnxruntime-qnn==2.4.0</code>
-              {prepOnly
-                ? ". Windows x64: preparation / plugin AOT only (not local HTP inference)."
-                : ". Windows ARM64: runtime install first; “QNN NPU ready” waits on the Snapdragon release gate."}
-              {!isQnnSnapdragonReleaseGatePassed()
-                ? " UI will show “QNN runtime installed”, not “QNN NPU ready”, until that gate passes."
-                : ""}
-            </>
-          }
-          detail={hardwareProbe?.qnn?.detail}
-          busy={hardwareInstallBusy || qnnInstall.state.testing}
-          installing={qnnInstall.state.installing}
-          installLabel="Install QNN runtime (.venvs/qnn)"
-          installingLabel="Installing QNN runtime…"
-          onInstall={() => void qnnInstall.install()}
-          error={qnnInstall.state.error}
-          log={qnnInstall.state.log}
-        />
-        {mode === "local-inference" && hardwareProbe?.qnn?.loadable ? (
+        {qnnNeedsInstall ? (
+          <PluginInstallBlock
+            description={
+              <>
+                Install prepares isolated <code className="text-slate-400">.venvs/qnn</code> with{" "}
+                <code className="text-slate-400">onnxruntime==1.26.0</code> +{" "}
+                <code className="text-slate-400">onnxruntime-qnn==2.4.0</code>
+                {prepOnly
+                  ? ". Windows x64: preparation / plugin AOT only (not local HTP inference)."
+                  : ". Windows ARM64: runtime install first; “QNN NPU ready” waits on the Snapdragon release gate."}
+                {!isQnnSnapdragonReleaseGatePassed()
+                  ? " UI will show “QNN runtime installed”, not “QNN NPU ready”, until that gate passes."
+                  : ""}
+              </>
+            }
+            detail={hardwareProbe?.qnn?.detail}
+            busy={hardwareInstallBusy || qnnInstall.state.testing}
+            installing={qnnInstall.state.installing}
+            installLabel="Install QNN runtime (.venvs/qnn)"
+            installingLabel="Installing QNN runtime…"
+            onInstall={() => void qnnInstall.install()}
+            error={qnnInstall.state.error}
+            log={qnnInstall.state.log}
+          />
+        ) : null}
+        {qnnShowTestNpu ? (
           <button
             type="button"
             disabled={hardwareInstallBusy || qnnInstall.state.installing || qnnInstall.state.testing}

--- a/src/components/features/HardwareProviderCard.tsx
+++ b/src/components/features/HardwareProviderCard.tsx
@@ -10,6 +10,12 @@ import {
 } from "@/components/ui";
 import type { OpenVinoInstallState } from "@/components/features/useOpenVinoInstall";
 import type { DirectMlInstallState } from "@/components/features/useDirectMlInstall";
+import type { QnnInstallState } from "@/components/features/useQnnInstall";
+import {
+  QNN_ADVANCED_QAIRT_DOCS_URL,
+  isQnnSnapdragonReleaseGatePassed,
+} from "@/lib/qnnDeps";
+import { qnnRuntimeUiLabel } from "@/lib/qnnReadiness";
 import {
   applyProviderConflictAutofixes,
   getProviderConflicts,
@@ -55,6 +61,7 @@ export interface HardwareProviderCardProps {
   trtRtxNeedsInstall: boolean;
   trtNeedsInstall: boolean;
   openvinoNeedsInstall: boolean;
+  qnnNeedsInstall: boolean;
   directMlNeedsInstall: boolean;
   hardwareInstallBusy: boolean;
   installingTrtRtx: boolean;
@@ -68,6 +75,11 @@ export interface HardwareProviderCardProps {
   openvinoInstall: {
     state: OpenVinoInstallState;
     install: () => Promise<void>;
+  };
+  qnnInstall: {
+    state: QnnInstallState;
+    install: () => Promise<void>;
+    testNpu: () => Promise<void>;
   };
   directMlInstall: {
     state: DirectMlInstallState;
@@ -225,6 +237,11 @@ function hardwareDetailFor(
       : "";
     return `OpenVINO ${hardwareProbe.openvino.version}${devices}`.trim();
   }
+  if (providerId === "QNNExecutionProvider" && hardwareProbe) {
+    const label = qnnRuntimeUiLabel(hardwareProbe);
+    const ver = hardwareProbe.qnn?.pluginVersion ? ` · plugin ${hardwareProbe.qnn.pluginVersion}` : "";
+    return `${label}${ver}`;
+  }
   if (providerId === "CPUExecutionProvider" && hardwareProbe) {
     return hardwareProbe.platform.cpuModel;
   }
@@ -320,6 +337,7 @@ function ProviderPluginInstalls({
   trtRtxNeedsInstall,
   trtNeedsInstall,
   openvinoNeedsInstall,
+  qnnNeedsInstall,
   directMlNeedsInstall,
   hardwareInstallBusy,
   installingTrtRtx,
@@ -331,6 +349,7 @@ function ProviderPluginInstalls({
   installTrtLog,
   onInstallTensorRt,
   openvinoInstall,
+  qnnInstall,
   directMlInstall,
   isPreMaxwellBox,
   cudaNeedsOrtGpuInstall,
@@ -348,6 +367,7 @@ function ProviderPluginInstalls({
   trtRtxNeedsInstall: boolean;
   trtNeedsInstall: boolean;
   openvinoNeedsInstall: boolean;
+  qnnNeedsInstall: boolean;
   directMlNeedsInstall: boolean;
   hardwareInstallBusy: boolean;
   installingTrtRtx: boolean;
@@ -359,6 +379,7 @@ function ProviderPluginInstalls({
   installTrtLog: string[];
   onInstallTensorRt: () => void;
   openvinoInstall: HardwareProviderCardProps["openvinoInstall"];
+  qnnInstall: HardwareProviderCardProps["qnnInstall"];
   directMlInstall: HardwareProviderCardProps["directMlInstall"];
   isPreMaxwellBox: boolean;
   cudaNeedsOrtGpuInstall: boolean;
@@ -436,6 +457,63 @@ function ProviderPluginInstalls({
         error={openvinoInstall.state.error}
         log={openvinoInstall.state.log}
       />
+    );
+  }
+  if (providerId === "QNNExecutionProvider" && qnnNeedsInstall) {
+    const mode = hardwareProbe?.qnn?.hostMode;
+    const prepOnly = mode === "preparation";
+    return (
+      <div className="mt-2 space-y-1.5 min-w-0" onClick={(e) => e.stopPropagation()}>
+        <PluginInstallBlock
+          description={
+            <>
+              Install prepares isolated <code className="text-slate-400">.venvs/qnn</code> with{" "}
+              <code className="text-slate-400">onnxruntime==1.26.0</code> +{" "}
+              <code className="text-slate-400">onnxruntime-qnn==2.4.0</code>
+              {prepOnly
+                ? ". Windows x64: preparation / plugin AOT only (not local HTP inference)."
+                : ". Windows ARM64: runtime install first; “QNN NPU ready” waits on the Snapdragon release gate."}
+              {!isQnnSnapdragonReleaseGatePassed()
+                ? " UI will show “QNN runtime installed”, not “QNN NPU ready”, until that gate passes."
+                : ""}
+            </>
+          }
+          detail={hardwareProbe?.qnn?.detail}
+          busy={hardwareInstallBusy || qnnInstall.state.testing}
+          installing={qnnInstall.state.installing}
+          installLabel="Install QNN runtime (.venvs/qnn)"
+          installingLabel="Installing QNN runtime…"
+          onInstall={() => void qnnInstall.install()}
+          error={qnnInstall.state.error}
+          log={qnnInstall.state.log}
+        />
+        {mode === "local-inference" && hardwareProbe?.qnn?.loadable ? (
+          <button
+            type="button"
+            disabled={hardwareInstallBusy || qnnInstall.state.installing || qnnInstall.state.testing}
+            onClick={() => void qnnInstall.testNpu()}
+            className="h-7 px-3 rounded border border-slate-600 text-slate-300 bg-slate-800/60 hover:bg-slate-800 text-[11px] font-bold disabled:opacity-50 flex items-center gap-1.5"
+          >
+            {qnnInstall.state.testing ? (
+              <>
+                <RefreshCw className="h-3 w-3 animate-spin" />
+                Testing QNN NPU…
+              </>
+            ) : (
+              "Test QNN NPU (cached HTP diagnostic)"
+            )}
+          </button>
+        ) : null}
+        <a
+          href={QNN_ADVANCED_QAIRT_DOCS_URL}
+          target="_blank"
+          rel="noreferrer"
+          className="inline-flex items-center gap-1 text-[10px] text-slate-500 hover:text-slate-300"
+          onClick={(e) => e.stopPropagation()}
+        >
+          Advanced QAIRT / SDK tooling <ExternalLink className="h-3 w-3" />
+        </a>
+      </div>
     );
   }
   if (providerId === "DmlExecutionProvider" && directMlNeedsInstall) {
@@ -628,6 +706,7 @@ export function HardwareProviderCard({
   trtRtxNeedsInstall,
   trtNeedsInstall,
   openvinoNeedsInstall,
+  qnnNeedsInstall,
   directMlNeedsInstall,
   hardwareInstallBusy,
   installingTrtRtx,
@@ -639,6 +718,7 @@ export function HardwareProviderCard({
   installTrtLog,
   onInstallTensorRt,
   openvinoInstall,
+  qnnInstall,
   directMlInstall,
   isPreMaxwellBox,
   cudaNeedsOrtGpuInstall,
@@ -668,6 +748,7 @@ export function HardwareProviderCard({
     (p.id === "NvTensorRTRTXExecutionProvider" && trtRtxNeedsInstall) ||
     (p.id === "TensorrtExecutionProvider" && trtNeedsInstall) ||
     (p.id === "OpenVINOExecutionProvider" && openvinoNeedsInstall) ||
+    (p.id === "QNNExecutionProvider" && qnnNeedsInstall) ||
     (p.id === "DmlExecutionProvider" && directMlNeedsInstall) ||
     (p.id === "CUDAExecutionProvider" && cudaNeedsOrtGpuInstall);
 
@@ -752,6 +833,7 @@ export function HardwareProviderCard({
             trtRtxNeedsInstall={trtRtxNeedsInstall}
             trtNeedsInstall={trtNeedsInstall}
             openvinoNeedsInstall={openvinoNeedsInstall}
+            qnnNeedsInstall={qnnNeedsInstall}
             directMlNeedsInstall={directMlNeedsInstall}
             hardwareInstallBusy={hardwareInstallBusy}
             installingTrtRtx={installingTrtRtx}
@@ -763,6 +845,7 @@ export function HardwareProviderCard({
             installTrtLog={installTrtLog}
             onInstallTensorRt={onInstallTensorRt}
             openvinoInstall={openvinoInstall}
+            qnnInstall={qnnInstall}
             directMlInstall={directMlInstall}
             isPreMaxwellBox={isPreMaxwellBox}
             cudaNeedsOrtGpuInstall={cudaNeedsOrtGpuInstall}

--- a/src/components/features/HardwareProviderCard.tsx
+++ b/src/components/features/HardwareProviderCard.tsx
@@ -61,8 +61,6 @@ export interface HardwareProviderCardProps {
   trtRtxNeedsInstall: boolean;
   trtNeedsInstall: boolean;
   openvinoNeedsInstall: boolean;
-  qnnNeedsInstall: boolean;
-  directMlNeedsInstall: boolean;
   hardwareInstallBusy: boolean;
   installingTrtRtx: boolean;
   installTrtRtxError: string | null;
@@ -337,8 +335,6 @@ function ProviderPluginInstalls({
   trtRtxNeedsInstall,
   trtNeedsInstall,
   openvinoNeedsInstall,
-  qnnNeedsInstall,
-  directMlNeedsInstall,
   hardwareInstallBusy,
   installingTrtRtx,
   installTrtRtxError,
@@ -367,8 +363,6 @@ function ProviderPluginInstalls({
   trtRtxNeedsInstall: boolean;
   trtNeedsInstall: boolean;
   openvinoNeedsInstall: boolean;
-  qnnNeedsInstall: boolean;
-  directMlNeedsInstall: boolean;
   hardwareInstallBusy: boolean;
   installingTrtRtx: boolean;
   installTrtRtxError: string | null;
@@ -459,6 +453,15 @@ function ProviderPluginInstalls({
       />
     );
   }
+  const qnnNeedsInstall =
+    Boolean(hardwareProbe) &&
+    isProviderDetectedLocally("QNNExecutionProvider", hardwareProbe) &&
+    hardwareProbe?.qnn?.loadable !== true;
+  const directMlNeedsInstall =
+    /^win(?:32|64)?$/i.test(hardwareProbe?.platform.os.trim() ?? "") &&
+    Boolean(hardwareProbe) &&
+    !isProviderDetectedLocally("DmlExecutionProvider", hardwareProbe);
+
   if (providerId === "QNNExecutionProvider" && qnnNeedsInstall) {
     const mode = hardwareProbe?.qnn?.hostMode;
     const prepOnly = mode === "preparation";
@@ -706,8 +709,6 @@ export function HardwareProviderCard({
   trtRtxNeedsInstall,
   trtNeedsInstall,
   openvinoNeedsInstall,
-  qnnNeedsInstall,
-  directMlNeedsInstall,
   hardwareInstallBusy,
   installingTrtRtx,
   installTrtRtxError,
@@ -744,6 +745,14 @@ export function HardwareProviderCard({
   const showSwitchAssist = pConflicts.length > 0 && (isSelected || !cardBlocked);
   const detectedLocally = isProviderDetectedLocally(p.id, hardwareProbe);
   const isWebGpuTarget = p.id === "WebGpuExecutionProvider";
+  const qnnNeedsInstall =
+    Boolean(hardwareProbe) &&
+    isProviderDetectedLocally("QNNExecutionProvider", hardwareProbe) &&
+    hardwareProbe?.qnn?.loadable !== true;
+  const directMlNeedsInstall =
+    /^win(?:32|64)?$/i.test(hardwareProbe?.platform.os.trim() ?? "") &&
+    Boolean(hardwareProbe) &&
+    !isProviderDetectedLocally("DmlExecutionProvider", hardwareProbe);
   const needsPluginInstall =
     (p.id === "NvTensorRTRTXExecutionProvider" && trtRtxNeedsInstall) ||
     (p.id === "TensorrtExecutionProvider" && trtNeedsInstall) ||
@@ -833,8 +842,6 @@ export function HardwareProviderCard({
             trtRtxNeedsInstall={trtRtxNeedsInstall}
             trtNeedsInstall={trtNeedsInstall}
             openvinoNeedsInstall={openvinoNeedsInstall}
-            qnnNeedsInstall={qnnNeedsInstall}
-            directMlNeedsInstall={directMlNeedsInstall}
             hardwareInstallBusy={hardwareInstallBusy}
             installingTrtRtx={installingTrtRtx}
             installTrtRtxError={installTrtRtxError}

--- a/src/components/features/IHVIntegrationPanel.tsx
+++ b/src/components/features/IHVIntegrationPanel.tsx
@@ -325,10 +325,8 @@ export function IHVIntegrationPanel({
   const [installOrtGpuLog, setInstallOrtGpuLog] = useState<string[]>([]);
 
   const hasAutoAppliedRef = useRef(false);
-  const controlledStateRef = useRef(propState);
-  useEffect(() => {
-    controlledStateRef.current = propState;
-  }, [propState]);
+  const latestStateRef = useRef(state);
+  latestStateRef.current = state;
 
   const runHardwareProbe = useCallback(
     async (refresh = false) => {
@@ -341,9 +339,8 @@ export function IHVIntegrationPanel({
         // Auto-apply recommended provider on first probe completion
         if (!hasAutoAppliedRef.current && result.recommendedProvider) {
           hasAutoAppliedRef.current = true;
-          const current = controlledStateRef.current ?? storeState.state;
           setState(
-            prepareProviderChange(current, result.recommendedProvider, result) ?? {
+            prepareProviderChange(latestStateRef.current, result.recommendedProvider, result) ?? {
               ihvProvider: result.recommendedProvider,
             },
           );
@@ -355,7 +352,7 @@ export function IHVIntegrationPanel({
         setProbeLoading(false);
       }
     },
-    [setState, storeState.state],
+    [setState],
   );
 
   // Shared mutex across hardware installs (families differ, but pip UX is serialized).

--- a/src/components/features/IHVIntegrationPanel.tsx
+++ b/src/components/features/IHVIntegrationPanel.tsx
@@ -40,6 +40,7 @@ import { PROVIDER_CATALOG } from "@/lib/providerCatalog";
 import { VramEstimateBanner } from "@/components/features/VramEstimateBanner";
 import { HardwareProviderCard } from "@/components/features/HardwareProviderCard";
 import { useOpenVinoInstall } from "@/components/features/useOpenVinoInstall";
+import { useQnnInstall } from "@/components/features/useQnnInstall";
 import { useDirectMlInstall } from "@/components/features/useDirectMlInstall";
 import { runNdjsonInstall } from "@/lib/ndjsonInstall";
 import {
@@ -364,10 +365,24 @@ export function IHVIntegrationPanel({
     isInstallBusy: installingTrt || installingTrtRtx || installingOrtGpu,
   });
 
+  const qnnInstall = useQnnInstall({
+    onProbeRefresh: runHardwareProbe,
+    isInstallBusy:
+      installingTrt ||
+      installingTrtRtx ||
+      installingOrtGpu ||
+      openvinoInstall.state.installing,
+  });
+
   const directMlInstall = useDirectMlInstall({
     onProbeRefresh: runHardwareProbe,
     isInstallBusy:
-      installingTrt || installingTrtRtx || installingOrtGpu || openvinoInstall.state.installing,
+      installingTrt ||
+      installingTrtRtx ||
+      installingOrtGpu ||
+      openvinoInstall.state.installing ||
+      qnnInstall.state.installing ||
+      qnnInstall.state.testing,
   });
 
   const trtRtxNeedsInstall =
@@ -378,6 +393,10 @@ export function IHVIntegrationPanel({
     Boolean(hardwareProbe) &&
     isProviderDetectedLocally("OpenVINOExecutionProvider", hardwareProbe) &&
     hardwareProbe?.openvino?.loadable !== true;
+  const qnnNeedsInstall =
+    Boolean(hardwareProbe) &&
+    isProviderDetectedLocally("QNNExecutionProvider", hardwareProbe) &&
+    hardwareProbe?.qnn?.loadable !== true;
   const directMlNeedsInstall = computeDirectMlNeedsInstall(hardwareProbe);
 
   // CUDA install / toolkit-link gating (from PR #106).
@@ -395,6 +414,8 @@ export function IHVIntegrationPanel({
     installingTrtRtx ||
     installingOrtGpu ||
     openvinoInstall.state.installing ||
+    qnnInstall.state.installing ||
+    qnnInstall.state.testing ||
     directMlInstall.state.installing;
 
   const handleInstallTensorRtRtx = async () => {
@@ -697,6 +718,7 @@ export function IHVIntegrationPanel({
                     trtRtxNeedsInstall={trtRtxNeedsInstall}
                     trtNeedsInstall={trtNeedsInstall}
                     openvinoNeedsInstall={openvinoNeedsInstall}
+                    qnnNeedsInstall={qnnNeedsInstall}
                     directMlNeedsInstall={directMlNeedsInstall}
                     hardwareInstallBusy={hardwareInstallBusy}
                     installingTrtRtx={installingTrtRtx}
@@ -708,6 +730,7 @@ export function IHVIntegrationPanel({
                     installTrtLog={installTrtLog}
                     onInstallTensorRt={() => void handleInstallTensorRt()}
                     openvinoInstall={openvinoInstall}
+                    qnnInstall={qnnInstall}
                     directMlInstall={directMlInstall}
                     isPreMaxwellBox={isPreMaxwellBox}
                     cudaNeedsOrtGpuInstall={cudaNeedsOrtGpuInstall}

--- a/src/components/features/IHVIntegrationPanel.tsx
+++ b/src/components/features/IHVIntegrationPanel.tsx
@@ -326,7 +326,9 @@ export function IHVIntegrationPanel({
 
   const hasAutoAppliedRef = useRef(false);
   const latestStateRef = useRef(state);
-  latestStateRef.current = state;
+  useEffect(() => {
+    latestStateRef.current = state;
+  }, [state]);
 
   const runHardwareProbe = useCallback(
     async (refresh = false) => {
@@ -999,45 +1001,19 @@ export function IHVIntegrationPanel({
                               onClick={() => {
                                 // Allow selecting undetected providers for cross-compile / remote targets
                                 const detected = detectedProviders.includes(p.id);
-                                if (!detected) {
-                                  setState({
-                                    ihvProvider: p.id,
-                                    ...(p.id === "OpenVINOExecutionProvider"
-                                      ? {
-                                          openvinoTargetDevice: pickOpenVinoTargetFromDevices(
-                                            hardwareProbe?.openvino?.devices,
-                                          ),
-                                        }
-                                      : {}),
-                                  });
-                                  return;
-                                }
-                                const patch = prepareProviderChange(state, p.id, hardwareProbe);
-                                if (patch) {
-                                  setState(patch);
-                                }
+                                const patch = prepareProviderChange(state, p.id, hardwareProbe, {
+                                  skipHardwareBlock: !detected,
+                                });
+                                if (patch) setState(patch);
                               }}
                               onKeyDown={(e) => {
                                 if (e.key !== "Enter" && e.key !== " ") return;
                                 e.preventDefault();
                                 const detected = detectedProviders.includes(p.id);
-                                if (!detected) {
-                                  setState({
-                                    ihvProvider: p.id,
-                                    ...(p.id === "OpenVINOExecutionProvider"
-                                      ? {
-                                          openvinoTargetDevice: pickOpenVinoTargetFromDevices(
-                                            hardwareProbe?.openvino?.devices,
-                                          ),
-                                        }
-                                      : {}),
-                                  });
-                                  return;
-                                }
-                                const patch = prepareProviderChange(state, p.id, hardwareProbe);
-                                if (patch) {
-                                  setState(patch);
-                                }
+                                const patch = prepareProviderChange(state, p.id, hardwareProbe, {
+                                  skipHardwareBlock: !detected,
+                                });
+                                if (patch) setState(patch);
                               }}
                               className={`p-2 px-1 text-center cursor-pointer transition-all relative select-none ${
                                 isSelectedProvider

--- a/src/components/features/IHVIntegrationPanel.tsx
+++ b/src/components/features/IHVIntegrationPanel.tsx
@@ -12,7 +12,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui";
 import { IHVProvider, UIState } from "@/types";
-import { usePipelineState, usePipelineStore } from "@/lib/stores/pipelineStore";
+import { usePipelineState } from "@/lib/stores/pipelineStore";
 import {
   applyProviderConflictAutofixes,
   getProviderConflicts,
@@ -30,7 +30,6 @@ import {
   fetchHardwareProbe,
   getSelectableProviders,
   isProviderDetectedLocally,
-  computeDirectMlNeedsInstall,
   type HardwareProbeResult,
 } from "@/lib/hardwareProbe";
 import {
@@ -342,7 +341,7 @@ export function IHVIntegrationPanel({
         // Auto-apply recommended provider on first probe completion
         if (!hasAutoAppliedRef.current && result.recommendedProvider) {
           hasAutoAppliedRef.current = true;
-          const current = controlledStateRef.current ?? usePipelineStore.getState().state;
+          const current = controlledStateRef.current ?? storeState.state;
           setState(
             prepareProviderChange(current, result.recommendedProvider, result) ?? {
               ihvProvider: result.recommendedProvider,
@@ -356,7 +355,7 @@ export function IHVIntegrationPanel({
         setProbeLoading(false);
       }
     },
-    [setState],
+    [setState, storeState.state],
   );
 
   // Shared mutex across hardware installs (families differ, but pip UX is serialized).
@@ -393,12 +392,6 @@ export function IHVIntegrationPanel({
     Boolean(hardwareProbe) &&
     isProviderDetectedLocally("OpenVINOExecutionProvider", hardwareProbe) &&
     hardwareProbe?.openvino?.loadable !== true;
-  const qnnNeedsInstall =
-    Boolean(hardwareProbe) &&
-    isProviderDetectedLocally("QNNExecutionProvider", hardwareProbe) &&
-    hardwareProbe?.qnn?.loadable !== true;
-  const directMlNeedsInstall = computeDirectMlNeedsInstall(hardwareProbe);
-
   // CUDA install / toolkit-link gating (from PR #106).
   const nvidiaGpus = hardwareProbe?.nvidia?.gpus ?? [];
   const isPreMaxwellBox = isPreMaxwellNvidiaBox(nvidiaGpus);
@@ -718,8 +711,6 @@ export function IHVIntegrationPanel({
                     trtRtxNeedsInstall={trtRtxNeedsInstall}
                     trtNeedsInstall={trtNeedsInstall}
                     openvinoNeedsInstall={openvinoNeedsInstall}
-                    qnnNeedsInstall={qnnNeedsInstall}
-                    directMlNeedsInstall={directMlNeedsInstall}
                     hardwareInstallBusy={hardwareInstallBusy}
                     installingTrtRtx={installingTrtRtx}
                     installTrtRtxError={installTrtRtxError}

--- a/src/components/features/IHVIntegrationPanel.tsx
+++ b/src/components/features/IHVIntegrationPanel.tsx
@@ -45,7 +45,6 @@ import { runNdjsonInstall } from "@/lib/ndjsonInstall";
 import {
   OPEN_VINO_TARGET_DEVICES,
   isOpenVinoTargetAvailable,
-  pickOpenVinoTargetFromDevices,
   type OpenVinoTargetDevice,
 } from "@/lib/openvinoDeps";
 import {

--- a/src/components/features/useQnnInstall.test.ts
+++ b/src/components/features/useQnnInstall.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { useQnnInstall } from "./useQnnInstall";
+
+vi.mock("@/lib/ndjsonInstall", () => ({
+  runNdjsonInstall: vi.fn(async () => undefined),
+}));
+
+import { runNdjsonInstall } from "@/lib/ndjsonInstall";
+
+describe("useQnnInstall", () => {
+  beforeEach(() => {
+    vi.mocked(runNdjsonInstall).mockClear();
+  });
+
+  it("streams install-qnn and refreshes probe", async () => {
+    const onProbeRefresh = vi.fn(async () => undefined);
+    const { result } = renderHook(() =>
+      useQnnInstall({ onProbeRefresh, isInstallBusy: false }),
+    );
+    await act(async () => {
+      await result.current.install();
+    });
+    expect(runNdjsonInstall).toHaveBeenCalledWith("/api/env/install-qnn", expect.any(Function));
+    expect(onProbeRefresh).toHaveBeenCalledWith(true);
+  });
+
+  it("streams test-qnn-npu for HTP diagnostic", async () => {
+    const onProbeRefresh = vi.fn(async () => undefined);
+    const { result } = renderHook(() =>
+      useQnnInstall({ onProbeRefresh, isInstallBusy: false }),
+    );
+    await act(async () => {
+      await result.current.testNpu();
+    });
+    expect(runNdjsonInstall).toHaveBeenCalledWith("/api/env/test-qnn-npu", expect.any(Function));
+    expect(onProbeRefresh).toHaveBeenCalledWith(true);
+  });
+
+  it("no-ops when another install is busy", async () => {
+    const onProbeRefresh = vi.fn(async () => undefined);
+    const { result } = renderHook(() =>
+      useQnnInstall({ onProbeRefresh, isInstallBusy: true }),
+    );
+    await act(async () => {
+      await result.current.install();
+    });
+    expect(runNdjsonInstall).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/features/useQnnInstall.ts
+++ b/src/components/features/useQnnInstall.ts
@@ -4,7 +4,7 @@
  * Streams NDJSON from POST /api/env/install-qnn and refreshes the
  * hardware probe on success. Optional Test QNN NPU hits /api/env/test-qnn-npu.
  */
-import { useCallback, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 import { runNdjsonInstall } from "@/lib/ndjsonInstall";
 
 export interface UseQnnInstallOptions {
@@ -34,9 +34,12 @@ export function useQnnInstall({
   const [testing, setTesting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [log, setLog] = useState<string[]>([]);
+  /** Synchronous busy guard so same-tick double clicks cannot start two requests. */
+  const busyRef = useRef(false);
 
   const install = useCallback(async () => {
-    if (isInstallBusy || installing || testing) return;
+    if (isInstallBusy || busyRef.current) return;
+    busyRef.current = true;
     setInstalling(true);
     setError(null);
     setLog([]);
@@ -51,12 +54,14 @@ export function useQnnInstall({
           : msg,
       );
     } finally {
+      busyRef.current = false;
       setInstalling(false);
     }
-  }, [isInstallBusy, installing, testing, onProbeRefresh]);
+  }, [isInstallBusy, onProbeRefresh]);
 
   const testNpu = useCallback(async () => {
-    if (isInstallBusy || installing || testing) return;
+    if (isInstallBusy || busyRef.current) return;
+    busyRef.current = true;
     setTesting(true);
     setError(null);
     setLog([]);
@@ -71,9 +76,10 @@ export function useQnnInstall({
           : msg,
       );
     } finally {
+      busyRef.current = false;
       setTesting(false);
     }
-  }, [isInstallBusy, installing, testing, onProbeRefresh]);
+  }, [isInstallBusy, onProbeRefresh]);
 
   return {
     state: { installing, testing, error, log },

--- a/src/components/features/useQnnInstall.ts
+++ b/src/components/features/useQnnInstall.ts
@@ -1,0 +1,83 @@
+/**
+ * QNN 2.x plugin runtime install hook for the Hardware panel.
+ *
+ * Streams NDJSON from POST /api/env/install-qnn and refreshes the
+ * hardware probe on success. Optional Test QNN NPU hits /api/env/test-qnn-npu.
+ */
+import { useCallback, useState } from "react";
+import { runNdjsonInstall } from "@/lib/ndjsonInstall";
+
+export interface UseQnnInstallOptions {
+  onProbeRefresh: (refresh?: boolean) => Promise<void>;
+  isInstallBusy: boolean;
+}
+
+export interface QnnInstallState {
+  installing: boolean;
+  testing: boolean;
+  error: string | null;
+  log: string[];
+}
+
+/**
+ * Manages QNN runtime installation UI state and the NDJSON install call.
+ */
+export function useQnnInstall({
+  onProbeRefresh,
+  isInstallBusy,
+}: UseQnnInstallOptions): {
+  state: QnnInstallState;
+  install: () => Promise<void>;
+  testNpu: () => Promise<void>;
+} {
+  const [installing, setInstalling] = useState(false);
+  const [testing, setTesting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [log, setLog] = useState<string[]>([]);
+
+  const install = useCallback(async () => {
+    if (isInstallBusy || installing || testing) return;
+    setInstalling(true);
+    setError(null);
+    setLog([]);
+    try {
+      await runNdjsonInstall("/api/env/install-qnn", setLog);
+      await onProbeRefresh(true);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      setError(
+        msg === "Failed to fetch"
+          ? "Could not reach the Olive Studio server (or the connection dropped during install). Keep pnpm dev running, then retry."
+          : msg,
+      );
+    } finally {
+      setInstalling(false);
+    }
+  }, [isInstallBusy, installing, testing, onProbeRefresh]);
+
+  const testNpu = useCallback(async () => {
+    if (isInstallBusy || installing || testing) return;
+    setTesting(true);
+    setError(null);
+    setLog([]);
+    try {
+      await runNdjsonInstall("/api/env/test-qnn-npu", setLog);
+      await onProbeRefresh(true);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      setError(
+        msg === "Failed to fetch"
+          ? "Could not reach the Olive Studio server during Test QNN NPU. Keep pnpm dev running, then retry."
+          : msg,
+      );
+    } finally {
+      setTesting(false);
+    }
+  }, [isInstallBusy, installing, testing, onProbeRefresh]);
+
+  return {
+    state: { installing, testing, error, log },
+    install,
+    testNpu,
+  };
+}

--- a/src/lib/__tests__/pipelineValidation.test.ts
+++ b/src/lib/__tests__/pipelineValidation.test.ts
@@ -327,6 +327,33 @@ describe("prepareProviderChange", () => {
     expect(result!.passes).toBeDefined();
   });
 
+  it("can skip hardware block for explicit retry / cross-compile selection", () => {
+    const state = baseState({ passes: basePasses({ peft: true }) });
+    const blocked = prepareProviderChange(state, "QNNExecutionProvider", {
+      probedAt: new Date().toISOString(),
+      platform: { os: "linux", arch: "x64", cpuModel: "x86", cpuCores: 8 },
+      detectedProviders: ["CPUExecutionProvider"],
+      recommendedProvider: "CPUExecutionProvider" as IHVProvider,
+      notes: [],
+    });
+    expect(blocked).toBeNull();
+    const allowed = prepareProviderChange(
+      state,
+      "QNNExecutionProvider",
+      {
+        probedAt: new Date().toISOString(),
+        platform: { os: "linux", arch: "x64", cpuModel: "x86", cpuCores: 8 },
+        detectedProviders: ["CPUExecutionProvider"],
+        recommendedProvider: "CPUExecutionProvider" as IHVProvider,
+        notes: [],
+      },
+      { skipHardwareBlock: true },
+    );
+    expect(allowed).not.toBeNull();
+    expect(allowed!.ihvProvider).toBe("QNNExecutionProvider");
+    expect(allowed!.passes?.peft).toBe(false);
+  });
+
   it("picks OpenVINO GPU target from probe devices when switching to OpenVINO", () => {
     const state = baseState();
     const result = prepareProviderChange(state, "OpenVINOExecutionProvider", {

--- a/src/lib/__tests__/pipelineValidation.test.ts
+++ b/src/lib/__tests__/pipelineValidation.test.ts
@@ -480,6 +480,54 @@ describe("getPipelineValidation", () => {
     const success = getPipelineValidation(baseState({ ihvProvider: "CUDAExecutionProvider" }));
     expect(success.statusLabel).toBe("Local checks passed");
   });
+
+  it("wires QNN readiness errors into Execute Live blocking", () => {
+    const probe = {
+      probedAt: new Date().toISOString(),
+      platform: { os: "linux", arch: "x64", cpuModel: "Intel", cpuCores: 8 },
+      detectedProviders: ["CPUExecutionProvider", "QNNExecutionProvider"] as IHVProvider[],
+      recommendedProvider: "CPUExecutionProvider" as IHVProvider,
+      notes: [],
+      qnn: {
+        available: false,
+        loadable: false,
+        preparation: false,
+        npuDevice: false,
+        potentialInference: false,
+        verifiedInference: false,
+        hostMode: "out-of-scope" as const,
+      },
+    };
+    const r = getPipelineValidation(baseState({ ihvProvider: "QNNExecutionProvider" }), {
+      hardwareProbe: probe,
+    });
+    expect(r.isBlocked).toBe(true);
+    expect(r.issues.some((i) => i.id === "qnn-readiness-qnn_out_of_scope")).toBe(true);
+  });
+
+  it("blocks QNN when runtime is not loadable on Windows ARM64", () => {
+    const probe = {
+      probedAt: new Date().toISOString(),
+      platform: { os: "win32", arch: "arm64", cpuModel: "Snapdragon", cpuCores: 8 },
+      detectedProviders: ["CPUExecutionProvider", "QNNExecutionProvider"] as IHVProvider[],
+      recommendedProvider: "QNNExecutionProvider" as IHVProvider,
+      notes: [],
+      qnn: {
+        available: true,
+        loadable: false,
+        preparation: true,
+        npuDevice: false,
+        potentialInference: true,
+        verifiedInference: false,
+        hostMode: "local-inference" as const,
+      },
+    };
+    const r = getPipelineValidation(baseState({ ihvProvider: "QNNExecutionProvider" }), {
+      hardwareProbe: probe,
+    });
+    expect(r.isBlocked).toBe(true);
+    expect(r.issues.some((i) => i.id === "qnn-readiness-qnn_runtime_missing")).toBe(true);
+  });
 });
 
 // ─── sanitizePipelineState ────────────────────────────────────

--- a/src/lib/__tests__/recipeHardwareCompatibility.test.ts
+++ b/src/lib/__tests__/recipeHardwareCompatibility.test.ts
@@ -480,6 +480,58 @@ describe("assessRecipeHardwareCompatibility — pre-Turing drift-guard (recipe-c
   });
 });
 
+describe("assessRecipeHardwareCompatibility — QNN install hint", () => {
+  it("returns compatible with onnxruntime-qnn install hint on Windows x64 preparation hosts", () => {
+    const probe = makeProbe({
+      platform: { os: "win32 10.0", arch: "x64", cpuModel: "Test CPU", cpuCores: 8 },
+      detectedProviders: ["CPUExecutionProvider", "QNNExecutionProvider"],
+      qnn: {
+        available: false,
+        loadable: false,
+        preparation: false,
+        npuDevice: false,
+        potentialInference: false,
+        verifiedInference: false,
+        hostMode: "preparation",
+      },
+    });
+    const result = assessRecipeHardwareCompatibility("QNN", probe);
+    expect(result.tier).toBe("compatible");
+    expect(result.requiresInstall?.kind).toBe("onnxruntime-qnn");
+    expect(result.requiresInstall?.installCommand).toContain("onnxruntime-qnn==2.4.0");
+    expect(result.reason).toMatch(/preparation|AOT/i);
+  });
+
+  it("omits install hint when QNN runtime is already loadable", () => {
+    const probe = makeProbe({
+      platform: { os: "win32 10.0", arch: "arm64", cpuModel: "Snapdragon", cpuCores: 8 },
+      detectedProviders: ["CPUExecutionProvider", "QNNExecutionProvider"],
+      qnn: {
+        available: true,
+        loadable: true,
+        preparation: true,
+        npuDevice: true,
+        potentialInference: true,
+        verifiedInference: false,
+        hostMode: "local-inference",
+      },
+    });
+    const result = assessRecipeHardwareCompatibility("QNN", probe);
+    expect(result.tier).toBe("compatible");
+    expect(result.requiresInstall).toBeUndefined();
+  });
+
+  it("marks QNN unavailable on non-Windows hosts", () => {
+    const probe = makeProbe({
+      platform: { os: "linux 6.8", arch: "x64", cpuModel: "Intel Xeon", cpuCores: 32 },
+      detectedProviders: ["CPUExecutionProvider"],
+    });
+    const result = assessRecipeHardwareCompatibility("QNN", probe);
+    expect(result.tier).toBe("unavailable");
+    expect(result.requiresInstall).toBeUndefined();
+  });
+});
+
 describe("assessRecipeHardwareCompatibility — DirectML install hint", () => {
   it("returns compatible with an onnxruntime-directml install hint on Windows when DML EP is missing", () => {
     const probe = makeProbe({

--- a/src/lib/__tests__/venvFamily.test.ts
+++ b/src/lib/__tests__/venvFamily.test.ts
@@ -33,25 +33,30 @@ describe("venvFamily policy", () => {
     expect(mandatoryFamilyForProvider("TensorrtExecutionProvider")).toBe("cuda");
     expect(mandatoryFamilyForProvider("DmlExecutionProvider")).toBe("default");
     expect(mandatoryFamilyForProvider("OpenVINOExecutionProvider")).toBe("openvino");
+    expect(mandatoryFamilyForProvider("QNNExecutionProvider")).toBe("qnn");
     expect(mandatoryFamilyForProvider("CPUExecutionProvider")).toBeNull();
   });
 
-  it("labels openvino family", () => {
+  it("labels openvino and qnn families", () => {
     expect(humanFamilyLabel("openvino")).toBe("OpenVINO runtime");
     expect(humanFamilyRootHint("openvino")).toBe(".venvs/openvino");
+    expect(humanFamilyLabel("qnn")).toBe("QNN runtime");
+    expect(humanFamilyRootHint("qnn")).toBe(".venvs/qnn");
   });
 
-  it("resolves single-job CPU with ready-environment reuse (not openvino)", () => {
+  it("resolves single-job CPU with ready-environment reuse (not openvino/qnn)", () => {
     expect(resolveVenvFamily("CPUExecutionProvider")).toBe("default");
     expect(
       resolveVenvFamily("CPUExecutionProvider", {
         default: { cpuUsable: false, prepared: false },
         cuda: { cpuUsable: true, prepared: true },
         openvino: { cpuUsable: true, prepared: true },
+        qnn: { cpuUsable: true, prepared: true },
       }),
     ).toBe("cuda");
     expect(resolveVenvFamily("CUDAExecutionProvider", emptyFamilyFlags())).toBe("cuda");
     expect(resolveVenvFamily("OpenVINOExecutionProvider", emptyFamilyFlags())).toBe("openvino");
+    expect(resolveVenvFamily("QNNExecutionProvider", emptyFamilyFlags())).toBe("qnn");
     expect(resolveVenvFamily("DmlExecutionProvider", emptyFamilyFlags())).toBe("default");
     expect(resolveVenvFamily("WebGpuExecutionProvider", emptyFamilyFlags())).toBe("default");
   });
@@ -75,6 +80,11 @@ describe("venvFamily policy", () => {
     expect(
       resolveRequiredFamilies(["CPUExecutionProvider", "OpenVINOExecutionProvider"]),
     ).toEqual(["default", "openvino"]);
+    expect(resolveRequiredFamilies(["QNNExecutionProvider"])).toEqual(["qnn"]);
+    expect(resolveRequiredFamilies(["CPUExecutionProvider", "QNNExecutionProvider"])).toEqual([
+      "default",
+      "qnn",
+    ]);
     expect(resolveRequiredFamilies(["CUDAExecutionProvider"])).toEqual(["cuda"]);
     expect(resolveRequiredFamilies(["WebGpuExecutionProvider"])).toEqual([]);
     expect(resolveRequiredFamilies([])).toEqual([]);

--- a/src/lib/hardwareProbe.test.ts
+++ b/src/lib/hardwareProbe.test.ts
@@ -573,14 +573,14 @@ describe("mergeDetectedProviders DirectML", () => {
 });
 
 describe("mergeDetectedProviders QNN", () => {
-  it("maps QNNExecutionProvider from ORT provider list", () => {
+  it("does not trust ORT QNN listing alone without host-compatible soft-detect", () => {
     const detected = mergeDetectedProviders({
       onnxRuntimeProviders: ["CPUExecutionProvider", "QNNExecutionProvider"],
       hasNvidiaGpu: false,
       hasRocmGpu: false,
       hasOpenVino: false,
     });
-    expect(detected).toContain("QNNExecutionProvider");
+    expect(detected).not.toContain("QNNExecutionProvider");
   });
 
   it("soft-detects QNN on compatible Windows hosts", () => {
@@ -599,5 +599,13 @@ describe("mergeDetectedProviders QNN", () => {
     ).toBe(true);
     expect(computeQnnCompatibleHardware({ os: "win32 10.0", arch: "x64" })).toBe(true);
     expect(computeQnnCompatibleHardware({ os: "linux 6.8", arch: "x64" })).toBe(false);
+    expect(
+      computeQnnCompatibleHardware({
+        os: "linux 6.8",
+        arch: "x64",
+        qnnLoadable: true,
+        ortReportsQnn: true,
+      }),
+    ).toBe(false);
   });
 });

--- a/src/lib/hardwareProbe.test.ts
+++ b/src/lib/hardwareProbe.test.ts
@@ -3,6 +3,7 @@ import {
   computeDirectMlHardwareReady,
   computeDirectMlNeedsInstall,
   computeOpenVinoCompatibleHardware,
+  computeQnnCompatibleHardware,
   getProviderAvailabilityBlock,
   isNvidiaGpuTensorRtFamily,
   mergeDetectedProviders,
@@ -568,5 +569,35 @@ describe("mergeDetectedProviders DirectML", () => {
       hasDirectMl: false,
     });
     expect(detected).toContain("DmlExecutionProvider");
+  });
+});
+
+describe("mergeDetectedProviders QNN", () => {
+  it("maps QNNExecutionProvider from ORT provider list", () => {
+    const detected = mergeDetectedProviders({
+      onnxRuntimeProviders: ["CPUExecutionProvider", "QNNExecutionProvider"],
+      hasNvidiaGpu: false,
+      hasRocmGpu: false,
+      hasOpenVino: false,
+    });
+    expect(detected).toContain("QNNExecutionProvider");
+  });
+
+  it("soft-detects QNN on compatible Windows hosts", () => {
+    const detected = mergeDetectedProviders({
+      hasNvidiaGpu: false,
+      hasRocmGpu: false,
+      hasOpenVino: false,
+      hasQnnCompatibleHardware: true,
+    });
+    expect(detected).toContain("QNNExecutionProvider");
+  });
+
+  it("computeQnnCompatibleHardware is Windows ARM64/x64 only", () => {
+    expect(
+      computeQnnCompatibleHardware({ os: "win32 10.0", arch: "arm64" }),
+    ).toBe(true);
+    expect(computeQnnCompatibleHardware({ os: "win32 10.0", arch: "x64" })).toBe(true);
+    expect(computeQnnCompatibleHardware({ os: "linux 6.8", arch: "x64" })).toBe(false);
   });
 });

--- a/src/lib/hardwareProbe.ts
+++ b/src/lib/hardwareProbe.ts
@@ -5,6 +5,7 @@ import {
   isPreMaxwellNvidiaBox,
   pinnedOrtGpuInstallCommand,
 } from "@/lib/cudaDeps";
+import { resolveQnnHostMode } from "@/lib/qnnDeps";
 
 /**
  * Compute capability is reported as `"<major>.<minor>"` (e.g. `"8.9"` for
@@ -174,8 +175,8 @@ const ORT_PROVIDER_MAP: Record<string, IHVProvider> = {
 };
 
 /**
- * Windows-first QNN host soft-compat: Win ARM64 (inference) or Win x64 (preparation),
- * or ORT already reporting QNNExecutionProvider / qnn.loadable.
+ * Windows-first QNN host soft-compat: Win ARM64 (inference) or Win x64 (preparation).
+ * Runtime signals (loadable / ORT-reported QNN) never override an out-of-scope host.
  */
 export function computeQnnCompatibleHardware(input: {
   os: string;
@@ -183,13 +184,12 @@ export function computeQnnCompatibleHardware(input: {
   qnnLoadable?: boolean;
   ortReportsQnn?: boolean;
 }): boolean {
-  if (input.qnnLoadable || input.ortReportsQnn) return true;
-  const os = input.os.toLowerCase();
-  const isWin =
-    /\bwin(?:dows(?:_nt)?|32|64)?\b/.test(os) || os.includes("win32") || os.includes("windows");
-  if (!isWin) return false;
-  const arch = input.arch.toLowerCase();
-  return arch === "arm64" || arch === "aarch64" || arch === "x64" || arch === "x86_64" || arch === "amd64";
+  const hostMode = resolveQnnHostMode({
+    platform: computeDirectMlHardwareReady({ os: input.os }) ? "win32" : "linux",
+    arch: input.arch,
+  });
+  if (hostMode === "out-of-scope") return false;
+  return true;
 }
 
 export function mapOrtProvidersToIhv(providers: string[]): IHVProvider[] {
@@ -278,6 +278,10 @@ export function mergeDetectedProviders(input: {
 
   if (input.onnxRuntimeProviders?.length) {
     for (const provider of mapOrtProvidersToIhv(input.onnxRuntimeProviders)) {
+      if (provider === "QNNExecutionProvider") {
+        // Host-boundary soft-detect below owns QNN; do not trust ORT listing alone.
+        continue;
+      }
       if (provider === "TensorrtExecutionProvider" && !tensorRtOk) {
         continue;
       }
@@ -314,7 +318,7 @@ export function mergeDetectedProviders(input: {
   if (input.hasDirectMl) {
     detected.add("DmlExecutionProvider");
   }
-  if (input.qnnLoadable || input.hasQnnCompatibleHardware) {
+  if (input.hasQnnCompatibleHardware) {
     detected.add("QNNExecutionProvider");
   }
 

--- a/src/lib/hardwareProbe.ts
+++ b/src/lib/hardwareProbe.ts
@@ -73,6 +73,30 @@ export interface OpenVinoProbeResult {
   detail?: string;
 }
 
+/** QNN 2.x plugin probe (isolated `.venvs/qnn`). */
+export interface QnnProbeResult {
+  available: boolean;
+  /** True when preparation capability is usable (plugin + QNN EpDevice). */
+  loadable?: boolean;
+  pluginVersion?: string;
+  pluginRegistered?: boolean;
+  preparation?: boolean;
+  /** OrtHardwareDeviceType.NPU filter (not CPU/emulator). */
+  npuDevice?: boolean;
+  potentialInference?: boolean;
+  /** Only true after Snapdragon release gate + cached HTP diagnostic. */
+  verifiedInference?: boolean;
+  htpSmoke?: {
+    status: "not_run" | "passed" | "failed";
+    detail?: string;
+    at?: string;
+  };
+  hostMode?: "local-inference" | "preparation" | "out-of-scope";
+  providers?: string[];
+  deviceTypes?: string[];
+  detail?: string;
+}
+
 export interface HardwareProbeResult {
   probedAt: string;
   platform: {
@@ -105,6 +129,7 @@ export interface HardwareProbeResult {
     gpus: GpuInfo[];
   };
   openvino?: OpenVinoProbeResult;
+  qnn?: QnnProbeResult;
   tensorrt?: {
     loadable: boolean;
     detail?: string;
@@ -143,9 +168,29 @@ const ORT_PROVIDER_MAP: Record<string, IHVProvider> = {
   NvTensorRtRtxExecutionProvider: "NvTensorRTRTXExecutionProvider",
   DmlExecutionProvider: "DmlExecutionProvider",
   OpenVINOExecutionProvider: "OpenVINOExecutionProvider",
+  QNNExecutionProvider: "QNNExecutionProvider",
   ROCMExecutionProvider: "ROCMExecutionProvider",
   WebGpuExecutionProvider: "WebGpuExecutionProvider",
 };
+
+/**
+ * Windows-first QNN host soft-compat: Win ARM64 (inference) or Win x64 (preparation),
+ * or ORT already reporting QNNExecutionProvider / qnn.loadable.
+ */
+export function computeQnnCompatibleHardware(input: {
+  os: string;
+  arch: string;
+  qnnLoadable?: boolean;
+  ortReportsQnn?: boolean;
+}): boolean {
+  if (input.qnnLoadable || input.ortReportsQnn) return true;
+  const os = input.os.toLowerCase();
+  const isWin =
+    /\bwin(?:dows(?:_nt)?|32|64)?\b/.test(os) || os.includes("win32") || os.includes("windows");
+  if (!isWin) return false;
+  const arch = input.arch.toLowerCase();
+  return arch === "arm64" || arch === "aarch64" || arch === "x64" || arch === "x86_64" || arch === "amd64";
+}
 
 export function mapOrtProvidersToIhv(providers: string[]): IHVProvider[] {
   const found = new Set<IHVProvider>();
@@ -217,6 +262,9 @@ export function mergeDetectedProviders(input: {
   hasOpenVinoCompatibleHardware?: boolean;
   /** True when onnxruntime reports DmlExecutionProvider (not merely Windows). */
   hasDirectMl?: boolean;
+  /** Soft-detect QNN on Windows ARM64/x64 or when the qnn family is loadable. */
+  hasQnnCompatibleHardware?: boolean;
+  qnnLoadable?: boolean;
   tensorRtLoadable?: boolean;
   tensorRtRtxLoadable?: boolean;
   nvidiaTensorRtFamilyCapable?: boolean;
@@ -266,6 +314,9 @@ export function mergeDetectedProviders(input: {
   if (input.hasDirectMl) {
     detected.add("DmlExecutionProvider");
   }
+  if (input.qnnLoadable || input.hasQnnCompatibleHardware) {
+    detected.add("QNNExecutionProvider");
+  }
 
   return Array.from(detected);
 }
@@ -279,12 +330,18 @@ export function mergeDetectedProviders(input: {
  */
 export function pickRecommendedProvider(
   detected: IHVProvider[],
-  opts?: { tensorRtRtxLoadable?: boolean; tensorRtLoadable?: boolean; openvinoLoadable?: boolean },
+  opts?: {
+    tensorRtRtxLoadable?: boolean;
+    tensorRtLoadable?: boolean;
+    openvinoLoadable?: boolean;
+    qnnLoadable?: boolean;
+  },
 ): IHVProvider {
   // Prefer installed acceleration stacks; otherwise CUDA is the safe NVIDIA default.
   const priority: IHVProvider[] = [
     ...(opts?.tensorRtRtxLoadable ? (["NvTensorRTRTXExecutionProvider"] as const) : []),
     ...(opts?.tensorRtLoadable ? (["TensorrtExecutionProvider"] as const) : []),
+    ...(opts?.qnnLoadable ? (["QNNExecutionProvider"] as const) : []),
     "CUDAExecutionProvider",
     "NvTensorRTRTXExecutionProvider",
     "TensorrtExecutionProvider",
@@ -326,8 +383,25 @@ function undetectedProviderReason(
   probe?: HardwareProbeResult | null,
 ): string {
   switch (provider) {
-    case "QNNExecutionProvider":
-      return "Qualcomm QNN requires Snapdragon / Hexagon NPU hardware on this machine.";
+    case "QNNExecutionProvider": {
+      if (!probe) {
+        return "Qualcomm QNN requires Windows ARM64 (Snapdragon NPU inference) or Windows x64 (plugin preparation).";
+      }
+      const mode = probe.qnn?.hostMode;
+      if (mode === "out-of-scope") {
+        return "QNN plugin install/UX is Windows-first in this Studio release (Win ARM64 inference / Win x64 preparation).";
+      }
+      if (probe.qnn?.loadable === true) {
+        return "QNN runtime is installed but not listed as selectable yet — refresh the hardware probe.";
+      }
+      if (mode === "preparation") {
+        return "Windows x64 QNN preparation: install the QNN runtime (.venvs/qnn with onnxruntime + onnxruntime-qnn) from Hardware. Local HTP inference is not claimed on x64.";
+      }
+      if (mode === "local-inference") {
+        return "Windows ARM64 Snapdragon: install the QNN runtime (.venvs/qnn) from Hardware. “QNN NPU ready” requires the Snapdragon release gate + HTP diagnostic.";
+      }
+      return "Qualcomm QNN requires Windows ARM64 (Snapdragon NPU) or Windows x64 (plugin preparation). Install from Hardware when this host is in scope.";
+    }
     case "ROCMExecutionProvider":
       return "AMD ROCm was not detected (no ROCm GPU or ROCm runtime on this machine).";
     case "OpenVINOExecutionProvider":

--- a/src/lib/pipelineValidation.ts
+++ b/src/lib/pipelineValidation.ts
@@ -504,7 +504,7 @@ function getQnnRecipeReadinessIssues(
     state,
     probe,
     ioConfig: extractRecipeIoConfig(recipe),
-    platform: probe
+    platform: probe?.platform
       ? { platform: probe.platform.os, arch: probe.platform.arch }
       : undefined,
   }).map((issue) => ({

--- a/src/lib/pipelineValidation.ts
+++ b/src/lib/pipelineValidation.ts
@@ -278,8 +278,9 @@ export function prepareProviderChange(
   state: UIState,
   providerId: IHVProvider,
   probe?: HardwareProbeResult | null,
+  options?: { skipHardwareBlock?: boolean },
 ): Partial<UIState> | null {
-  if (getProviderHardwareBlock(providerId, probe)) {
+  if (!options?.skipHardwareBlock && getProviderHardwareBlock(providerId, probe)) {
     return null;
   }
 

--- a/src/lib/pipelineValidation.ts
+++ b/src/lib/pipelineValidation.ts
@@ -2,6 +2,7 @@ import { IHVProvider, UIState, OliveRecipe } from "@/types";
 import { isMemoryOffloadAvailable } from "@/lib/memoryOffload";
 import { getProviderAvailabilityBlock, type HardwareProbeResult } from "@/lib/hardwareProbe";
 import { buildOliveRecipe, isPyTorchNativeQuantMethod } from "@/lib/oliveRecipeBuilder";
+import { assessQnnRecipeReadiness, type QnnReadinessIssue } from "@/lib/qnnReadiness";
 import { isKnownPass, getPassSchema } from "@/lib/schemaEngine";
 import { pickOpenVinoTargetFromDevices } from "@/lib/openvinoDeps";
 
@@ -467,6 +468,53 @@ function getProviderHardwareIssues(state: UIState, probe?: HardwareProbeResult |
   ];
 }
 
+function qnnReadinessSeverityToPipeline(severity: QnnReadinessIssue["severity"]): IssueSeverity {
+  switch (severity) {
+    case "error":
+      return "critical";
+    case "warning":
+      return "warning";
+    case "info":
+      return "info";
+    default: {
+      const _exhaustive: never = severity;
+      return _exhaustive;
+    }
+  }
+}
+
+function extractRecipeIoConfig(recipe: OliveRecipe): unknown {
+  const inputModel = recipe.input_model as { io_config?: unknown } | undefined;
+  return inputModel?.io_config;
+}
+
+/**
+ * Maps QNN HTP / host-mode readiness into pipeline issues so Execute Live
+ * and recipe validation honor fail-closed + dynamic-shape gates.
+ */
+function getQnnRecipeReadinessIssues(
+  state: UIState,
+  recipe: OliveRecipe,
+  probe?: HardwareProbeResult | null,
+): PipelineIssue[] {
+  if (state.ihvProvider !== "QNNExecutionProvider") return [];
+
+  return assessQnnRecipeReadiness({
+    state,
+    probe,
+    ioConfig: extractRecipeIoConfig(recipe),
+    platform: probe
+      ? { platform: probe.platform.os, arch: probe.platform.arch }
+      : undefined,
+  }).map((issue) => ({
+    id: `qnn-readiness-${issue.code}`,
+    severity: qnnReadinessSeverityToPipeline(issue.severity),
+    title: `QNN readiness: ${issue.code.replace(/_/g, " ")}`,
+    description: issue.message,
+    affectedPasses: ["provider"],
+  }));
+}
+
 function inputModelFormats(inputModel: { type?: string }): string[] {
   switch (inputModel.type) {
     case "HfModel":
@@ -682,6 +730,7 @@ export function getPipelineValidation(
     ...getCrossPassIssues(state),
     ...getProviderIssues(state),
     ...getProviderHardwareIssues(state, options?.hardwareProbe),
+    ...getQnnRecipeReadinessIssues(state, recipe, options?.hardwareProbe),
     ...getLocalExecutionIssues(state, options?.forLocalExecution),
     ...getAdvisoryIssues(state),
     ...getRecipeRuntimeIssues(state, recipe),

--- a/src/lib/qnnDeps.test.ts
+++ b/src/lib/qnnDeps.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "vitest";
+import {
+  ONNXRUNTIME_QNN_FAMILY_ORT_PACKAGE,
+  ONNXRUNTIME_QNN_PLUGIN_PACKAGE,
+  PINNED_ONNXRUNTIME_QNN_FAMILY_ORT_VERSION,
+  PINNED_ONNXRUNTIME_QNN_PLUGIN_VERSION,
+  isQnnSnapdragonReleaseGatePassed,
+  qnnNumpyPinForPythonMinor,
+  qnnOrtInstallArgs,
+  qnnPackageConstraints,
+  qnnStackInstallCommand,
+  qnnStackLabel,
+  qnnSupplementalInstallArgs,
+  resolveQnnHostMode,
+} from "./qnnDeps";
+
+describe("qnnDeps", () => {
+  it("pins the QNN 2.4.0 tested ORT/plugin pair", () => {
+    expect(ONNXRUNTIME_QNN_FAMILY_ORT_PACKAGE).toBe("onnxruntime");
+    expect(PINNED_ONNXRUNTIME_QNN_FAMILY_ORT_VERSION).toBe("1.26.0");
+    expect(ONNXRUNTIME_QNN_PLUGIN_PACKAGE).toBe("onnxruntime-qnn");
+    expect(PINNED_ONNXRUNTIME_QNN_PLUGIN_VERSION).toBe("2.4.0");
+    expect(qnnOrtInstallArgs()).toEqual(["onnxruntime==1.26.0"]);
+    expect(qnnSupplementalInstallArgs()).toContain("onnxruntime-qnn==2.4.0");
+  });
+
+  it("pins NumPy per supported Python minor and rejects 3.10", () => {
+    expect(qnnNumpyPinForPythonMinor("3.10")).toBeNull();
+    expect(qnnNumpyPinForPythonMinor("3.11")).toBe("1.26.4");
+    expect(qnnNumpyPinForPythonMinor("3.12")).toBe("2.2.6");
+    expect(qnnNumpyPinForPythonMinor("3.13")).toBe("2.2.6");
+  });
+
+  it("keeps constraints and labels in lockstep with pins", () => {
+    expect(qnnPackageConstraints()).toContain("onnxruntime==1.26.0");
+    expect(qnnPackageConstraints()).toContain("onnxruntime-qnn==2.4.0");
+    expect(qnnStackLabel()).toContain("1.26.0");
+    expect(qnnStackLabel()).toContain("2.4.0");
+    expect(qnnStackInstallCommand()).toContain("onnxruntime-qnn==2.4.0");
+  });
+
+  it("resolves Windows-first host modes", () => {
+    expect(resolveQnnHostMode({ platform: "win32", arch: "arm64" })).toBe("local-inference");
+    expect(resolveQnnHostMode({ platform: "win32", arch: "x64" })).toBe("preparation");
+    expect(resolveQnnHostMode({ platform: "linux", arch: "x64" })).toBe("out-of-scope");
+    expect(resolveQnnHostMode({ platform: "darwin", arch: "arm64" })).toBe("out-of-scope");
+  });
+
+  it("keeps Snapdragon release gate closed until hardware validation", () => {
+    expect(isQnnSnapdragonReleaseGatePassed()).toBe(false);
+  });
+});

--- a/src/lib/qnnDeps.ts
+++ b/src/lib/qnnDeps.ts
@@ -1,0 +1,113 @@
+/**
+ * QNN 2.x plugin EP installation metadata for the isolated qnn venv family.
+ *
+ * `.venvs/qnn` uses standard `onnxruntime` plus the `onnxruntime-qnn` plugin
+ * package (not a replacement ORT distribution). Pins match QNN EP 2.4.0's
+ * compiled/tested ORT pair for deterministic family builds.
+ *
+ * @see https://github.com/onnxruntime/onnxruntime-qnn
+ */
+
+/** Canonical ORT wheel for the qnn family (not DirectML / GPU / OpenVINO). */
+export const ONNXRUNTIME_QNN_FAMILY_ORT_PACKAGE = "onnxruntime";
+export const PINNED_ONNXRUNTIME_QNN_FAMILY_ORT_VERSION = "1.26.0";
+
+/** QNN 2.x plugin package installed beside standard ORT. */
+export const ONNXRUNTIME_QNN_PLUGIN_PACKAGE = "onnxruntime-qnn";
+export const PINNED_ONNXRUNTIME_QNN_PLUGIN_VERSION = "2.4.0";
+
+/**
+ * Tested NumPy pins per CPython minor (QNN requires 1.25.2 or >=1.26.4).
+ * Spike-verified on CPython 3.12 with the ORT/plugin pair above.
+ */
+export const QNN_NUMPY_PINS: Readonly<Record<"3.11" | "3.12" | "3.13", string>> = {
+  "3.11": "1.26.4",
+  "3.12": "2.2.6",
+  "3.13": "2.2.6",
+};
+
+/** CPython minors accepted for the qnn family in the current Studio release. */
+export const QNN_FAMILY_PYTHON_MINORS = ["3.11", "3.12", "3.13"] as const;
+export type QnnFamilyPythonMinor = (typeof QNN_FAMILY_PYTHON_MINORS)[number];
+
+/** Advanced QAIRT tooling docs (not required for ordinary plugin install). */
+export const QNN_ADVANCED_QAIRT_DOCS_URL =
+  "https://docs.qualcomm.com/bundle/publicresource/topics/80-63442-10/introduction.html";
+
+export function isQnnFamilyPythonMinor(minor: string): minor is QnnFamilyPythonMinor {
+  return (QNN_FAMILY_PYTHON_MINORS as readonly string[]).includes(minor);
+}
+
+/** Exact NumPy pin for a supported Python minor, or null if unsupported. */
+export function qnnNumpyPinForPythonMinor(minor: string): string | null {
+  if (!isQnnFamilyPythonMinor(minor)) return null;
+  return QNN_NUMPY_PINS[minor];
+}
+
+/** Marker-based NumPy constraints for pip (one pin per supported minor). */
+export function qnnNumpyConstraintArgs(): string[] {
+  return QNN_FAMILY_PYTHON_MINORS.map(
+    (minor) => `numpy==${QNN_NUMPY_PINS[minor]}; python_version=="${minor}"`,
+  );
+}
+
+export function qnnOrtInstallArgs(): string[] {
+  return [`${ONNXRUNTIME_QNN_FAMILY_ORT_PACKAGE}==${PINNED_ONNXRUNTIME_QNN_FAMILY_ORT_VERSION}`];
+}
+
+/** Supplemental packages: QNN plugin + NumPy pins (not ORT distributions). */
+export function qnnSupplementalInstallArgs(): string[] {
+  return [
+    `${ONNXRUNTIME_QNN_PLUGIN_PACKAGE}==${PINNED_ONNXRUNTIME_QNN_PLUGIN_VERSION}`,
+    ...qnnNumpyConstraintArgs(),
+  ];
+}
+
+export function qnnPackageConstraints(): string[] {
+  return [
+    `${ONNXRUNTIME_QNN_FAMILY_ORT_PACKAGE}==${PINNED_ONNXRUNTIME_QNN_FAMILY_ORT_VERSION}`,
+    `${ONNXRUNTIME_QNN_PLUGIN_PACKAGE}==${PINNED_ONNXRUNTIME_QNN_PLUGIN_VERSION}`,
+    ...qnnNumpyConstraintArgs(),
+  ];
+}
+
+export function qnnSupplementalConstraints(): string[] {
+  return [
+    `${ONNXRUNTIME_QNN_PLUGIN_PACKAGE}==${PINNED_ONNXRUNTIME_QNN_PLUGIN_VERSION}`,
+    ...qnnNumpyConstraintArgs(),
+  ];
+}
+
+export function qnnStackLabel(): string {
+  return `${ONNXRUNTIME_QNN_FAMILY_ORT_PACKAGE}==${PINNED_ONNXRUNTIME_QNN_FAMILY_ORT_VERSION} + ${ONNXRUNTIME_QNN_PLUGIN_PACKAGE}==${PINNED_ONNXRUNTIME_QNN_PLUGIN_VERSION}`;
+}
+
+export function qnnStackInstallCommand(): string {
+  return `pip install ${ONNXRUNTIME_QNN_FAMILY_ORT_PACKAGE}==${PINNED_ONNXRUNTIME_QNN_FAMILY_ORT_VERSION} ${ONNXRUNTIME_QNN_PLUGIN_PACKAGE}==${PINNED_ONNXRUNTIME_QNN_PLUGIN_VERSION}`;
+}
+
+/**
+ * True when Studio may claim verified “QNN NPU ready” UI.
+ * Remains false until the Snapdragon release gate passes on real hardware.
+ * Kept as a function so call sites type-check while the gate is still closed.
+ */
+export function isQnnSnapdragonReleaseGatePassed(): boolean {
+  return false;
+}
+
+/** @deprecated Prefer {@link isQnnSnapdragonReleaseGatePassed}. */
+export const QNN_SNAPDRAGON_RELEASE_GATE_PASSED = false as boolean;
+
+/** Host mode for Windows-first QNN release scope. */
+export type QnnHostMode = "local-inference" | "preparation" | "out-of-scope";
+
+export function resolveQnnHostMode(opts: {
+  platform: NodeJS.Platform | string;
+  arch: string;
+}): QnnHostMode {
+  if (opts.platform !== "win32") return "out-of-scope";
+  const arch = opts.arch.toLowerCase();
+  if (arch === "arm64" || arch === "aarch64") return "local-inference";
+  if (arch === "x64" || arch === "x86_64" || arch === "amd64") return "preparation";
+  return "out-of-scope";
+}

--- a/src/lib/qnnReadiness.test.ts
+++ b/src/lib/qnnReadiness.test.ts
@@ -100,6 +100,14 @@ describe("qnnReadiness", () => {
     expect(isQnnSnapdragonReleaseGatePassed()).toBe(false);
   });
 
+  it("does not treat missing NPU as an error when no probe is supplied", () => {
+    const issues = assessQnnRecipeReadiness({
+      state: { ihvProvider: "QNNExecutionProvider", passes: basePasses },
+      hostMode: "local-inference",
+    });
+    expect(issues.some((i) => i.code === "qnn_npu_missing")).toBe(false);
+  });
+
   it("keeps UI label below NPU ready until release gate", () => {
     expect(qnnRuntimeUiLabel(probe())).toBe("QNN runtime installed (NPU device)");
     expect(qnnExplicitRetryProviders()).toEqual([

--- a/src/lib/qnnReadiness.test.ts
+++ b/src/lib/qnnReadiness.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+import {
+  assessQnnRecipeReadiness,
+  isQnnSdkBackedPass,
+  isUnresolvedDynamicDim,
+  modelIoHasUnresolvedDynamicShapes,
+  qnnExplicitRetryProviders,
+  qnnRuntimeUiLabel,
+} from "./qnnReadiness";
+import { isQnnSnapdragonReleaseGatePassed } from "./qnnDeps";
+import type { HardwareProbeResult } from "./hardwareProbe";
+import type { UIState } from "@/types";
+
+const basePasses = {
+  conversion: true,
+  conversionSourceFormat: "pytorch" as const,
+  conversionFormat: "onnx" as const,
+  conversionOpset: 17,
+  conversionInputTargetTypes: "",
+  quantization: false,
+  quantMethod: "ptq" as const,
+  quantPrecision: "int8" as const,
+  gptqBlockSize: 128,
+  gptqDescAct: false,
+  gptqGroupSize: 128,
+  awqGroupSize: 128,
+  awqDampPercent: 0.01,
+  awqSym: false,
+  qatQuantPrecision: "int8" as const,
+  qatCalibrateMethod: "minmax" as const,
+  qatCalibrateSteps: 100,
+  quantPreset: "",
+  pruning: false,
+  pruningSparsity: 0.5,
+  pruningType: "unstructured" as const,
+  pruningMethod: "magnitude" as const,
+  pruningCriteria: "l1_norm" as const,
+  splitting: false,
+  onnxTransforms: false,
+  peft: false,
+  peftMethod: "lora" as const,
+  diffusionLora: false,
+};
+
+function probe(partial: Partial<HardwareProbeResult["qnn"]> = {}): HardwareProbeResult {
+  return {
+    probedAt: new Date().toISOString(),
+    platform: { os: "win32 10.0", arch: "arm64", cpuModel: "Snapdragon", cpuCores: 8 },
+    detectedProviders: ["CPUExecutionProvider", "QNNExecutionProvider"],
+    recommendedProvider: "QNNExecutionProvider",
+    notes: [],
+    qnn: {
+      available: true,
+      loadable: true,
+      preparation: true,
+      npuDevice: true,
+      potentialInference: true,
+      verifiedInference: false,
+      hostMode: "local-inference",
+      ...partial,
+    },
+  };
+}
+
+describe("qnnReadiness", () => {
+  it("classifies dynamic dims and io_config shapes", () => {
+    expect(isUnresolvedDynamicDim("batch")).toBe(true);
+    expect(isUnresolvedDynamicDim(-1)).toBe(true);
+    expect(isUnresolvedDynamicDim(1)).toBe(false);
+    expect(
+      modelIoHasUnresolvedDynamicShapes({
+        input_shapes: [[1, "seq"]],
+      }),
+    ).toBe(true);
+    expect(
+      modelIoHasUnresolvedDynamicShapes({
+        input_shapes: [[1, 128]],
+      }),
+    ).toBe(false);
+  });
+
+  it("gates SDK-backed passes separately from plugin prep", () => {
+    expect(isQnnSdkBackedPass("QNNConversion")).toBe(true);
+    expect(isQnnSdkBackedPass("QNNPreprocess")).toBe(false);
+  });
+
+  it("emits fail-closed + unverified NPU issues for ARM64 inference", () => {
+    const state = {
+      ihvProvider: "QNNExecutionProvider" as const,
+      passes: basePasses,
+    } satisfies Pick<UIState, "ihvProvider" | "passes">;
+    const issues = assessQnnRecipeReadiness({
+      state,
+      probe: probe(),
+      ioConfig: { input_shapes: [[1, "dyn"]] },
+    });
+    expect(issues.some((i) => i.code === "qnn_dynamic_shapes" && i.severity === "error")).toBe(true);
+    expect(issues.some((i) => i.code === "qnn_fail_closed")).toBe(true);
+    expect(issues.some((i) => i.code === "qnn_npu_unverified")).toBe(true);
+    expect(isQnnSnapdragonReleaseGatePassed()).toBe(false);
+  });
+
+  it("keeps UI label below NPU ready until release gate", () => {
+    expect(qnnRuntimeUiLabel(probe())).toBe("QNN runtime installed (NPU device)");
+    expect(qnnExplicitRetryProviders()).toEqual([
+      "DmlExecutionProvider",
+      "CPUExecutionProvider",
+    ]);
+  });
+});

--- a/src/lib/qnnReadiness.ts
+++ b/src/lib/qnnReadiness.ts
@@ -160,7 +160,7 @@ export function assessQnnRecipeReadiness(input: {
     }
   }
 
-  if (input.probe?.qnn?.loadable !== true) {
+  if (input.probe && input.probe.qnn?.loadable !== true) {
     issues.push({
       severity: "error",
       code: "qnn_runtime_missing",

--- a/src/lib/qnnReadiness.ts
+++ b/src/lib/qnnReadiness.ts
@@ -143,14 +143,17 @@ export function assessQnnRecipeReadiness(input: {
   }
 
   if (mode === "local-inference") {
-    if (!input.probe?.qnn?.npuDevice) {
+    if (input.probe && !input.probe.qnn?.npuDevice) {
       issues.push({
         severity: "error",
         code: "qnn_npu_missing",
         message:
           "No QNN OrtEpDevice with OrtHardwareDeviceType.NPU. CPU/emulator QNN devices do not satisfy inference readiness.",
       });
-    } else if (!isQnnSnapdragonReleaseGatePassed() || !input.probe.qnn.verifiedInference) {
+    } else if (
+      input.probe?.qnn?.npuDevice &&
+      (!isQnnSnapdragonReleaseGatePassed() || !input.probe.qnn.verifiedInference)
+    ) {
       issues.push({
         severity: "warning",
         code: "qnn_npu_unverified",

--- a/src/lib/qnnReadiness.ts
+++ b/src/lib/qnnReadiness.ts
@@ -1,0 +1,206 @@
+/**
+ * QNN HTP shape / model-readiness validation and fail-closed retry helpers.
+ *
+ * Hard failures: unresolved dynamic shapes for HTP; no QNN NPU when inference
+ * intended; registration failure. Warnings: FP where QDQ is preferable.
+ * SDK-backed Olive passes stay gated separately from plugin prep/inference.
+ */
+import type { IHVProvider, UIState } from "@/types";
+import {
+  QNN_ADVANCED_QAIRT_DOCS_URL,
+  isQnnSnapdragonReleaseGatePassed,
+  resolveQnnHostMode,
+  type QnnHostMode,
+} from "@/lib/qnnDeps";
+import type { HardwareProbeResult } from "@/lib/hardwareProbe";
+
+export type QnnReadinessSeverity = "error" | "warning" | "info";
+
+export type QnnReadinessIssue = {
+  severity: QnnReadinessSeverity;
+  code: string;
+  message: string;
+};
+
+/** Olive passes that still require external QAIRT SDK (`QNN_SDK_ROOT`). */
+export const QNN_SDK_BACKED_PASS_NAMES = [
+  "QNNConversion",
+  "QNNModelLibGenerator",
+  "QNNContextBinaryGenerator",
+] as const;
+
+/** Plugin-based passes that do not imply a full QAIRT SDK install. */
+export const QNN_PLUGIN_PASS_NAMES = [
+  "QNNPreprocess",
+  "OnnxQuantization",
+  "OnnxStaticQuantization",
+  "EPContextBinaryGenerator",
+] as const;
+
+export function isQnnSdkBackedPass(passName: string): boolean {
+  return (QNN_SDK_BACKED_PASS_NAMES as readonly string[]).includes(passName);
+}
+
+/** True when a dim is dynamic / symbolic (unresolved for HTP). */
+export function isUnresolvedDynamicDim(dim: unknown): boolean {
+  if (dim === null || dim === undefined) return true;
+  if (typeof dim === "string") {
+    const trimmed = dim.trim();
+    if (!trimmed) return true;
+    if (/^\d+$/.test(trimmed)) return false;
+    return true;
+  }
+  if (typeof dim === "number") {
+    return !Number.isFinite(dim) || dim <= 0;
+  }
+  return true;
+}
+
+export function modelIoHasUnresolvedDynamicShapes(ioConfig: unknown): boolean {
+  if (!ioConfig || typeof ioConfig !== "object") return false;
+  const cfg = ioConfig as {
+    input_shapes?: unknown;
+    output_shapes?: unknown;
+    input_names?: unknown;
+  };
+  const shapes = [cfg.input_shapes, cfg.output_shapes].filter(Boolean);
+  for (const block of shapes) {
+    if (!Array.isArray(block)) continue;
+    for (const shape of block) {
+      if (!Array.isArray(shape)) continue;
+      if (shape.some((d) => isUnresolvedDynamicDim(d))) return true;
+    }
+  }
+  return false;
+}
+
+export function qnnQuantizationRecommendation(state: Pick<UIState, "passes">): QnnReadinessIssue | null {
+  if (!state.passes.quantization) {
+    return {
+      severity: "warning",
+      code: "qnn_fp_model",
+      message:
+        "FP models often under-utilize HTP. Prefer ONNX QDQ / PTQ preprocessing for QNN deployment coverage.",
+    };
+  }
+  if (state.passes.quantMethod && state.passes.quantMethod !== "ptq") {
+    return {
+      severity: "warning",
+      code: "qnn_quant_method",
+      message: `QNN targets support PTQ-style ONNX quantization in Studio; ${state.passes.quantMethod} is not the preferred path.`,
+    };
+  }
+  return null;
+}
+
+export function assessQnnRecipeReadiness(input: {
+  state: Pick<UIState, "ihvProvider" | "passes">;
+  /** Optional Olive io_config / shape block for HTP static-shape checks. */
+  ioConfig?: unknown;
+  probe?: HardwareProbeResult | null;
+  hostMode?: QnnHostMode;
+  platform?: { platform: NodeJS.Platform | string; arch: string };
+}): QnnReadinessIssue[] {
+  if (input.state.ihvProvider !== "QNNExecutionProvider") return [];
+
+  const issues: QnnReadinessIssue[] = [];
+  const mode =
+    input.hostMode ??
+    input.probe?.qnn?.hostMode ??
+    (input.platform
+      ? resolveQnnHostMode(input.platform)
+      : resolveQnnHostMode({
+          platform: typeof process !== "undefined" ? process.platform : "linux",
+          arch: typeof process !== "undefined" ? process.arch : "x64",
+        }));
+
+  if (mode === "out-of-scope") {
+    issues.push({
+      severity: "error",
+      code: "qnn_out_of_scope",
+      message:
+        "QNN workflows are Windows-first in this release (Win ARM64 inference / Win x64 preparation).",
+    });
+    return issues;
+  }
+
+  if (mode === "preparation") {
+    issues.push({
+      severity: "info",
+      code: "qnn_prep_only",
+      message:
+        "Windows x64: plugin preparation / AOT only. Local HTP inference is not claimed. SDK-backed Olive passes still need QAIRT separately.",
+    });
+  }
+
+  if (input.ioConfig !== undefined && modelIoHasUnresolvedDynamicShapes(input.ioConfig)) {
+    issues.push({
+      severity: "error",
+      code: "qnn_dynamic_shapes",
+      message:
+        "Unresolved dynamic shapes are a hard failure for HTP. Fix static shapes / io_config before a QNN inference session.",
+    });
+  }
+
+  if (mode === "local-inference") {
+    if (!input.probe?.qnn?.npuDevice) {
+      issues.push({
+        severity: "error",
+        code: "qnn_npu_missing",
+        message:
+          "No QNN OrtEpDevice with OrtHardwareDeviceType.NPU. CPU/emulator QNN devices do not satisfy inference readiness.",
+      });
+    } else if (!isQnnSnapdragonReleaseGatePassed() || !input.probe.qnn.verifiedInference) {
+      issues.push({
+        severity: "warning",
+        code: "qnn_npu_unverified",
+        message:
+          "QNN runtime / NPU device present. UI will not claim “QNN NPU ready” until the Snapdragon release gate and cached HTP diagnostic pass.",
+      });
+    }
+  }
+
+  if (input.probe?.qnn?.loadable !== true) {
+    issues.push({
+      severity: "error",
+      code: "qnn_runtime_missing",
+      message:
+        "QNN runtime not ready in .venvs/qnn. Install onnxruntime==1.26.0 + onnxruntime-qnn==2.4.0 from Hardware.",
+    });
+  }
+
+  const quant = qnnQuantizationRecommendation(input.state);
+  if (quant) issues.push(quant);
+
+  issues.push({
+    severity: "info",
+    code: "qnn_fail_closed",
+    message:
+      "QNN sessions are fail-closed (no automatic DirectML/CPU fallback). On failure use Retry with DirectML or Retry with CPU explicitly.",
+  });
+
+  issues.push({
+    severity: "info",
+    code: "qnn_sdk_docs",
+    message: `Advanced QAIRT / SDK-backed passes: ${QNN_ADVANCED_QAIRT_DOCS_URL}`,
+  });
+
+  return issues;
+}
+
+/** Explicit retry targets after a fail-closed QNN job (never automatic). */
+export function qnnExplicitRetryProviders(): IHVProvider[] {
+  return ["DmlExecutionProvider", "CPUExecutionProvider"];
+}
+
+export function qnnRuntimeUiLabel(probe?: HardwareProbeResult | null): string {
+  if (probe?.qnn?.verifiedInference && isQnnSnapdragonReleaseGatePassed()) {
+    return "QNN NPU ready";
+  }
+  if (probe?.qnn?.loadable) {
+    if (probe.qnn.hostMode === "preparation") return "QNN runtime installed (preparation)";
+    if (probe.qnn.npuDevice) return "QNN runtime installed (NPU device)";
+    return "QNN runtime installed";
+  }
+  return "QNN runtime not installed";
+}

--- a/src/lib/recipeHardwareCompatibility.ts
+++ b/src/lib/recipeHardwareCompatibility.ts
@@ -171,7 +171,7 @@ export function assessRecipeHardwareCompatibility(
 
   if (targetDevice === "QNN") {
     const hostMode = resolveQnnHostMode({
-      platform: probe.platform.os.toLowerCase().includes("win") ? "win32" : "linux",
+      platform: /^win(?:32|64)?$/i.test(probe.platform.os.trim()) ? "win32" : "linux",
       arch: probe.platform.arch,
     });
     const qnnCompatible = computeQnnCompatibleHardware({

--- a/src/lib/recipeHardwareCompatibility.ts
+++ b/src/lib/recipeHardwareCompatibility.ts
@@ -10,12 +10,14 @@ import {
   type HardwareProbeResult,
   isProviderDetectedLocally,
   computeDirectMlHardwareReady,
+  computeQnnCompatibleHardware,
 } from "@/lib/hardwareProbe";
 import {
   CUDA_TOOLKIT_MIN_COMPUTE_CAPABILITY,
   isPreMaxwellNvidiaBox,
   pinnedOrtGpuInstallCommand,
 } from "@/lib/cudaDeps";
+import { qnnStackInstallCommand, resolveQnnHostMode } from "@/lib/qnnDeps";
 import type { IHVProvider } from "@/types";
 
 export type RecipeHardwareCompatTier = "compatible" | "unavailable" | "unknown";
@@ -27,7 +29,12 @@ export type RecipeHardwareCompatTier = "compatible" | "unavailable" | "unknown";
  * counts as hardware-compatible so `hideIncompatibleRecipes` does not drop it.
  */
 export interface RecipeInstallHint {
-  kind: "tensorrt" | "tensorrt-rtx" | "onnxruntime-gpu" | "onnxruntime-directml";
+  kind:
+    | "tensorrt"
+    | "tensorrt-rtx"
+    | "onnxruntime-gpu"
+    | "onnxruntime-directml"
+    | "onnxruntime-qnn";
   /** Provider the recipe expects once deps land. */
   provider: IHVProvider;
   /** Underlying detail string from the probe (may be empty). */
@@ -56,7 +63,7 @@ function ePInstallHint(args: {
   probe: HardwareProbeResult;
   requiredProvider: IHVProvider;
   kind: RecipeInstallHint["kind"];
-  detailKey?: "tensorrt" | "tensorRtRtx" | "cuda";
+  detailKey?: "tensorrt" | "tensorRtRtx" | "cuda" | "qnn";
   depLabel: string;
   installCommand: string;
   /** Override the "supported family" label (defaults to NVIDIA GPU or CPU model). */
@@ -163,18 +170,66 @@ export function assessRecipeHardwareCompatibility(
   }
 
   if (targetDevice === "QNN") {
-    if (isProviderDetectedLocally("QNNExecutionProvider", probe)) {
+    const hostMode = resolveQnnHostMode({
+      platform: probe.platform.os.toLowerCase().includes("win") ? "win32" : "linux",
+      arch: probe.platform.arch,
+    });
+    const qnnCompatible = computeQnnCompatibleHardware({
+      os: probe.platform.os,
+      arch: probe.platform.arch,
+      qnnLoadable: probe.qnn?.loadable === true,
+      ortReportsQnn: probe.onnxRuntimeProviders?.includes("QNNExecutionProvider"),
+    });
+    if (isProviderDetectedLocally("QNNExecutionProvider", probe) || qnnCompatible) {
+      if (probe.qnn?.loadable === true) {
+        return {
+          tier: "compatible",
+          targetDevice,
+          reason:
+            hostMode === "preparation"
+              ? "QNN runtime installed for Windows x64 preparation / plugin AOT (not local HTP inference)."
+              : probe.qnn.npuDevice
+                ? "QNN runtime installed with NPU EpDevice (verified “QNN NPU ready” gated separately)."
+                : "QNN runtime installed (.venvs/qnn).",
+          requiredProvider: "QNNExecutionProvider",
+        };
+      }
+      if (hostMode === "out-of-scope") {
+        return {
+          tier: "unavailable",
+          targetDevice,
+          reason:
+            "QNN plugin install/UX is Windows-first in this Studio release (Win ARM64 inference / Win x64 preparation).",
+          requiredProvider: "QNNExecutionProvider",
+        };
+      }
       return {
         tier: "compatible",
         targetDevice,
-        reason: "Qualcomm QNN / Hexagon NPU detected.",
+        reason:
+          hostMode === "preparation"
+            ? "Windows x64 can prepare QNN plugin / AOT recipes — install .venvs/qnn first."
+            : "Windows ARM64 Snapdragon host can run QNN — install .venvs/qnn first.",
         requiredProvider: "QNNExecutionProvider",
+        requiresInstall: ePInstallHint({
+          probe,
+          requiredProvider: "QNNExecutionProvider",
+          kind: "onnxruntime-qnn",
+          detailKey: "qnn",
+          depLabel: "QNN runtime (onnxruntime + onnxruntime-qnn plugin in .venvs/qnn)",
+          installCommand: qnnStackInstallCommand(),
+          deviceLabel:
+            hostMode === "preparation"
+              ? "Windows x64 (preparation / AOT)"
+              : "Windows ARM64 Snapdragon NPU",
+        }),
       };
     }
     return {
       tier: "unavailable",
       targetDevice,
-      reason: "QNN requires Snapdragon / Hexagon dev hardware (not detected on this desktop).",
+      reason:
+        "QNN requires Windows ARM64 (Snapdragon NPU inference) or Windows x64 (plugin preparation). Not detected on this host.",
       requiredProvider: "QNNExecutionProvider",
     };
   }

--- a/src/lib/recipeHardwareCompatibility.ts
+++ b/src/lib/recipeHardwareCompatibility.ts
@@ -171,7 +171,7 @@ export function assessRecipeHardwareCompatibility(
 
   if (targetDevice === "QNN") {
     const hostMode = resolveQnnHostMode({
-      platform: /^win(?:32|64)?$/i.test(probe.platform.os.trim()) ? "win32" : "linux",
+      platform: computeDirectMlHardwareReady({ os: probe.platform.os }) ? "win32" : "linux",
       arch: probe.platform.arch,
     });
     const qnnCompatible = computeQnnCompatibleHardware({

--- a/src/lib/venvFamily.ts
+++ b/src/lib/venvFamily.ts
@@ -162,18 +162,10 @@ export function resolveRequiredFamilies(
       families.add("default");
     } else if (flags.cuda.cpuUsable) {
       families.add("cuda");
-    } else if (families.size > 0) {
-      // Provisionally reuse a family this preflight will create for a non-CPU provider.
-      // Prefer cuda if present (CPU+CUDA → cuda only), else any mandatory family
-      // except specialized EP-only families (openvino / qnn).
-      if (families.has("cuda")) {
-        /* keep cuda only for CPU placement */
-      } else if (![...families].every((f) => f === "openvino" || f === "qnn")) {
-        families.add("default");
-      } else {
-        families.add("default");
-      }
+    } else if (families.has("cuda")) {
+      // CPU+CUDA batch: reuse cuda for CPU placement (do not create default solely for CPU).
     } else {
+      // CPU must not run in openvino/qnn alone; provision default when CUDA isn’t available.
       families.add("default");
     }
   }

--- a/src/lib/venvFamily.ts
+++ b/src/lib/venvFamily.ts
@@ -5,9 +5,14 @@
  */
 import type { IHVProvider } from "@/types";
 
-export type VenvFamily = "default" | "cuda" | "openvino";
+export type VenvFamily = "default" | "cuda" | "openvino" | "qnn";
 
-export const VENV_FAMILIES: readonly VenvFamily[] = ["default", "cuda", "openvino"] as const;
+export const VENV_FAMILIES: readonly VenvFamily[] = [
+  "default",
+  "cuda",
+  "openvino",
+  "qnn",
+] as const;
 
 /** Known Olive Studio execution-provider IDs (exhaustive). */
 export const KNOWN_IHV_PROVIDERS: readonly IHVProvider[] = [
@@ -81,6 +86,7 @@ export function emptyFamilyFlags(): RuntimeFamilyFlags {
     default: { cpuUsable: false, prepared: false },
     cuda: { cpuUsable: false, prepared: false },
     openvino: { cpuUsable: false, prepared: false },
+    qnn: { cpuUsable: false, prepared: false },
   };
 }
 
@@ -93,8 +99,9 @@ export function mandatoryFamilyForProvider(provider: IHVProvider): VenvFamily | 
       return "cuda";
     case "OpenVINOExecutionProvider":
       return "openvino";
-    case "DmlExecutionProvider":
     case "QNNExecutionProvider":
+      return "qnn";
+    case "DmlExecutionProvider":
     case "ROCMExecutionProvider":
       return "default";
     case "CPUExecutionProvider":
@@ -121,7 +128,7 @@ export function resolveVenvFamily(
   if (provider === "WebGpuExecutionProvider") return "default";
 
   // CPU: prefer default if CPU-usable; else cuda if CPU-usable; else default (will create).
-  // Do not place CPU jobs on the openvino family.
+  // Do not place CPU jobs on the openvino or qnn families.
   if (flags.default.cpuUsable) return "default";
   if (flags.cuda.cpuUsable) return "cuda";
   return "default";
@@ -157,9 +164,12 @@ export function resolveRequiredFamilies(
       families.add("cuda");
     } else if (families.size > 0) {
       // Provisionally reuse a family this preflight will create for a non-CPU provider.
-      // Prefer cuda if present (CPU+CUDA → cuda only), else any mandatory family.
+      // Prefer cuda if present (CPU+CUDA → cuda only), else any mandatory family
+      // except specialized EP-only families (openvino / qnn).
       if (families.has("cuda")) {
         /* keep cuda only for CPU placement */
+      } else if (![...families].every((f) => f === "openvino" || f === "qnn")) {
+        families.add("default");
       } else {
         families.add("default");
       }
@@ -172,6 +182,7 @@ export function resolveRequiredFamilies(
   if (families.has("default")) ordered.push("default");
   if (families.has("cuda")) ordered.push("cuda");
   if (families.has("openvino")) ordered.push("openvino");
+  if (families.has("qnn")) ordered.push("qnn");
   return ordered;
 }
 
@@ -181,6 +192,8 @@ export function humanFamilyLabel(family: VenvFamily): string {
       return "CUDA runtime";
     case "openvino":
       return "OpenVINO runtime";
+    case "qnn":
+      return "QNN runtime";
     case "default":
       return "default runtime";
     default: {
@@ -196,6 +209,8 @@ export function humanFamilyRootHint(family: VenvFamily): string {
       return ".venvs/cuda";
     case "openvino":
       return ".venvs/openvino";
+    case "qnn":
+      return ".venvs/qnn";
     case "default":
       return ".venv";
     default: {

--- a/src/server/routes/env.ts
+++ b/src/server/routes/env.ts
@@ -17,6 +17,7 @@ import { ensureTensorRtRtx, ensureTensorRt } from "./tensorrt.ts";
 import { ensureOpenVino } from "../services/olive/openvino.ts";
 import { ensureOnnxRuntimeGpu } from "../services/olive/cuda.ts";
 import { ensureDirectMl } from "../services/olive/directml.ts";
+import { ensureQnn, runQnnHtpDiagnostic } from "../services/olive/qnn.ts";
 import { fsWriteRateLimit, heavyCommandRateLimit } from "../middleware/rateLimit.ts";
 import { resolveAllowedPythonFile } from "../services/venv/pythonGuard.ts";
 
@@ -108,6 +109,14 @@ export function mountEnvRoutes(router: Router): void {
 
   router.post("/env/install-openvino", heavyCommandRateLimit, async (_req, res) => {
     await withVenvPipInstallMutex(() => streamNdjsonInstall(res, ensureOpenVino));
+  });
+
+  router.post("/env/install-qnn", heavyCommandRateLimit, async (_req, res) => {
+    await withVenvPipInstallMutex(() => streamNdjsonInstall(res, ensureQnn));
+  });
+
+  router.post("/env/test-qnn-npu", heavyCommandRateLimit, async (_req, res) => {
+    await withVenvPipInstallMutex(() => streamNdjsonInstall(res, runQnnHtpDiagnostic));
   });
 
   router.post("/env/install-directml", heavyCommandRateLimit, async (_req, res) => {

--- a/src/server/routes/olive.providerRouting.test.ts
+++ b/src/server/routes/olive.providerRouting.test.ts
@@ -134,7 +134,35 @@ describe("POST /olive/run provider routing", () => {
     expect(venv.ensureProviderCapability).toHaveBeenCalledWith(
       "CUDAExecutionProvider",
       expect.any(Function),
+      undefined,
     );
     expect(spawnSpy).toHaveBeenCalled();
+  });
+
+  it("routes QNN recipes with preparation/inference usage based on host mode", async () => {
+    vi.mocked(venv.ensureProviderCapability).mockResolvedValue({
+      ok: true,
+      family: "qnn",
+      python: "/tmp/mock-qnn-python",
+    });
+    spawnSpy.mockImplementation(() => mockSpawnProcess() as never);
+
+    const res = await fetch(`${baseUrl}/api/olive/run`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        recipeJson: JSON.stringify(recipeWithProvider("QNNExecutionProvider")),
+      }),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { ok: boolean; jobId?: string };
+    expect(body.ok).toBe(true);
+    expect(venv.ensureProviderCapability).toHaveBeenCalledWith(
+      "QNNExecutionProvider",
+      expect.any(Function),
+      {
+        usage: process.platform === "win32" && process.arch === "arm64" ? "inference" : "preparation",
+      },
+    );
   });
 });

--- a/src/server/routes/olive.providerRouting.test.ts
+++ b/src/server/routes/olive.providerRouting.test.ts
@@ -42,9 +42,18 @@ vi.mock("../../lib/oliveRecipeSchema.ts", () => ({
   validateOliveRecipeStructure: () => ({ valid: true, errors: [] }),
 }));
 
+vi.mock("../../lib/qnnDeps.ts", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../lib/qnnDeps.ts")>();
+  return {
+    ...actual,
+    resolveQnnHostMode: vi.fn(() => "preparation" as const),
+  };
+});
+
 const { mountOliveRoutes } = await import("./olive.ts");
 const { jobRegistry } = await import("../services/olive/state.ts");
 const venv = await import("../services/venv/index.ts");
+const qnnDeps = await import("../../lib/qnnDeps.ts");
 
 let server: Server;
 let baseUrl: string;
@@ -140,6 +149,7 @@ describe("POST /olive/run provider routing", () => {
   });
 
   it("routes QNN recipes with preparation/inference usage based on host mode", async () => {
+    vi.mocked(qnnDeps.resolveQnnHostMode).mockReturnValue("preparation");
     vi.mocked(venv.ensureProviderCapability).mockResolvedValue({
       ok: true,
       family: "qnn",
@@ -160,9 +170,23 @@ describe("POST /olive/run provider routing", () => {
     expect(venv.ensureProviderCapability).toHaveBeenCalledWith(
       "QNNExecutionProvider",
       expect.any(Function),
-      {
-        usage: process.platform === "win32" && process.arch === "arm64" ? "inference" : "preparation",
-      },
+      { usage: "preparation" },
     );
+  });
+
+  it("rejects QNN recipes on out-of-scope hosts before capability setup", async () => {
+    vi.mocked(qnnDeps.resolveQnnHostMode).mockReturnValue("out-of-scope");
+    const res = await fetch(`${baseUrl}/api/olive/run`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        recipeJson: JSON.stringify(recipeWithProvider("QNNExecutionProvider")),
+      }),
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { ok: boolean; error?: string };
+    expect(body.ok).toBe(false);
+    expect(body.error).toMatch(/Windows-first/i);
+    expect(venv.ensureProviderCapability).not.toHaveBeenCalled();
   });
 });

--- a/src/server/routes/olive.ts
+++ b/src/server/routes/olive.ts
@@ -14,6 +14,8 @@ import { enrichRecipeMemoryOffloadForRun } from "../../lib/memoryOffload.ts";
 import { isGpuExecutionProvider } from "../../lib/oliveGpuRuntime.ts";
 import { normalizeIhvProvider } from "../../lib/venvFamily.ts";
 import { resolveQnnHostMode } from "../../lib/qnnDeps.ts";
+import { assessQnnRecipeReadiness } from "../../lib/qnnReadiness.ts";
+import { DEFAULT_PASSES } from "../../lib/defaultPasses.ts";
 
 import {
   jobRegistry,
@@ -78,6 +80,23 @@ export function mountOliveRoutes(router: Router): void {
         ok: false,
         error: `Unknown execution provider: ${String(providerRaw)}`,
       });
+    }
+
+    if (provider === "QNNExecutionProvider") {
+      const inputModel = recipe.input_model as { io_config?: unknown } | undefined;
+      const hostMode = resolveQnnHostMode({ platform: process.platform, arch: process.arch });
+      const hardFailures = assessQnnRecipeReadiness({
+        state: { ihvProvider: provider, passes: DEFAULT_PASSES },
+        ioConfig: inputModel?.io_config,
+        hostMode,
+        platform: { platform: process.platform, arch: process.arch },
+      }).filter((issue) => issue.severity === "error");
+      if (hardFailures.length > 0) {
+        return res.status(400).json({
+          ok: false,
+          error: hardFailures.map((issue) => issue.message).join("; "),
+        });
+      }
     }
 
     // Canonicalize EP token before enrich/serialize so Olive never sees aliases (e.g. trt).

--- a/src/server/routes/olive.ts
+++ b/src/server/routes/olive.ts
@@ -25,6 +25,7 @@ import {
   finalizeJob,
 } from "../services/olive/state.ts";
 import { pushLog, startGpuMetricsTimer, stopGpuMetricsTimer } from "../services/olive/gpu.ts";
+import { probeQnn } from "../services/olive/qnn.ts";
 import { getVenvPython } from "../services/venv/paths.ts";
 import {
   ensureProviderCapability,
@@ -34,6 +35,7 @@ import {
 } from "../services/venv/index.ts";
 import type { OliveRecipe, OliveJob } from "../types.ts";
 import { oliveRunRateLimit } from "../middleware/rateLimit.ts";
+import type { HardwareProbeResult } from "../../lib/hardwareProbe.ts";
 
 /** Grace period after SIGTERM before escalating cancel to SIGKILL. */
 export const CANCEL_SIGKILL_GRACE_MS = 10_000;
@@ -163,6 +165,42 @@ export function mountOliveRoutes(router: Router): void {
       }
 
       const venvPython = capResult.python ?? getVenvPython(capResult.family);
+
+      if (provider === "QNNExecutionProvider" && venvPython) {
+        const hostMode = resolveQnnHostMode({ platform: process.platform, arch: process.arch });
+        if (hostMode === "local-inference") {
+          const qnn = await probeQnn(venvPython);
+          const inputModel = recipe.input_model as { io_config?: unknown } | undefined;
+          const probe: HardwareProbeResult = {
+            probedAt: new Date().toISOString(),
+            platform: {
+              os: process.platform,
+              arch: process.arch,
+              cpuModel: "",
+              cpuCores: 0,
+            },
+            detectedProviders: ["QNNExecutionProvider"],
+            recommendedProvider: "QNNExecutionProvider",
+            notes: [],
+            qnn,
+          };
+          const hardFailures = assessQnnRecipeReadiness({
+            state: { ihvProvider: provider, passes: DEFAULT_PASSES },
+            ioConfig: inputModel?.io_config,
+            hostMode,
+            probe,
+          }).filter((issue) => issue.severity === "error");
+          if (hardFailures.length > 0) {
+            const error = hardFailures.map((issue) => issue.message).join("; ");
+            job.status = "failed";
+            pushLog(job, `[error] ${error}`);
+            cleanupJobArtifacts(job);
+            finalizeJob(job);
+            return res.status(400).json({ ok: false, jobId, error });
+          }
+        }
+      }
+
       const env = await buildOliveRunEnvironment(venvPython, provider, process.env, capResult.family);
       if (bailIfCancelled()) return;
 

--- a/src/server/routes/olive.ts
+++ b/src/server/routes/olive.ts
@@ -13,6 +13,7 @@ import { validateOliveRecipeStructure } from "../../lib/oliveRecipeSchema.ts";
 import { enrichRecipeMemoryOffloadForRun } from "../../lib/memoryOffload.ts";
 import { isGpuExecutionProvider } from "../../lib/oliveGpuRuntime.ts";
 import { normalizeIhvProvider } from "../../lib/venvFamily.ts";
+import { resolveQnnHostMode } from "../../lib/qnnDeps.ts";
 
 import {
   jobRegistry,
@@ -118,7 +119,19 @@ export function mountOliveRoutes(router: Router): void {
       // Retain the listener so /olive/cancel can detach it if setup is pending.
       const venvListener = (line: string) => pushLog(job, line);
       job.venvListener = venvListener;
-      const capResult = await ensureProviderCapability(provider, venvListener);
+      const capResult = await ensureProviderCapability(
+        provider,
+        venvListener,
+        provider === "QNNExecutionProvider"
+          ? {
+              usage:
+                resolveQnnHostMode({ platform: process.platform, arch: process.arch }) ===
+                "local-inference"
+                  ? "inference"
+                  : "preparation",
+            }
+          : undefined,
+      );
       // Setup finished for this caller — the listener is no longer registered.
       job.venvListener = undefined;
       if (bailIfCancelled()) return;

--- a/src/server/routes/system.ts
+++ b/src/server/routes/system.ts
@@ -43,7 +43,7 @@ import {
   markQnnVenvLoadable,
   markTensorRtVenvLoadable,
   mergeOrtProvidersForDisplay,
-  resolveDirectMlHardwareReady,
+  resolveDirectMlEpDetected,
 } from "./systemHardwareProbePolicy.ts";
 
 const execFileAsync = promisify(execFile);
@@ -551,10 +551,10 @@ async function probeSystemHardware(opts: SystemProbeOptions): Promise<HardwarePr
     hasRocmGpu: Boolean(rocm?.gpus.length),
     hasOpenVino: Boolean(openvino?.available),
     hasOpenVinoCompatibleHardware,
-    // Hardware readiness (Windows / DX12 class) lists DirectML as selectable;
-    // EP registration remains separate for install CTAs (directMlNeedsInstall).
-    hasDirectMl: resolveDirectMlHardwareReady({
-      os: platform.os,
+    // Hardware readiness (Windows / DX12 class) is separate from EP registration.
+    // hasDirectMl must reflect ORT reporting DmlExecutionProvider so install CTAs stay accurate.
+    hasDirectMl: resolveDirectMlEpDetected({
+      defaultProviders: onnxRuntimeProviders,
     }),
     hasQnnCompatibleHardware,
     qnnLoadable: qnnVenvLoadable,

--- a/src/server/routes/system.ts
+++ b/src/server/routes/system.ts
@@ -16,13 +16,19 @@ import { envForFamily } from "../services/venv/pathIsolation.ts";
 import { parseCudaVersionFromNvidiaSmi } from "../services/olive/cuda.ts";
 import {
   computeOpenVinoCompatibleHardware,
+  computeQnnCompatibleHardware,
   isNvidiaGpuTensorRtFamily,
   mergeDetectedProviders,
   pickRecommendedProvider,
   TENSORRT_FAMILY_MIN_COMPUTE_CAPABILITY,
   type HardwareProbeResult,
   type OpenVinoProbeResult,
+  type QnnProbeResult,
 } from "../../lib/hardwareProbe.ts";
+import {
+  isQnnSnapdragonReleaseGatePassed,
+  resolveQnnHostMode,
+} from "../../lib/qnnDeps.ts";
 import {
   isPreMaxwellNvidiaBox,
   CUDA_SM_FLOOR,
@@ -34,6 +40,7 @@ import {
   parseOrtGpuProbe,
 } from "../../lib/oliveGpuRuntime.ts";
 import {
+  markQnnVenvLoadable,
   markTensorRtVenvLoadable,
   mergeOrtProvidersForDisplay,
   resolveDirectMlHardwareReady,
@@ -210,6 +217,7 @@ export interface SystemProbeOptions {
     env?: NodeJS.ProcessEnv,
   ) => Promise<{ loadable: boolean; detail?: string; version?: string }>;
   probeOpenVino: (python: string) => Promise<OpenVinoProbeResult>;
+  probeQnn: (python: string) => Promise<QnnProbeResult>;
 }
 
 /**
@@ -237,9 +245,12 @@ async function probeSystemHardware(opts: SystemProbeOptions): Promise<HardwarePr
 
   let openvino: OpenVinoProbeResult | undefined;
   let openvinoVenvAvailable = false;
+  let qnn: QnnProbeResult | undefined;
+  let qnnVenvLoadable = false;
   let defaultOrtProviders: string[] | undefined;
   let cudaOrtProviders: string[] | undefined;
   let openvinoOrtProviders: string[] | undefined;
+  let qnnOrtProviders: string[] | undefined;
   let systemOrtProviders: string[] | undefined;
   let tensorrt: HardwareProbeResult["tensorrt"];
   let tensorRtRtx: HardwareProbeResult["tensorRtRtx"];
@@ -251,12 +262,15 @@ async function probeSystemHardware(opts: SystemProbeOptions): Promise<HardwarePr
   const defaultPython = getVenvPython("default");
   const cudaPython = getVenvPython("cuda");
   const openvinoPython = getVenvPython("openvino");
+  const qnnPython = getVenvPython("qnn");
   const cudaPythonExists = fs.existsSync(cudaPython);
   const openvinoPythonExists = fs.existsSync(openvinoPython);
+  const qnnPythonExists = fs.existsSync(qnnPython);
   const pythonCandidates: string[] = [];
   if (fs.existsSync(defaultPython)) pythonCandidates.push(defaultPython);
   if (cudaPythonExists) pythonCandidates.push(cudaPython);
   if (openvinoPythonExists) pythonCandidates.push(openvinoPython);
+  if (qnnPythonExists) pythonCandidates.push(qnnPython);
   const systemPython = await findSystemPython();
   if (systemPython) pythonCandidates.push(systemPython);
 
@@ -264,28 +278,46 @@ async function probeSystemHardware(opts: SystemProbeOptions): Promise<HardwarePr
     const isDefault = python === defaultPython;
     const isCuda = python === cudaPython;
     const isOpenvino = python === openvinoPython;
+    const isQnn = python === qnnPython;
     const familyEnv = isCuda
       ? envForFamily("cuda")
       : isOpenvino
         ? envForFamily("openvino")
-        : isDefault
-          ? envForFamily("default")
-          : process.env;
-    const [pyResult, ov] = await Promise.all([
+        : isQnn
+          ? envForFamily("qnn")
+          : isDefault
+            ? envForFamily("default")
+            : process.env;
+    const [pyResult, ov, qnnProbe] = await Promise.all([
       probePythonRuntime(python, familyEnv),
       isOpenvino
         ? opts.probeOpenVino(python)
         : Promise.resolve({ available: false } as OpenVinoProbeResult),
+      isQnn
+        ? opts.probeQnn(python)
+        : Promise.resolve({ available: false } as QnnProbeResult),
     ]);
     const hasOpenVinoSignal = Boolean(ov.version || ov.devices?.length || ov.optimumIntel || ov.detail);
     if (isOpenvino && (hasOpenVinoSignal || ov.available)) {
       openvino = ov;
       openvinoVenvAvailable = ov.available;
     }
+    if (isQnn && (qnnProbe.available || qnnProbe.detail || qnnProbe.pluginVersion)) {
+      qnn = qnnProbe;
+      if (
+        markQnnVenvLoadable({
+          isQnn: true,
+          loadable: Boolean(qnnProbe.loadable || qnnProbe.preparation),
+        })
+      ) {
+        qnnVenvLoadable = true;
+      }
+    }
     if (pyResult.onnxRuntimeProviders?.length) {
       if (isDefault) defaultOrtProviders = pyResult.onnxRuntimeProviders;
       else if (isCuda) cudaOrtProviders = pyResult.onnxRuntimeProviders;
       else if (isOpenvino) openvinoOrtProviders = pyResult.onnxRuntimeProviders;
+      else if (isQnn) qnnOrtProviders = pyResult.onnxRuntimeProviders;
       else systemOrtProviders = pyResult.onnxRuntimeProviders;
     }
     // CUDA / TRT probes prefer the cuda-family python, with PATH isolation so
@@ -358,6 +390,7 @@ async function probeSystemHardware(opts: SystemProbeOptions): Promise<HardwarePr
     defaultOrtProviders,
     cudaOrtProviders,
     openvinoOrtProviders,
+    qnnOrtProviders,
     systemOrtProviders,
   );
   if (defaultOrtProviders?.length) {
@@ -366,6 +399,8 @@ async function probeSystemHardware(opts: SystemProbeOptions): Promise<HardwarePr
     notes.push("ONNX Runtime providers probed via CUDA runtime.");
   } else if (openvinoOrtProviders?.length) {
     notes.push("ONNX Runtime providers probed via OpenVINO runtime.");
+  } else if (qnnOrtProviders?.length) {
+    notes.push("ONNX Runtime providers probed via QNN runtime.");
   } else if (systemOrtProviders?.length) {
     notes.push("ONNX Runtime providers probed via system Python.");
   }
@@ -430,7 +465,39 @@ async function probeSystemHardware(opts: SystemProbeOptions): Promise<HardwarePr
   } else {
     notes.push("OpenVINO Python stack not found locally (needs openvino + optimum-intel).");
   }
-  notes.push("QNN requires Snapdragon/Hexagon dev hardware — not probed on desktop.");
+  const qnnHostMode = resolveQnnHostMode({ platform: process.platform, arch: platform.arch });
+  if (qnnVenvLoadable) {
+    if (qnn?.verifiedInference && isQnnSnapdragonReleaseGatePassed()) {
+      notes.push(
+        `QNN NPU ready${qnn.pluginVersion ? ` (plugin ${qnn.pluginVersion})` : ""} — fail-closed HTP diagnostic passed.`,
+      );
+    } else if (qnnHostMode === "preparation") {
+      notes.push(
+        `QNN runtime installed${qnn?.pluginVersion ? ` (${qnn.pluginVersion})` : ""} — Windows x64 preparation / plugin AOT only (not local HTP inference).`,
+      );
+    } else if (qnn?.npuDevice) {
+      notes.push(
+        `QNN runtime installed with NPU EpDevice${qnn.pluginVersion ? ` (${qnn.pluginVersion})` : ""}. “QNN NPU ready” waits on the Snapdragon release gate` +
+          (qnn.htpSmoke?.status === "passed" ? " (HTP diagnostic already cached)." : " + Test QNN NPU."),
+      );
+    } else {
+      notes.push(
+        `QNN runtime installed${qnn?.pluginVersion ? ` (${qnn.pluginVersion})` : ""} — plugin registration ok; NPU device not filtered yet.`,
+      );
+    }
+  } else if (qnnHostMode === "local-inference" || qnnHostMode === "preparation") {
+    notes.push(
+      qnn?.detail
+        ? `QNN stack not ready (${qnn.detail}). Use Install QNN runtime in Hardware (.venvs/qnn).`
+        : qnnHostMode === "preparation"
+          ? "Windows x64: install QNN runtime for plugin preparation / AOT (not local HTP inference)."
+          : "Windows ARM64: install QNN runtime (.venvs/qnn) for Snapdragon NPU workflows.",
+    );
+  } else {
+    notes.push(
+      "QNN plugin install/UX is Windows-first in this release (Win ARM64 inference / Win x64 preparation).",
+    );
+  }
 
   // Surface pre-Maxwell NVIDIA boxes (every detected GPU below the CUDA 12
   // toolkit floor) so the IHV panel / recipe compat layer can suppress the
@@ -469,6 +536,15 @@ async function probeSystemHardware(opts: SystemProbeOptions): Promise<HardwarePr
     openvinoDevices: openvino?.devices,
   });
 
+  const hasQnnCompatibleHardware = computeQnnCompatibleHardware({
+    os: platform.os,
+    arch: platform.arch,
+    qnnLoadable: qnnVenvLoadable,
+    ortReportsQnn: Boolean(
+      onnxRuntimeProviders?.includes("QNNExecutionProvider") || qnnOrtProviders?.includes("QNNExecutionProvider"),
+    ),
+  });
+
   const detectedProviders = mergeDetectedProviders({
     onnxRuntimeProviders,
     hasNvidiaGpu: Boolean(nvidia?.gpus.length),
@@ -480,6 +556,8 @@ async function probeSystemHardware(opts: SystemProbeOptions): Promise<HardwarePr
     hasDirectMl: resolveDirectMlHardwareReady({
       os: platform.os,
     }),
+    hasQnnCompatibleHardware,
+    qnnLoadable: qnnVenvLoadable,
     tensorRtLoadable: tensorRtVenvLoadable,
     tensorRtRtxLoadable: tensorRtRtxVenvLoadable,
     nvidiaTensorRtFamilyCapable,
@@ -494,6 +572,37 @@ async function probeSystemHardware(opts: SystemProbeOptions): Promise<HardwarePr
     openvino: openvino
       ? { ...openvino, available: openvinoVenvAvailable, loadable: openvinoVenvAvailable }
       : undefined,
+    qnn: qnn
+      ? {
+          ...qnn,
+          available: qnnVenvLoadable,
+          loadable: qnnVenvLoadable,
+          hostMode: qnn.hostMode ?? qnnHostMode,
+        }
+      : qnnHostMode !== "out-of-scope"
+        ? {
+            available: false,
+            loadable: false,
+            preparation: false,
+            npuDevice: false,
+            potentialInference: false,
+            verifiedInference: false,
+            hostMode: qnnHostMode,
+            detail:
+              qnnHostMode === "preparation"
+                ? "QNN runtime not installed (.venvs/qnn) — Windows x64 preparation / plugin AOT only"
+                : "QNN runtime not installed (.venvs/qnn)",
+          }
+        : {
+            available: false,
+            loadable: false,
+            preparation: false,
+            npuDevice: false,
+            potentialInference: false,
+            verifiedInference: false,
+            hostMode: qnnHostMode,
+            detail: "QNN plugin install/UX is Windows-first in this release",
+          },
     // UI consumers (IHV panel) read `.loadable`; keep it aligned with .venv readiness.
     tensorrt: tensorrt ? { ...tensorrt, loadable: tensorRtVenvLoadable } : tensorrt,
     tensorRtRtx: tensorRtRtx ? { ...tensorRtRtx, loadable: tensorRtRtxVenvLoadable } : tensorRtRtx,
@@ -504,6 +613,7 @@ async function probeSystemHardware(opts: SystemProbeOptions): Promise<HardwarePr
       tensorRtRtxLoadable: tensorRtRtxVenvLoadable,
       tensorRtLoadable: tensorRtVenvLoadable,
       openvinoLoadable: openvinoVenvAvailable,
+      qnnLoadable: qnnVenvLoadable,
     }),
     notes,
   };

--- a/src/server/routes/systemHardwareProbePolicy.test.ts
+++ b/src/server/routes/systemHardwareProbePolicy.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import {
+  markQnnVenvLoadable,
   markTensorRtVenvLoadable,
   mergeOrtProvidersForDisplay,
   resolveDirectMlDetected,
@@ -73,13 +74,20 @@ describe("systemHardwareProbePolicy", () => {
         ["CPUExecutionProvider"],
         ["CUDAExecutionProvider"],
         ["OpenVINOExecutionProvider"],
+        ["QNNExecutionProvider"],
         ["DmlExecutionProvider"],
       ),
     ).toEqual([
       "CPUExecutionProvider",
       "CUDAExecutionProvider",
       "OpenVINOExecutionProvider",
+      "QNNExecutionProvider",
       "DmlExecutionProvider",
     ]);
+  });
+
+  it("marks QNN loadable only on the qnn family python", () => {
+    expect(markQnnVenvLoadable({ isQnn: true, loadable: true })).toBe(true);
+    expect(markQnnVenvLoadable({ isQnn: false, loadable: true })).toBe(false);
   });
 });

--- a/src/server/routes/systemHardwareProbePolicy.ts
+++ b/src/server/routes/systemHardwareProbePolicy.ts
@@ -39,7 +39,7 @@ export function markTensorRtVenvLoadable(input: {
   );
 }
 
-/** Merge ORT provider lists with stable order: default → cuda → openvino → system. */
+/** Merge ORT provider lists with stable order: default → cuda → openvino → qnn → system. */
 export function mergeOrtProvidersForDisplay(
   ...lists: Array<string[] | undefined>
 ): string[] | undefined {
@@ -55,4 +55,12 @@ export function mergeOrtProvidersForDisplay(
     }
   }
   return out.length > 0 ? out : undefined;
+}
+
+/** Prefer qnn-family python for QNN EP readiness notes. */
+export function markQnnVenvLoadable(input: {
+  isQnn: boolean;
+  loadable: boolean;
+}): boolean {
+  return input.isQnn && input.loadable;
 }

--- a/src/server/routes/systemHardwareProbePolicy.ts
+++ b/src/server/routes/systemHardwareProbePolicy.ts
@@ -20,7 +20,7 @@ export function resolveDirectMlEpDetected(input: {
 /**
  * @deprecated Prefer resolveDirectMlEpDetected for EP / install-guidance callers.
  * Kept as an alias of EP detection for older call sites / tests.
- * Host readiness for detectedProviders listing uses resolveDirectMlHardwareReady.
+ * Host readiness uses resolveDirectMlHardwareReady; do not pass that into hasDirectMl.
  */
 export function resolveDirectMlDetected(input: {
   defaultProviders?: string[];

--- a/src/server/services/olive/qnn.test.ts
+++ b/src/server/services/olive/qnn.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import {
+  getQnnHtpDiagnosticPath,
+  readQnnHtpDiagnosticCache,
+  writeQnnHtpDiagnosticCache,
+} from "./qnn.ts";
+import fs from "fs";
+import os from "os";
+import path from "path";
+
+describe("qnn HTP diagnostic cache", () => {
+  it("defaults to not_run when cache file is absent", () => {
+    const prev = process.cwd();
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "olive-qnn-cache-"));
+    try {
+      process.chdir(tmp);
+      expect(readQnnHtpDiagnosticCache()).toEqual({ status: "not_run" });
+      expect(getQnnHtpDiagnosticPath()).toContain(".olive-studio");
+      writeQnnHtpDiagnosticCache({ status: "failed", detail: "no npu" });
+      expect(readQnnHtpDiagnosticCache().status).toBe("failed");
+      expect(readQnnHtpDiagnosticCache().detail).toBe("no npu");
+    } finally {
+      process.chdir(prev);
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/server/services/olive/qnn.ts
+++ b/src/server/services/olive/qnn.ts
@@ -1,0 +1,396 @@
+/**
+ * QNN 2.x plugin EP probe / ensure for the isolated `.venvs/qnn` family.
+ *
+ * Production registration uses Olive's native EP library + OrtEpDevice path
+ * (import onnxruntime_qnn / Olive maybe_register_ep_libraries). sitecustomize
+ * and InferenceSession monkeypatches are spike-only and must not ship here.
+ */
+import fs from "fs";
+import os from "os";
+import path from "path";
+
+import {
+  ONNXRUNTIME_QNN_PLUGIN_PACKAGE,
+  PINNED_ONNXRUNTIME_QNN_PLUGIN_VERSION,
+  isQnnSnapdragonReleaseGatePassed,
+  qnnStackLabel,
+  resolveQnnHostMode,
+  type QnnHostMode,
+} from "../../../lib/qnnDeps.ts";
+import type { QnnProbeResult } from "../../../lib/hardwareProbe.ts";
+import { execFileAsync } from "../shared/exec.ts";
+import { ensureVenvFamily } from "../venv/familyEnsure.ts";
+import { envForFamily } from "../venv/pathIsolation.ts";
+import { getVenvPython } from "../venv/paths.ts";
+import { invalidateRuntimeStatusCache } from "../venv/status.ts";
+
+const QNN_MARK = "OLIVE_QNN:";
+
+/** Cached HTP diagnostic under .olive-studio (never on every status refresh). */
+export function getQnnHtpDiagnosticPath(): string {
+  return path.join(process.cwd(), ".olive-studio", "qnn-htp-diagnostic.json");
+}
+
+export type QnnHtpDiagnosticCache = {
+  status: "not_run" | "passed" | "failed";
+  detail?: string;
+  at?: string;
+};
+
+export function readQnnHtpDiagnosticCache(): QnnHtpDiagnosticCache {
+  try {
+    const raw = fs.readFileSync(getQnnHtpDiagnosticPath(), "utf-8");
+    const parsed = JSON.parse(raw) as QnnHtpDiagnosticCache;
+    if (parsed?.status === "passed" || parsed?.status === "failed" || parsed?.status === "not_run") {
+      return parsed;
+    }
+  } catch {
+    /* absent / corrupt → not_run */
+  }
+  return { status: "not_run" };
+}
+
+export function writeQnnHtpDiagnosticCache(cache: QnnHtpDiagnosticCache): void {
+  const dir = path.dirname(getQnnHtpDiagnosticPath());
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(
+    getQnnHtpDiagnosticPath(),
+    JSON.stringify({ ...cache, at: cache.at ?? new Date().toISOString() }, null, 2),
+    "utf-8",
+  );
+}
+
+function buildProbeScript(): string {
+  return `
+import json
+import importlib.metadata as m
+
+def emit(key, value):
+    print(${JSON.stringify(QNN_MARK)} + key + "=" + str(value).replace(chr(10), " "))
+
+plugin_version = None
+try:
+    plugin_version = m.distribution(${JSON.stringify(ONNXRUNTIME_QNN_PLUGIN_PACKAGE)}).version
+    emit("plugin_version", plugin_version)
+except Exception as exc:
+    emit("plugin_error", str(exc).replace(chr(10), " "))
+
+try:
+    import onnxruntime_qnn  # noqa: F401 — side-effect registration for QNN 2.x
+    emit("plugin_import", "1")
+except Exception as exc:
+    emit("plugin_import_error", str(exc).replace(chr(10), " "))
+
+any_qnn = False
+npu = False
+providers = []
+try:
+    import onnxruntime as ort
+    providers = list(ort.get_available_providers())
+    emit("ort_providers", ",".join(providers))
+    emit("qnn_ep_listed", "1" if "QNNExecutionProvider" in providers else "0")
+    try:
+        from olive.common.ort_inference import maybe_register_ep_libraries
+        maybe_register_ep_libraries()
+        emit("olive_register", "1")
+    except Exception as exc:
+        emit("olive_register_error", str(exc).replace(chr(10), " "))
+    for device in ort.get_ep_devices():
+        if getattr(device, "ep_name", None) != "QNNExecutionProvider":
+            continue
+        any_qnn = True
+        dtype = getattr(getattr(device, "device", None), "type", None)
+        is_npu = dtype == ort.OrtHardwareDeviceType.NPU
+        if is_npu:
+            npu = True
+        emit("device", ("NPU" if is_npu else getattr(dtype, "name", str(dtype))))
+except Exception as exc:
+    emit("ort_error", str(exc).replace(chr(10), " "))
+
+emit("qnn_ep_any", "1" if any_qnn else "0")
+emit("qnn_ep_npu", "1" if npu else "0")
+`.trim();
+}
+
+interface ProbeAccumulator {
+  pluginVersion?: string;
+  pluginImport?: boolean;
+  providers?: string[];
+  qnnEpListed?: boolean;
+  anyQnnDevice?: boolean;
+  npuDevice?: boolean;
+  deviceTypes?: string[];
+  detail?: string;
+  oliveRegister?: boolean;
+}
+
+function parseProbeOutput(out: string): ProbeAccumulator {
+  const acc: ProbeAccumulator = { deviceTypes: [] };
+  const handlers: Record<string, (value: string) => void> = {
+    plugin_version: (value) => {
+      if (value) acc.pluginVersion = value;
+    },
+    plugin_error: (value) => {
+      if (!acc.detail) acc.detail = value || "onnxruntime-qnn not installed";
+    },
+    plugin_import: () => {
+      acc.pluginImport = true;
+    },
+    plugin_import_error: (value) => {
+      acc.pluginImport = false;
+      if (!acc.detail) acc.detail = value || "onnxruntime_qnn import failed";
+    },
+    ort_providers: (value) => {
+      acc.providers = value ? value.split(",").filter(Boolean) : [];
+    },
+    qnn_ep_listed: (value) => {
+      acc.qnnEpListed = value === "1";
+    },
+    olive_register: () => {
+      acc.oliveRegister = true;
+    },
+    olive_register_error: () => {
+      acc.oliveRegister = false;
+    },
+    device: (value) => {
+      if (value) acc.deviceTypes?.push(value);
+    },
+    qnn_ep_any: (value) => {
+      acc.anyQnnDevice = value === "1";
+    },
+    qnn_ep_npu: (value) => {
+      acc.npuDevice = value === "1";
+    },
+    ort_error: (value) => {
+      if (!acc.detail) acc.detail = value || "onnxruntime QNN probe failed";
+    },
+  };
+
+  for (const line of out.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed.startsWith(QNN_MARK)) continue;
+    const payload = trimmed.slice(QNN_MARK.length);
+    const idx = payload.indexOf("=");
+    if (idx < 0) continue;
+    handlers[payload.slice(0, idx)]?.(payload.slice(idx + 1).trim());
+  }
+  return acc;
+}
+
+function hostMode(): QnnHostMode {
+  return resolveQnnHostMode({ platform: process.platform, arch: os.arch() });
+}
+
+/**
+ * Probe the qnn-family Python for plugin install, EpDevice registration, and NPU filter.
+ */
+export async function probeQnn(python: string): Promise<QnnProbeResult> {
+  const mode = hostMode();
+  const htp = readQnnHtpDiagnosticCache();
+  try {
+    const { stdout, stderr } = await execFileAsync(python, ["-c", buildProbeScript()], {
+      env: envForFamily("qnn"),
+      timeout: 60_000,
+    });
+    const acc = parseProbeOutput(`${stdout}\n${stderr}`);
+    const pluginInstalled = Boolean(acc.pluginVersion || acc.pluginImport);
+    const preparation =
+      pluginInstalled && (acc.anyQnnDevice === true || acc.qnnEpListed === true);
+    const potentialInference = mode === "local-inference" && acc.npuDevice === true;
+    const verifiedInference =
+      potentialInference && htp.status === "passed" && isQnnSnapdragonReleaseGatePassed();
+
+    let detail: string | undefined;
+    if (!pluginInstalled) {
+      detail = acc.detail ?? "onnxruntime-qnn plugin not installed in .venvs/qnn";
+    } else if (mode === "out-of-scope") {
+      detail =
+        "QNN plugin install/UX is Windows-first in this release (Win ARM64 inference / Win x64 preparation).";
+    } else if (!preparation) {
+      detail =
+        acc.detail ??
+        "QNN plugin present but no QNNExecutionProvider EpDevice registered (Olive native registration path).";
+    } else if (mode === "preparation") {
+      detail =
+        "QNN preparation / plugin AOT ready on Windows x64. Local HTP inference is not claimed on this host.";
+    } else if (potentialInference && !verifiedInference) {
+      detail = isQnnSnapdragonReleaseGatePassed()
+        ? htp.status === "failed"
+          ? `QNN NPU device found but HTP diagnostic failed${htp.detail ? `: ${htp.detail}` : ""}`
+          : "QNN NPU device found. Run Test QNN NPU (cached HTP diagnostic) before verified inference."
+        : "QNN runtime installed with NPU device. Verified “QNN NPU ready” waits on the Snapdragon release gate.";
+    }
+
+    return {
+      available: preparation,
+      loadable: preparation,
+      pluginVersion: acc.pluginVersion,
+      pluginRegistered: preparation,
+      preparation,
+      npuDevice: acc.npuDevice === true,
+      potentialInference,
+      verifiedInference,
+      htpSmoke: htp,
+      hostMode: mode,
+      providers: acc.providers,
+      deviceTypes: acc.deviceTypes,
+      detail,
+    };
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      available: false,
+      loadable: false,
+      preparation: false,
+      npuDevice: false,
+      potentialInference: false,
+      verifiedInference: false,
+      htpSmoke: htp,
+      hostMode: mode,
+      detail: message,
+    };
+  }
+}
+
+/**
+ * Ensure `.venvs/qnn` exists with the pinned ORT + plugin stack, then re-probe.
+ */
+export async function ensureQnn(
+  onLine: (line: string) => void,
+): Promise<{ ok: boolean; error?: string; probe?: QnnProbeResult }> {
+  const mode = hostMode();
+  if (mode === "out-of-scope") {
+    return {
+      ok: false,
+      error:
+        "QNN runtime install is Windows-first (Win ARM64 local inference / Win x64 plugin preparation). This host is out of release scope.",
+    };
+  }
+
+  onLine(`[deps] Ensuring QNN family (${qnnStackLabel()}) for ${mode}...`);
+  const venvResult = await ensureVenvFamily("qnn", onLine);
+  if (!venvResult.ok) {
+    return {
+      ok: false,
+      error: venvResult.error ?? "Failed to create or prepare the QNN runtime",
+    };
+  }
+
+  const venvPython = getVenvPython("qnn");
+  if (!fs.existsSync(venvPython)) {
+    return {
+      ok: false,
+      error: "QNN runtime is incomplete (missing python). Use Setup runtime, then retry.",
+    };
+  }
+
+  invalidateRuntimeStatusCache();
+  const probe = await probeQnn(venvPython);
+  if (probe.preparation) {
+    onLine(
+      `[deps] QNN plugin verified${probe.pluginVersion ? ` (${probe.pluginVersion})` : ""} ✓` +
+        (probe.npuDevice ? " [NPU EpDevice]" : " [preparation EpDevice]"),
+    );
+    if (mode === "preparation") {
+      onLine(
+        "[deps] Windows x64: preparation / plugin AOT only. Local HTP inference is not claimed.",
+      );
+    }
+    return { ok: true, probe };
+  }
+
+  return {
+    ok: false,
+    error:
+      probe.detail ??
+      `QNN stack not loadable after install (expected ${ONNXRUNTIME_QNN_PLUGIN_PACKAGE}==${PINNED_ONNXRUNTIME_QNN_PLUGIN_VERSION})`,
+    probe,
+  };
+}
+
+/**
+ * Optional ARM64 HTP fail-closed session diagnostic (cached; never on every refresh).
+ * Creates a tiny static graph and InferenceSession with CPU fallback disabled.
+ */
+export async function runQnnHtpDiagnostic(
+  onLine: (line: string) => void,
+): Promise<{ ok: boolean; error?: string; probe?: QnnProbeResult }> {
+  const mode = hostMode();
+  if (mode !== "local-inference") {
+    return {
+      ok: false,
+      error: "HTP diagnostic is only available on Windows ARM64 (local inference host mode).",
+    };
+  }
+  const ensure = await ensureQnn(onLine);
+  if (!ensure.ok) return ensure;
+  const python = getVenvPython("qnn");
+  const script = `
+import tempfile, os
+import numpy as np
+import onnx
+from onnx import helper, TensorProto
+import onnxruntime as ort
+try:
+    import onnxruntime_qnn  # noqa: F401
+except Exception:
+    pass
+try:
+    from olive.common.ort_inference import maybe_register_ep_libraries
+    maybe_register_ep_libraries()
+except Exception:
+    pass
+
+npu_devices = [
+    d for d in ort.get_ep_devices()
+    if d.ep_name == "QNNExecutionProvider"
+    and d.device.type == ort.OrtHardwareDeviceType.NPU
+]
+if not npu_devices:
+    raise SystemExit("No QNN NPU OrtEpDevice (OrtHardwareDeviceType.NPU)")
+
+X = helper.make_tensor_value_info("X", TensorProto.FLOAT, [1, 2])
+Y = helper.make_tensor_value_info("Y", TensorProto.FLOAT, [1, 2])
+node = helper.make_node("Identity", ["X"], ["Y"])
+graph = helper.make_graph([node], "qnn_htp_smoke", [X], [Y])
+model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 17)])
+fd, model_path = tempfile.mkstemp(suffix=".onnx")
+os.close(fd)
+onnx.save(model, model_path)
+so = ort.SessionOptions()
+# Fail-closed: no silent CPU fallback for validation sessions.
+providers = [("QNNExecutionProvider", {"disable_cpu_ep_fallback": "1", "backend_type": "htp"})]
+try:
+    sess = ort.InferenceSession(model_path, sess_options=so, providers=providers)
+    out = sess.run(None, {"X": np.ones((1, 2), dtype=np.float32)})
+    assert out and out[0] is not None
+    print(${JSON.stringify(QNN_MARK)} + "htp=passed")
+finally:
+    try:
+        os.remove(model_path)
+    except Exception:
+        pass
+`.trim();
+
+  try {
+    onLine("[deps] Running fail-closed QNN HTP session diagnostic...");
+    const { stdout, stderr } = await execFileAsync(python, ["-c", script], {
+      env: envForFamily("qnn"),
+      timeout: 120_000,
+    });
+    const combined = `${stdout}\n${stderr}`;
+    if (combined.includes(`${QNN_MARK}htp=passed`)) {
+      writeQnnHtpDiagnosticCache({ status: "passed", detail: "Fail-closed HTP session + inference ok" });
+      onLine("[deps] QNN HTP diagnostic passed ✓");
+      invalidateRuntimeStatusCache();
+      return { ok: true, probe: await probeQnn(python) };
+    }
+    const detail = combined.trim().split(/\r?\n/).slice(-3).join(" ") || "HTP diagnostic failed";
+    writeQnnHtpDiagnosticCache({ status: "failed", detail });
+    return { ok: false, error: detail, probe: await probeQnn(python) };
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    writeQnnHtpDiagnosticCache({ status: "failed", detail: msg });
+    return { ok: false, error: msg, probe: await probeQnn(python) };
+  }
+}

--- a/src/server/services/olive/qnn.ts
+++ b/src/server/services/olive/qnn.ts
@@ -195,7 +195,9 @@ export async function probeQnn(python: string): Promise<QnnProbeResult> {
     const acc = parseProbeOutput(`${stdout}\n${stderr}`);
     const pluginInstalled = Boolean(acc.pluginVersion || acc.pluginImport);
     const preparation =
-      pluginInstalled && (acc.anyQnnDevice === true || acc.qnnEpListed === true);
+      mode !== "out-of-scope" &&
+      pluginInstalled &&
+      (acc.anyQnnDevice === true || acc.qnnEpListed === true);
     const potentialInference = mode === "local-inference" && acc.npuDevice === true;
     const verifiedInference =
       potentialInference && htp.status === "passed" && isQnnSnapdragonReleaseGatePassed();
@@ -387,10 +389,12 @@ finally:
     }
     const detail = combined.trim().split(/\r?\n/).slice(-3).join(" ") || "HTP diagnostic failed";
     writeQnnHtpDiagnosticCache({ status: "failed", detail });
+    invalidateRuntimeStatusCache();
     return { ok: false, error: detail, probe: await probeQnn(python) };
   } catch (err: unknown) {
     const msg = err instanceof Error ? err.message : String(err);
     writeQnnHtpDiagnosticCache({ status: "failed", detail: msg });
+    invalidateRuntimeStatusCache();
     return { ok: false, error: msg, probe: await probeQnn(python) };
   }
 }

--- a/src/server/services/venv/capabilityEnsure.ts
+++ b/src/server/services/venv/capabilityEnsure.ts
@@ -11,6 +11,7 @@ import { ensureOpenVino } from "../olive/openvino.ts";
 import { ensureOnnxRuntimeGpu } from "../olive/cuda.ts";
 import { ensureTensorRt } from "../olive/tensorrt.ts";
 import { ensureTensorRtRtx } from "../olive/tensorrt-rtx.ts";
+import { ensureQnn } from "../olive/qnn.ts";
 import { ensureVenvFamily } from "./familyEnsure.ts";
 import { getVenvPython } from "./paths.ts";
 import {
@@ -19,9 +20,20 @@ import {
   getDualRuntimeStatus,
   invalidateRuntimeStatusCache,
   probeFamilyStatus,
+  type CapabilityStatus,
 } from "./status.ts";
 
 type SetupListener = (line: string) => void;
+
+export type ProviderCapabilityUsage = "inference" | "preparation";
+
+export type EnsureProviderCapabilityOptions = {
+  /**
+   * QNN splits preparation (plugin AOT / x64) vs inference (Win ARM64 NPU).
+   * Other providers ignore this today.
+   */
+  usage?: ProviderCapabilityUsage;
+};
 
 export type EnsureProviderCapabilityResult = {
   ok: boolean;
@@ -30,6 +42,14 @@ export type EnsureProviderCapabilityResult = {
   python: string | null;
 };
 
+function qnnCapabilityForUsage(
+  status: Awaited<ReturnType<typeof probeFamilyStatus>>,
+  usage: ProviderCapabilityUsage,
+): CapabilityStatus | undefined {
+  if (usage === "preparation") return status.capabilities.qnnPreparation;
+  return status.capabilities.qnnInference ?? status.capabilities.qnnPreparation;
+}
+
 /**
  * Ensure the correct venv family exists and the requested provider capability
  * is usable. Callers must have already normalized the provider ID.
@@ -37,6 +57,7 @@ export type EnsureProviderCapabilityResult = {
 export async function ensureProviderCapability(
   provider: IHVProvider,
   onLine: SetupListener,
+  opts?: EnsureProviderCapabilityOptions,
 ): Promise<EnsureProviderCapabilityResult> {
   const dual = await getDualRuntimeStatus({ force: true });
   const flags = familyFlagsFromStatus(dual.families);
@@ -60,15 +81,15 @@ export async function ensureProviderCapability(
 
   invalidateRuntimeStatusCache();
   const status = await probeFamilyStatus(family);
-  const cap = capabilityForProvider(status, provider);
+  const usage = opts?.usage ?? "inference";
+  const cap =
+    provider === "QNNExecutionProvider"
+      ? qnnCapabilityForUsage(status, usage)
+      : capabilityForProvider(status, provider);
 
-  // Providers without a capability slot (QNN/ROCm/WebGPU) only need the family base.
+  // Providers without a capability slot (ROCm/WebGPU) only need the family base.
   if (cap === undefined) {
-    if (
-      provider === "QNNExecutionProvider" ||
-      provider === "ROCMExecutionProvider" ||
-      provider === "WebGpuExecutionProvider"
-    ) {
+    if (provider === "ROCMExecutionProvider" || provider === "WebGpuExecutionProvider") {
       return { ok: true, family, python: getVenvPython(family) };
     }
     return {
@@ -100,10 +121,14 @@ async function installCapabilityPackages(
     switch (provider) {
       case "CPUExecutionProvider":
       case "DmlExecutionProvider":
-      case "QNNExecutionProvider":
       case "ROCMExecutionProvider":
       case "WebGpuExecutionProvider":
         return { ok: true };
+
+      case "QNNExecutionProvider": {
+        const result = await ensureQnn(onLine);
+        return result.ok ? { ok: true } : { ok: false, error: result.error };
+      }
 
       case "OpenVINOExecutionProvider": {
         const result = await ensureOpenVino(onLine);

--- a/src/server/services/venv/capabilityEnsure.ts
+++ b/src/server/services/venv/capabilityEnsure.ts
@@ -47,7 +47,8 @@ function qnnCapabilityForUsage(
   usage: ProviderCapabilityUsage,
 ): CapabilityStatus | undefined {
   if (usage === "preparation") return status.capabilities.qnnPreparation;
-  return status.capabilities.qnnInference ?? status.capabilities.qnnPreparation;
+  // Fail-closed: inference must not fall back to preparation capability.
+  return status.capabilities.qnnInference;
 }
 
 /**

--- a/src/server/services/venv/familyEnsure.ts
+++ b/src/server/services/venv/familyEnsure.ts
@@ -32,6 +32,13 @@ import {
   getLegacyGpuBackupRoot,
 } from "./spec.ts";
 import { invalidateRuntimeStatusCache, listInstalledOrtDistributions } from "./status.ts";
+import { getPythonVersion } from "./systemPython.ts";
+import {
+  isQnnFamilyPythonMinor,
+  PINNED_ONNXRUNTIME_QNN_FAMILY_ORT_VERSION,
+  PINNED_ONNXRUNTIME_QNN_PLUGIN_VERSION,
+  qnnNumpyPinForPythonMinor,
+} from "../../../lib/qnnDeps.ts";
 
 type SetupListener = (line: string) => void;
 
@@ -104,12 +111,58 @@ function buildingPython(family: VenvFamily): string {
  * Build a family into its `.building` root and validate imports.
  * Does not promote — callers promote after peer builds succeed when needed.
  */
+async function assertQnnFamilyPythonGate(
+  systemPython: string,
+  onLine: SetupListener,
+): Promise<{ ok: true; minor: string; numpyPin: string } | { ok: false; error: string }> {
+  if (process.platform !== "win32") {
+    return {
+      ok: false,
+      error:
+        "QNN runtime install is Windows-first in this Studio release (Win ARM64 inference / Win x64 preparation). Other platforms are out of scope before .venvs/qnn.building is created.",
+    };
+  }
+  const arch = process.arch.toLowerCase();
+  if (!["x64", "arm64"].includes(arch)) {
+    return {
+      ok: false,
+      error: `QNN runtime requires Windows x64 or ARM64 (got arch ${process.arch}). Rejected before creating .venvs/qnn.building.`,
+    };
+  }
+  const ver = await getPythonVersion(systemPython);
+  if (!ver) {
+    return { ok: false, error: "Could not probe Python version for QNN family build." };
+  }
+  const minor = `${ver.major}.${ver.minor}`;
+  if (!isQnnFamilyPythonMinor(minor)) {
+    return {
+      ok: false,
+      error: `QNN runtime requires CPython 3.11–3.13 (got ${ver.text}). Python 3.10 is rejected before creating .venvs/qnn.building.`,
+    };
+  }
+  const numpyPin = qnnNumpyPinForPythonMinor(minor);
+  if (!numpyPin) {
+    return { ok: false, error: `No tested NumPy pin for Python ${minor}.` };
+  }
+  onLine(
+    `[setup] QNN family Python gate passed (${ver.text}, win32/${arch}); NumPy pin ${numpyPin}`,
+  );
+  return { ok: true, minor, numpyPin };
+}
+
 async function buildFamilyTree(
   family: VenvFamily,
   systemPython: string,
   onLine: SetupListener,
 ): Promise<{ ok: boolean; error?: string }> {
   try {
+    let qnnNumpyPin: string | undefined;
+    if (family === "qnn") {
+      const gate = await assertQnnFamilyPythonGate(systemPython, onLine);
+      if (!gate.ok) return { ok: false, error: gate.error };
+      qnnNumpyPin = gate.numpyPin;
+    }
+
     clearBuildingRoot(family);
     await createVenvAt(getFamilyBuildingRoot(family), systemPython, onLine);
     const py = buildingPython(family);
@@ -135,7 +188,23 @@ async function buildFamilyTree(
       buildEnv,
       "pip",
     );
-    await execFileAsync(py, ["-c", "import olive, onnxruntime"], {
+
+    if (spec.supplementalInstallArgs?.length) {
+      onLine(`[setup] Installing supplemental packages for ${family}...`);
+      await runPythonModule(
+        py,
+        ["-m", "pip", "install", ...spec.supplementalInstallArgs],
+        onLine,
+        buildEnv,
+        "pip",
+      );
+    }
+
+    const importCheck =
+      family === "qnn"
+        ? "import olive, onnxruntime, onnxruntime_qnn, numpy"
+        : "import olive, onnxruntime";
+    await execFileAsync(py, ["-c", importCheck], {
       env: buildEnv,
       timeout: 30_000,
     });
@@ -145,6 +214,15 @@ async function buildFamilyTree(
       ortDistribution: spec.ortDistribution,
       ortVersionSpec: spec.ortVersionSpec,
       createdAt: new Date().toISOString(),
+      ...(family === "qnn"
+        ? {
+            packages: {
+              onnxruntime: PINNED_ONNXRUNTIME_QNN_FAMILY_ORT_VERSION,
+              onnxruntimeQnn: PINNED_ONNXRUNTIME_QNN_PLUGIN_VERSION,
+              numpy: qnnNumpyPin,
+            },
+          }
+        : {}),
     });
     return { ok: true };
   } catch (err: unknown) {
@@ -184,6 +262,22 @@ async function familyNeedsRebuild(family: VenvFamily): Promise<boolean> {
   if (!dists.includes(spec.ortDistribution)) return true;
   if (conflictingOrtDistributions(spec.ortDistribution).some((c) => dists.includes(c))) {
     return true;
+  }
+  if (family === "qnn") {
+    try {
+      await execFileAsync(py, ["-c", "import onnxruntime_qnn, numpy"], { timeout: 15_000 });
+    } catch {
+      return true;
+    }
+    const packages = manifest.packages;
+    if (
+      !packages?.onnxruntimeQnn ||
+      packages.onnxruntimeQnn !== PINNED_ONNXRUNTIME_QNN_PLUGIN_VERSION ||
+      !packages.onnxruntime ||
+      packages.onnxruntime !== PINNED_ONNXRUNTIME_QNN_FAMILY_ORT_VERSION
+    ) {
+      return true;
+    }
   }
   return false;
 }

--- a/src/server/services/venv/packageConstraints.test.ts
+++ b/src/server/services/venv/packageConstraints.test.ts
@@ -72,6 +72,19 @@ describe("packageConstraints", () => {
     ]);
   });
 
+  it("allows qnn family onnxruntime + onnxruntime-qnn plugin (not a conflicting ORT dist)", () => {
+    expect(findForbiddenOrtInstallArgs("qnn", ["onnxruntime==1.26.0"])).toEqual([]);
+    expect(findForbiddenOrtInstallArgs("qnn", ["onnxruntime-qnn==2.4.0"])).toEqual([]);
+    expect(findForbiddenOrtInstallArgs("qnn", ["onnxruntime-directml"])).toEqual([
+      "onnxruntime-directml",
+    ]);
+    expect(findForbiddenOrtInstallArgs("qnn", ["onnxruntime-gpu"])).toEqual(["onnxruntime-gpu"]);
+    expect(getFamilySpec("qnn").supplementalInstallArgs?.some((a) => a.includes("onnxruntime-qnn"))).toBe(
+      true,
+    );
+    expect(getFamilySpec("qnn").ortDistribution).toBe("onnxruntime");
+  });
+
   it("injects a --constraint file from family packageConstraints", () => {
     const { args, cleanup } = withFamilyPipConstraintArgs("cuda", ["tensorrt"]);
     cleanups.push(cleanup);

--- a/src/server/services/venv/packageConstraints.test.ts
+++ b/src/server/services/venv/packageConstraints.test.ts
@@ -98,6 +98,18 @@ describe("packageConstraints", () => {
     expect(fs.existsSync(constraintPath)).toBe(false);
   });
 
+  it("merges supplemental constraints into the qnn constraint file", () => {
+    const { args, cleanup } = withFamilyPipConstraintArgs("qnn", ["olive-ai"]);
+    cleanups.push(cleanup);
+    const body = fs.readFileSync(args[1]!, "utf8");
+    for (const line of getFamilySpec("qnn").supplementalConstraints ?? []) {
+      expect(body).toContain(line);
+    }
+    for (const line of getFamilySpec("qnn").packageConstraints) {
+      expect(body).toContain(line);
+    }
+  });
+
   it("skips flag values when scanning for forbidden ORT packages", () => {
     expect(
       findForbiddenOrtInstallArgs("default", [

--- a/src/server/services/venv/packageConstraints.ts
+++ b/src/server/services/venv/packageConstraints.ts
@@ -10,8 +10,15 @@ import fs from "fs";
 import os from "os";
 import path from "path";
 import type { VenvFamily } from "../../../lib/venvFamily.ts";
-import { getFamilySpec } from "./spec.ts";
+import { ALL_ORT_DISTRIBUTIONS, getFamilySpec, ORT_PLUGIN_PACKAGE_NAMES } from "./spec.ts";
 import { listInstalledOrtDistributions } from "./status.ts";
+
+const ORT_PLUGIN_SET = new Set(
+  ORT_PLUGIN_PACKAGE_NAMES.map((n) => n.toLowerCase().replace(/[_.-]+/g, "-")),
+);
+const ORT_DIST_SET = new Set(
+  ALL_ORT_DISTRIBUTIONS.map((n) => n.toLowerCase().replace(/[_.-]+/g, "-")),
+);
 
 /** Pip flags that take a following value (skip that value when scanning packages). */
 const PIP_FLAGS_WITH_VALUE = new Set([
@@ -61,9 +68,14 @@ export function packageNameFromPipArg(arg: string): string | null {
   return base || null;
 }
 
+/**
+ * Mutually exclusive ORT wheels only. Plugin packages (onnxruntime-qnn 2.x)
+ * are exempt — they install beside standard onnxruntime.
+ */
 function isOrtDistributionName(name: string): boolean {
   const normalized = normalizeDistName(name);
-  return normalized === "onnxruntime" || normalized.startsWith("onnxruntime-");
+  if (ORT_PLUGIN_SET.has(normalized)) return false;
+  return ORT_DIST_SET.has(normalized);
 }
 
 /** Canonical ORT package names allowed by the family's packageConstraints. */
@@ -108,13 +120,19 @@ export function withFamilyPipConstraintArgs(
   family: VenvFamily,
   args: string[],
 ): { args: string[]; cleanup: () => void } {
-  const constraints = getFamilySpec(family).packageConstraints;
-  if (constraints.length === 0) {
+  const spec = getFamilySpec(family);
+  const constraints = [
+    ...spec.packageConstraints,
+    ...(spec.supplementalConstraints ?? []),
+  ];
+  // Deduplicate while preserving order.
+  const unique = Array.from(new Set(constraints));
+  if (unique.length === 0) {
     return { args: [...args], cleanup: () => undefined };
   }
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "olive-studio-pip-constraint-"));
   const file = path.join(dir, "constraints.txt");
-  const lines = constraints.filter((c) => c.trim() && !c.trim().startsWith("-"));
+  const lines = unique.filter((c) => c.trim() && !c.trim().startsWith("-"));
   fs.writeFileSync(file, `${lines.join("\n")}\n`, "utf8");
   return {
     args: ["--constraint", file, ...args],

--- a/src/server/services/venv/paths.test.ts
+++ b/src/server/services/venv/paths.test.ts
@@ -25,11 +25,19 @@ describe("venv paths", () => {
     expect(scripts).toContain(".venv");
   });
 
-  it("resolves cuda family under .venvs/cuda", () => {
-    expect(getFamilyRoot("cuda")).toContain(path.join(".venvs", "cuda"));
-    const python = getVenvPython("cuda");
-    expect(python).toContain(".venvs");
-    expect(python).toContain("cuda");
-    expect(getVenvScriptsDir("cuda")).toContain("cuda");
+  it.each(["cuda", "openvino", "qnn"] as const)(
+    "resolves the %s family under .venvs/<family>",
+    (family) => {
+      const segment = path.join(".venvs", family);
+      expect(getFamilyRoot(family)).toContain(segment);
+      const python = getVenvPython(family);
+      expect(python).toContain(segment);
+      expect(python).toMatch(/python(\.exe)?$/);
+      expect(getVenvScriptsDir(family)).toContain(segment);
+    },
+  );
+
+  it("keeps the default family outside .venvs", () => {
+    expect(getFamilyRoot("default")).not.toContain(`.venvs${path.sep}`);
   });
 });

--- a/src/server/services/venv/spec.ts
+++ b/src/server/services/venv/spec.ts
@@ -11,12 +11,27 @@ import {
   openvinoOrtInstallArgs,
   openvinoPackageConstraints,
 } from "../../../lib/openvinoDeps.ts";
+import {
+  ONNXRUNTIME_QNN_FAMILY_ORT_PACKAGE,
+  PINNED_ONNXRUNTIME_QNN_FAMILY_ORT_VERSION,
+  PINNED_ONNXRUNTIME_QNN_PLUGIN_VERSION,
+  qnnOrtInstallArgs,
+  qnnPackageConstraints,
+  qnnSupplementalConstraints,
+  qnnSupplementalInstallArgs,
+} from "../../../lib/qnnDeps.ts";
 
 export type OrtDistributionName =
   | "onnxruntime"
   | "onnxruntime-directml"
   | "onnxruntime-gpu"
   | "onnxruntime-openvino";
+
+/**
+ * Plugin / support packages that live beside canonical ORT and must not be
+ * treated as mutually exclusive ORT distributions (e.g. onnxruntime-qnn 2.x).
+ */
+export const ORT_PLUGIN_PACKAGE_NAMES = ["onnxruntime-qnn"] as const;
 
 export type VenvFamilySpec = {
   family: VenvFamily;
@@ -26,6 +41,13 @@ export type VenvFamilySpec = {
   ortVersionSpec?: string;
   /** Pip install args for the canonical ORT wheel (no conflicting flavors). */
   ortInstallArgs: string[];
+  /**
+   * Additional family-owned packages installed after canonical ORT
+   * (plugins, bridges, pinned NumPy, etc.).
+   */
+  supplementalInstallArgs?: string[];
+  /** Extra pip constraint lines for supplemental packages (merged into constraints). */
+  supplementalConstraints?: string[];
   /** Pip install args for olive-ai (+ requests) into a fresh family tree. */
   oliveInstallArgs: string[];
   packageConstraints: string[];
@@ -33,7 +55,7 @@ export type VenvFamilySpec = {
 };
 
 /** Bump when pins / layout change so ensure triggers an isolated rebuild. */
-export const VENV_SPEC_VERSION = 3;
+export const VENV_SPEC_VERSION = 4;
 
 /** Pinned olive-ai range for family builds (avoid floating major). */
 export const PINNED_OLIVE_AI_INSTALL = "olive-ai>=0.9.0,<1";
@@ -69,6 +91,8 @@ export function getFamilyRoot(family: VenvFamily): string {
       return path.join(process.cwd(), ".venvs", "cuda");
     case "openvino":
       return path.join(process.cwd(), ".venvs", "openvino");
+    case "qnn":
+      return path.join(process.cwd(), ".venvs", "qnn");
     case "default":
       return path.join(process.cwd(), ".venv");
     default: {
@@ -84,6 +108,8 @@ export function getFamilyBuildingRoot(family: VenvFamily): string {
       return path.join(process.cwd(), ".venvs", "cuda.building");
     case "openvino":
       return path.join(process.cwd(), ".venvs", "openvino.building");
+    case "qnn":
+      return path.join(process.cwd(), ".venvs", "qnn.building");
     case "default":
       return path.join(process.cwd(), ".venv.building");
     default: {
@@ -99,6 +125,8 @@ export function getFamilyBackupRoot(family: VenvFamily, stamp = Date.now()): str
       return path.join(process.cwd(), ".venvs", `cuda.backup-${stamp}`);
     case "openvino":
       return path.join(process.cwd(), ".venvs", `openvino.backup-${stamp}`);
+    case "qnn":
+      return path.join(process.cwd(), ".venvs", `qnn.backup-${stamp}`);
     case "default":
       return path.join(process.cwd(), `.venv.backup-${stamp}`);
     default: {
@@ -138,6 +166,20 @@ export function getFamilySpec(family: VenvFamily): VenvFamilySpec {
         packageConstraints: openvinoPackageConstraints(),
         specVersion: VENV_SPEC_VERSION,
       };
+    case "qnn":
+      return {
+        family: "qnn",
+        root: getFamilyRoot("qnn"),
+        buildingRoot: getFamilyBuildingRoot("qnn"),
+        ortDistribution: ONNXRUNTIME_QNN_FAMILY_ORT_PACKAGE,
+        ortVersionSpec: PINNED_ONNXRUNTIME_QNN_FAMILY_ORT_VERSION,
+        ortInstallArgs: qnnOrtInstallArgs(),
+        supplementalInstallArgs: qnnSupplementalInstallArgs(),
+        supplementalConstraints: qnnSupplementalConstraints(),
+        oliveInstallArgs: [...OLIVE_INSTALL_ARGS],
+        packageConstraints: qnnPackageConstraints(),
+        specVersion: VENV_SPEC_VERSION,
+      };
     case "default": {
       const ort = defaultOrtDistribution();
       return {
@@ -164,7 +206,15 @@ export type VenvManifest = {
   ortDistribution: OrtDistributionName;
   ortVersionSpec?: string;
   createdAt: string;
+  packages?: {
+    onnxruntime?: string;
+    onnxruntimeQnn?: string;
+    numpy?: string;
+  };
 };
+
+/** Exported for tests / ensure logs. */
+export const QNN_FAMILY_PLUGIN_VERSION = PINNED_ONNXRUNTIME_QNN_PLUGIN_VERSION;
 
 export function conflictingOrtDistributions(canonical: OrtDistributionName): OrtDistributionName[] {
   return ALL_ORT_DISTRIBUTIONS.filter((d) => d !== canonical);

--- a/src/server/services/venv/status.ts
+++ b/src/server/services/venv/status.ts
@@ -63,7 +63,11 @@ export type DualRuntimeStatus = {
 };
 
 const STATUS_TTL_MS = 8_000;
-let cachedStatus: { at: number; value: DualRuntimeStatus } | null = null;
+let cachedStatus: {
+  at: number;
+  value: DualRuntimeStatus;
+  options: { systemPython: string | null; configuredPython: string | null; venvOnUserPath: boolean };
+} | null = null;
 
 export function invalidateRuntimeStatusCache(): void {
   cachedStatus = null;
@@ -129,7 +133,8 @@ try:
         if getattr(device, "ep_name", None) != "QNNExecutionProvider":
             continue
         out["qnn_ep_any"] = True
-        if device.device.type == ort.OrtHardwareDeviceType.NPU:
+        device_type = getattr(getattr(device, "device", None), "type", None)
+        if device_type == ort.OrtHardwareDeviceType.NPU:
             out["qnn_ep_npu"] = True
 except Exception as exc:
     out["ort_error"] = str(exc)
@@ -411,7 +416,19 @@ export async function getDualRuntimeStatus(opts?: {
   configuredPython?: string | null;
   venvOnUserPath?: boolean;
 }): Promise<DualRuntimeStatus> {
-  if (!opts?.force && cachedStatus && Date.now() - cachedStatus.at < STATUS_TTL_MS) {
+  const options = {
+    systemPython: opts?.systemPython ?? null,
+    configuredPython: opts?.configuredPython ?? null,
+    venvOnUserPath: opts?.venvOnUserPath ?? false,
+  };
+  if (
+    !opts?.force &&
+    cachedStatus &&
+    Date.now() - cachedStatus.at < STATUS_TTL_MS &&
+    cachedStatus.options.systemPython === options.systemPython &&
+    cachedStatus.options.configuredPython === options.configuredPython &&
+    cachedStatus.options.venvOnUserPath === options.venvOnUserPath
+  ) {
     return cachedStatus.value;
   }
 
@@ -444,13 +461,13 @@ export async function getDualRuntimeStatus(opts?: {
 
   const value: DualRuntimeStatus = {
     families,
-    systemPython: opts?.systemPython ?? null,
-    configuredPython: opts?.configuredPython ?? null,
+    systemPython: options.systemPython,
+    configuredPython: options.configuredPython,
     platform: process.platform,
-    venvOnUserPath: opts?.venvOnUserPath ?? false,
+    venvOnUserPath: options.venvOnUserPath,
     hint,
   };
-  cachedStatus = { at: Date.now(), value };
+  cachedStatus = { at: Date.now(), value, options };
   return value;
 }
 

--- a/src/server/services/venv/status.ts
+++ b/src/server/services/venv/status.ts
@@ -46,6 +46,10 @@ export type RuntimeFamilyStatus = {
     openvino?: CapabilityStatus;
     tensorrt?: CapabilityStatus;
     tensorrtRtx?: CapabilityStatus;
+    /** Plugin registration + any QNN EpDevice (prep / AOT). */
+    qnnPreparation?: CapabilityStatus;
+    /** Win ARM64 + OrtHardwareDeviceType.NPU (potential inference). */
+    qnnInference?: CapabilityStatus;
   };
 };
 
@@ -89,6 +93,9 @@ out = {
   "tensorrt": None,
   "tensorrt_rtx": None,
   "optimum_intel": None,
+  "onnxruntime_qnn": None,
+  "qnn_ep_any": False,
+  "qnn_ep_npu": False,
 }
 try:
     import olive
@@ -102,8 +109,28 @@ for n in ["onnxruntime", "onnxruntime-directml", "onnxruntime-gpu", "onnxruntime
     except Exception:
         pass
 try:
+    dist = m.distribution("onnxruntime-qnn")
+    out["onnxruntime_qnn"] = dist.version
+except Exception:
+    pass
+try:
     import onnxruntime as ort
     out["providers"] = list(ort.get_available_providers())
+    try:
+        import onnxruntime_qnn  # noqa: F401
+    except Exception:
+        pass
+    try:
+        from olive.common.ort_inference import maybe_register_ep_libraries
+        maybe_register_ep_libraries()
+    except Exception:
+        pass
+    for device in ort.get_ep_devices():
+        if getattr(device, "ep_name", None) != "QNNExecutionProvider":
+            continue
+        out["qnn_ep_any"] = True
+        if device.device.type == ort.OrtHardwareDeviceType.NPU:
+            out["qnn_ep_npu"] = True
 except Exception as exc:
     out["ort_error"] = str(exc)
 try:
@@ -138,6 +165,9 @@ type ProbeJson = {
   optimum_intel?: string | null;
   tensorrt?: string | null;
   tensorrt_rtx?: string | null;
+  onnxruntime_qnn?: string | null;
+  qnn_ep_any?: boolean;
+  qnn_ep_npu?: boolean;
 };
 
 function missing(detail?: string): CapabilityStatus {
@@ -248,6 +278,39 @@ function buildCapabilities(
     }
   }
 
+  if (family === "qnn") {
+    if (process.platform !== "win32") {
+      caps.qnnPreparation = unsupported(
+        "QNN plugin install/UX is Windows-first in this Studio release",
+      );
+      caps.qnnInference = unsupported(
+        "QNN local HTP inference is Windows ARM64 Snapdragon only in this release",
+      );
+    } else if (!probe?.onnxruntime_qnn) {
+      caps.qnnPreparation = missing("onnxruntime-qnn plugin not installed");
+      caps.qnnInference = missing("onnxruntime-qnn plugin not installed");
+    } else if (!probe.qnn_ep_any && !providers.has("QNNExecutionProvider")) {
+      caps.qnnPreparation = broken(
+        "onnxruntime-qnn installed but no QNN EpDevice registered (Olive native registration)",
+      );
+      caps.qnnInference = broken("QNN EpDevice registration failed");
+    } else {
+      caps.qnnPreparation = usable();
+      const arch = process.arch.toLowerCase();
+      if (arch === "arm64" || arch === "aarch64") {
+        caps.qnnInference = probe.qnn_ep_npu
+          ? usable()
+          : missing(
+              "No QNN OrtEpDevice with OrtHardwareDeviceType.NPU (CPU/emulator devices do not count for inference)",
+            );
+      } else {
+        caps.qnnInference = unsupported(
+          "Windows x64 supports QNN preparation / plugin AOT only (not local HTP inference)",
+        );
+      }
+    }
+  }
+
   return caps;
 }
 
@@ -285,11 +348,16 @@ export async function probeFamilyStatus(family: VenvFamily): Promise<RuntimeFami
             ? {
                 openvino: missing("venv missing"),
               }
-            : {
-                cuda: missing("venv missing"),
-                tensorrt: missing("venv missing"),
-                tensorrtRtx: missing("venv missing"),
-              }),
+            : family === "qnn"
+              ? {
+                  qnnPreparation: missing("venv missing"),
+                  qnnInference: missing("venv missing"),
+                }
+              : {
+                  cuda: missing("venv missing"),
+                  tensorrt: missing("venv missing"),
+                  tensorrtRtx: missing("venv missing"),
+                }),
       },
     };
   }
@@ -355,19 +423,24 @@ export async function getDualRuntimeStatus(opts?: {
   const defaultOk = families.default.integrityHealthy;
   const cudaOk = families.cuda.integrityHealthy;
   const openvinoOk = families.openvino.integrityHealthy;
+  const qnnOk = families.qnn.integrityHealthy;
   const hint = !opts?.systemPython
     ? "No system Python found. Need 3.10–3.13 (3.12 recommended). Set python.exe below or OLIVE_STUDIO_PYTHON."
     : !families.default.exists
       ? "Default runtime (.venv) missing — Install Olive venv now, or first Execute Live will create it."
       : !defaultOk
         ? "Default runtime needs repair (Open Olive runtime / Install Olive venv)."
-        : cudaOk && openvinoOk
-          ? "Default, CUDA, and OpenVINO runtimes ready."
-          : cudaOk
-            ? "Default and CUDA runtimes ready. OpenVINO runtime (.venvs/openvino) is created on first OpenVINO job."
-            : openvinoOk
-              ? "Default and OpenVINO runtimes ready. CUDA runtime will be created on first CUDA/TensorRT job."
-              : "Default runtime ready. CUDA and OpenVINO runtimes are created on first use.";
+        : cudaOk && openvinoOk && qnnOk
+          ? "Default, CUDA, OpenVINO, and QNN runtimes ready."
+          : cudaOk && openvinoOk
+            ? "Default, CUDA, and OpenVINO runtimes ready. QNN runtime (.venvs/qnn) is created on first QNN job."
+            : cudaOk
+              ? "Default and CUDA runtimes ready. OpenVINO / QNN runtimes are created on first use."
+              : openvinoOk
+                ? "Default and OpenVINO runtimes ready. CUDA / QNN runtimes are created on first use."
+                : qnnOk
+                  ? "Default and QNN runtimes ready. CUDA / OpenVINO runtimes are created on first use."
+                  : "Default runtime ready. CUDA, OpenVINO, and QNN runtimes are created on first use.";
 
   const value: DualRuntimeStatus = {
     families,
@@ -400,6 +473,9 @@ export function capabilityForProvider(
     case "NvTensorRTRTXExecutionProvider":
       return status.capabilities.tensorrtRtx;
     case "QNNExecutionProvider":
+      // Prefer inference when usable; else preparation (x64 AOT / pre-NPU).
+      if (status.capabilities.qnnInference?.usable) return status.capabilities.qnnInference;
+      return status.capabilities.qnnPreparation;
     case "ROCMExecutionProvider":
     case "WebGpuExecutionProvider":
       return undefined;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds Qualcomm QNN 2.x **plugin** EP parity as an isolated `.venvs/qnn` family (standard `onnxruntime==1.26.0` + `onnxruntime-qnn==2.4.0`), not an ORT distribution swap.

- **Family foundation:** Python 3.11–3.13 + Windows x64/ARM64 gate before `qnn.building`; `supplementalInstallArgs` / NumPy pins; prep vs inference capabilities; remove QNN no-op on default family
- **Registration:** Olive-native plugin registration path; `OrtHardwareDeviceType.NPU` filter; `POST /api/env/install-qnn` + optional cached `POST /api/env/test-qnn-npu`
- **UX:** Win ARM64 inference wording; Win x64 preparation/AOT only; out-of-scope elsewhere; UI says “QNN runtime installed” until Snapdragon release gate
- **Recipe/docs:** HTP shape/readiness helpers, fail-closed explicit Retry with DirectML/CPU, `docs/hardware/qnn.md`

## Test plan

- [x] `pnpm vitest run` QNN-related lib tests
- [x] `pnpm vitest run --config vitest.server.config.ts` packageConstraints / probe policy / qnn / olive routing
- [x] `pnpm vitest run --config vitest.component.config.ts` useQnnInstall
- [x] `pnpm exec tsc --noEmit`
- [ ] Snapdragon release gate on real Win ARM64 NPU (not claimed in this PR)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2b535738-d5f0-4757-a515-3dd5308947c7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2b535738-d5f0-4757-a515-3dd5308947c7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tonythethompson/Olive-Studio/pull/117?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

