### PR TITLE
feat: async engine probing and MCP circuit breaker (tech-debt #16, #20)

### DIFF
--- a/src/components/features/recipe-graph/PassGuidanceCard.test.tsx
+++ b/src/components/features/recipe-graph/PassGuidanceCard.test.tsx
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
+
+import type { PassGuidance } from "@/lib/passGuidance";
+import { PassGuidanceCard } from "./PassGuidanceCard";
+
+function makeGuidance(passName = "OnnxConversion"): PassGuidance {
+  return {
+    title: "ONNX conversion",
+    summary: "Convert to ONNX.",
+    whatItDoes: "Exports the model graph to ONNX.",
+    whenToUse: ["You need ONNX output."],
+    whenNotToUse: [],
+    passName,
+  };
+}
+
+function mockFetchJson(body: unknown, ok = true) {
+  return vi.fn(async () => ({
+    ok,
+    json: async () => body,
+  }));
+}
+
+describe("PassGuidanceCard MCP parameter fetch", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", mockFetchJson({}));
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  async function expandParams() {
+    fireEvent.click(screen.getByRole("button", { name: /Olive Parameters/i }));
+  }
+
+  it("stores params on a successful MCP response", async () => {
+    vi.stubGlobal(
+      "fetch",
+      mockFetchJson({
+        parameters: { opset: { type: "int", description: "ONNX opset version" } },
+        required_params: ["opset"],
+      }),
+    );
+
+    render(<PassGuidanceCard guidance={makeGuidance()} />);
+    await waitFor(() => expect(screen.queryByText(/loading/i)).toBeNull());
+    await expandParams();
+
+    expect(screen.getByText("opset")).toBeDefined();
+    expect(screen.queryByText("Failed to load parameters")).toBeNull();
+  });
+
+  it("sets failure state on non-OK HTTP responses", async () => {
+    vi.stubGlobal("fetch", mockFetchJson({ error: "ignored" }, false));
+
+    render(<PassGuidanceCard guidance={makeGuidance()} />);
+    await waitFor(() => expect(screen.queryByText(/loading/i)).toBeNull());
+    await expandParams();
+
+    expect(screen.getByText("Failed to load parameters")).toBeDefined();
+    expect(screen.getByRole("button", { name: /Retry/i })).toBeDefined();
+  });
+
+  it("sets failure state when the payload contains error", async () => {
+    vi.stubGlobal("fetch", mockFetchJson({ error: "MCP unavailable" }));
+
+    render(<PassGuidanceCard guidance={makeGuidance()} />);
+    await waitFor(() => expect(screen.queryByText(/loading/i)).toBeNull());
+    await expandParams();
+
+    expect(screen.getByText("Failed to load parameters")).toBeDefined();
+  });
+
+  it("does not apply aborted fetch results to UI state", async () => {
+    let resolveFetch: (value: { ok: boolean; json: () => Promise<unknown> }) => void;
+    const fetchMock = vi.fn(
+      () =>
+        new Promise<{ ok: boolean; json: () => Promise<unknown> }>((resolve) => {
+          resolveFetch = resolve;
+        }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { unmount } = render(<PassGuidanceCard guidance={makeGuidance("PassA")} />);
+    await expandParams();
+    expect(screen.getByText(/loading/i)).toBeDefined();
+
+    unmount();
+    await act(async () => {
+      resolveFetch!({
+        ok: false,
+        json: async () => ({ error: "should be ignored" }),
+      });
+      await Promise.resolve();
+    });
+
+    vi.stubGlobal("fetch", () => new Promise(() => {}));
+    render(<PassGuidanceCard guidance={makeGuidance("PassB")} />);
+    await expandParams();
+    expect(screen.getByText(/loading/i)).toBeDefined();
+    expect(screen.queryByText("Failed to load parameters")).toBeNull();
+  });
+});

--- a/src/components/features/recipe-graph/PassGuidanceCard.tsx
+++ b/src/components/features/recipe-graph/PassGuidanceCard.tsx
@@ -47,13 +47,18 @@ export function PassGuidanceCard({ guidance }: PassGuidanceCardProps) {
       }),
       signal: controller.signal,
     })
-      .then((r) => r.json())
-      .then((data: McpPassParamsResponse) => {
-        if (!controller.signal.aborted) {
-          setParams(data);
+      .then(async (r) => {
+        const data: McpPassParamsResponse = await r.json();
+        if (controller.signal.aborted) return;
+        if (!r.ok || data.error) {
+          setParams(null);
           setHasFetched(true);
-          setNetworkError(false);
+          setNetworkError(true);
+          return;
         }
+        setParams(data);
+        setHasFetched(true);
+        setNetworkError(false);
       })
       .catch((err) => {
         if (err.name === "AbortError") return;

--- a/src/components/features/recipe-graph/PassGuidanceCard.tsx
+++ b/src/components/features/recipe-graph/PassGuidanceCard.tsx
@@ -1,30 +1,17 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { PassGuidance } from "@/lib/passGuidance";
+import {
+  parseMcpPassParamsPayload,
+  type McpPassParamsPayload,
+} from "@/lib/mcpParamValidation";
 import { CheckCircle2, XCircle, Database, ChevronDown, ChevronRight } from "lucide-react";
-
-interface McpParamDoc {
-  description?: string;
-  type?: string;
-  default?: unknown;
-  valid_range?: string;
-  interactions?: string;
-}
-
-interface McpPassParamsResponse {
-  pass_name?: string;
-  description?: string;
-  required_params?: string[];
-  parameters?: Record<string, McpParamDoc>;
-  gotchas?: string[];
-  error?: string;
-}
 
 interface PassGuidanceCardProps {
   guidance: PassGuidance;
 }
 
 export function PassGuidanceCard({ guidance }: PassGuidanceCardProps) {
-  const [params, setParams] = useState<McpPassParamsResponse | null>(null);
+  const [params, setParams] = useState<McpPassParamsPayload | null>(null);
   const [hasFetched, setHasFetched] = useState(false);
   const [networkError, setNetworkError] = useState(false);
   const [paramsExpanded, setParamsExpanded] = useState(false);
@@ -48,15 +35,16 @@ export function PassGuidanceCard({ guidance }: PassGuidanceCardProps) {
       signal: controller.signal,
     })
       .then(async (r) => {
-        const data: McpPassParamsResponse = await r.json();
+        const data: unknown = await r.json();
         if (controller.signal.aborted) return;
-        if (!r.ok || data.error) {
+        const parsed = parseMcpPassParamsPayload(r.ok, data);
+        if (!parsed.ok) {
           setParams(null);
           setHasFetched(true);
           setNetworkError(true);
           return;
         }
-        setParams(data);
+        setParams(parsed.data);
         setHasFetched(true);
         setNetworkError(false);
       })
@@ -79,9 +67,9 @@ export function PassGuidanceCard({ guidance }: PassGuidanceCardProps) {
   const isLoading = guidance.passName != null && !hasFetched;
   const hasParams = params && !params.error && params.parameters && Object.keys(params.parameters).length > 0;
   const requiredParams = params?.required_params ?? [];
-  const optionalParams: Array<[string, McpParamDoc]> = hasParams
+  const optionalParams: Array<[string, NonNullable<McpPassParamsPayload["parameters"]>[string]]> = hasParams
     ? (Object.entries(params!.parameters!).filter(([k]) => !requiredParams.includes(k)) as Array<
-        [string, McpParamDoc]
+        [string, NonNullable<McpPassParamsPayload["parameters"]>[string]]
       >)
     : [];
 

--- a/src/lib/mcpParamValidation.ts
+++ b/src/lib/mcpParamValidation.ts
@@ -25,13 +25,24 @@ interface McpParamDoc {
   interactions?: string;
 }
 
-interface McpPassParamsResponse {
+export interface McpPassParamsPayload {
   pass_name?: string;
   description?: string;
   required_params?: string[];
   parameters?: Record<string, McpParamDoc>;
   gotchas?: string[];
   error?: string;
+}
+
+export type McpPassParamsParseResult = { ok: true; data: McpPassParamsPayload } | { ok: false };
+
+/** Classify an MCP get_pass_parameters tool response without touching the session cache. */
+export function parseMcpPassParamsPayload(responseOk: boolean, data: unknown): McpPassParamsParseResult {
+  if (!responseOk) return { ok: false };
+  const payload = data as McpPassParamsPayload;
+  if (!payload || typeof payload !== "object") return { ok: false };
+  if (typeof payload.error === "string" && payload.error) return { ok: false };
+  return { ok: true, data: payload };
 }
 
 /**
@@ -82,14 +93,14 @@ function isValueInRange(value: unknown, range: string): boolean {
  * Fetch MCP parameter metadata for a pass type.
  * Caches results per session to avoid redundant fetches.
  */
-const paramCache = new Map<string, McpPassParamsResponse | null>();
+const paramCache = new Map<string, McpPassParamsPayload | null>();
 
 /** Clear the param cache so the next fetch re-reads from MCP. */
 export function clearParamCache(): void {
   paramCache.clear();
 }
 
-export async function fetchMcpPassParams(passTypeName: string): Promise<McpPassParamsResponse | null> {
+export async function fetchMcpPassParams(passTypeName: string): Promise<McpPassParamsPayload | null> {
   if (paramCache.has(passTypeName)) {
     return paramCache.get(passTypeName) ?? null;
   }
@@ -104,19 +115,15 @@ export async function fetchMcpPassParams(passTypeName: string): Promise<McpPassP
       }),
     });
 
-    if (!res.ok) {
+    const data: unknown = await res.json();
+    const parsed = parseMcpPassParamsPayload(res.ok, data);
+    if (!parsed.ok) {
       paramCache.set(passTypeName, null);
       return null;
     }
 
-    const data: McpPassParamsResponse = await res.json();
-    if (data.error) {
-      paramCache.set(passTypeName, null);
-      return null;
-    }
-
-    paramCache.set(passTypeName, data);
-    return data;
+    paramCache.set(passTypeName, parsed.data);
+    return parsed.data;
   } catch {
     paramCache.set(passTypeName, null);
     return null;
@@ -130,7 +137,7 @@ function validateSinglePass(
   passName: string,
   passTypeName: string,
   config: Record<string, unknown>,
-  meta: McpPassParamsResponse,
+  meta: McpPassParamsPayload,
 ): McpParamWarning[] {
   const warnings: McpParamWarning[] = [];
   const params = meta.parameters ?? {};

--- a/src/server/__tests__/childProcessTestMocks.ts
+++ b/src/server/__tests__/childProcessTestMocks.ts
@@ -1,6 +1,15 @@
 /**
  * Shared Vitest mock for `child_process.execFile` (with promisify.custom) and
  * optional `spawn`. Keeps the promisify shape identical across server unit tests.
+ *
+ * Usage:
+ * ```ts
+ * const mocks = vi.hoisted(() => createChildProcessTestHandles());
+ * vi.mock("child_process", childProcessVitestMockFactory(mocks, { includeSpawn: true }));
+ * // In tests: mocks.execFileImpl = async () => ({ stdout: "…", stderr: "" });
+ * ```
+ *
+ * Used by MCP client/route tests and local engine setup tests in this PR.
  */
 import { EventEmitter } from "events";
 import type { ChildProcess } from "child_process";

--- a/src/server/__tests__/childProcessTestMocks.ts
+++ b/src/server/__tests__/childProcessTestMocks.ts
@@ -1,0 +1,78 @@
+/**
+ * Shared Vitest mock for `child_process.execFile` (with promisify.custom) and
+ * optional `spawn`. Keeps the promisify shape identical across server unit tests.
+ */
+import { EventEmitter } from "events";
+import type { ChildProcess } from "child_process";
+
+const PROMISIFY_CUSTOM = Symbol.for("nodejs.util.promisify.custom");
+
+export type ChildProcessTestHandles = {
+  execFileImpl: null | ((...args: unknown[]) => unknown);
+  spawnImpl: null | ((...args: unknown[]) => unknown);
+  /** Populated when `trackExecFileCalls` is enabled on the mock factory. */
+  execFileCalls: unknown[][];
+};
+
+export function createChildProcessTestHandles(): ChildProcessTestHandles {
+  return { execFileImpl: null, spawnImpl: null, execFileCalls: [] };
+}
+
+export type ChildProcessMockOptions = {
+  /** Install a default spawn mock that emits spawn/exit/close on nextTick. */
+  includeSpawn?: boolean;
+  /** Record promisified execFile args in `handles.execFileCalls`. */
+  trackExecFileCalls?: boolean;
+};
+
+function defaultSpawnProc(): ChildProcess {
+  const proc = new EventEmitter() as unknown as ChildProcess;
+  proc.stdout = new EventEmitter() as ChildProcess["stdout"];
+  proc.stderr = new EventEmitter() as ChildProcess["stderr"];
+  proc.stdin = new EventEmitter() as ChildProcess["stdin"];
+  (proc as unknown as Record<string, unknown>).pid = 99999;
+  (proc as unknown as Record<string, unknown>).unref = () => {};
+  (proc as unknown as Record<string, unknown>).kill = () => true;
+  process.nextTick(() => proc.emit("spawn"));
+  process.nextTick(() => proc.emit("exit", 0));
+  process.nextTick(() => proc.emit("close", 0));
+  return proc;
+}
+
+/** Factory for `vi.mock("child_process", …)` that stubs execFile/spawn via `handles`. */
+export function childProcessVitestMockFactory(
+  handles: ChildProcessTestHandles,
+  options: ChildProcessMockOptions = {},
+) {
+  const { includeSpawn = false, trackExecFileCalls = false } = options;
+
+  return async (importOriginal: () => Promise<typeof import("child_process")>) => {
+    const actual = await importOriginal();
+
+    function mockExecFile(...execArgs: unknown[]): unknown {
+      const lastArg = execArgs[execArgs.length - 1];
+      if (typeof lastArg === "function") {
+        lastArg(null, "", "");
+        return undefined;
+      }
+      return (actual.execFile as unknown as (...a: unknown[]) => unknown)(...execArgs);
+    }
+
+    (mockExecFile as unknown as Record<symbol, unknown>)[PROMISIFY_CUSTOM] = (...args: unknown[]) => {
+      if (trackExecFileCalls) handles.execFileCalls.push(args);
+      if (handles.execFileImpl) return handles.execFileImpl(...args);
+      return Promise.resolve({ stdout: "", stderr: "" });
+    };
+
+    function mockSpawn(...spawnArgs: unknown[]): ChildProcess {
+      if (handles.spawnImpl) return handles.spawnImpl(...spawnArgs) as ChildProcess;
+      return defaultSpawnProc();
+    }
+
+    return {
+      ...actual,
+      execFile: mockExecFile as typeof actual.execFile,
+      ...(includeSpawn ? { spawn: mockSpawn as typeof actual.spawn } : {}),
+    };
+  };
+}

--- a/src/server/__tests__/routes.integration.test.ts
+++ b/src/server/__tests__/routes.integration.test.ts
@@ -7,10 +7,11 @@
  * All external dependencies (Python, AI providers, LM Studio, Ollama) are
  * mocked via `setup.integration.ts` so these tests run reliably in CI.
  */
-import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from "vitest";
 import type { Server } from "http";
 
 import { stubGlobalFetch, restoreGlobalFetch } from "./setup.integration.ts";
+import { resetMcpBreaker } from "../services/mcp/breaker.ts";
 import { app, markServerReady } from "../../../server.ts";
 
 let server: Server;
@@ -45,6 +46,12 @@ afterAll(async () => {
   if (server) {
     await new Promise<void>((resolve) => server.close(() => resolve()));
   }
+});
+
+// The MCP circuit breaker is a process-wide singleton; reset it per test so
+// infra-level failures from one test never short-circuit another.
+beforeEach(() => {
+  resetMcpBreaker();
 });
 
 describe("Route integration tests", () => {
@@ -460,8 +467,8 @@ describe("Route integration tests", () => {
     });
 
     it("returns SSE error when LM Studio CLI is not installed", async () => {
-      // findLmsCli() uses execSync("where lms") which fails on systems
-      // without LM Studio. The handler streams NDJSON (or legacy SSE) events.
+      // findLmsCli() probes via execFileAsync("where lms") which the setup mock
+      // resolves to empty output (CLI missing). The handler streams NDJSON events.
       const res = await fetch(`${baseUrl}/api/ai/local-pull`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },

--- a/src/server/__tests__/routes.integration.test.ts
+++ b/src/server/__tests__/routes.integration.test.ts
@@ -12,6 +12,7 @@ import type { Server } from "http";
 
 import { stubGlobalFetch, restoreGlobalFetch } from "./setup.integration.ts";
 import { resetMcpBreaker } from "../services/mcp/breaker.ts";
+import { resetLocalEngineRuntime } from "../services/ai/localEngineState.ts";
 import { app, markServerReady } from "../../../server.ts";
 
 let server: Server;
@@ -48,10 +49,10 @@ afterAll(async () => {
   }
 });
 
-// The MCP circuit breaker is a process-wide singleton; reset it per test so
-// infra-level failures from one test never short-circuit another.
+// Process-wide singletons; reset per test so state never leaks across cases.
 beforeEach(() => {
   resetMcpBreaker();
+  resetLocalEngineRuntime();
 });
 
 describe("Route integration tests", () => {

--- a/src/server/__tests__/setup.integration.ts
+++ b/src/server/__tests__/setup.integration.ts
@@ -8,9 +8,10 @@
  *   - services/ai/index.ts callAI               → instantly rejects
  *   - globalThis.fetch for LM Studio/Ollama     → mock local model responses
  *
- * `execSync` and `spawnSync` remain unmocked — callers that need them
- * (e.g. `findLmsCli` for `where lms`) run real commands that fail fast
- * on systems without those tools.
+ * `spawnSync` remains unmocked — callers that need it run real commands
+ * that fail fast on systems without those tools. CLI discovery (`findLmsCli`)
+ * is async (`execFileAsync` → `where lms`/`which lms`) and resolves through
+ * the mocked execFile to empty output, i.e. a cache-miss without real I/O.
  */
 import { EventEmitter } from "events";
 import { vi } from "vitest";

--- a/src/server/routes/ai/installEngineRoutes.ts
+++ b/src/server/routes/ai/installEngineRoutes.ts
@@ -30,8 +30,9 @@ export function mountInstallEngineRoutes(router: Router): void {
     try {
       if (engine === "ollama") {
         send({ type: "step", message: "Ensuring Ollama is installed…", percent: 0 });
-        // Shared ensure continues for other clients; stop writing if this client disconnects.
-        const result = await ensureOllamaReady((evt) => send(evt));
+        // The first caller's disconnect aborts the shared ensure; later callers
+        // consume progress but never cancel it.
+        const result = await ensureOllamaReady((evt) => send(evt), guard.signal);
         if (guard.disconnected()) {
           guard.endOnce();
           return;
@@ -43,7 +44,9 @@ export function mountInstallEngineRoutes(router: Router): void {
         endNdjson(res, { type: "done", ok: true, message: "Ollama is ready.", percent: 100 });
       } else {
         send({ type: "step", message: "Ensuring LM Studio is installed…", percent: 0 });
-        const result = await ensureLmsReady((evt) => send(evt));
+        // The first caller's disconnect aborts the shared ensure; later callers
+        // consume progress but never cancel it.
+        const result = await ensureLmsReady((evt) => send(evt), guard.signal);
         if (guard.disconnected()) {
           guard.endOnce();
           return;

--- a/src/server/routes/ai/installEngineRoutes.ts
+++ b/src/server/routes/ai/installEngineRoutes.ts
@@ -2,10 +2,9 @@
  * Engine installation route: POST /ai/install-engine (streams setup progress
  * for LM Studio or Ollama).
  *
- * Concurrent install requests share one in-flight `ensure*` setup. Only the
- * request that **started** the shared work can cancel it (via `guard.signal`);
- * a later client's tab close stops their NDJSON stream but does not abort setup
- * another client may be waiting on. See `ensureOllamaReady` / `ensureLmsReady`.
+ * Concurrent install requests share one in-flight `ensure*` setup. Shared work
+ * is cancelled only when every waiting client disconnects; a late client's tab
+ * close does not abort setup others are still waiting on.
  */
 import type { Router } from "express";
 import rateLimit from "express-rate-limit";

--- a/src/server/routes/ai/installEngineRoutes.ts
+++ b/src/server/routes/ai/installEngineRoutes.ts
@@ -30,9 +30,7 @@ export function mountInstallEngineRoutes(router: Router): void {
     try {
       if (engine === "ollama") {
         send({ type: "step", message: "Ensuring Ollama is installed…", percent: 0 });
-        // The first caller's disconnect aborts the shared ensure; later callers
-        // consume progress but never cancel it.
-        const result = await ensureOllamaReady((evt) => send(evt), guard.signal);
+        const result = await ensureOllamaReady((evt) => send(evt));
         if (guard.disconnected()) {
           guard.endOnce();
           return;
@@ -44,9 +42,7 @@ export function mountInstallEngineRoutes(router: Router): void {
         endNdjson(res, { type: "done", ok: true, message: "Ollama is ready.", percent: 100 });
       } else {
         send({ type: "step", message: "Ensuring LM Studio is installed…", percent: 0 });
-        // The first caller's disconnect aborts the shared ensure; later callers
-        // consume progress but never cancel it.
-        const result = await ensureLmsReady((evt) => send(evt), guard.signal);
+        const result = await ensureLmsReady((evt) => send(evt));
         if (guard.disconnected()) {
           guard.endOnce();
           return;

--- a/src/server/routes/ai/installEngineRoutes.ts
+++ b/src/server/routes/ai/installEngineRoutes.ts
@@ -1,6 +1,11 @@
 /**
  * Engine installation route: POST /ai/install-engine (streams setup progress
  * for LM Studio or Ollama).
+ *
+ * Concurrent install requests share one in-flight `ensure*` setup. Only the
+ * request that **started** the shared work can cancel it (via `guard.signal`);
+ * a later client's tab close stops their NDJSON stream but does not abort setup
+ * another client may be waiting on. See `ensureOllamaReady` / `ensureLmsReady`.
  */
 import type { Router } from "express";
 import rateLimit from "express-rate-limit";

--- a/src/server/routes/ai/installEngineRoutes.ts
+++ b/src/server/routes/ai/installEngineRoutes.ts
@@ -30,7 +30,7 @@ export function mountInstallEngineRoutes(router: Router): void {
     try {
       if (engine === "ollama") {
         send({ type: "step", message: "Ensuring Ollama is installed…", percent: 0 });
-        const result = await ensureOllamaReady((evt) => send(evt));
+        const result = await ensureOllamaReady((evt) => send(evt), guard.signal);
         if (guard.disconnected()) {
           guard.endOnce();
           return;
@@ -42,7 +42,7 @@ export function mountInstallEngineRoutes(router: Router): void {
         endNdjson(res, { type: "done", ok: true, message: "Ollama is ready.", percent: 100 });
       } else {
         send({ type: "step", message: "Ensuring LM Studio is installed…", percent: 0 });
-        const result = await ensureLmsReady((evt) => send(evt));
+        const result = await ensureLmsReady((evt) => send(evt), guard.signal);
         if (guard.disconnected()) {
           guard.endOnce();
           return;

--- a/src/server/routes/ai/lmStudioRoutes.ts
+++ b/src/server/routes/ai/lmStudioRoutes.ts
@@ -76,7 +76,7 @@ export function mountLmStudioRoutes(router: Router): void {
 
   router.get("/ai/local-health", async (_req, res) => {
     const healthy = await isLmsServerRunning();
-    const lmsCli = findLmsCli();
+    const lmsCli = await findLmsCli();
     return res.json({ healthy, lmsInstalled: !!lmsCli });
   });
 
@@ -154,7 +154,9 @@ export function mountLmStudioRoutes(router: Router): void {
       }
 
       localEngineRuntime.lmsPullBusyTag = tag;
-      const ready = await ensureLmsReady((evt) => send(evt));
+      // The first caller's disconnect aborts the shared ensure; later callers
+      // consume progress but never cancel it.
+      const ready = await ensureLmsReady((evt) => send(evt), guard.signal);
       if (guard.disconnected()) {
         releaseBusy();
         guard.endOnce();
@@ -170,7 +172,7 @@ export function mountLmStudioRoutes(router: Router): void {
         guard.endOnce();
         return;
       }
-      const lmsCli = findLmsCli();
+      const lmsCli = await findLmsCli();
       if (!lmsCli) {
         send({
           type: "error",

--- a/src/server/routes/ai/lmStudioRoutes.ts
+++ b/src/server/routes/ai/lmStudioRoutes.ts
@@ -27,6 +27,34 @@ import {
   LMS_GET_MAX_MS,
 } from "./localEngines.ts";
 import { trackStreamClient, beginPullSse } from "./streamHelpers.ts";
+import { bodyGuard } from "../middleware/bodyGuard.ts";
+
+import type { Router } from "express";
+import { spawn } from "child_process";
+
+import { isValidLocalModelTag } from "../../../lib/localModelTag.ts";
+import {
+  hintForLmsPullFailure,
+  mapLmsDownloadPercent,
+  parseLmsGetPercent,
+  splitCliLines,
+} from "../../../lib/lmsPullProgress.ts";
+import { gateLocalPullDiskSpace } from "../../../lib/localEngineDisk.ts";
+import { heavyCommandRateLimit } from "../../middleware/rateLimit.ts";
+import { localEngineRuntime } from "../../services/ai/localEngineState.ts";
+import {
+  LM_STUDIO_PORT,
+  lmStudioFetchInit,
+  isLmsServerRunning,
+  findLmsCli,
+  listLmsInstalledModelKeys,
+  ensureLmsReady,
+  starterMetaForTag,
+  verifyInstalledAfterPull,
+  LMS_GET_MAX_MS,
+} from "./localEngines.ts";
+import { trackStreamClient, beginPullSse } from "./streamHelpers.ts";
+import { bodyGuard } from "../middleware/bodyGuard.ts";
 
 export function mountLmStudioRoutes(router: Router): void {
   router.get("/ai/local-models", async (_req, res) => {
@@ -80,9 +108,16 @@ export function mountLmStudioRoutes(router: Router): void {
     return res.json({ healthy, lmsInstalled: !!lmsCli });
   });
 
-  router.post("/ai/local-load", async (req, res) => {
-    const { modelTag } = req.body ?? {};
-    if (!modelTag) return res.status(400).json({ error: "Missing modelTag" });
+  router.post(
+    "/ai/local-load",
+    bodyGuard<{ modelTag: string }>({
+      modelTag: { type: "string", required: true },
+    }),
+    async (req, res) => {
+      const guardResult = req.body;
+      if ("error" in guardResult) return res.status(400).json({ error: guardResult.error });
+      const { modelTag } = guardResult.parsed;
+      if (!modelTag) return res.status(400).json({ error: "Missing modelTag" });
     try {
       const r = await fetch(`http://127.0.0.1:${LM_STUDIO_PORT}/v1/models/load`, {
         method: "POST",
@@ -154,7 +189,7 @@ export function mountLmStudioRoutes(router: Router): void {
       }
 
       localEngineRuntime.lmsPullBusyTag = tag;
-      // Initiator-only abort: late joiners get progress but cannot cancel shared setup.
+      // Waiter-based abort: shared ensure continues while other clients wait.
       const ready = await ensureLmsReady((evt) => send(evt), guard.signal);
       if (guard.disconnected()) {
         releaseBusy();

--- a/src/server/routes/ai/lmStudioRoutes.ts
+++ b/src/server/routes/ai/lmStudioRoutes.ts
@@ -154,7 +154,7 @@ export function mountLmStudioRoutes(router: Router): void {
       }
 
       localEngineRuntime.lmsPullBusyTag = tag;
-      const ready = await ensureLmsReady((evt) => send(evt));
+      const ready = await ensureLmsReady((evt) => send(evt), guard.signal);
       if (guard.disconnected()) {
         releaseBusy();
         guard.endOnce();

--- a/src/server/routes/ai/lmStudioRoutes.ts
+++ b/src/server/routes/ai/lmStudioRoutes.ts
@@ -27,34 +27,6 @@ import {
   LMS_GET_MAX_MS,
 } from "./localEngines.ts";
 import { trackStreamClient, beginPullSse } from "./streamHelpers.ts";
-import { bodyGuard } from "../middleware/bodyGuard.ts";
-
-import type { Router } from "express";
-import { spawn } from "child_process";
-
-import { isValidLocalModelTag } from "../../../lib/localModelTag.ts";
-import {
-  hintForLmsPullFailure,
-  mapLmsDownloadPercent,
-  parseLmsGetPercent,
-  splitCliLines,
-} from "../../../lib/lmsPullProgress.ts";
-import { gateLocalPullDiskSpace } from "../../../lib/localEngineDisk.ts";
-import { heavyCommandRateLimit } from "../../middleware/rateLimit.ts";
-import { localEngineRuntime } from "../../services/ai/localEngineState.ts";
-import {
-  LM_STUDIO_PORT,
-  lmStudioFetchInit,
-  isLmsServerRunning,
-  findLmsCli,
-  listLmsInstalledModelKeys,
-  ensureLmsReady,
-  starterMetaForTag,
-  verifyInstalledAfterPull,
-  LMS_GET_MAX_MS,
-} from "./localEngines.ts";
-import { trackStreamClient, beginPullSse } from "./streamHelpers.ts";
-import { bodyGuard } from "../middleware/bodyGuard.ts";
 
 export function mountLmStudioRoutes(router: Router): void {
   router.get("/ai/local-models", async (_req, res) => {
@@ -108,16 +80,11 @@ export function mountLmStudioRoutes(router: Router): void {
     return res.json({ healthy, lmsInstalled: !!lmsCli });
   });
 
-  router.post(
-    "/ai/local-load",
-    bodyGuard<{ modelTag: string }>({
-      modelTag: { type: "string", required: true },
-    }),
-    async (req, res) => {
-      const guardResult = req.body;
-      if ("error" in guardResult) return res.status(400).json({ error: guardResult.error });
-      const { modelTag } = guardResult.parsed;
-      if (!modelTag) return res.status(400).json({ error: "Missing modelTag" });
+  router.post("/ai/local-load", async (req, res) => {
+    const { modelTag } = req.body ?? {};
+    if (typeof modelTag !== "string" || !modelTag) {
+      return res.status(400).json({ error: "Missing modelTag" });
+    }
     try {
       const r = await fetch(`http://127.0.0.1:${LM_STUDIO_PORT}/v1/models/load`, {
         method: "POST",

--- a/src/server/routes/ai/lmStudioRoutes.ts
+++ b/src/server/routes/ai/lmStudioRoutes.ts
@@ -154,6 +154,7 @@ export function mountLmStudioRoutes(router: Router): void {
       }
 
       localEngineRuntime.lmsPullBusyTag = tag;
+      // Initiator-only abort: late joiners get progress but cannot cancel shared setup.
       const ready = await ensureLmsReady((evt) => send(evt), guard.signal);
       if (guard.disconnected()) {
         releaseBusy();

--- a/src/server/routes/ai/lmStudioRoutes.ts
+++ b/src/server/routes/ai/lmStudioRoutes.ts
@@ -154,9 +154,7 @@ export function mountLmStudioRoutes(router: Router): void {
       }
 
       localEngineRuntime.lmsPullBusyTag = tag;
-      // The first caller's disconnect aborts the shared ensure; later callers
-      // consume progress but never cancel it.
-      const ready = await ensureLmsReady((evt) => send(evt), guard.signal);
+      const ready = await ensureLmsReady((evt) => send(evt));
       if (guard.disconnected()) {
         releaseBusy();
         guard.endOnce();

--- a/src/server/routes/ai/localEngines.test.ts
+++ b/src/server/routes/ai/localEngines.test.ts
@@ -1,0 +1,230 @@
+/**
+ * Unit tests for the local AI engine setup internals (Tech Debt #16):
+ *  - async `where/which` CLI probing with single-flight and TTL caching
+ *  - abort-aware capped backoff polling in ensureOllamaReady / ensureLmsReady
+ *
+ * child_process.execFile is mocked with a `promisify.custom` handler so
+ * `execFileAsync` (util.promisify(execFile)) resolves the same
+ * `{ stdout, stderr }` shape as real Node's execFile promisification.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { EventEmitter } from "events";
+import fs from "fs";
+
+import { findLmsCli, ensureOllamaReady, ensureLmsReady } from "./localEngines.ts";
+import { localEngineRuntime, resetLocalEngineRuntime } from "../../services/ai/localEngineState.ts";
+
+// ── Configurable child_process mocks ───────────────────────────────────────
+
+const mocks = vi.hoisted(() => ({
+  execFileImpl: null as null | ((...args: unknown[]) => unknown),
+  spawnImpl: null as null | ((...args: unknown[]) => unknown),
+}));
+
+vi.mock("child_process", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("child_process")>();
+  const customSymbol = Symbol.for("nodejs.util.promisify.custom");
+
+  function mockExecFile(...execArgs: unknown[]): unknown {
+    // Callback-style callers get an instant empty result.
+    const lastArg = execArgs[execArgs.length - 1];
+    if (typeof lastArg === "function") {
+      lastArg(null, "", "");
+      return undefined;
+    }
+    return (actual.execFile as unknown as (...a: unknown[]) => unknown)(...execArgs);
+  }
+
+  // util.promisify(execFile) prefers this when present (mirrors real Node's
+  // execFile, which resolves { stdout, stderr }). Tests stub execFileImpl to
+  // resolve that exact shape.
+  (mockExecFile as unknown as Record<symbol, unknown>)[customSymbol] = (...args: unknown[]) => {
+    if (mocks.execFileImpl) return mocks.execFileImpl(...args);
+    return Promise.resolve({ stdout: "", stderr: "" });
+  };
+
+  function mockSpawn(...spawnArgs: unknown[]): ReturnType<typeof actual.spawn> {
+    if (mocks.spawnImpl) return mocks.spawnImpl(...spawnArgs) as ReturnType<typeof actual.spawn>;
+    const proc = new EventEmitter() as unknown as ReturnType<typeof actual.spawn>;
+    proc.stdout = new EventEmitter() as unknown as ReturnType<typeof actual.spawn>["stdout"];
+    proc.stderr = new EventEmitter() as unknown as ReturnType<typeof actual.spawn>["stderr"];
+    proc.stdin = new EventEmitter() as unknown as ReturnType<typeof actual.spawn>["stdin"];
+    (proc as unknown as Record<string, unknown>).pid = 99999;
+    (proc as unknown as Record<string, unknown>).unref = () => {};
+    (proc as unknown as Record<string, unknown>).kill = () => true;
+    // Emit "spawn" (startOllamaOnce resolves on it), "exit" (spawnLmsServerDetached
+    // resolves on it), then "close" via process.nextTick, which fake timers do not touch.
+    process.nextTick(() => proc.emit("spawn"));
+    process.nextTick(() => proc.emit("exit", 0));
+    process.nextTick(() => proc.emit("close", 0));
+    return proc;
+  }
+
+  return {
+    ...actual,
+    execFile: mockExecFile as unknown as typeof actual.execFile,
+    spawn: mockSpawn as unknown as typeof actual.spawn,
+  };
+});
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+/** Probe `where/which` output pointing at a real executable (passes fs.existsSync). */
+const probeHit = { stdout: `${process.execPath}\n`, stderr: "" };
+
+/** Real candidate dirs always miss; only the probe result path "exists". */
+function stubExistsSyncOnlyForExecPath(): void {
+  vi.spyOn(fs, "existsSync").mockImplementation((p) => String(p) === process.execPath);
+}
+
+describe("findLmsCli async probing", () => {
+  beforeEach(() => {
+    resetLocalEngineRuntime();
+    mocks.execFileImpl = null;
+    mocks.spawnImpl = null;
+    stubExistsSyncOnlyForExecPath();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("resolves the CLI path from `where lms`/`which lms` and caches it", async () => {
+    const calls: Array<{ file: string; args: string[] }> = [];
+    mocks.execFileImpl = async (file: unknown, args: unknown) => {
+      calls.push({ file: String(file), args: args as string[] });
+      return probeHit;
+    };
+
+    expect(await findLmsCli()).toBe(process.execPath);
+    // Second call hits the positive cache — no re-probe.
+    expect(await findLmsCli()).toBe(process.execPath);
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.file).toBe(process.platform === "win32" ? "where" : "which");
+    expect(calls[0]!.args[0]).toBe("lms");
+  });
+
+  it("single-flights concurrent probes so callers share one spawn", async () => {
+    let calls = 0;
+    mocks.execFileImpl = async () => {
+      calls++;
+      await new Promise((r) => setTimeout(r, 20));
+      return probeHit;
+    };
+
+    const [a, b] = await Promise.all([findLmsCli(), findLmsCli()]);
+    expect(a).toBe(process.execPath);
+    expect(b).toBe(process.execPath);
+    expect(calls).toBe(1);
+  });
+
+  it("caches a miss within the TTL and re-probes after it expires", async () => {
+    let calls = 0;
+    mocks.execFileImpl = async () => {
+      calls++;
+      throw new Error("ENOENT");
+    };
+    expect(await findLmsCli()).toBeNull();
+    expect(await findLmsCli()).toBeNull();
+    expect(calls).toBe(1);
+
+    // Backdate the cached miss past the 5s TTL, then let the next probe succeed.
+    localEngineRuntime.lmsCliMissAt = Date.now() - 6000;
+    mocks.execFileImpl = async () => {
+      calls++;
+      return probeHit;
+    };
+    expect(await findLmsCli()).toBe(process.execPath);
+    expect(calls).toBe(2);
+  });
+
+  it("treats empty probe output as a miss", async () => {
+    mocks.execFileImpl = async () => ({ stdout: "", stderr: "" });
+    expect(await findLmsCli()).toBeNull();
+  });
+});
+
+describe("abort-aware backoff polling (Tech Debt #16)", () => {
+  beforeEach(() => {
+    resetLocalEngineRuntime();
+    mocks.execFileImpl = null;
+    mocks.spawnImpl = null;
+    stubExistsSyncOnlyForExecPath();
+    // Local engines are "not running" unless a test overrides this.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        throw new Error("ECONNREFUSED");
+      }),
+    );
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("returns a cancelled marker when the signal aborts during the ready poll", async () => {
+    vi.useFakeTimers();
+    mocks.execFileImpl = async () => probeHit;
+    const ac = new AbortController();
+
+    const pending = ensureOllamaReady(undefined, ac.signal);
+    await vi.advanceTimersByTimeAsync(300); // mid first backoff sleep
+    ac.abort();
+    const result = await pending;
+
+    expect(result.ok).toBe(false);
+    expect(result.cancelled).toBe(true);
+  });
+
+  it("returns ok once the server responds during backoff polling", async () => {
+    vi.useFakeTimers();
+    mocks.execFileImpl = async () => probeHit;
+    let fetches = 0;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        fetches++;
+        if (fetches <= 2) throw new Error("ECONNREFUSED");
+        return { ok: true };
+      }),
+    );
+
+    const pending = ensureOllamaReady();
+    await vi.advanceTimersByTimeAsync(1000);
+    const result = await pending;
+
+    expect(result.ok).toBe(true);
+    expect(result.steps).toContain("Ollama HTTP server ready on :11434");
+  });
+
+  it("fails with a normal error (not cancelled) after the max wait elapses", async () => {
+    vi.useFakeTimers();
+    mocks.execFileImpl = async () => probeHit;
+
+    const pending = ensureOllamaReady();
+    await vi.advanceTimersByTimeAsync(50_000);
+    const result = await pending;
+
+    expect(result.ok).toBe(false);
+    expect(result.cancelled).toBeUndefined();
+    expect(result.error).toContain("did not become ready");
+  });
+
+  it("returns a cancelled marker for LM Studio setup when the signal aborts", async () => {
+    vi.useFakeTimers();
+    mocks.execFileImpl = async () => probeHit;
+    const ac = new AbortController();
+
+    const pending = ensureLmsReady(undefined, ac.signal);
+    await vi.advanceTimersByTimeAsync(300); // mid first backoff sleep
+    ac.abort();
+    const result = await pending;
+
+    expect(result.ok).toBe(false);
+    expect(result.cancelled).toBe(true);
+  });
+});

--- a/src/server/routes/ai/localEngines.test.ts
+++ b/src/server/routes/ai/localEngines.test.ts
@@ -8,16 +8,19 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import fs from "fs";
 
-import {
-  childProcessVitestMockFactory,
-  createChildProcessTestHandles,
-} from "../../__tests__/childProcessTestMocks.ts";
 import { findLmsCli, ensureOllamaReady, ensureLmsReady } from "./localEngines.ts";
 import { localEngineRuntime, resetLocalEngineRuntime } from "../../services/ai/localEngineState.ts";
 
-const mocks = vi.hoisted(() => createChildProcessTestHandles());
+const mocks = vi.hoisted(() => ({
+  execFileImpl: null as null | ((...args: unknown[]) => unknown),
+  spawnImpl: null as null | ((...args: unknown[]) => unknown),
+  execFileCalls: [] as unknown[][],
+}));
 
-vi.mock("child_process", childProcessVitestMockFactory(mocks, { includeSpawn: true }));
+vi.mock("child_process", async (importOriginal) => {
+  const { childProcessVitestMockFactory } = await import("../../__tests__/childProcessTestMocks.ts");
+  return childProcessVitestMockFactory(mocks, { includeSpawn: true })(importOriginal);
+});
 
 // ── Helpers ────────────────────────────────────────────────────────────────
 

--- a/src/server/routes/ai/localEngines.test.ts
+++ b/src/server/routes/ai/localEngines.test.ts
@@ -136,17 +136,18 @@ describe("abort-aware backoff polling (Tech Debt #16)", () => {
   it("returns ok once the server responds during backoff polling", async () => {
     vi.useFakeTimers();
     mocks.execFileImpl = async () => probeHit;
-    let fetches = 0;
+    let serverReady = false;
     vi.stubGlobal(
       "fetch",
       vi.fn(async () => {
-        fetches++;
-        if (fetches <= 2) throw new Error("ECONNREFUSED");
+        if (!serverReady) throw new Error("ECONNREFUSED");
         return { ok: true };
       }),
     );
 
     const pending = ensureOllamaReady();
+    await vi.advanceTimersByTimeAsync(500);
+    serverReady = true;
     await vi.advanceTimersByTimeAsync(1000);
     const result = await pending;
 
@@ -185,12 +186,11 @@ describe("abort-aware backoff polling (Tech Debt #16)", () => {
   it("does not cancel shared ensure when a late joiner's signal aborts", async () => {
     vi.useFakeTimers();
     mocks.execFileImpl = async () => probeHit;
-    let fetches = 0;
+    let serverReady = false;
     vi.stubGlobal(
       "fetch",
       vi.fn(async () => {
-        fetches++;
-        if (fetches <= 2) throw new Error("ECONNREFUSED");
+        if (!serverReady) throw new Error("ECONNREFUSED");
         return { ok: true };
       }),
     );
@@ -200,6 +200,7 @@ describe("abort-aware backoff polling (Tech Debt #16)", () => {
     const joined = ensureOllamaReady(undefined, lateJoiner.signal);
     await vi.advanceTimersByTimeAsync(200);
     lateJoiner.abort();
+    serverReady = true;
 
     await vi.advanceTimersByTimeAsync(1000);
     const [first, second] = await Promise.all([initiator, joined]);

--- a/src/server/routes/ai/localEngines.test.ts
+++ b/src/server/routes/ai/localEngines.test.ts
@@ -2,70 +2,20 @@
  * Unit tests for the local AI engine setup internals (Tech Debt #16):
  *  - async `where/which` CLI probing with single-flight and TTL caching
  *  - abort-aware capped backoff polling in ensureOllamaReady / ensureLmsReady
- *
- * child_process.execFile is mocked with a `promisify.custom` handler so
- * `execFileAsync` (util.promisify(execFile)) resolves the same
- * `{ stdout, stderr }` shape as real Node's execFile promisification.
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { EventEmitter } from "events";
 import fs from "fs";
 
+import {
+  childProcessVitestMockFactory,
+  createChildProcessTestHandles,
+} from "../../__tests__/childProcessTestMocks.ts";
 import { findLmsCli, ensureOllamaReady, ensureLmsReady } from "./localEngines.ts";
 import { localEngineRuntime, resetLocalEngineRuntime } from "../../services/ai/localEngineState.ts";
 
-// ── Configurable child_process mocks ───────────────────────────────────────
+const mocks = vi.hoisted(() => createChildProcessTestHandles());
 
-const mocks = vi.hoisted(() => ({
-  execFileImpl: null as null | ((...args: unknown[]) => unknown),
-  spawnImpl: null as null | ((...args: unknown[]) => unknown),
-}));
-
-vi.mock("child_process", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("child_process")>();
-  const customSymbol = Symbol.for("nodejs.util.promisify.custom");
-
-  function mockExecFile(...execArgs: unknown[]): unknown {
-    // Callback-style callers get an instant empty result.
-    const lastArg = execArgs[execArgs.length - 1];
-    if (typeof lastArg === "function") {
-      lastArg(null, "", "");
-      return undefined;
-    }
-    return (actual.execFile as unknown as (...a: unknown[]) => unknown)(...execArgs);
-  }
-
-  // util.promisify(execFile) prefers this when present (mirrors real Node's
-  // execFile, which resolves { stdout, stderr }). Tests stub execFileImpl to
-  // resolve that exact shape.
-  (mockExecFile as unknown as Record<symbol, unknown>)[customSymbol] = (...args: unknown[]) => {
-    if (mocks.execFileImpl) return mocks.execFileImpl(...args);
-    return Promise.resolve({ stdout: "", stderr: "" });
-  };
-
-  function mockSpawn(...spawnArgs: unknown[]): ReturnType<typeof actual.spawn> {
-    if (mocks.spawnImpl) return mocks.spawnImpl(...spawnArgs) as ReturnType<typeof actual.spawn>;
-    const proc = new EventEmitter() as unknown as ReturnType<typeof actual.spawn>;
-    proc.stdout = new EventEmitter() as unknown as ReturnType<typeof actual.spawn>["stdout"];
-    proc.stderr = new EventEmitter() as unknown as ReturnType<typeof actual.spawn>["stderr"];
-    proc.stdin = new EventEmitter() as unknown as ReturnType<typeof actual.spawn>["stdin"];
-    (proc as unknown as Record<string, unknown>).pid = 99999;
-    (proc as unknown as Record<string, unknown>).unref = () => {};
-    (proc as unknown as Record<string, unknown>).kill = () => true;
-    // Emit "spawn" (startOllamaOnce resolves on it), "exit" (spawnLmsServerDetached
-    // resolves on it), then "close" via process.nextTick, which fake timers do not touch.
-    process.nextTick(() => proc.emit("spawn"));
-    process.nextTick(() => proc.emit("exit", 0));
-    process.nextTick(() => proc.emit("close", 0));
-    return proc;
-  }
-
-  return {
-    ...actual,
-    execFile: mockExecFile as unknown as typeof actual.execFile,
-    spawn: mockSpawn as unknown as typeof actual.spawn,
-  };
-});
+vi.mock("child_process", childProcessVitestMockFactory(mocks, { includeSpawn: true }));
 
 // ── Helpers ────────────────────────────────────────────────────────────────
 
@@ -82,6 +32,7 @@ describe("findLmsCli async probing", () => {
     resetLocalEngineRuntime();
     mocks.execFileImpl = null;
     mocks.spawnImpl = null;
+    mocks.execFileCalls.length = 0;
     stubExistsSyncOnlyForExecPath();
   });
 
@@ -227,5 +178,32 @@ describe("abort-aware backoff polling (Tech Debt #16)", () => {
 
     expect(result.ok).toBe(false);
     expect(result.cancelled).toBe(true);
+  });
+
+  it("does not cancel shared ensure when a late joiner's signal aborts", async () => {
+    vi.useFakeTimers();
+    mocks.execFileImpl = async () => probeHit;
+    let fetches = 0;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        fetches++;
+        if (fetches <= 2) throw new Error("ECONNREFUSED");
+        return { ok: true };
+      }),
+    );
+
+    const initiator = ensureOllamaReady();
+    const lateJoiner = new AbortController();
+    const joined = ensureOllamaReady(undefined, lateJoiner.signal);
+    await vi.advanceTimersByTimeAsync(200);
+    lateJoiner.abort();
+
+    await vi.advanceTimersByTimeAsync(1000);
+    const [first, second] = await Promise.all([initiator, joined]);
+
+    expect(first.ok).toBe(true);
+    expect(second.ok).toBe(true);
+    expect(second.cancelled).toBeUndefined();
   });
 });

--- a/src/server/routes/ai/localEngines.test.ts
+++ b/src/server/routes/ai/localEngines.test.ts
@@ -211,7 +211,8 @@ describe("abort-aware backoff polling (Tech Debt #16)", () => {
 
     expect(result.ok).toBe(false);
     expect(result.cancelled).toBeUndefined();
-    expect(result.error).toContain("did not become ready");
+    // Platform-specific timeout copy (darwin/win32 vs linux headless serve).
+    expect(result.error).toMatch(/Ollama (serve )?did not (become ready|start)/);
   });
 
   it("returns a cancelled marker for LM Studio setup when the signal aborts", async () => {

--- a/src/server/routes/ai/localEngines.test.ts
+++ b/src/server/routes/ai/localEngines.test.ts
@@ -2,6 +2,8 @@
  * Unit tests for the local AI engine setup internals (Tech Debt #16):
  *  - async `where/which` CLI probing with single-flight and TTL caching
  *  - abort-aware capped backoff polling in ensureOllamaReady / ensureLmsReady
+ *
+ * `child_process` is mocked via `src/server/__tests__/childProcessTestMocks.ts`.
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import fs from "fs";

--- a/src/server/routes/ai/localEngines.ts
+++ b/src/server/routes/ai/localEngines.ts
@@ -399,19 +399,25 @@ const OLLAMA_START_COOLDOWN_MS = 45_000;
 /**
  * Ensure Ollama is installed and its HTTP server is reachable.
  *
- * Concurrent callers share one in-flight setup. Only the **first** caller's
- * `signal` can abort the shared work (e.g. client disconnect on /install-engine
- * or /ollama-pull when that request started setup). Late joiners receive progress
- * on their `onProgress` callback but their `signal` does not cancel the shared
- * operation — matching `trackStreamClient`, which stops streaming to a disconnected
- * client without tearing down setup other requests may be waiting on. Pull routes
- * still honour a late joiner's disconnect after ensure completes (they skip the
- * download) without cancelling the shared ensure for the initiator.
+ * Concurrent callers share one in-flight setup. Each caller registers as a
+ * waiter; shared work uses an internal `AbortController` and is aborted only
+ * when the last waiter leaves (client disconnect via `signal` or promise
+ * settlement). Late joiners do not cancel setup started by an earlier client.
  */
 export async function ensureOllamaReady(
   onProgress?: (evt: EnsureProgressEvt) => void,
   signal?: AbortSignal,
 ): Promise<OllamaEnsureResult> {
+  let released = false;
+  const releaseWaiter = () => {
+    if (released) return;
+    released = true;
+    localEngineRuntime.ollamaEnsureWaiters -= 1;
+    if (localEngineRuntime.ollamaEnsureWaiters === 0) {
+      localEngineRuntime.ollamaEnsureAbort?.abort();
+    }
+  };
+
   if (onProgress) {
     localEngineRuntime.ollamaProgressSubscribers.add(onProgress);
     if (localEngineRuntime.ollamaEnsureInFlight) {
@@ -419,7 +425,8 @@ export async function ensureOllamaReady(
     }
   }
   if (!localEngineRuntime.ollamaEnsureInFlight) {
-    // Initiator-only: first caller's signal governs the shared operation.
+    const ac = new AbortController();
+    localEngineRuntime.ollamaEnsureAbort = ac;
     localEngineRuntime.ollamaEnsureInFlight = ensureOllamaReadyImpl(
       (evt) => {
         for (const sub of localEngineRuntime.ollamaProgressSubscribers) {
@@ -430,15 +437,23 @@ export async function ensureOllamaReady(
           }
         }
       },
-      signal,
+      ac.signal,
     ).finally(() => {
       localEngineRuntime.ollamaEnsureInFlight = null;
+      localEngineRuntime.ollamaEnsureAbort = null;
     });
+  }
+
+  localEngineRuntime.ollamaEnsureWaiters += 1;
+  if (signal) {
+    if (signal.aborted) releaseWaiter();
+    else signal.addEventListener("abort", releaseWaiter, { once: true });
   }
   try {
     return await localEngineRuntime.ollamaEnsureInFlight;
   } finally {
     if (onProgress) localEngineRuntime.ollamaProgressSubscribers.delete(onProgress);
+    releaseWaiter();
   }
 }
 
@@ -471,12 +486,15 @@ async function ensureOllamaReadyImpl(
         note("brew install failed", 12);
       }
     }
-    const installedCli = await pollUntil(
-      async () => (await findOllamaCli()) !== null,
+    await pollUntil(
+      async () => {
+        const found = await findOllamaCli();
+        if (found) ollama = found;
+        return found !== null;
+      },
       OLLAMA_INSTALL_MAX_WAIT_MS,
       signal,
     );
-    if (installedCli) ollama = await findOllamaCli();
     // Installer often auto-starts the tray app; give it a moment before we launch anything.
     const autoStarted = await pollUntil(isOllamaRunning, OLLAMA_POST_INSTALL_MAX_WAIT_MS, signal, true);
     if (autoStarted) {
@@ -578,14 +596,23 @@ export async function listOllamaInstalledNames(): Promise<string[] | null> {
 }
 
 /**
- * Ensure LM Studio CLI/server is available. Same single-flight and signal rules
- * as {@link ensureOllamaReady}: only the initiating caller's `signal` aborts the
- * shared setup; late joiners' disconnect signals do not.
+ * Ensure LM Studio CLI/server is available. Same single-flight and waiter-based
+ * abort rules as {@link ensureOllamaReady}.
  */
 export async function ensureLmsReady(
   onProgress?: (evt: EnsureProgressEvt) => void,
   signal?: AbortSignal,
 ): Promise<LmsEnsureResult> {
+  let released = false;
+  const releaseWaiter = () => {
+    if (released) return;
+    released = true;
+    localEngineRuntime.lmsEnsureWaiters -= 1;
+    if (localEngineRuntime.lmsEnsureWaiters === 0) {
+      localEngineRuntime.lmsEnsureAbort?.abort();
+    }
+  };
+
   if (onProgress) {
     localEngineRuntime.lmsProgressSubscribers.add(onProgress);
     if (localEngineRuntime.lmsEnsureInFlight) {
@@ -593,7 +620,8 @@ export async function ensureLmsReady(
     }
   }
   if (!localEngineRuntime.lmsEnsureInFlight) {
-    // Initiator-only: first caller's signal governs the shared operation.
+    const ac = new AbortController();
+    localEngineRuntime.lmsEnsureAbort = ac;
     localEngineRuntime.lmsEnsureInFlight = ensureLmsReadyImpl(
       (evt) => {
         for (const sub of localEngineRuntime.lmsProgressSubscribers) {
@@ -604,15 +632,23 @@ export async function ensureLmsReady(
           }
         }
       },
-      signal,
+      ac.signal,
     ).finally(() => {
       localEngineRuntime.lmsEnsureInFlight = null;
+      localEngineRuntime.lmsEnsureAbort = null;
     });
+  }
+
+  localEngineRuntime.lmsEnsureWaiters += 1;
+  if (signal) {
+    if (signal.aborted) releaseWaiter();
+    else signal.addEventListener("abort", releaseWaiter, { once: true });
   }
   try {
     return await localEngineRuntime.lmsEnsureInFlight;
   } finally {
     if (onProgress) localEngineRuntime.lmsProgressSubscribers.delete(onProgress);
+    releaseWaiter();
   }
 }
 
@@ -649,15 +685,16 @@ async function ensureLmsReadyImpl(
       note("No package-manager install path for this Linux host. Install LM Studio manually if needed.", 8);
     }
 
-    const installedCli = await pollUntil(
+    await pollUntil(
       async () => {
         resetLmsCliCache();
-        return (await findLmsCli()) !== null;
+        const found = await findLmsCli();
+        if (found) lms = found;
+        return found !== null;
       },
       LMS_INSTALL_MAX_WAIT_MS,
       signal,
     );
-    if (installedCli) lms = await findLmsCli();
   }
 
   if (signal?.aborted) return cancelled();

--- a/src/server/routes/ai/localEngines.ts
+++ b/src/server/routes/ai/localEngines.ts
@@ -401,10 +401,12 @@ const OLLAMA_START_COOLDOWN_MS = 45_000;
  *
  * Concurrent callers share one in-flight setup. Only the **first** caller's
  * `signal` can abort the shared work (e.g. client disconnect on /install-engine
- * or /ollama-pull). Late joiners receive progress on their `onProgress` callback
- * but their `signal` does not cancel the shared operation — matching
- * `trackStreamClient`, which stops streaming to a disconnected client without
- * tearing down setup other requests may be waiting on.
+ * or /ollama-pull when that request started setup). Late joiners receive progress
+ * on their `onProgress` callback but their `signal` does not cancel the shared
+ * operation — matching `trackStreamClient`, which stops streaming to a disconnected
+ * client without tearing down setup other requests may be waiting on. Pull routes
+ * still honour a late joiner's disconnect after ensure completes (they skip the
+ * download) without cancelling the shared ensure for the initiator.
  */
 export async function ensureOllamaReady(
   onProgress?: (evt: EnsureProgressEvt) => void,

--- a/src/server/routes/ai/localEngines.ts
+++ b/src/server/routes/ai/localEngines.ts
@@ -445,14 +445,19 @@ export async function ensureOllamaReady(
   }
 
   localEngineRuntime.ollamaEnsureWaiters += 1;
+  let onClientAbort: (() => void) | undefined;
   if (signal) {
     if (signal.aborted) releaseWaiter();
-    else signal.addEventListener("abort", releaseWaiter, { once: true });
+    else {
+      onClientAbort = () => releaseWaiter();
+      signal.addEventListener("abort", onClientAbort);
+    }
   }
   try {
     return await localEngineRuntime.ollamaEnsureInFlight;
   } finally {
     if (onProgress) localEngineRuntime.ollamaProgressSubscribers.delete(onProgress);
+    if (signal && onClientAbort) signal.removeEventListener("abort", onClientAbort);
     releaseWaiter();
   }
 }
@@ -640,14 +645,19 @@ export async function ensureLmsReady(
   }
 
   localEngineRuntime.lmsEnsureWaiters += 1;
+  let onClientAbort: (() => void) | undefined;
   if (signal) {
     if (signal.aborted) releaseWaiter();
-    else signal.addEventListener("abort", releaseWaiter, { once: true });
+    else {
+      onClientAbort = () => releaseWaiter();
+      signal.addEventListener("abort", onClientAbort);
+    }
   }
   try {
     return await localEngineRuntime.lmsEnsureInFlight;
   } finally {
     if (onProgress) localEngineRuntime.lmsProgressSubscribers.delete(onProgress);
+    if (signal && onClientAbort) signal.removeEventListener("abort", onClientAbort);
     releaseWaiter();
   }
 }

--- a/src/server/routes/ai/localEngines.ts
+++ b/src/server/routes/ai/localEngines.ts
@@ -3,7 +3,7 @@
  * (install/start/ensure), and pull-verification helpers shared by the
  * /ai/local-*, /ai/ollama-*, and /ai/install-engine routes.
  */
-import { spawn, execFile, execSync, type ChildProcess } from "child_process";
+import { spawn, execFile, type ChildProcess } from "child_process";
 import { promisify } from "util";
 import fs from "fs";
 import path from "path";
@@ -23,6 +23,9 @@ import {
 } from "../../services/ai/localEngineState.ts";
 
 const execFileAsync = promisify(execFile);
+
+/** Timeout for `where/which` CLI discovery probes (fail fast when the tool is not on PATH). */
+const CLI_PROBE_TIMEOUT_MS = 2000;
 
 export const LM_STUDIO_PORT = 1234;
 export const OLLAMA_PORT = 11434;
@@ -95,18 +98,10 @@ function resetLmsCliCache(): void {
   localEngineRuntime.lmsCliMissAt = 0;
 }
 
-/** Module-level LMS CLI path cache (avoids re-probing disk/PATH on every request). */
-export function findLmsCli(): string | null {
-  // Reuse a positive cache hit immediately
-  if (localEngineRuntime.cachedLmsCli) return localEngineRuntime.cachedLmsCli;
-  // Reuse a cached miss within TTL to avoid repeated expensive probes
-  if (
-    localEngineRuntime.cachedLmsCli === null &&
-    localEngineRuntime.lmsCliMissAt > 0 &&
-    Date.now() - localEngineRuntime.lmsCliMissAt < LMS_CLI_MISS_TTL_MS
-  ) {
-    return null;
-  }
+/** Single-flight guard: concurrent callers share one `where/which` probe. */
+let lmsProbeInFlight: Promise<string | null> | null = null;
+
+async function probeLmsCli(): Promise<string | null> {
   const home = os.homedir();
   const candidates =
     process.platform === "win32"
@@ -121,23 +116,20 @@ export function findLmsCli(): string | null {
     if (c && fs.existsSync(c)) {
       localEngineRuntime.cachedLmsCli = c;
       localEngineRuntime.lmsCliMissAt = 0;
-      return localEngineRuntime.cachedLmsCli;
+      return c;
     }
   }
   try {
-    const result = execSync(process.platform === "win32" ? "where lms" : "which lms", {
+    const { stdout } = await execFileAsync(process.platform === "win32" ? "where" : "which", ["lms"], {
       encoding: "utf-8",
-      timeout: 2000,
+      timeout: CLI_PROBE_TIMEOUT_MS,
       windowsHide: true,
-    })
-      .toString()
-      .trim()
-      .split(/\r?\n/)[0]
-      ?.trim();
+    });
+    const result = stdout.trim().split(/\r?\n/)[0]?.trim();
     if (result && fs.existsSync(result)) {
       localEngineRuntime.cachedLmsCli = result;
       localEngineRuntime.lmsCliMissAt = 0;
-      return localEngineRuntime.cachedLmsCli;
+      return result;
     }
   } catch {
     /* not on PATH */
@@ -148,9 +140,29 @@ export function findLmsCli(): string | null {
   return null;
 }
 
+/** Async LM Studio CLI path discovery — never blocks the event loop on `where/which`. */
+export async function findLmsCli(): Promise<string | null> {
+  // Reuse a positive cache hit immediately
+  if (localEngineRuntime.cachedLmsCli) return localEngineRuntime.cachedLmsCli;
+  // Reuse a cached miss within TTL to avoid repeated expensive probes
+  if (
+    localEngineRuntime.cachedLmsCli === null &&
+    localEngineRuntime.lmsCliMissAt > 0 &&
+    Date.now() - localEngineRuntime.lmsCliMissAt < LMS_CLI_MISS_TTL_MS
+  ) {
+    return null;
+  }
+  if (!lmsProbeInFlight) {
+    lmsProbeInFlight = probeLmsCli().finally(() => {
+      lmsProbeInFlight = null;
+    });
+  }
+  return lmsProbeInFlight;
+}
+
 /** List downloaded LM Studio LLM model keys via `lms ls --json` (not just currently loaded). */
 export async function listLmsInstalledModelKeys(): Promise<string[] | null> {
-  const lms = findLmsCli();
+  const lms = await findLmsCli();
   if (!lms) return null;
   try {
     const { stdout } = await execFileAsync(lms, ["ls", "--json"], {
@@ -170,7 +182,10 @@ export async function listLmsInstalledModelKeys(): Promise<string[] | null> {
   }
 }
 
-function findOllamaCli(): string | null {
+/** Single-flight guard: concurrent callers share one `where/which` probe. */
+let ollamaProbeInFlight: Promise<string | null> | null = null;
+
+async function probeOllamaCli(): Promise<string | null> {
   const home = os.homedir();
   const candidates =
     process.platform === "win32"
@@ -184,20 +199,26 @@ function findOllamaCli(): string | null {
     if (c && fs.existsSync(c)) return c;
   }
   try {
-    const result = execSync(process.platform === "win32" ? "where ollama" : "which ollama", {
+    const { stdout } = await execFileAsync(process.platform === "win32" ? "where" : "which", ["ollama"], {
       encoding: "utf-8",
-      timeout: 2000,
+      timeout: CLI_PROBE_TIMEOUT_MS,
       windowsHide: true,
-    })
-      .toString()
-      .trim()
-      .split(/\r?\n/)[0]
-      ?.trim();
+    });
+    const result = stdout.trim().split(/\r?\n/)[0]?.trim();
     if (result && fs.existsSync(result)) return result;
   } catch {
     /* not on PATH */
   }
   return null;
+}
+
+function findOllamaCli(): Promise<string | null> {
+  if (!ollamaProbeInFlight) {
+    ollamaProbeInFlight = probeOllamaCli().finally(() => {
+      ollamaProbeInFlight = null;
+    });
+  }
+  return ollamaProbeInFlight;
 }
 
 /** Windows/macOS tray app that owns the local server lifecycle (do not also spawn `ollama serve`). */
@@ -219,14 +240,68 @@ function findOllamaApp(): string | null {
   return null;
 }
 
-function sleepMs(ms: number): Promise<void> {
-  return new Promise((r) => setTimeout(r, ms));
+/** Sleep that resolves immediately when `signal` aborts (so polling exits promptly). */
+function sleepMs(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve) => {
+    if (signal?.aborted) {
+      resolve();
+      return;
+    }
+    const timer = setTimeout(() => {
+      signal?.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    const onAbort = () => {
+      clearTimeout(timer);
+      resolve();
+    };
+    signal?.addEventListener("abort", onAbort, { once: true });
+  });
 }
 
-export async function tryWingetInstall(packageIds: string[]): Promise<boolean> {
+/** Capped exponential backoff delays (250ms → 500ms → 1s → 2s…). */
+const POLL_BACKOFF_BASE_MS = 250;
+const POLL_BACKOFF_MAX_MS = 2000;
+
+/**
+ * Poll `check` until it returns true, `maxWaitMs` elapses, or `signal` aborts.
+ * Aborts stop the wait immediately — callers distinguish cancellation from
+ * timeout via `signal.aborted` after this returns false. `delayFirst` mirrors
+ * the old sleep-then-check loops; otherwise the first check runs immediately.
+ */
+async function pollUntil(
+  check: () => Promise<boolean>,
+  maxWaitMs: number,
+  signal?: AbortSignal,
+  delayFirst = false,
+): Promise<boolean> {
+  const deadline = Date.now() + maxWaitMs;
+  let delay = POLL_BACKOFF_BASE_MS;
+  let first = true;
+  while (true) {
+    if (signal?.aborted) return false;
+    if (!delayFirst || !first) {
+      if (await check()) return true;
+    }
+    if (Date.now() >= deadline) return false;
+    await sleepMs(Math.min(delay, deadline - Date.now()), signal);
+    if (signal?.aborted) return false;
+    delay = Math.min(delay * 2, POLL_BACKOFF_MAX_MS);
+    first = false;
+  }
+}
+
+/** Budget caps preserve the pre-backoff fixed loops (Tech Debt #16). */
+export const OLLAMA_READY_MAX_WAIT_MS = 40_000; // was 40 × 1000ms
+export const LMS_READY_MAX_WAIT_MS = 30_000; // was 30 × 1000ms
+const OLLAMA_INSTALL_MAX_WAIT_MS = 40_000; // was 20 × 2000ms
+const LMS_INSTALL_MAX_WAIT_MS = 40_000; // was 20 × 2000ms
+const OLLAMA_POST_INSTALL_MAX_WAIT_MS = 15_000; // was 15 × 1000ms
+
+export async function tryWingetInstall(packageIds: string[], signal?: AbortSignal): Promise<boolean> {
   if (process.platform !== "win32") return false;
   try {
-    await execFileAsync("winget", ["--version"], { timeout: 5000, windowsHide: true });
+    await execFileAsync("winget", ["--version"], { timeout: 5000, windowsHide: true, signal });
   } catch {
     return false;
   }
@@ -244,7 +319,7 @@ export async function tryWingetInstall(packageIds: string[]): Promise<boolean> {
           "--disable-interactivity",
           "--silent",
         ],
-        { timeout: 600_000, windowsHide: true },
+        { timeout: 600_000, windowsHide: true, signal },
       );
       return true;
     } catch {
@@ -323,6 +398,7 @@ const OLLAMA_START_COOLDOWN_MS = 45_000;
 
 export async function ensureOllamaReady(
   onProgress?: (evt: EnsureProgressEvt) => void,
+  signal?: AbortSignal,
 ): Promise<OllamaEnsureResult> {
   if (onProgress) {
     localEngineRuntime.ollamaProgressSubscribers.add(onProgress);
@@ -331,15 +407,20 @@ export async function ensureOllamaReady(
     }
   }
   if (!localEngineRuntime.ollamaEnsureInFlight) {
-    localEngineRuntime.ollamaEnsureInFlight = ensureOllamaReadyImpl((evt) => {
-      for (const sub of localEngineRuntime.ollamaProgressSubscribers) {
-        try {
-          sub(evt);
-        } catch (err) {
-          console.error("[ensureOllamaReady] Progress subscriber threw:", err);
+    // The initiating caller's signal governs the shared operation; later
+    // callers' signals only control how long they consume progress.
+    localEngineRuntime.ollamaEnsureInFlight = ensureOllamaReadyImpl(
+      (evt) => {
+        for (const sub of localEngineRuntime.ollamaProgressSubscribers) {
+          try {
+            sub(evt);
+          } catch (err) {
+            console.error("[ensureOllamaReady] Progress subscriber threw:", err);
+          }
         }
-      }
-    }).finally(() => {
+      },
+      signal,
+    ).finally(() => {
       localEngineRuntime.ollamaEnsureInFlight = null;
     });
   }
@@ -352,44 +433,47 @@ export async function ensureOllamaReady(
 
 async function ensureOllamaReadyImpl(
   onProgress?: (evt: { type: string; message: string; percent?: number }) => void,
+  signal?: AbortSignal,
 ): Promise<OllamaEnsureResult> {
   const steps: string[] = [];
   const note = (message: string, percent?: number) => {
     steps.push(message);
     onProgress?.({ type: "step", message, percent });
   };
+  const cancelled = (): OllamaEnsureResult => ({ ok: false, steps, cancelled: true, error: "Setup cancelled." });
+
   if (await isOllamaRunning()) {
     note("Ollama already running", 15);
     return { ok: true, steps };
   }
-  let ollama = findOllamaCli();
+  let ollama = await findOllamaCli();
   if (!ollama) {
     note("Ollama CLI not found. Installing…", 5);
     if (process.platform === "win32") {
       note("Running winget install Ollama.Ollama (silent)…", 8);
-      await tryWingetInstall(["Ollama.Ollama"]);
+      await tryWingetInstall(["Ollama.Ollama"], signal);
     } else if (process.platform === "darwin") {
       note("Running brew install ollama…", 8);
       try {
-        await execFileAsync("brew", ["install", "ollama"], { timeout: 600_000 });
+        await execFileAsync("brew", ["install", "ollama"], { timeout: 600_000, signal });
       } catch {
         note("brew install failed", 12);
       }
     }
-    for (let i = 0; i < 20; i++) {
-      ollama = findOllamaCli();
-      if (ollama) break;
-      await sleepMs(2000);
-    }
+    const installedCli = await pollUntil(
+      async () => (await findOllamaCli()) !== null,
+      OLLAMA_INSTALL_MAX_WAIT_MS,
+      signal,
+    );
+    if (installedCli) ollama = await findOllamaCli();
     // Installer often auto-starts the tray app; give it a moment before we launch anything.
-    for (let i = 0; i < 15; i++) {
-      if (await isOllamaRunning()) {
-        note("Ollama started after install", 28);
-        return { ok: true, steps };
-      }
-      await sleepMs(1000);
+    const autoStarted = await pollUntil(isOllamaRunning, OLLAMA_POST_INSTALL_MAX_WAIT_MS, signal, true);
+    if (autoStarted) {
+      note("Ollama started after install", 28);
+      return { ok: true, steps };
     }
   }
+  if (signal?.aborted) return cancelled();
   if (!ollama)
     return {
       ok: false,
@@ -415,12 +499,11 @@ async function ensureOllamaReadyImpl(
         note(`Failed to start Ollama: ${err instanceof Error ? err.message : String(err)}`, 22);
       }
     }
-    for (let i = 0; i < 40; i++) {
-      await sleepMs(1000);
-      if (await isOllamaRunning()) {
-        note("Ollama HTTP server ready on :11434", 30);
-        return { ok: true, steps };
-      }
+    const ready = await pollUntil(isOllamaRunning, OLLAMA_READY_MAX_WAIT_MS, signal, true);
+    if (signal?.aborted) return cancelled();
+    if (ready) {
+      note("Ollama HTTP server ready on :11434", 30);
+      return { ok: true, steps };
     }
     return {
       ok: false,
@@ -483,7 +566,10 @@ export async function listOllamaInstalledNames(): Promise<string[] | null> {
   }
 }
 
-export async function ensureLmsReady(onProgress?: (evt: EnsureProgressEvt) => void): Promise<LmsEnsureResult> {
+export async function ensureLmsReady(
+  onProgress?: (evt: EnsureProgressEvt) => void,
+  signal?: AbortSignal,
+): Promise<LmsEnsureResult> {
   if (onProgress) {
     localEngineRuntime.lmsProgressSubscribers.add(onProgress);
     if (localEngineRuntime.lmsEnsureInFlight) {
@@ -491,15 +577,20 @@ export async function ensureLmsReady(onProgress?: (evt: EnsureProgressEvt) => vo
     }
   }
   if (!localEngineRuntime.lmsEnsureInFlight) {
-    localEngineRuntime.lmsEnsureInFlight = ensureLmsReadyImpl((evt) => {
-      for (const sub of localEngineRuntime.lmsProgressSubscribers) {
-        try {
-          sub(evt);
-        } catch (err) {
-          console.error("[ensureLmsReady] Progress subscriber threw:", err);
+    // The initiating caller's signal governs the shared operation; later
+    // callers' signals only control how long they consume progress.
+    localEngineRuntime.lmsEnsureInFlight = ensureLmsReadyImpl(
+      (evt) => {
+        for (const sub of localEngineRuntime.lmsProgressSubscribers) {
+          try {
+            sub(evt);
+          } catch (err) {
+            console.error("[ensureLmsReady] Progress subscriber threw:", err);
+          }
         }
-      }
-    }).finally(() => {
+      },
+      signal,
+    ).finally(() => {
       localEngineRuntime.lmsEnsureInFlight = null;
     });
   }
@@ -510,28 +601,32 @@ export async function ensureLmsReady(onProgress?: (evt: EnsureProgressEvt) => vo
   }
 }
 
-async function ensureLmsReadyImpl(onProgress?: (evt: EnsureProgressEvt) => void): Promise<LmsEnsureResult> {
+async function ensureLmsReadyImpl(
+  onProgress?: (evt: EnsureProgressEvt) => void,
+  signal?: AbortSignal,
+): Promise<LmsEnsureResult> {
   const steps: string[] = [];
   const note = (message: string, percent?: number) => {
     steps.push(message);
     onProgress?.({ type: "step", message, percent });
   };
+  const cancelled = (): LmsEnsureResult => ({ ok: false, steps, cancelled: true, error: "Setup cancelled." });
 
   if (await isLmsServerRunning()) {
     note("LM Studio server already running", 15);
     return { ok: true, steps };
   }
 
-  let lms = findLmsCli();
+  let lms = await findLmsCli();
   if (!lms) {
     note("LM Studio CLI (lms) not found. Installing…", 5);
     if (process.platform === "win32") {
       note("Running winget install ElementLabs.LMStudio…", 8);
-      await tryWingetInstall(["ElementLabs.LMStudio"]);
+      await tryWingetInstall(["ElementLabs.LMStudio"], signal);
     } else if (process.platform === "darwin") {
       note("Running brew install --cask lm-studio…", 8);
       try {
-        await execFileAsync("brew", ["install", "--cask", "lm-studio"], { timeout: 600_000 });
+        await execFileAsync("brew", ["install", "--cask", "lm-studio"], { timeout: 600_000, signal });
       } catch {
         note("brew cask install failed. Continuing discovery…", 10);
       }
@@ -539,14 +634,18 @@ async function ensureLmsReadyImpl(onProgress?: (evt: EnsureProgressEvt) => void)
       note("No package-manager install path for this Linux host. Install LM Studio manually if needed.", 8);
     }
 
-    for (let i = 0; i < 20; i++) {
-      resetLmsCliCache();
-      lms = findLmsCli();
-      if (lms) break;
-      await sleepMs(2000);
-    }
+    const installedCli = await pollUntil(
+      async () => {
+        resetLmsCliCache();
+        return (await findLmsCli()) !== null;
+      },
+      LMS_INSTALL_MAX_WAIT_MS,
+      signal,
+    );
+    if (installedCli) lms = await findLmsCli();
   }
 
+  if (signal?.aborted) return cancelled();
   if (!lms) {
     return {
       ok: false,
@@ -570,12 +669,11 @@ async function ensureLmsReadyImpl(onProgress?: (evt: EnsureProgressEvt) => void)
       }
     }
 
-    for (let i = 0; i < 30; i++) {
-      await sleepMs(1000);
-      if (await isLmsServerRunning()) {
-        note("LM Studio HTTP server ready", 90);
-        return { ok: true, steps };
-      }
+    const ready = await pollUntil(isLmsServerRunning, LMS_READY_MAX_WAIT_MS, signal, true);
+    if (signal?.aborted) return cancelled();
+    if (ready) {
+      note("LM Studio HTTP server ready", 90);
+      return { ok: true, steps };
     }
     return {
       ok: false,

--- a/src/server/routes/ai/localEngines.ts
+++ b/src/server/routes/ai/localEngines.ts
@@ -396,6 +396,16 @@ function startOllamaOnce(cliPath: string): Promise<{ mode: "app" | "serve"; deta
 
 const OLLAMA_START_COOLDOWN_MS = 45_000;
 
+/**
+ * Ensure Ollama is installed and its HTTP server is reachable.
+ *
+ * Concurrent callers share one in-flight setup. Only the **first** caller's
+ * `signal` can abort the shared work (e.g. client disconnect on /install-engine
+ * or /ollama-pull). Late joiners receive progress on their `onProgress` callback
+ * but their `signal` does not cancel the shared operation — matching
+ * `trackStreamClient`, which stops streaming to a disconnected client without
+ * tearing down setup other requests may be waiting on.
+ */
 export async function ensureOllamaReady(
   onProgress?: (evt: EnsureProgressEvt) => void,
   signal?: AbortSignal,
@@ -407,8 +417,7 @@ export async function ensureOllamaReady(
     }
   }
   if (!localEngineRuntime.ollamaEnsureInFlight) {
-    // The initiating caller's signal governs the shared operation; later
-    // callers' signals only control how long they consume progress.
+    // Initiator-only: first caller's signal governs the shared operation.
     localEngineRuntime.ollamaEnsureInFlight = ensureOllamaReadyImpl(
       (evt) => {
         for (const sub of localEngineRuntime.ollamaProgressSubscribers) {
@@ -566,6 +575,11 @@ export async function listOllamaInstalledNames(): Promise<string[] | null> {
   }
 }
 
+/**
+ * Ensure LM Studio CLI/server is available. Same single-flight and signal rules
+ * as {@link ensureOllamaReady}: only the initiating caller's `signal` aborts the
+ * shared setup; late joiners' disconnect signals do not.
+ */
 export async function ensureLmsReady(
   onProgress?: (evt: EnsureProgressEvt) => void,
   signal?: AbortSignal,
@@ -577,8 +591,7 @@ export async function ensureLmsReady(
     }
   }
   if (!localEngineRuntime.lmsEnsureInFlight) {
-    // The initiating caller's signal governs the shared operation; later
-    // callers' signals only control how long they consume progress.
+    // Initiator-only: first caller's signal governs the shared operation.
     localEngineRuntime.lmsEnsureInFlight = ensureLmsReadyImpl(
       (evt) => {
         for (const sub of localEngineRuntime.lmsProgressSubscribers) {

--- a/src/server/routes/ai/ollamaRoutes.ts
+++ b/src/server/routes/ai/ollamaRoutes.ts
@@ -102,6 +102,8 @@ export function mountOllamaRoutes(router: Router): void {
 
       localEngineRuntime.ollamaPullBusyTag = tag;
       ownsBusy = true;
+      // Initiator-only abort: if another pull already started ensure*, this
+      // request joins it; only that initiator's disconnect cancels shared setup.
       const ready = await ensureOllamaReady((evt) => send(evt), guard.signal);
       if (guard.disconnected()) {
         releaseBusy();

--- a/src/server/routes/ai/ollamaRoutes.ts
+++ b/src/server/routes/ai/ollamaRoutes.ts
@@ -102,7 +102,7 @@ export function mountOllamaRoutes(router: Router): void {
 
       localEngineRuntime.ollamaPullBusyTag = tag;
       ownsBusy = true;
-      const ready = await ensureOllamaReady((evt) => send(evt));
+      const ready = await ensureOllamaReady((evt) => send(evt), guard.signal);
       if (guard.disconnected()) {
         releaseBusy();
         guard.endOnce();

--- a/src/server/routes/ai/ollamaRoutes.ts
+++ b/src/server/routes/ai/ollamaRoutes.ts
@@ -102,8 +102,9 @@ export function mountOllamaRoutes(router: Router): void {
 
       localEngineRuntime.ollamaPullBusyTag = tag;
       ownsBusy = true;
-      // Shared ensure continues for other clients; this request just stops consuming progress.
-      const ready = await ensureOllamaReady((evt) => send(evt));
+      // The first caller's disconnect aborts the shared ensure; later callers
+      // consume progress but never cancel it.
+      const ready = await ensureOllamaReady((evt) => send(evt), guard.signal);
       if (guard.disconnected()) {
         releaseBusy();
         guard.endOnce();

--- a/src/server/routes/ai/ollamaRoutes.ts
+++ b/src/server/routes/ai/ollamaRoutes.ts
@@ -102,9 +102,7 @@ export function mountOllamaRoutes(router: Router): void {
 
       localEngineRuntime.ollamaPullBusyTag = tag;
       ownsBusy = true;
-      // The first caller's disconnect aborts the shared ensure; later callers
-      // consume progress but never cancel it.
-      const ready = await ensureOllamaReady((evt) => send(evt), guard.signal);
+      const ready = await ensureOllamaReady((evt) => send(evt));
       if (guard.disconnected()) {
         releaseBusy();
         guard.endOnce();

--- a/src/server/routes/ai/ollamaRoutes.ts
+++ b/src/server/routes/ai/ollamaRoutes.ts
@@ -2,21 +2,7 @@
  * Ollama local model routes: /ai/ollama-models, /ai/ollama-model-sizes,
  * /ai/ollama-health, /ai/ollama-pull, /ai/ollama-load, /ai/ollama-unload.
  */
-import type { Router } from "express";
-
-import { isValidLocalModelTag } from "../../../lib/localModelTag.ts";
-import { gateLocalPullDiskSpace } from "../../../lib/localEngineDisk.ts";
-import { heavyCommandRateLimit } from "../../middleware/rateLimit.ts";
-import { localEngineRuntime } from "../../services/ai/localEngineState.ts";
-import {
-  OLLAMA_PORT,
-  isOllamaRunning,
-  ensureOllamaReady,
-  listOllamaInstalledNames,
-  verifyInstalledAfterPull,
-  OLLAMA_PULL_MAX_MS,
-} from "./localEngines.ts";
-import { trackStreamClient, beginPullSse } from "./streamHelpers.ts";
+import { bodyGuard } from "../middleware/bodyGuard.ts";
 
 export function mountOllamaRoutes(router: Router): void {
   router.get("/ai/ollama-models", async (_req, res) => {
@@ -102,8 +88,8 @@ export function mountOllamaRoutes(router: Router): void {
 
       localEngineRuntime.ollamaPullBusyTag = tag;
       ownsBusy = true;
-      // Initiator-only abort: if another pull already started ensure*, this
-      // request joins it; only that initiator's disconnect cancels shared setup.
+      // Waiter-based abort: disconnect removes this client; shared ensure continues
+      // while other clients are still waiting.
       const ready = await ensureOllamaReady((evt) => send(evt), guard.signal);
       if (guard.disconnected()) {
         releaseBusy();

--- a/src/server/routes/ai/ollamaRoutes.ts
+++ b/src/server/routes/ai/ollamaRoutes.ts
@@ -2,7 +2,21 @@
  * Ollama local model routes: /ai/ollama-models, /ai/ollama-model-sizes,
  * /ai/ollama-health, /ai/ollama-pull, /ai/ollama-load, /ai/ollama-unload.
  */
-import { bodyGuard } from "../middleware/bodyGuard.ts";
+import type { Router } from "express";
+
+import { isValidLocalModelTag } from "../../../lib/localModelTag.ts";
+import { gateLocalPullDiskSpace } from "../../../lib/localEngineDisk.ts";
+import { heavyCommandRateLimit } from "../../middleware/rateLimit.ts";
+import { localEngineRuntime } from "../../services/ai/localEngineState.ts";
+import {
+  OLLAMA_PORT,
+  isOllamaRunning,
+  ensureOllamaReady,
+  listOllamaInstalledNames,
+  verifyInstalledAfterPull,
+  OLLAMA_PULL_MAX_MS,
+} from "./localEngines.ts";
+import { trackStreamClient, beginPullSse } from "./streamHelpers.ts";
 
 export function mountOllamaRoutes(router: Router): void {
   router.get("/ai/ollama-models", async (_req, res) => {

--- a/src/server/routes/ai/streamHelpers.ts
+++ b/src/server/routes/ai/streamHelpers.ts
@@ -25,6 +25,8 @@ export function endNdjson(res: import("express").Response, final: Record<string,
 /**
  * Track client disconnect for long-running NDJSON streams.
  * Does not cancel shared ensure* single-flight work used by other requests.
+ * Pass `guard.signal` as the initiator signal so client disconnect aborts setup
+ * only when this request started the shared operation (see ensure* JSDoc).
  */
 export function trackStreamClient(
   req: import("express").Request,

--- a/src/server/routes/ai/streamHelpers.ts
+++ b/src/server/routes/ai/streamHelpers.ts
@@ -24,9 +24,8 @@ export function endNdjson(res: import("express").Response, final: Record<string,
 
 /**
  * Track client disconnect for long-running NDJSON streams.
- * Does not cancel shared ensure* single-flight work used by other requests.
- * Pass `guard.signal` as the initiator signal so client disconnect aborts setup
- * only when this request started the shared operation (see ensure* JSDoc).
+ * Pass `guard.signal` to `ensure*` so disconnect removes this client as a waiter.
+ * Shared setup aborts only when no waiters remain (see ensure* JSDoc).
  */
 export function trackStreamClient(
   req: import("express").Request,

--- a/src/server/routes/mcp.test.ts
+++ b/src/server/routes/mcp.test.ts
@@ -6,6 +6,8 @@
  * successful proxied call that spawns (mocked) Python.
  *
  * `fs.readFileSync` is stubbed per-test so no real KB file is required.
+ *
+ * `child_process` is mocked via `src/server/__tests__/childProcessTestMocks.ts`.
  */
 import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach, vi } from "vitest";
 import express from "express";

--- a/src/server/routes/mcp.test.ts
+++ b/src/server/routes/mcp.test.ts
@@ -6,9 +6,6 @@
  * successful proxied call that spawns (mocked) Python.
  *
  * `fs.readFileSync` is stubbed per-test so no real KB file is required.
- * `child_process.execFile` is mocked with a `promisify.custom` handler (the
- * same pattern as services/mcp/client.test.ts) so `promisify(execFile)` in the
- * client resolves `{ stdout, stderr }` instead of hanging forever callback-style.
  */
 import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach, vi } from "vitest";
 import express from "express";
@@ -16,45 +13,17 @@ import type { Server } from "http";
 import fs from "fs";
 import { execFile } from "child_process";
 
+import {
+  childProcessVitestMockFactory,
+  createChildProcessTestHandles,
+} from "../__tests__/childProcessTestMocks.ts";
 import { mountMcpRoutes } from "./mcp.ts";
 import { setKbStatusCache } from "../services/mcp/state.ts";
 import mcpBreaker, { resetMcpBreaker } from "../services/mcp/breaker.ts";
 
-const mcpToolMocks = vi.hoisted(() => ({
-  execFileImpl: null as null | ((...args: unknown[]) => unknown),
-  calls: [] as unknown[][],
-}));
+const mcpToolMocks = vi.hoisted(() => createChildProcessTestHandles());
 
-// The KB tests never touch child_process; the tool-proxy tests drive execFile
-// through the client's promisified handle, so the mock must expose the custom
-// promisify symbol or the promise would never settle.
-vi.mock("child_process", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("child_process")>();
-  const customSymbol = Symbol.for("nodejs.util.promisify.custom");
-
-  const mockExecFile = vi.fn((...execArgs: unknown[]) => {
-    // Callback-style callers get an instant empty result.
-    const lastArg = execArgs[execArgs.length - 1];
-    if (typeof lastArg === "function") {
-      lastArg(null, "", "");
-      return undefined;
-    }
-    return (actual.execFile as unknown as (...a: unknown[]) => unknown)(...execArgs);
-  });
-
-  // util.promisify(execFile) prefers this when present (mirrors real Node's
-  // execFile, which resolves { stdout, stderr }).
-  (mockExecFile as unknown as Record<symbol, unknown>)[customSymbol] = (...args: unknown[]) => {
-    mcpToolMocks.calls.push(args);
-    if (mcpToolMocks.execFileImpl) return mcpToolMocks.execFileImpl(...args);
-    return Promise.resolve({ stdout: "", stderr: "" });
-  };
-
-  return {
-    ...actual,
-    execFile: mockExecFile as unknown as typeof actual.execFile,
-  };
-});
+vi.mock("child_process", childProcessVitestMockFactory(mcpToolMocks, { trackExecFileCalls: true }));
 
 const VALID_KB = JSON.stringify({
   version: "2.0",
@@ -105,7 +74,7 @@ beforeEach(() => {
   setKbStatusCache(null);
   resetMcpBreaker();
   mcpToolMocks.execFileImpl = null;
-  mcpToolMocks.calls.length = 0;
+  mcpToolMocks.execFileCalls.length = 0;
 });
 
 afterEach(() => {
@@ -202,9 +171,9 @@ describe("POST /api/mcp/tool", () => {
   it("short-circuits with 503 when the breaker is open", async () => {
     const execFileMock = vi.mocked(execFile);
     // Trip the process-wide singleton breaker without spawning anything.
-    mcpBreaker.recordFailure();
-    mcpBreaker.recordFailure();
-    mcpBreaker.recordFailure();
+    mcpBreaker.recordFailure(0);
+    mcpBreaker.recordFailure(0);
+    mcpBreaker.recordFailure(0);
 
     const res = await fetch(`${baseUrl}/api/mcp/tool`, {
       method: "POST",
@@ -235,6 +204,6 @@ describe("POST /api/mcp/tool", () => {
     expect(body).toEqual({ ok: true });
     // The client's promisified execFile (custom-symbol handler) was actually
     // invoked and settled — exercising the path that used to hang forever.
-    expect(mcpToolMocks.calls).toHaveLength(1);
+    expect(mcpToolMocks.execFileCalls).toHaveLength(1);
   });
 });

--- a/src/server/routes/mcp.test.ts
+++ b/src/server/routes/mcp.test.ts
@@ -2,16 +2,59 @@
  * Route-level coverage for the MCP KB endpoints: the failure taxonomy
  * (missing / unreadable / invalid JSON / schema-invalid), sanitized client
  * error messages, caching of a successful status, and the non-2xx sync failure.
+ * Also covers the tool proxy: the open-breaker 503 short-circuit and a
+ * successful proxied call that spawns (mocked) Python.
  *
  * `fs.readFileSync` is stubbed per-test so no real KB file is required.
+ * `child_process.execFile` is mocked with a `promisify.custom` handler (the
+ * same pattern as services/mcp/client.test.ts) so `promisify(execFile)` in the
+ * client resolves `{ stdout, stderr }` instead of hanging forever callback-style.
  */
 import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach, vi } from "vitest";
 import express from "express";
 import type { Server } from "http";
 import fs from "fs";
+import { execFile } from "child_process";
 
 import { mountMcpRoutes } from "./mcp.ts";
 import { setKbStatusCache } from "../services/mcp/state.ts";
+import mcpBreaker, { resetMcpBreaker } from "../services/mcp/breaker.ts";
+
+const mcpToolMocks = vi.hoisted(() => ({
+  execFileImpl: null as null | ((...args: unknown[]) => unknown),
+  calls: [] as unknown[][],
+}));
+
+// The KB tests never touch child_process; the tool-proxy tests drive execFile
+// through the client's promisified handle, so the mock must expose the custom
+// promisify symbol or the promise would never settle.
+vi.mock("child_process", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("child_process")>();
+  const customSymbol = Symbol.for("nodejs.util.promisify.custom");
+
+  const mockExecFile = vi.fn((...execArgs: unknown[]) => {
+    // Callback-style callers get an instant empty result.
+    const lastArg = execArgs[execArgs.length - 1];
+    if (typeof lastArg === "function") {
+      lastArg(null, "", "");
+      return undefined;
+    }
+    return (actual.execFile as unknown as (...a: unknown[]) => unknown)(...execArgs);
+  });
+
+  // util.promisify(execFile) prefers this when present (mirrors real Node's
+  // execFile, which resolves { stdout, stderr }).
+  (mockExecFile as unknown as Record<symbol, unknown>)[customSymbol] = (...args: unknown[]) => {
+    mcpToolMocks.calls.push(args);
+    if (mcpToolMocks.execFileImpl) return mcpToolMocks.execFileImpl(...args);
+    return Promise.resolve({ stdout: "", stderr: "" });
+  };
+
+  return {
+    ...actual,
+    execFile: mockExecFile as unknown as typeof actual.execFile,
+  };
+});
 
 const VALID_KB = JSON.stringify({
   version: "2.0",
@@ -60,6 +103,9 @@ afterAll(async () => {
 
 beforeEach(() => {
   setKbStatusCache(null);
+  resetMcpBreaker();
+  mcpToolMocks.execFileImpl = null;
+  mcpToolMocks.calls.length = 0;
 });
 
 afterEach(() => {
@@ -149,5 +195,46 @@ describe("POST /api/mcp/sync-kb", () => {
     const body = await res.json();
     expect(body).toMatchObject({ ok: false, reason: "missing" });
     expect(body.error).toBe("Knowledge base has not been generated yet.");
+  });
+});
+
+describe("POST /api/mcp/tool", () => {
+  it("short-circuits with 503 when the breaker is open", async () => {
+    const execFileMock = vi.mocked(execFile);
+    // Trip the process-wide singleton breaker without spawning anything.
+    mcpBreaker.recordFailure();
+    mcpBreaker.recordFailure();
+    mcpBreaker.recordFailure();
+
+    const res = await fetch(`${baseUrl}/api/mcp/tool`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ toolName: "x", args: {} }),
+    });
+
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body).toEqual({ available: false, error: expect.any(String) });
+    // The short-circuit must not spawn a Python subprocess.
+    expect(execFileMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 200 with the tool result when the closed breaker proxies valid JSON", async () => {
+    mcpToolMocks.execFileImpl = () =>
+      Promise.resolve({ stdout: '[{"tool":"x","result":{"ok":true}}]', stderr: "" });
+
+    const res = await fetch(`${baseUrl}/api/mcp/tool`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ toolName: "x", args: {} }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    // Clients expect the tool payload at the top level, not wrapped in `result`.
+    expect(body).toEqual({ ok: true });
+    // The client's promisified execFile (custom-symbol handler) was actually
+    // invoked and settled — exercising the path that used to hang forever.
+    expect(mcpToolMocks.calls).toHaveLength(1);
   });
 });

--- a/src/server/routes/mcp.test.ts
+++ b/src/server/routes/mcp.test.ts
@@ -13,19 +13,28 @@ import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach, vi } 
 import express from "express";
 import type { Server } from "http";
 import fs from "fs";
-import { execFile } from "child_process";
 
-import {
-  childProcessVitestMockFactory,
-  createChildProcessTestHandles,
-} from "../__tests__/childProcessTestMocks.ts";
 import { mountMcpRoutes } from "./mcp.ts";
 import { setKbStatusCache } from "../services/mcp/state.ts";
 import mcpBreaker, { resetMcpBreaker } from "../services/mcp/breaker.ts";
 
-const mcpToolMocks = vi.hoisted(() => createChildProcessTestHandles());
+const mcpToolMocks = vi.hoisted(() => ({
+  execFileImpl: null as null | ((...args: unknown[]) => unknown),
+  spawnImpl: null as null | ((...args: unknown[]) => unknown),
+  execFileCalls: [] as unknown[][],
+}));
 
-vi.mock("child_process", childProcessVitestMockFactory(mcpToolMocks, { trackExecFileCalls: true }));
+vi.mock("child_process", async (importOriginal) => {
+  const { childProcessVitestMockFactory } = await import("../__tests__/childProcessTestMocks.ts");
+  return childProcessVitestMockFactory(mcpToolMocks, { trackExecFileCalls: true })(importOriginal);
+});
+
+function tripMcpBreaker(): void {
+  for (let i = 0; i < 3; i += 1) {
+    const admission = mcpBreaker.beforeCall();
+    if (admission) mcpBreaker.recordFailure(admission.epoch);
+  }
+}
 
 const VALID_KB = JSON.stringify({
   version: "2.0",
@@ -171,11 +180,7 @@ describe("POST /api/mcp/sync-kb", () => {
 
 describe("POST /api/mcp/tool", () => {
   it("short-circuits with 503 when the breaker is open", async () => {
-    const execFileMock = vi.mocked(execFile);
-    // Trip the process-wide singleton breaker without spawning anything.
-    mcpBreaker.recordFailure(0);
-    mcpBreaker.recordFailure(0);
-    mcpBreaker.recordFailure(0);
+    tripMcpBreaker();
 
     const res = await fetch(`${baseUrl}/api/mcp/tool`, {
       method: "POST",
@@ -187,7 +192,7 @@ describe("POST /api/mcp/tool", () => {
     const body = await res.json();
     expect(body).toEqual({ available: false, error: expect.any(String) });
     // The short-circuit must not spawn a Python subprocess.
-    expect(execFileMock).not.toHaveBeenCalled();
+    expect(mcpToolMocks.execFileCalls).toHaveLength(0);
   });
 
   it("returns 200 with the tool result when the closed breaker proxies valid JSON", async () => {

--- a/src/server/routes/mcp.ts
+++ b/src/server/routes/mcp.ts
@@ -13,7 +13,7 @@ import {
   isKbSyncInProgress,
   setKbSyncInProgress,
 } from "../services/mcp/state.ts";
-import { callOliveMcpTool } from "../services/mcp/client.ts";
+import { callOliveMcpTool, MCP_UNAVAILABLE_ERROR } from "../services/mcp/client.ts";
 import { kbStatusRateLimit, kbSyncRateLimit } from "../middleware/rateLimit.ts";
 import { readStudioConfig, writeStudioConfig } from "../config.ts";
 import type { KbStatusCache } from "../types.ts";
@@ -200,6 +200,9 @@ export function mountMcpRoutes(router: Router): void {
     }
     try {
       const out = await callOliveMcpTool(toolName, args ?? {});
+      if (out.unavailable) {
+        return res.status(503).json({ available: false, error: out.error ?? MCP_UNAVAILABLE_ERROR });
+      }
       if (out.error) {
         return res.status(500).json({ error: out.error });
       }

--- a/src/server/services/ai/localEngineState.ts
+++ b/src/server/services/ai/localEngineState.ts
@@ -21,6 +21,11 @@ export interface LocalEngineRuntime {
   ollamaPullBusyTag: string | null;
   ollamaProgressSubscribers: Set<(evt: EnsureProgressEvt) => void>;
   lmsProgressSubscribers: Set<(evt: EnsureProgressEvt) => void>;
+  /** Aborts shared Ollama setup when the last waiter disconnects. */
+  ollamaEnsureAbort: AbortController | null;
+  lmsEnsureAbort: AbortController | null;
+  ollamaEnsureWaiters: number;
+  lmsEnsureWaiters: number;
 }
 
 function createLocalEngineRuntime(): LocalEngineRuntime {
@@ -34,6 +39,10 @@ function createLocalEngineRuntime(): LocalEngineRuntime {
     ollamaPullBusyTag: null,
     ollamaProgressSubscribers: new Set(),
     lmsProgressSubscribers: new Set(),
+    ollamaEnsureAbort: null,
+    lmsEnsureAbort: null,
+    ollamaEnsureWaiters: 0,
+    lmsEnsureWaiters: 0,
   };
 }
 

--- a/src/server/services/ai/localEngineState.ts
+++ b/src/server/services/ai/localEngineState.ts
@@ -1,8 +1,8 @@
 /** Progress event emitted while ensuring a local engine is installed/running. */
 export type EnsureProgressEvt = { type: string; message: string; percent?: number };
 
-export type OllamaEnsureResult = { ok: boolean; error?: string; steps: string[] };
-export type LmsEnsureResult = { ok: boolean; error?: string; openedUrl?: string; steps: string[] };
+export type OllamaEnsureResult = { ok: boolean; error?: string; steps: string[]; cancelled?: boolean };
+export type LmsEnsureResult = { ok: boolean; error?: string; openedUrl?: string; steps: string[]; cancelled?: boolean };
 
 export interface LocalEngineRuntime {
   /** Cached `lms` CLI path (`undefined` = not probed yet, `null` = probed, missing). */

--- a/src/server/services/mcp/breaker.test.ts
+++ b/src/server/services/mcp/breaker.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Unit tests for the MCP circuit breaker with an injected fake clock.
+ */
+import { describe, it, expect } from "vitest";
+import { createMcpCircuitBreaker } from "./breaker.ts";
+
+const FAILURE_THRESHOLD = 3;
+const COOLDOWN_MS = 30_000;
+
+describe("createMcpCircuitBreaker", () => {
+  it("allows calls while closed", () => {
+    const breaker = createMcpCircuitBreaker({ now: () => 0 });
+
+    expect(breaker.beforeCall()).toBe(true);
+    expect(breaker.isOpen()).toBe(false);
+    expect(breaker.status()).toEqual({ open: false, failures: 0, openedAt: null });
+  });
+
+  it("opens after the failure threshold is reached", () => {
+    const t = 0;
+    const breaker = createMcpCircuitBreaker({
+      failureThreshold: FAILURE_THRESHOLD,
+      cooldownMs: COOLDOWN_MS,
+      now: () => t,
+    });
+
+    breaker.recordFailure();
+    breaker.recordFailure();
+    expect(breaker.isOpen()).toBe(false);
+
+    breaker.recordFailure();
+    expect(breaker.isOpen()).toBe(true);
+    expect(breaker.beforeCall()).toBe(false);
+    expect(breaker.status()).toEqual({ open: true, failures: FAILURE_THRESHOLD, openedAt: 0 });
+  });
+
+  it("does not increment failures when a call is short-circuited", () => {
+    const t = 0;
+    const breaker = createMcpCircuitBreaker({
+      failureThreshold: FAILURE_THRESHOLD,
+      cooldownMs: COOLDOWN_MS,
+      now: () => t,
+    });
+
+    for (let i = 0; i < FAILURE_THRESHOLD; i += 1) breaker.recordFailure();
+
+    expect(breaker.beforeCall()).toBe(false);
+    expect(breaker.status().failures).toBe(FAILURE_THRESHOLD);
+  });
+
+  it("allows a half-open probe once the cooldown has elapsed", () => {
+    let t = 0;
+    const breaker = createMcpCircuitBreaker({
+      failureThreshold: FAILURE_THRESHOLD,
+      cooldownMs: COOLDOWN_MS,
+      now: () => t,
+    });
+
+    for (let i = 0; i < FAILURE_THRESHOLD; i += 1) breaker.recordFailure();
+    expect(breaker.beforeCall()).toBe(false);
+
+    t += COOLDOWN_MS;
+    expect(breaker.isOpen()).toBe(false);
+    expect(breaker.beforeCall()).toBe(true);
+  });
+
+  it("refreshes the cooldown when a half-open probe fails", () => {
+    let t = 0;
+    const breaker = createMcpCircuitBreaker({
+      failureThreshold: FAILURE_THRESHOLD,
+      cooldownMs: COOLDOWN_MS,
+      now: () => t,
+    });
+
+    for (let i = 0; i < FAILURE_THRESHOLD; i += 1) breaker.recordFailure();
+    t += COOLDOWN_MS;
+
+    breaker.recordFailure();
+    expect(breaker.isOpen()).toBe(true);
+    expect(breaker.beforeCall()).toBe(false);
+
+    // Still open right up to the refreshed cooldown boundary…
+    t += COOLDOWN_MS - 1;
+    expect(breaker.isOpen()).toBe(true);
+    // …and closes once the full cooldown has elapsed again.
+    t += 1;
+    expect(breaker.isOpen()).toBe(false);
+  });
+
+  it("closes and zeroes failures on success", () => {
+    const t = 0;
+    const breaker = createMcpCircuitBreaker({
+      failureThreshold: FAILURE_THRESHOLD,
+      cooldownMs: COOLDOWN_MS,
+      now: () => t,
+    });
+
+    for (let i = 0; i < FAILURE_THRESHOLD; i += 1) breaker.recordFailure();
+    breaker.recordSuccess();
+
+    expect(breaker.isOpen()).toBe(false);
+    expect(breaker.beforeCall()).toBe(true);
+    expect(breaker.status()).toEqual({ open: false, failures: 0, openedAt: null });
+  });
+
+  it("resets to closed with zero failures", () => {
+    const t = 0;
+    const breaker = createMcpCircuitBreaker({
+      failureThreshold: FAILURE_THRESHOLD,
+      cooldownMs: COOLDOWN_MS,
+      now: () => t,
+    });
+
+    for (let i = 0; i < FAILURE_THRESHOLD; i += 1) breaker.recordFailure();
+    breaker.reset();
+
+    expect(breaker.isOpen()).toBe(false);
+    expect(breaker.beforeCall()).toBe(true);
+    expect(breaker.status()).toEqual({ open: false, failures: 0, openedAt: null });
+  });
+
+  it("stays closed when recordSuccess is called while closed", () => {
+    const breaker = createMcpCircuitBreaker({ now: () => 0 });
+
+    breaker.recordSuccess();
+
+    expect(breaker.isOpen()).toBe(false);
+    expect(breaker.status()).toEqual({ open: false, failures: 0, openedAt: null });
+  });
+});

--- a/src/server/services/mcp/breaker.test.ts
+++ b/src/server/services/mcp/breaker.test.ts
@@ -7,6 +7,11 @@ import { createMcpCircuitBreaker } from "./breaker.ts";
 const FAILURE_THRESHOLD = 3;
 const COOLDOWN_MS = 30_000;
 
+function requireAdmission(admission: false | { epoch: number }): { epoch: number } {
+  if (admission === false) throw new Error("expected admission");
+  return admission;
+}
+
 describe("createMcpCircuitBreaker", () => {
   it("allows calls while closed", () => {
     const breaker = createMcpCircuitBreaker({ now: () => 0 });
@@ -133,15 +138,15 @@ describe("createMcpCircuitBreaker", () => {
       now: () => 0,
     });
 
-    const first = breaker.beforeCall();
+    const first = requireAdmission(breaker.beforeCall());
     expect(first).toEqual({ epoch: 0 });
 
-    breaker.recordFailure(0);
-    breaker.recordFailure(0);
+    breaker.recordFailure(first.epoch);
+    breaker.recordFailure(first.epoch);
     expect(breaker.isOpen()).toBe(true);
 
     // Late success from the pre-open admission must not close the breaker.
-    breaker.recordSuccess(first!.epoch);
+    breaker.recordSuccess(first.epoch);
     expect(breaker.isOpen()).toBe(true);
     expect(breaker.beforeCall()).toBe(false);
   });
@@ -154,18 +159,18 @@ describe("createMcpCircuitBreaker", () => {
       now: () => t,
     });
 
-    const stale = breaker.beforeCall();
-    breaker.recordFailure(stale!.epoch);
+    const stale = requireAdmission(breaker.beforeCall());
+    breaker.recordFailure(stale.epoch);
     expect(breaker.isOpen()).toBe(true);
 
     t += COOLDOWN_MS;
-    const probe = breaker.beforeCall();
+    const probe = requireAdmission(breaker.beforeCall());
     expect(probe).toEqual({ epoch: 1 });
-    breaker.recordFailure(probe!.epoch);
+    breaker.recordFailure(probe.epoch);
     expect(breaker.isOpen()).toBe(true);
 
     // Stale success from the original closed-state call must not clear the breaker.
-    breaker.recordSuccess(stale!.epoch);
+    breaker.recordSuccess(stale.epoch);
     expect(breaker.isOpen()).toBe(true);
     expect(breaker.beforeCall()).toBe(false);
   });
@@ -178,7 +183,7 @@ describe("createMcpCircuitBreaker", () => {
       now: () => t,
     });
 
-    const stale = breaker.beforeCall();
+    const stale = requireAdmission(breaker.beforeCall());
     expect(stale).toEqual({ epoch: 0 });
 
     breaker.recordFailure(0);
@@ -187,16 +192,16 @@ describe("createMcpCircuitBreaker", () => {
     expect(breaker.isOpen()).toBe(true);
 
     t += COOLDOWN_MS;
-    const probe = breaker.beforeCall();
+    const probe = requireAdmission(breaker.beforeCall());
     expect(probe).toEqual({ epoch: 1 });
 
     // Late success from the pre-open admission must not clear half-open state.
-    breaker.recordSuccess(stale!.epoch);
-    expect(breaker.isOpen()).toBe(true);
+    breaker.recordSuccess(stale.epoch);
+    expect(breaker.isOpen()).toBe(false);
     expect(breaker.beforeCall()).toBe(false);
 
     // The actual recovery probe failure must still reopen the breaker.
-    breaker.recordFailure(probe!.epoch);
+    breaker.recordFailure(probe.epoch);
     expect(breaker.isOpen()).toBe(true);
     expect(breaker.beforeCall()).toBe(false);
   });

--- a/src/server/services/mcp/breaker.test.ts
+++ b/src/server/services/mcp/breaker.test.ts
@@ -11,7 +11,7 @@ describe("createMcpCircuitBreaker", () => {
   it("allows calls while closed", () => {
     const breaker = createMcpCircuitBreaker({ now: () => 0 });
 
-    expect(breaker.beforeCall()).toBe(true);
+    expect(breaker.beforeCall()).toEqual({ epoch: 0 });
     expect(breaker.isOpen()).toBe(false);
     expect(breaker.status()).toEqual({ open: false, failures: 0, openedAt: null });
   });
@@ -24,11 +24,11 @@ describe("createMcpCircuitBreaker", () => {
       now: () => t,
     });
 
-    breaker.recordFailure();
-    breaker.recordFailure();
+    breaker.recordFailure(0);
+    breaker.recordFailure(0);
     expect(breaker.isOpen()).toBe(false);
 
-    breaker.recordFailure();
+    breaker.recordFailure(0);
     expect(breaker.isOpen()).toBe(true);
     expect(breaker.beforeCall()).toBe(false);
     expect(breaker.status()).toEqual({ open: true, failures: FAILURE_THRESHOLD, openedAt: 0 });
@@ -42,7 +42,7 @@ describe("createMcpCircuitBreaker", () => {
       now: () => t,
     });
 
-    for (let i = 0; i < FAILURE_THRESHOLD; i += 1) breaker.recordFailure();
+    for (let i = 0; i < FAILURE_THRESHOLD; i += 1) breaker.recordFailure(0);
 
     expect(breaker.beforeCall()).toBe(false);
     expect(breaker.status().failures).toBe(FAILURE_THRESHOLD);
@@ -56,12 +56,12 @@ describe("createMcpCircuitBreaker", () => {
       now: () => t,
     });
 
-    for (let i = 0; i < FAILURE_THRESHOLD; i += 1) breaker.recordFailure();
+    for (let i = 0; i < FAILURE_THRESHOLD; i += 1) breaker.recordFailure(0);
     expect(breaker.beforeCall()).toBe(false);
 
     t += COOLDOWN_MS;
     expect(breaker.isOpen()).toBe(false);
-    expect(breaker.beforeCall()).toBe(true);
+    expect(breaker.beforeCall()).toEqual({ epoch: 1 });
   });
 
   it("refreshes the cooldown when a half-open probe fails", () => {
@@ -72,17 +72,15 @@ describe("createMcpCircuitBreaker", () => {
       now: () => t,
     });
 
-    for (let i = 0; i < FAILURE_THRESHOLD; i += 1) breaker.recordFailure();
+    for (let i = 0; i < FAILURE_THRESHOLD; i += 1) breaker.recordFailure(0);
     t += COOLDOWN_MS;
 
-    breaker.recordFailure();
+    breaker.recordFailure(1);
     expect(breaker.isOpen()).toBe(true);
     expect(breaker.beforeCall()).toBe(false);
 
-    // Still open right up to the refreshed cooldown boundary…
     t += COOLDOWN_MS - 1;
     expect(breaker.isOpen()).toBe(true);
-    // …and closes once the full cooldown has elapsed again.
     t += 1;
     expect(breaker.isOpen()).toBe(false);
   });
@@ -95,11 +93,11 @@ describe("createMcpCircuitBreaker", () => {
       now: () => t,
     });
 
-    for (let i = 0; i < FAILURE_THRESHOLD; i += 1) breaker.recordFailure();
-    breaker.recordSuccess();
+    for (let i = 0; i < FAILURE_THRESHOLD; i += 1) breaker.recordFailure(0);
+    breaker.recordSuccess(1);
 
     expect(breaker.isOpen()).toBe(false);
-    expect(breaker.beforeCall()).toBe(true);
+    expect(breaker.beforeCall()).toEqual({ epoch: 1 });
     expect(breaker.status()).toEqual({ open: false, failures: 0, openedAt: null });
   });
 
@@ -111,20 +109,64 @@ describe("createMcpCircuitBreaker", () => {
       now: () => t,
     });
 
-    for (let i = 0; i < FAILURE_THRESHOLD; i += 1) breaker.recordFailure();
+    for (let i = 0; i < FAILURE_THRESHOLD; i += 1) breaker.recordFailure(0);
     breaker.reset();
 
     expect(breaker.isOpen()).toBe(false);
-    expect(breaker.beforeCall()).toBe(true);
+    expect(breaker.beforeCall()).toEqual({ epoch: 2 });
     expect(breaker.status()).toEqual({ open: false, failures: 0, openedAt: null });
   });
 
   it("stays closed when recordSuccess is called while closed", () => {
     const breaker = createMcpCircuitBreaker({ now: () => 0 });
 
-    breaker.recordSuccess();
+    breaker.recordSuccess(0);
 
     expect(breaker.isOpen()).toBe(false);
     expect(breaker.status()).toEqual({ open: false, failures: 0, openedAt: null });
+  });
+
+  it("ignores stale completions from before the breaker opened", () => {
+    const breaker = createMcpCircuitBreaker({
+      failureThreshold: 2,
+      cooldownMs: COOLDOWN_MS,
+      now: () => 0,
+    });
+
+    const first = breaker.beforeCall();
+    expect(first).toEqual({ epoch: 0 });
+
+    breaker.recordFailure(0);
+    breaker.recordFailure(0);
+    expect(breaker.isOpen()).toBe(true);
+
+    // Late success from the pre-open admission must not close the breaker.
+    breaker.recordSuccess(first!.epoch);
+    expect(breaker.isOpen()).toBe(true);
+    expect(breaker.beforeCall()).toBe(false);
+  });
+
+  it("ignores stale success after a failed recovery probe", () => {
+    let t = 0;
+    const breaker = createMcpCircuitBreaker({
+      failureThreshold: 1,
+      cooldownMs: COOLDOWN_MS,
+      now: () => t,
+    });
+
+    const stale = breaker.beforeCall();
+    breaker.recordFailure(stale!.epoch);
+    expect(breaker.isOpen()).toBe(true);
+
+    t += COOLDOWN_MS;
+    const probe = breaker.beforeCall();
+    expect(probe).toEqual({ epoch: 1 });
+    breaker.recordFailure(probe!.epoch);
+    expect(breaker.isOpen()).toBe(true);
+
+    // Stale success from the original closed-state call must not clear the breaker.
+    breaker.recordSuccess(stale!.epoch);
+    expect(breaker.isOpen()).toBe(true);
+    expect(breaker.beforeCall()).toBe(false);
   });
 });

--- a/src/server/services/mcp/breaker.test.ts
+++ b/src/server/services/mcp/breaker.test.ts
@@ -169,4 +169,35 @@ describe("createMcpCircuitBreaker", () => {
     expect(breaker.isOpen()).toBe(true);
     expect(breaker.beforeCall()).toBe(false);
   });
+
+  it("does not let a pre-open success cancel an in-flight recovery probe", () => {
+    let t = 0;
+    const breaker = createMcpCircuitBreaker({
+      failureThreshold: FAILURE_THRESHOLD,
+      cooldownMs: COOLDOWN_MS,
+      now: () => t,
+    });
+
+    const stale = breaker.beforeCall();
+    expect(stale).toEqual({ epoch: 0 });
+
+    breaker.recordFailure(0);
+    breaker.recordFailure(0);
+    breaker.recordFailure(0);
+    expect(breaker.isOpen()).toBe(true);
+
+    t += COOLDOWN_MS;
+    const probe = breaker.beforeCall();
+    expect(probe).toEqual({ epoch: 1 });
+
+    // Late success from the pre-open admission must not clear half-open state.
+    breaker.recordSuccess(stale!.epoch);
+    expect(breaker.isOpen()).toBe(true);
+    expect(breaker.beforeCall()).toBe(false);
+
+    // The actual recovery probe failure must still reopen the breaker.
+    breaker.recordFailure(probe!.epoch);
+    expect(breaker.isOpen()).toBe(true);
+    expect(breaker.beforeCall()).toBe(false);
+  });
 });

--- a/src/server/services/mcp/breaker.ts
+++ b/src/server/services/mcp/breaker.ts
@@ -5,13 +5,21 @@
  * failure, timeout, non-JSON output), subsequent tool calls short-circuit
  * instead of spawning a Python subprocess per call. Tool-level errors
  * (bad tool name, invalid args) never trip the breaker.
+ *
+ * Each admitted call receives an `epoch` token. `recordSuccess` /
+ * `recordFailure` apply only when the token matches the breaker's current
+ * epoch, so a subprocess that was admitted before the breaker opened (or
+ * before a failed recovery probe) cannot overwrite newer state when it
+ * completes late.
  */
+
+export type McpCallAdmission = { epoch: number };
 
 export type McpCircuitBreaker = {
   isOpen(): boolean;
-  beforeCall(): boolean;
-  recordSuccess(): void;
-  recordFailure(): void;
+  beforeCall(): McpCallAdmission | false;
+  recordSuccess(epoch: number): void;
+  recordFailure(epoch: number): void;
   reset(): void;
   status(): { open: boolean; failures: number; openedAt: number | null };
 };
@@ -34,6 +42,8 @@ export function createMcpCircuitBreaker(
   let failures = 0;
   let openedAt: number | null = null;
   let halfOpenProbeInFlight = false;
+  /** Bumped when the breaker opens/reopens or a recovery probe succeeds. */
+  let epoch = 0;
 
   function isOpen(): boolean {
     return openedAt !== null && now() - openedAt < cooldownMs;
@@ -41,35 +51,42 @@ export function createMcpCircuitBreaker(
 
   return {
     isOpen,
-    beforeCall(): boolean {
-      if (openedAt === null) return true;
+    beforeCall(): McpCallAdmission | false {
+      if (openedAt === null) return { epoch };
       if (isOpen()) return false;
       // Admit exactly one recovery probe after the cooldown expires.
       if (halfOpenProbeInFlight) return false;
       halfOpenProbeInFlight = true;
-      return true;
+      return { epoch };
     },
-    recordSuccess(): void {
+    recordSuccess(admittedEpoch: number): void {
+      if (admittedEpoch !== epoch) return;
+      const wasRecoveryProbe = halfOpenProbeInFlight;
       failures = 0;
       openedAt = null;
       halfOpenProbeInFlight = false;
+      if (wasRecoveryProbe) epoch += 1;
     },
-    recordFailure(): void {
+    recordFailure(admittedEpoch: number): void {
+      if (admittedEpoch !== epoch) return;
+      halfOpenProbeInFlight = false;
       if (openedAt !== null) {
         // Re-open after a failed recovery probe (or an already-open call).
         openedAt = now();
-        halfOpenProbeInFlight = false;
+        epoch += 1;
         return;
       }
       failures += 1;
       if (failures >= failureThreshold) {
         openedAt = now();
+        epoch += 1;
       }
     },
     reset(): void {
       failures = 0;
       openedAt = null;
       halfOpenProbeInFlight = false;
+      epoch += 1;
     },
     status(): { open: boolean; failures: number; openedAt: number | null } {
       return { open: isOpen(), failures, openedAt };

--- a/src/server/services/mcp/breaker.ts
+++ b/src/server/services/mcp/breaker.ts
@@ -33,6 +33,7 @@ export function createMcpCircuitBreaker(
 
   let failures = 0;
   let openedAt: number | null = null;
+  let halfOpenProbeInFlight = false;
 
   function isOpen(): boolean {
     return openedAt !== null && now() - openedAt < cooldownMs;
@@ -41,16 +42,23 @@ export function createMcpCircuitBreaker(
   return {
     isOpen,
     beforeCall(): boolean {
-      return !isOpen();
+      if (openedAt === null) return true;
+      if (isOpen()) return false;
+      // Admit exactly one recovery probe after the cooldown expires.
+      if (halfOpenProbeInFlight) return false;
+      halfOpenProbeInFlight = true;
+      return true;
     },
     recordSuccess(): void {
       failures = 0;
       openedAt = null;
+      halfOpenProbeInFlight = false;
     },
     recordFailure(): void {
       if (openedAt !== null) {
-        // Already open — refresh the cooldown but never grow `failures` past the trip point.
+        // Re-open after a failed recovery probe (or an already-open call).
         openedAt = now();
+        halfOpenProbeInFlight = false;
         return;
       }
       failures += 1;
@@ -61,6 +69,7 @@ export function createMcpCircuitBreaker(
     reset(): void {
       failures = 0;
       openedAt = null;
+      halfOpenProbeInFlight = false;
     },
     status(): { open: boolean; failures: number; openedAt: number | null } {
       return { open: isOpen(), failures, openedAt };

--- a/src/server/services/mcp/breaker.ts
+++ b/src/server/services/mcp/breaker.ts
@@ -1,0 +1,79 @@
+/**
+ * Circuit breaker for the Olive MCP server subprocess.
+ *
+ * When the MCP server keeps failing at the INFRASTRUCTURE level (spawn
+ * failure, timeout, non-JSON output), subsequent tool calls short-circuit
+ * instead of spawning a Python subprocess per call. Tool-level errors
+ * (bad tool name, invalid args) never trip the breaker.
+ */
+
+export type McpCircuitBreaker = {
+  isOpen(): boolean;
+  beforeCall(): boolean;
+  recordSuccess(): void;
+  recordFailure(): void;
+  reset(): void;
+  status(): { open: boolean; failures: number; openedAt: number | null };
+};
+
+/**
+ * Creates an independent circuit breaker with injectable clock and thresholds.
+ *
+ * @param options - failureThreshold (default 3), cooldownMs (default 30_000), now (default Date.now)
+ * @returns A circuit breaker sharing no state with any other instance
+ */
+export function createMcpCircuitBreaker(
+  options: { failureThreshold?: number; cooldownMs?: number; now?: () => number } = {},
+): McpCircuitBreaker {
+  const failureThreshold = options.failureThreshold ?? 3;
+  const cooldownMs = options.cooldownMs ?? 30_000;
+  // Resolve Date.now through the global at call time so fake timers (vitest)
+  // can control the default clock; explicit `now` injectables are unaffected.
+  const now = options.now ?? (() => Date.now());
+
+  let failures = 0;
+  let openedAt: number | null = null;
+
+  function isOpen(): boolean {
+    return openedAt !== null && now() - openedAt < cooldownMs;
+  }
+
+  return {
+    isOpen,
+    beforeCall(): boolean {
+      return !isOpen();
+    },
+    recordSuccess(): void {
+      failures = 0;
+      openedAt = null;
+    },
+    recordFailure(): void {
+      if (openedAt !== null) {
+        // Already open — refresh the cooldown but never grow `failures` past the trip point.
+        openedAt = now();
+        return;
+      }
+      failures += 1;
+      if (failures >= failureThreshold) {
+        openedAt = now();
+      }
+    },
+    reset(): void {
+      failures = 0;
+      openedAt = null;
+    },
+    status(): { open: boolean; failures: number; openedAt: number | null } {
+      return { open: isOpen(), failures, openedAt };
+    },
+  };
+}
+
+/** Process-wide breaker shared by the MCP tool client. */
+const mcpBreaker = createMcpCircuitBreaker();
+
+/** Resets the process-wide MCP breaker (used by tests and manual recovery). */
+export function resetMcpBreaker(): void {
+  mcpBreaker.reset();
+}
+
+export default mcpBreaker;

--- a/src/server/services/mcp/client.test.ts
+++ b/src/server/services/mcp/client.test.ts
@@ -140,6 +140,38 @@ describe("callOliveMcpTools circuit-breaker integration", () => {
     expect(mcpBreaker.status().open).toBe(true);
   });
 
+  it("does not let a pre-open success cancel a half-open recovery probe", async () => {
+    vi.useFakeTimers();
+    try {
+      let resolveExec: ((value: { stdout: string; stderr: string }) => void) | undefined;
+      mocks.execFileImpl = () =>
+        new Promise<{ stdout: string; stderr: string }>((resolve) => {
+          resolveExec = resolve;
+        });
+
+      const slow = callOliveMcpTools([{ toolName: "x", args: {} }]);
+      mockExecFileReject("spawn python ENOENT");
+      await callOliveMcpTools([{ toolName: "x", args: {} }]);
+      await callOliveMcpTools([{ toolName: "x", args: {} }]);
+      expect(mcpBreaker.status().open).toBe(true);
+
+      vi.advanceTimersByTime(30_000);
+      const probe = callOliveMcpTools([{ toolName: "x", args: {} }]);
+
+      resolveExec!({ stdout: '[{"tool":"x","result":{"ok":true}}]', stderr: "" });
+      await slow;
+
+      mockExecFileReject("spawn python ENOENT");
+      const probeOut = await probe;
+
+      expect(probeOut).toEqual([{ error: "spawn python ENOENT", unavailable: true }]);
+      expect(mcpBreaker.status().open).toBe(true);
+      expect(mocks.execFileCalls).toHaveLength(4);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("does not inflate the failures counter while the breaker is open", async () => {
     mockExecFileReject("spawn python ENOENT");
     await callOliveMcpTools([{ toolName: "x", args: {} }]);

--- a/src/server/services/mcp/client.test.ts
+++ b/src/server/services/mcp/client.test.ts
@@ -1,6 +1,8 @@
 /**
  * Unit tests for the Olive MCP tool client's circuit-breaker integration.
  * No real Python subprocess is ever spawned.
+ *
+ * `child_process` is mocked via `src/server/__tests__/childProcessTestMocks.ts`.
  */
 import { describe, it, expect, beforeEach, vi } from "vitest";
 

--- a/src/server/services/mcp/client.test.ts
+++ b/src/server/services/mcp/client.test.ts
@@ -1,45 +1,17 @@
 /**
  * Unit tests for the Olive MCP tool client's circuit-breaker integration.
- *
- * child_process.execFile is mocked with a `promisify.custom` handler so
- * `execFileAsync` (util.promisify(execFile)) resolves the same
- * `{ stdout, stderr }` shape as real Node's execFile promisification.
  * No real Python subprocess is ever spawned.
  */
 import { describe, it, expect, beforeEach, vi } from "vitest";
 
-const mocks = vi.hoisted(() => ({
-  execFileImpl: null as null | ((...args: unknown[]) => unknown),
-  calls: [] as unknown[][],
-}));
+import {
+  childProcessVitestMockFactory,
+  createChildProcessTestHandles,
+} from "../../__tests__/childProcessTestMocks.ts";
 
-vi.mock("child_process", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("child_process")>();
-  const customSymbol = Symbol.for("nodejs.util.promisify.custom");
+const mocks = vi.hoisted(() => createChildProcessTestHandles());
 
-  function mockExecFile(...execArgs: unknown[]): unknown {
-    // Callback-style callers get an instant empty result.
-    const lastArg = execArgs[execArgs.length - 1];
-    if (typeof lastArg === "function") {
-      lastArg(null, "", "");
-      return undefined;
-    }
-    return (actual.execFile as unknown as (...a: unknown[]) => unknown)(...execArgs);
-  }
-
-  // util.promisify(execFile) prefers this when present (mirrors real Node's
-  // execFile, which resolves { stdout, stderr }). Tests stub execFileImpl to
-  // resolve that exact shape.
-  (mockExecFile as unknown as Record<symbol, unknown>)[customSymbol] = (...args: unknown[]) => {
-    if (mocks.execFileImpl) return mocks.execFileImpl(...args);
-    return Promise.resolve({ stdout: "", stderr: "" });
-  };
-
-  return {
-    ...actual,
-    execFile: mockExecFile as unknown as typeof actual.execFile,
-  };
-});
+vi.mock("child_process", childProcessVitestMockFactory(mocks));
 
 import { callOliveMcpTools, callOliveMcpTool, MCP_UNAVAILABLE_ERROR } from "./client.ts";
 import mcpBreaker, { resetMcpBreaker } from "./breaker.ts";
@@ -47,7 +19,7 @@ import mcpBreaker, { resetMcpBreaker } from "./breaker.ts";
 /** Makes the next execFile call resolve with the given stdout/stderr. */
 function mockExecFileResolve(stdout: string, stderr = ""): void {
   mocks.execFileImpl = (...args: unknown[]) => {
-    mocks.calls.push(args);
+    mocks.execFileCalls.push(args);
     return Promise.resolve({ stdout, stderr });
   };
 }
@@ -55,7 +27,7 @@ function mockExecFileResolve(stdout: string, stderr = ""): void {
 /** Makes the next execFile call reject like a failed spawn. */
 function mockExecFileReject(message: string): void {
   mocks.execFileImpl = (...args: unknown[]) => {
-    mocks.calls.push(args);
+    mocks.execFileCalls.push(args);
     return Promise.reject(Object.assign(new Error(message), { code: "ENOENT" }));
   };
 }
@@ -64,7 +36,7 @@ describe("callOliveMcpTools circuit-breaker integration", () => {
   beforeEach(() => {
     resetMcpBreaker();
     mocks.execFileImpl = null;
-    mocks.calls.length = 0;
+    mocks.execFileCalls.length = 0;
   });
 
   it("returns results for valid JSON output and records success", async () => {
@@ -74,7 +46,7 @@ describe("callOliveMcpTools circuit-breaker integration", () => {
 
     expect(out).toEqual([{ result: { ok: true } }]);
     expect(mcpBreaker.status()).toEqual({ open: false, failures: 0, openedAt: null });
-    expect(mocks.calls).toHaveLength(1);
+    expect(mocks.execFileCalls).toHaveLength(1);
   });
 
   it("returns unavailable errors and records a failure on spawn failure", async () => {
@@ -85,7 +57,7 @@ describe("callOliveMcpTools circuit-breaker integration", () => {
     expect(out).toHaveLength(1);
     expect(out[0]).toMatchObject({ error: "spawn python ENOENT", unavailable: true });
     expect(mcpBreaker.status()).toMatchObject({ open: false, failures: 1 });
-    expect(mocks.calls).toHaveLength(1);
+    expect(mocks.execFileCalls).toHaveLength(1);
   });
 
   it("returns unavailable errors and records a failure on non-JSON output", async () => {
@@ -109,12 +81,12 @@ describe("callOliveMcpTools circuit-breaker integration", () => {
   });
 
   it("single-tool calls inherit the unavailable short-circuit", async () => {
-    for (let i = 0; i < 3; i += 1) mcpBreaker.recordFailure();
+    for (let i = 0; i < 3; i += 1) mcpBreaker.recordFailure(0);
 
     const out = await callOliveMcpTool("x", {});
 
     expect(out).toEqual({ error: MCP_UNAVAILABLE_ERROR, unavailable: true });
-    expect(mocks.calls).toHaveLength(0);
+    expect(mocks.execFileCalls).toHaveLength(0);
   });
 
   it("marks non-array JSON output as an unavailable infra failure", async () => {
@@ -124,7 +96,7 @@ describe("callOliveMcpTools circuit-breaker integration", () => {
 
     expect(out).toEqual([{ error: "MCP batch returned non-array JSON", unavailable: true }]);
     expect(mcpBreaker.status()).toMatchObject({ open: false, failures: 1 });
-    expect(mocks.calls).toHaveLength(1);
+    expect(mocks.execFileCalls).toHaveLength(1);
   });
 
   it("closes the breaker after a successful half-open probe", async () => {
@@ -136,7 +108,6 @@ describe("callOliveMcpTools circuit-breaker integration", () => {
       await callOliveMcpTools([{ toolName: "x", args: {} }]);
       expect(mcpBreaker.status()).toMatchObject({ open: true, failures: 3 });
 
-      // Advance past the cooldown — the breaker is half-open and admits a probe.
       vi.advanceTimersByTime(30_000);
       expect(mcpBreaker.status().open).toBe(false);
 
@@ -148,6 +119,25 @@ describe("callOliveMcpTools circuit-breaker integration", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it("ignores a stale subprocess success after the breaker opened", async () => {
+    let resolveExec: ((value: { stdout: string; stderr: string }) => void) | undefined;
+    mocks.execFileImpl = () =>
+      new Promise<{ stdout: string; stderr: string }>((resolve) => {
+        resolveExec = resolve;
+      });
+
+    const slow = callOliveMcpTools([{ toolName: "x", args: {} }]);
+    mockExecFileReject("spawn python ENOENT");
+    await callOliveMcpTools([{ toolName: "x", args: {} }]);
+    await callOliveMcpTools([{ toolName: "x", args: {} }]);
+    expect(mcpBreaker.status().open).toBe(true);
+
+    resolveExec!({ stdout: '[{"tool":"x","result":{"ok":true}}]', stderr: "" });
+    await slow;
+
+    expect(mcpBreaker.status().open).toBe(true);
   });
 
   it("does not inflate the failures counter while the breaker is open", async () => {
@@ -162,6 +152,6 @@ describe("callOliveMcpTools circuit-breaker integration", () => {
 
     expect(out).toEqual({ error: MCP_UNAVAILABLE_ERROR, unavailable: true });
     expect(mcpBreaker.status().failures).toBe(failuresBefore);
-    expect(mocks.calls).toHaveLength(3);
+    expect(mocks.execFileCalls).toHaveLength(3);
   });
 });

--- a/src/server/services/mcp/client.test.ts
+++ b/src/server/services/mcp/client.test.ts
@@ -8,14 +8,24 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 
 import { callOliveMcpTools, callOliveMcpTool, MCP_UNAVAILABLE_ERROR } from "./client.ts";
 import mcpBreaker, { resetMcpBreaker } from "./breaker.ts";
-import {
-  childProcessVitestMockFactory,
-  createChildProcessTestHandles,
-} from "../../__tests__/childProcessTestMocks.ts";
 
-const mocks = vi.hoisted(() => createChildProcessTestHandles());
+const mocks = vi.hoisted(() => ({
+  execFileImpl: null as null | ((...args: unknown[]) => unknown),
+  spawnImpl: null as null | ((...args: unknown[]) => unknown),
+  execFileCalls: [] as unknown[][],
+}));
 
-vi.mock("child_process", childProcessVitestMockFactory(mocks));
+vi.mock("child_process", async (importOriginal) => {
+  const { childProcessVitestMockFactory } = await import("../../__tests__/childProcessTestMocks.ts");
+  return childProcessVitestMockFactory(mocks)(importOriginal);
+});
+
+function tripMcpBreaker(): void {
+  for (let i = 0; i < 3; i += 1) {
+    const admission = mcpBreaker.beforeCall();
+    if (admission) mcpBreaker.recordFailure(admission.epoch);
+  }
+}
 
 /** Makes the next execFile call resolve with the given stdout/stderr. */
 function mockExecFileResolve(stdout: string, stderr = ""): void {
@@ -82,7 +92,7 @@ describe("callOliveMcpTools circuit-breaker integration", () => {
   });
 
   it("single-tool calls inherit the unavailable short-circuit", async () => {
-    for (let i = 0; i < 3; i += 1) mcpBreaker.recordFailure(0);
+    tripMcpBreaker();
 
     const out = await callOliveMcpTool("x", {});
 
@@ -133,6 +143,7 @@ describe("callOliveMcpTools circuit-breaker integration", () => {
     mockExecFileReject("spawn python ENOENT");
     await callOliveMcpTools([{ toolName: "x", args: {} }]);
     await callOliveMcpTools([{ toolName: "x", args: {} }]);
+    await callOliveMcpTools([{ toolName: "x", args: {} }]);
     expect(mcpBreaker.status().open).toBe(true);
 
     resolveExec!({ stdout: '[{"tool":"x","result":{"ok":true}}]', stderr: "" });
@@ -152,6 +163,7 @@ describe("callOliveMcpTools circuit-breaker integration", () => {
 
       const slow = callOliveMcpTools([{ toolName: "x", args: {} }]);
       mockExecFileReject("spawn python ENOENT");
+      await callOliveMcpTools([{ toolName: "x", args: {} }]);
       await callOliveMcpTools([{ toolName: "x", args: {} }]);
       await callOliveMcpTools([{ toolName: "x", args: {} }]);
       expect(mcpBreaker.status().open).toBe(true);

--- a/src/server/services/mcp/client.test.ts
+++ b/src/server/services/mcp/client.test.ts
@@ -1,0 +1,167 @@
+/**
+ * Unit tests for the Olive MCP tool client's circuit-breaker integration.
+ *
+ * child_process.execFile is mocked with a `promisify.custom` handler so
+ * `execFileAsync` (util.promisify(execFile)) resolves the same
+ * `{ stdout, stderr }` shape as real Node's execFile promisification.
+ * No real Python subprocess is ever spawned.
+ */
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  execFileImpl: null as null | ((...args: unknown[]) => unknown),
+  calls: [] as unknown[][],
+}));
+
+vi.mock("child_process", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("child_process")>();
+  const customSymbol = Symbol.for("nodejs.util.promisify.custom");
+
+  function mockExecFile(...execArgs: unknown[]): unknown {
+    // Callback-style callers get an instant empty result.
+    const lastArg = execArgs[execArgs.length - 1];
+    if (typeof lastArg === "function") {
+      lastArg(null, "", "");
+      return undefined;
+    }
+    return (actual.execFile as unknown as (...a: unknown[]) => unknown)(...execArgs);
+  }
+
+  // util.promisify(execFile) prefers this when present (mirrors real Node's
+  // execFile, which resolves { stdout, stderr }). Tests stub execFileImpl to
+  // resolve that exact shape.
+  (mockExecFile as unknown as Record<symbol, unknown>)[customSymbol] = (...args: unknown[]) => {
+    if (mocks.execFileImpl) return mocks.execFileImpl(...args);
+    return Promise.resolve({ stdout: "", stderr: "" });
+  };
+
+  return {
+    ...actual,
+    execFile: mockExecFile as unknown as typeof actual.execFile,
+  };
+});
+
+import { callOliveMcpTools, callOliveMcpTool, MCP_UNAVAILABLE_ERROR } from "./client.ts";
+import mcpBreaker, { resetMcpBreaker } from "./breaker.ts";
+
+/** Makes the next execFile call resolve with the given stdout/stderr. */
+function mockExecFileResolve(stdout: string, stderr = ""): void {
+  mocks.execFileImpl = (...args: unknown[]) => {
+    mocks.calls.push(args);
+    return Promise.resolve({ stdout, stderr });
+  };
+}
+
+/** Makes the next execFile call reject like a failed spawn. */
+function mockExecFileReject(message: string): void {
+  mocks.execFileImpl = (...args: unknown[]) => {
+    mocks.calls.push(args);
+    return Promise.reject(Object.assign(new Error(message), { code: "ENOENT" }));
+  };
+}
+
+describe("callOliveMcpTools circuit-breaker integration", () => {
+  beforeEach(() => {
+    resetMcpBreaker();
+    mocks.execFileImpl = null;
+    mocks.calls.length = 0;
+  });
+
+  it("returns results for valid JSON output and records success", async () => {
+    mockExecFileResolve('[{"tool":"x","result":{"ok":true}}]');
+
+    const out = await callOliveMcpTools([{ toolName: "x", args: {} }]);
+
+    expect(out).toEqual([{ result: { ok: true } }]);
+    expect(mcpBreaker.status()).toEqual({ open: false, failures: 0, openedAt: null });
+    expect(mocks.calls).toHaveLength(1);
+  });
+
+  it("returns unavailable errors and records a failure on spawn failure", async () => {
+    mockExecFileReject("spawn python ENOENT");
+
+    const out = await callOliveMcpTools([{ toolName: "x", args: {} }]);
+
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({ error: "spawn python ENOENT", unavailable: true });
+    expect(mcpBreaker.status()).toMatchObject({ open: false, failures: 1 });
+    expect(mocks.calls).toHaveLength(1);
+  });
+
+  it("returns unavailable errors and records a failure on non-JSON output", async () => {
+    mockExecFileResolve("not json");
+
+    const out = await callOliveMcpTools([{ toolName: "x", args: {} }]);
+
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({ error: expect.any(String), unavailable: true });
+    expect(mcpBreaker.status()).toMatchObject({ open: false, failures: 1 });
+  });
+
+  it("does not trip the breaker on row-level tool errors", async () => {
+    mockExecFileResolve('[{"tool":"x","error":"bad tool"}]');
+
+    const out = await callOliveMcpTools([{ toolName: "x", args: {} }]);
+
+    expect(out).toEqual([{ error: "bad tool" }]);
+    expect(out[0]).not.toHaveProperty("unavailable");
+    expect(mcpBreaker.status()).toEqual({ open: false, failures: 0, openedAt: null });
+  });
+
+  it("single-tool calls inherit the unavailable short-circuit", async () => {
+    for (let i = 0; i < 3; i += 1) mcpBreaker.recordFailure();
+
+    const out = await callOliveMcpTool("x", {});
+
+    expect(out).toEqual({ error: MCP_UNAVAILABLE_ERROR, unavailable: true });
+    expect(mocks.calls).toHaveLength(0);
+  });
+
+  it("marks non-array JSON output as an unavailable infra failure", async () => {
+    mockExecFileResolve('{"not":"an array"}');
+
+    const out = await callOliveMcpTools([{ toolName: "x", args: {} }]);
+
+    expect(out).toEqual([{ error: "MCP batch returned non-array JSON", unavailable: true }]);
+    expect(mcpBreaker.status()).toMatchObject({ open: false, failures: 1 });
+    expect(mocks.calls).toHaveLength(1);
+  });
+
+  it("closes the breaker after a successful half-open probe", async () => {
+    vi.useFakeTimers();
+    try {
+      mockExecFileReject("spawn python ENOENT");
+      await callOliveMcpTools([{ toolName: "x", args: {} }]);
+      await callOliveMcpTools([{ toolName: "x", args: {} }]);
+      await callOliveMcpTools([{ toolName: "x", args: {} }]);
+      expect(mcpBreaker.status()).toMatchObject({ open: true, failures: 3 });
+
+      // Advance past the cooldown — the breaker is half-open and admits a probe.
+      vi.advanceTimersByTime(30_000);
+      expect(mcpBreaker.status().open).toBe(false);
+
+      mockExecFileResolve('[{"tool":"x","result":{"ok":true}}]');
+      const out = await callOliveMcpTools([{ toolName: "x", args: {} }]);
+
+      expect(out).toEqual([{ result: { ok: true } }]);
+      expect(mcpBreaker.status()).toEqual({ open: false, failures: 0, openedAt: null });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not inflate the failures counter while the breaker is open", async () => {
+    mockExecFileReject("spawn python ENOENT");
+    await callOliveMcpTools([{ toolName: "x", args: {} }]);
+    await callOliveMcpTools([{ toolName: "x", args: {} }]);
+    await callOliveMcpTools([{ toolName: "x", args: {} }]);
+    expect(mcpBreaker.status().open).toBe(true);
+
+    const failuresBefore = mcpBreaker.status().failures;
+    const out = await callOliveMcpTool("x", {});
+
+    expect(out).toEqual({ error: MCP_UNAVAILABLE_ERROR, unavailable: true });
+    expect(mcpBreaker.status().failures).toBe(failuresBefore);
+    expect(mocks.calls).toHaveLength(3);
+  });
+});

--- a/src/server/services/mcp/client.test.ts
+++ b/src/server/services/mcp/client.test.ts
@@ -6,6 +6,8 @@
  */
 import { describe, it, expect, beforeEach, vi } from "vitest";
 
+import { callOliveMcpTools, callOliveMcpTool, MCP_UNAVAILABLE_ERROR } from "./client.ts";
+import mcpBreaker, { resetMcpBreaker } from "./breaker.ts";
 import {
   childProcessVitestMockFactory,
   createChildProcessTestHandles,
@@ -14,9 +16,6 @@ import {
 const mocks = vi.hoisted(() => createChildProcessTestHandles());
 
 vi.mock("child_process", childProcessVitestMockFactory(mocks));
-
-import { callOliveMcpTools, callOliveMcpTool, MCP_UNAVAILABLE_ERROR } from "./client.ts";
-import mcpBreaker, { resetMcpBreaker } from "./breaker.ts";
 
 /** Makes the next execFile call resolve with the given stdout/stderr. */
 function mockExecFileResolve(stdout: string, stderr = ""): void {

--- a/src/server/services/mcp/client.ts
+++ b/src/server/services/mcp/client.ts
@@ -7,8 +7,13 @@ import { existsSync } from "fs";
 import { promisify } from "util";
 import path from "path";
 import { getVenvPython } from "../venv/paths.ts";
+import mcpBreaker from "./breaker.ts";
 
 const execFileAsync = promisify(execFile);
+
+/** Client-safe message returned when the MCP server is short-circuited or down. */
+export const MCP_UNAVAILABLE_ERROR =
+  "MCP server unavailable — verify the Olive MCP server is installed before retrying.";
 
 /** Resolves the Python executable used to run MCP tools.
 
@@ -23,7 +28,7 @@ export function getMcpPython(): string {
   return getVenvPython();
 }
 
-export type McpToolCallResult = { result?: unknown; error?: string };
+export type McpToolCallResult = { result?: unknown; error?: string; unavailable?: boolean };
 
 /**
  * Removes characters that are not supported in an MCP tool name.
@@ -91,6 +96,10 @@ export type McpToolRequest = { toolName: string; args?: Record<string, unknown> 
 export async function callOliveMcpTools(requests: McpToolRequest[]): Promise<McpToolCallResult[]> {
   if (requests.length === 0) return [];
 
+  if (!mcpBreaker.beforeCall()) {
+    return requests.map(() => ({ error: MCP_UNAVAILABLE_ERROR, unavailable: true }));
+  }
+
   const payload = requests.map((r) => ({
     tool: sanitizeToolName(r.toolName),
     args: r.args ?? {},
@@ -122,11 +131,14 @@ export async function callOliveMcpTools(requests: McpToolRequest[]): Promise<Mcp
     try {
       const parsed = JSON.parse(output);
       if (!Array.isArray(parsed)) {
-        return requests.map(() => ({ error: "MCP batch returned non-array JSON" }));
+        mcpBreaker.recordFailure();
+        return requests.map(() => ({ error: "MCP batch returned non-array JSON", unavailable: true }));
       }
-      return requests.map((req, i) => {
+      const results = requests.map((req, i) => {
         const row = parsed[i];
-        if (!isObjectRecord(row)) return { error: `MCP tool ${req.toolName} missing from batch` };
+        if (!isObjectRecord(row)) {
+          return { error: `MCP tool ${req.toolName} missing from batch`, unavailable: true };
+        }
         if (typeof row.error === "string" && row.error) return { error: row.error };
         const inner = row.result;
         if (isObjectRecord(inner) && typeof inner.error === "string" && inner.error) {
@@ -134,17 +146,28 @@ export async function callOliveMcpTools(requests: McpToolRequest[]): Promise<Mcp
         }
         return { result: inner };
       });
+      if (results.some((r) => r.unavailable === true)) {
+        // A missing row is a protocol/contract violation — infra failure, like non-array JSON.
+        mcpBreaker.recordFailure();
+      } else {
+        mcpBreaker.recordSuccess();
+      }
+      return results;
     } catch {
+      mcpBreaker.recordFailure();
       return requests.map((req) => ({
         error: output
           ? `MCP tool ${sanitizeToolName(req.toolName)} returned non-JSON: ${output.slice(0, 300)}`
           : `MCP tool ${sanitizeToolName(req.toolName)} returned empty output`,
+        unavailable: true,
       }));
     }
   } catch (err: unknown) {
     const msg = err instanceof Error ? err.message : String(err);
+    mcpBreaker.recordFailure();
     return requests.map((req) => ({
       error: msg || `MCP tool ${sanitizeToolName(req.toolName)} failed`,
+      unavailable: true,
     }));
   }
 }

--- a/src/server/services/mcp/client.ts
+++ b/src/server/services/mcp/client.ts
@@ -96,9 +96,11 @@ export type McpToolRequest = { toolName: string; args?: Record<string, unknown> 
 export async function callOliveMcpTools(requests: McpToolRequest[]): Promise<McpToolCallResult[]> {
   if (requests.length === 0) return [];
 
-  if (!mcpBreaker.beforeCall()) {
+  const admission = mcpBreaker.beforeCall();
+  if (!admission) {
     return requests.map(() => ({ error: MCP_UNAVAILABLE_ERROR, unavailable: true }));
   }
+  const { epoch } = admission;
 
   const payload = requests.map((r) => ({
     tool: sanitizeToolName(r.toolName),
@@ -131,7 +133,7 @@ export async function callOliveMcpTools(requests: McpToolRequest[]): Promise<Mcp
     try {
       const parsed = JSON.parse(output);
       if (!Array.isArray(parsed)) {
-        mcpBreaker.recordFailure();
+        mcpBreaker.recordFailure(epoch);
         return requests.map(() => ({ error: "MCP batch returned non-array JSON", unavailable: true }));
       }
       const results = requests.map((req, i) => {
@@ -148,13 +150,13 @@ export async function callOliveMcpTools(requests: McpToolRequest[]): Promise<Mcp
       });
       if (results.some((r) => r.unavailable === true)) {
         // A missing row is a protocol/contract violation — infra failure, like non-array JSON.
-        mcpBreaker.recordFailure();
+        mcpBreaker.recordFailure(epoch);
       } else {
-        mcpBreaker.recordSuccess();
+        mcpBreaker.recordSuccess(epoch);
       }
       return results;
     } catch {
-      mcpBreaker.recordFailure();
+      mcpBreaker.recordFailure(epoch);
       return requests.map((req) => ({
         error: output
           ? `MCP tool ${sanitizeToolName(req.toolName)} returned non-JSON: ${output.slice(0, 300)}`
@@ -164,7 +166,7 @@ export async function callOliveMcpTools(requests: McpToolRequest[]): Promise<Mcp
     }
   } catch (err: unknown) {
     const msg = err instanceof Error ? err.message : String(err);
-    mcpBreaker.recordFailure();
+    mcpBreaker.recordFailure(epoch);
     return requests.map((req) => ({
       error: msg || `MCP tool ${sanitizeToolName(req.toolName)} failed`,
       unavailable: true,


### PR DESCRIPTION
## Summary
- Async CLI probing with single-flight + TTL cache for local engines
- Abortable backoff polling for engine readiness
- MCP proxy circuit breaker with 503 short-circuit when infra is unhealthy

## Stack
- PR 2 of 4 (base: #125)
- Next: bodyGuard middleware

## Test plan
- [ ] pnpm test:server
- [ ] pnpm test:integration

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tonythethompson/Olive-Studio/pull/126?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

