### PR TITLE
feat: bodyGuard middleware for type-safe request parsing (tech-debt #13)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,4 @@ bun.lock
 /.playwright-mcp
 /.cursor/worktrees
 /.amazonq
+install.sh

--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,4 @@ bun.lock
 /.cursor/worktrees
 /.amazonq
 install.sh
+/node_modules.stale-body-guard

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,6 +10,7 @@ overrides:
   body-parser@<1.20.6: '>=1.20.6'
   uuid@<11.1.1: '>=11.1.1'
   fast-uri@>=3.0.0 <3.1.5: '>=3.1.5'
+  js-yaml@>=4.0.0 <4.3.1: '>=4.3.1 <5.0.0'
   minimatch: ^10.2.5
   brace-expansion: '>=5.0.9'
   adm-zip@<0.6.0: '>=0.6.0 <1.0.0'
@@ -3492,8 +3493,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   jsdoc-type-pratt-parser@4.8.0:
@@ -5433,7 +5434,7 @@ snapshots:
       globals: 14.0.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       minimatch: 10.2.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -7163,7 +7164,7 @@ snapshots:
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.1
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       parse-json: 5.2.0
     optionalDependencies:
       typescript: 6.0.3
@@ -8179,7 +8180,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.3.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -14,6 +14,8 @@ overrides:
   uuid@<11.1.1: '>=11.1.1'
   # GHSA-7p8r-x3mc-p8w7: fast-uri host confusion via backslash authority (dev: commitlint → ajv).
   'fast-uri@>=3.0.0 <3.1.5': '>=3.1.5'
+  # GHSA-5p4m-2wfm-xmqj / CVE-2026-59870: js-yaml !!omap quadratic CPU (dev: eslint/commitlint).
+  'js-yaml@>=4.0.0 <4.3.1': '>=4.3.1 <5.0.0'
   minimatch: '^10.2.5'
   brace-expansion: '>=5.0.9'
   # @huggingface/transformers → onnxruntime-node / sharp (arena local NLP).

--- a/src/lib/__tests__/pipelineValidation.test.ts
+++ b/src/lib/__tests__/pipelineValidation.test.ts
@@ -20,6 +20,7 @@ import {
   isProviderCompatibleWithPasses,
   getQuantMethodActivationBlock,
   prepareProviderChange,
+  parseUIStatePayload,
 } from "@/lib/pipelineValidation";
 import { DEFAULT_PASSES } from "@/lib/defaultPasses";
 import type { UIState, IHVProvider } from "@/types";
@@ -705,5 +706,21 @@ describe("commitUiStateUpdate", () => {
     });
     expect(n.ihvProvider).toBe("CPUExecutionProvider");
     expect(n.passes.conversionFormat).toBe("onnx");
+  });
+});
+
+describe("parseUIStatePayload", () => {
+  it("accepts a complete UIState payload", () => {
+    const result = parseUIStatePayload(baseState());
+    expect(result.ok).toBe(true);
+  });
+
+  it("rejects incomplete state objects", () => {
+    const result = parseUIStatePayload({
+      modelSource: "huggingface",
+      ihvProvider: "CPUExecutionProvider",
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toContain("passes");
   });
 });

--- a/src/lib/pipelineValidation.ts
+++ b/src/lib/pipelineValidation.ts
@@ -1,4 +1,4 @@
-import { IHVProvider, UIState, OliveRecipe } from "@/types";
+import { IHVProvider, ModelSource, UIState, OliveRecipe } from "@/types";
 import { isMemoryOffloadAvailable } from "@/lib/memoryOffload";
 import { getProviderAvailabilityBlock, type HardwareProbeResult } from "@/lib/hardwareProbe";
 import { buildOliveRecipe, isPyTorchNativeQuantMethod } from "@/lib/oliveRecipeBuilder";
@@ -886,6 +886,54 @@ export function sanitizePipelineState(state: UIState): UIState {
   }
 
   return current;
+}
+
+const UI_STATE_MODEL_SOURCES = new Set<ModelSource>(["huggingface", "local", "azure"]);
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/** Validates an untrusted `state` payload before `buildAiWorkspaceContext`. */
+export function parseUIStatePayload(
+  value: unknown,
+): { ok: true; state: UIState } | { ok: false; error: string } {
+  if (!isPlainRecord(value)) {
+    return { ok: false, error: "state must be a JSON object" };
+  }
+  if (
+    typeof value.modelSource !== "string" ||
+    !UI_STATE_MODEL_SOURCES.has(value.modelSource as ModelSource)
+  ) {
+    return { ok: false, error: "state.modelSource is invalid" };
+  }
+  if (typeof value.ihvProvider !== "string" || !value.ihvProvider.endsWith("ExecutionProvider")) {
+    return { ok: false, error: "state.ihvProvider is invalid" };
+  }
+  if (!isPlainRecord(value.passes)) {
+    return { ok: false, error: "state.passes must be a JSON object" };
+  }
+  if (!Array.isArray(value.localFiles)) {
+    return { ok: false, error: "state.localFiles must be an array" };
+  }
+  for (const field of [
+    "hfModelId",
+    "hfDataset",
+    "azureModelPath",
+    "cacheDir",
+    "azureStr",
+    "openvinoTargetDevice",
+    "memoryOffload",
+    "cudaVersion",
+  ] as const) {
+    if (typeof value[field] !== "string") {
+      return { ok: false, error: `state.${field} must be a string` };
+    }
+  }
+  if (typeof value.distributedCaching !== "boolean") {
+    return { ok: false, error: "state.distributedCaching must be a boolean" };
+  }
+  return { ok: true, state: value as unknown as UIState };
 }
 
 export function commitUiStateUpdate(prev: UIState, partial: Partial<UIState>): UIState {

--- a/src/server/__tests__/routes.integration.test.ts
+++ b/src/server/__tests__/routes.integration.test.ts
@@ -163,6 +163,25 @@ describe("Route integration tests", () => {
     });
   });
 
+  // ─── POST /api/ai/analyze-state ────────────────────────────────────────────
+
+  describe("POST /api/ai/analyze-state", () => {
+    it("returns 400 when state is incomplete", async () => {
+      const res = await fetch(`${baseUrl}/api/ai/analyze-state`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          state: { modelSource: "huggingface", ihvProvider: "CPUExecutionProvider" },
+        }),
+      });
+
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body).toHaveProperty("error");
+      expect(String(body.error)).toContain("passes");
+    });
+  });
+
   // ─── GET /api/mcp/kb-status ──────────────────────────────────────────────
 
   describe("GET /api/mcp/kb-status", () => {

--- a/src/server/middleware/bodyGuard.test.ts
+++ b/src/server/middleware/bodyGuard.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+
+import { parseBody } from "./bodyGuard.ts";
+
+describe("parseBody", () => {
+  it("treats an empty string as missing for required json fields", () => {
+    const result = parseBody<{ recipe: unknown }>({ recipe: "" }, {
+      recipe: { type: "json", message: "Missing recipe" },
+    });
+
+    expect(result).toEqual({ error: "Missing recipe" });
+  });
+
+  it("treats an empty string as missing for required string fields", () => {
+    const result = parseBody<{ token: string }>({ token: "" }, {
+      token: { type: "string" },
+    });
+
+    expect(result).toEqual({ error: "token is required and must be a string" });
+  });
+
+  it("accepts a non-empty JSON string for json fields", () => {
+    const result = parseBody<{ recipe: unknown }>({ recipe: '{"passes":{}}' }, {
+      recipe: { type: "json" },
+    });
+
+    expect(result).toEqual({ parsed: { recipe: '{"passes":{}}' } });
+  });
+
+  it("omits optional json fields when the value is an empty string", () => {
+    const result = parseBody<{ note?: unknown }>({ note: "" }, {
+      note: { type: "json", required: false },
+    });
+
+    expect(result).toEqual({ parsed: {} });
+  });
+});

--- a/src/server/middleware/bodyGuard.test.ts
+++ b/src/server/middleware/bodyGuard.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 
-import { parseBody } from "./bodyGuard.ts";
+import { parseBody, isParseBodyError } from "./bodyGuard.ts";
 
 describe("parseBody", () => {
   it("treats an empty string as missing for required json fields", () => {
@@ -33,5 +33,13 @@ describe("parseBody", () => {
     });
 
     expect(result).toEqual({ parsed: {} });
+  });
+
+  it("narrows error results with isParseBodyError", () => {
+    const result = parseBody<{ token: string }>({}, { token: { type: "string" } });
+    expect(isParseBodyError(result)).toBe(true);
+    if (isParseBodyError(result)) {
+      expect(result.error).toContain("token is required");
+    }
   });
 });

--- a/src/server/middleware/bodyGuard.test.ts
+++ b/src/server/middleware/bodyGuard.test.ts
@@ -19,6 +19,14 @@ describe("parseBody", () => {
     expect(result).toEqual({ error: "token is required and must be a string" });
   });
 
+  it("rejects malformed JSON strings for json fields", () => {
+    const result = parseBody<{ recipe: unknown }>({ recipe: "{ not json " }, {
+      recipe: { type: "json", message: "Missing recipe" },
+    });
+
+    expect(result).toEqual({ error: "recipe must be a string or JSON object" });
+  });
+
   it("accepts a non-empty JSON string for json fields", () => {
     const result = parseBody<{ recipe: unknown }>({ recipe: '{"passes":{}}' }, {
       recipe: { type: "json" },

--- a/src/server/middleware/bodyGuard.ts
+++ b/src/server/middleware/bodyGuard.ts
@@ -53,7 +53,17 @@ const TYPE_CHECKERS: Record<BodyFieldType, (value: unknown) => boolean> = {
   "string[]": (value) =>
     Array.isArray(value) && value.every((item) => typeof item === "string"),
   // Recipes arrive either pre-parsed or as a JSON string.
-  json: (value) => typeof value === "string" || isPlainObject(value),
+function isJsonString(value: string): boolean {
+  try {
+    JSON.parse(value);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const TYPE_CHECKERS: Record<BodyFieldType, (value: unknown) => boolean> = {
+  json: (value) => isPlainObject(value) || (typeof value === "string" && isJsonString(value)),
   // Pass-through fields with their own lenient handling downstream (e.g. clamps).
   // Does not narrow the parsed generic — callers must treat these as `unknown`.
   unknown: () => true,

--- a/src/server/middleware/bodyGuard.ts
+++ b/src/server/middleware/bodyGuard.ts
@@ -32,7 +32,9 @@ export type BodySpec<T extends Record<string, unknown>> = {
   [K in keyof T]: BodyFieldSpec;
 };
 
-export type ParseBodyResult<T> = { parsed: T } | { error: string };
+export type ParseBodyResult<T> =
+  | { parsed: T; error?: never }
+  | { error: string; parsed?: never };
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -43,7 +45,7 @@ const TYPE_CHECKERS: Record<BodyFieldType, (value: unknown) => boolean> = {
   number: (value) => typeof value === "number" && Number.isFinite(value),
   boolean: (value) => typeof value === "boolean",
   object: (value) => isPlainObject(value),
-  string[]: (value) =>
+  "string[]": (value) =>
     Array.isArray(value) && value.every((item) => typeof item === "string"),
   // Recipes arrive either pre-parsed or as a JSON string.
   json: (value) => typeof value === "string" || isPlainObject(value),
@@ -56,7 +58,7 @@ const TYPE_DESCRIPTIONS: Record<BodyFieldType, string> = {
   number: "a number",
   boolean: "a boolean",
   object: "an object",
-  string[]: "an array of strings",
+  "string[]": "an array of strings",
   json: "a string or JSON object",
   unknown: "a value",
 };

--- a/src/server/middleware/bodyGuard.ts
+++ b/src/server/middleware/bodyGuard.ts
@@ -55,6 +55,7 @@ const TYPE_CHECKERS: Record<BodyFieldType, (value: unknown) => boolean> = {
   // Recipes arrive either pre-parsed or as a JSON string.
   json: (value) => typeof value === "string" || isPlainObject(value),
   // Pass-through fields with their own lenient handling downstream (e.g. clamps).
+  // Does not narrow the parsed generic — callers must treat these as `unknown`.
   unknown: () => true,
 };
 

--- a/src/server/middleware/bodyGuard.ts
+++ b/src/server/middleware/bodyGuard.ts
@@ -36,6 +36,11 @@ export type ParseBodyResult<T> =
   | { parsed: T; error?: never }
   | { error: string; parsed?: never };
 
+/** Narrows a `parseBody` result to the error branch for safe early returns. */
+export function isParseBodyError<T>(result: ParseBodyResult<T>): result is { error: string } {
+  return "error" in result;
+}
+
 function isPlainObject(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }

--- a/src/server/middleware/bodyGuard.ts
+++ b/src/server/middleware/bodyGuard.ts
@@ -45,14 +45,6 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-const TYPE_CHECKERS: Record<BodyFieldType, (value: unknown) => boolean> = {
-  string: (value) => typeof value === "string",
-  number: (value) => typeof value === "number" && Number.isFinite(value),
-  boolean: (value) => typeof value === "boolean",
-  object: (value) => isPlainObject(value),
-  "string[]": (value) =>
-    Array.isArray(value) && value.every((item) => typeof item === "string"),
-  // Recipes arrive either pre-parsed or as a JSON string.
 function isJsonString(value: string): boolean {
   try {
     JSON.parse(value);
@@ -63,6 +55,13 @@ function isJsonString(value: string): boolean {
 }
 
 const TYPE_CHECKERS: Record<BodyFieldType, (value: unknown) => boolean> = {
+  string: (value) => typeof value === "string",
+  number: (value) => typeof value === "number" && Number.isFinite(value),
+  boolean: (value) => typeof value === "boolean",
+  object: (value) => isPlainObject(value),
+  "string[]": (value) =>
+    Array.isArray(value) && value.every((item) => typeof item === "string"),
+  // Recipes arrive either pre-parsed or as a JSON string.
   json: (value) => isPlainObject(value) || (typeof value === "string" && isJsonString(value)),
   // Pass-through fields with their own lenient handling downstream (e.g. clamps).
   // Does not narrow the parsed generic — callers must treat these as `unknown`.

--- a/src/server/middleware/bodyGuard.ts
+++ b/src/server/middleware/bodyGuard.ts
@@ -40,7 +40,7 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
 
 const TYPE_CHECKERS: Record<BodyFieldType, (value: unknown) => boolean> = {
   string: (value) => typeof value === "string",
-  number: (value) => typeof value === "number",
+  number: (value) => typeof value === "number" && Number.isFinite(value),
   boolean: (value) => typeof value === "boolean",
   object: (value) => isPlainObject(value),
   string[]: (value) =>
@@ -61,10 +61,10 @@ const TYPE_DESCRIPTIONS: Record<BodyFieldType, string> = {
   unknown: "a value",
 };
 
-/** Undefined, null, and (for strings) the empty string all count as absent. */
+/** Undefined, null, and empty strings for string-like fields count as absent. */
 function isFieldMissing(spec: BodyFieldSpec, value: unknown): boolean {
   if (value === undefined || value === null) return true;
-  return spec.type === "string" && value === "";
+  return (spec.type === "string" || spec.type === "json") && value === "";
 }
 
 export function parseBody<T extends Record<string, unknown>>(

--- a/src/server/middleware/bodyGuard.ts
+++ b/src/server/middleware/bodyGuard.ts
@@ -1,0 +1,99 @@
+/**
+ * Request-body boundary parser for route handlers.
+ *
+ * Express's `express.json()` middleware leaves `req.body` as `any`: a client
+ * can send a number where the handler expects a string, or an array where it
+ * expects an object. `parseBody` converts that untyped value into a
+ * discriminated result so handlers only ever touch trusted, field-typed data
+ * (Law 2: parse at the boundary, don't validate deep in the handler).
+ */
+export type BodyFieldType =
+  | "string"
+  | "number"
+  | "boolean"
+  | "object"
+  | "string[]"
+  | "json"
+  | "unknown";
+
+export interface BodyFieldSpec {
+  /** The shape the field must have when present. */
+  type: BodyFieldType;
+  /** Whether the field must be present. Defaults to `true`. */
+  required?: boolean;
+  /**
+   * Overrides the error returned when a required field is absent.
+   * Type mismatches always use the generated `"<field> must be <type>"` message.
+   */
+  message?: string;
+}
+
+export type BodySpec<T extends Record<string, unknown>> = {
+  [K in keyof T]: BodyFieldSpec;
+};
+
+export type ParseBodyResult<T> = { parsed: T } | { error: string };
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+const TYPE_CHECKERS: Record<BodyFieldType, (value: unknown) => boolean> = {
+  string: (value) => typeof value === "string",
+  number: (value) => typeof value === "number",
+  boolean: (value) => typeof value === "boolean",
+  object: (value) => isPlainObject(value),
+  string[]: (value) =>
+    Array.isArray(value) && value.every((item) => typeof item === "string"),
+  // Recipes arrive either pre-parsed or as a JSON string.
+  json: (value) => typeof value === "string" || isPlainObject(value),
+  // Pass-through fields with their own lenient handling downstream (e.g. clamps).
+  unknown: () => true,
+};
+
+const TYPE_DESCRIPTIONS: Record<BodyFieldType, string> = {
+  string: "a string",
+  number: "a number",
+  boolean: "a boolean",
+  object: "an object",
+  string[]: "an array of strings",
+  json: "a string or JSON object",
+  unknown: "a value",
+};
+
+/** Undefined, null, and (for strings) the empty string all count as absent. */
+function isFieldMissing(spec: BodyFieldSpec, value: unknown): boolean {
+  if (value === undefined || value === null) return true;
+  return spec.type === "string" && value === "";
+}
+
+export function parseBody<T extends Record<string, unknown>>(
+  body: unknown,
+  spec: BodySpec<T>,
+): ParseBodyResult<T> {
+  if (!isPlainObject(body)) {
+    return { error: "Request body must be a JSON object" };
+  }
+
+  const parsed: Record<string, unknown> = {};
+  for (const field of Object.keys(spec) as Array<keyof T & string>) {
+    const fieldSpec = spec[field];
+    const value = body[field];
+    if (isFieldMissing(fieldSpec, value)) {
+      if (fieldSpec.required ?? true) {
+        return {
+          error:
+            fieldSpec.message ??
+            `${field} is required and must be ${TYPE_DESCRIPTIONS[fieldSpec.type]}`,
+        };
+      }
+      continue;
+    }
+    if (!TYPE_CHECKERS[fieldSpec.type](value)) {
+      return { error: `${field} must be ${TYPE_DESCRIPTIONS[fieldSpec.type]}` };
+    }
+    parsed[field] = value;
+  }
+
+  return { parsed: parsed as T };
+}

--- a/src/server/routes/ai/chatRoutes.ts
+++ b/src/server/routes/ai/chatRoutes.ts
@@ -4,6 +4,8 @@
  */
 import type { Router } from "express";
 
+import { parseBody } from "../../middleware/bodyGuard.ts";
+
 import { callAI } from "../../services/ai/index.ts";
 import {
   buildOliveAssistantSystemPrompt,
@@ -20,11 +22,25 @@ import {
 import { CHAT_JSON_RESPONSE_CONTRACT, parseChatStructuredReply } from "../../../lib/chatActions.ts";
 import { getChatScopeBlock } from "../../../lib/chatScope.ts";
 import { validateOliveRecipeStructure } from "../../../lib/oliveRecipeSchema.ts";
+import type { UIState } from "../../../types.ts";
 
 export function mountChatRoutes(router: Router): void {
   router.post("/ai/chat", async (req, res) => {
-    const { message, chatHistory, workspaceContext, state } = req.body ?? {};
-    if (!message || typeof message !== "string") return res.status(400).json({ error: "Missing message" });
+    const body = parseBody<{
+      message: string;
+      chatHistory?: unknown;
+      workspaceContext?: unknown;
+      state?: UIState;
+    }>(req.body, {
+      message: { type: "string", message: "Missing message" },
+      // Optional context fields are lenient by design: the handler ignores
+      // malformed values, so pass them through unvalidated (unknown).
+      chatHistory: { type: "unknown", required: false },
+      workspaceContext: { type: "unknown", required: false },
+      state: { type: "unknown", required: false },
+    });
+    if (!body.parsed) return res.status(400).json({ error: body.error });
+    const { message, chatHistory, workspaceContext, state } = body.parsed;
     try {
       const scopeBlock = getChatScopeBlock(message);
       if (scopeBlock) {
@@ -82,8 +98,11 @@ export function mountChatRoutes(router: Router): void {
   // ─── Pipeline Validation & Analysis ──────────────────────────────────────
 
   router.post("/ai/validate", async (req, res) => {
-    const { recipe } = req.body ?? {};
-    if (!recipe) return res.status(400).json({ error: "Missing recipe" });
+    const body = parseBody<{ recipe: unknown }>(req.body, {
+      recipe: { type: "json", message: "Missing recipe" },
+    });
+    if (!body.parsed) return res.status(400).json({ error: body.error });
+    const { recipe } = body.parsed;
     try {
       const validation = validateOliveRecipeStructure(
         typeof recipe === "string" ? JSON.parse(recipe) : recipe,
@@ -105,8 +124,11 @@ export function mountChatRoutes(router: Router): void {
   });
 
   router.post("/ai/analyze-state", async (req, res) => {
-    const { state } = req.body ?? {};
-    if (!state) return res.status(400).json({ error: "Missing state" });
+    const body = parseBody<{ state: UIState }>(req.body, {
+      state: { type: "object", message: "Missing state" },
+    });
+    if (!body.parsed) return res.status(400).json({ error: body.error });
+    const { state } = body.parsed;
     try {
       const ctx = buildAiWorkspaceContext(state);
       // Cap context so small models still have room for full-sentence JSON.

--- a/src/server/routes/ai/chatRoutes.ts
+++ b/src/server/routes/ai/chatRoutes.ts
@@ -30,7 +30,7 @@ export function mountChatRoutes(router: Router): void {
       message: string;
       chatHistory?: unknown;
       workspaceContext?: unknown;
-      state?: UIState;
+      state?: unknown;
     }>(req.body, {
       message: { type: "string", message: "Missing message" },
       // Optional context fields are lenient by design: the handler ignores
@@ -58,7 +58,7 @@ export function mountChatRoutes(router: Router): void {
         if (workspaceContext && typeof workspaceContext === "object") {
           workspace = workspaceContext as AiWorkspaceContext;
         } else if (state && typeof state === "object") {
-          workspace = buildAiWorkspaceContext(state);
+          workspace = buildAiWorkspaceContext(state as UIState);
         }
         workspaceBlock = workspace ? formatAiWorkspaceContextForPrompt(workspace) : null;
       } catch {

--- a/src/server/routes/ai/chatRoutes.ts
+++ b/src/server/routes/ai/chatRoutes.ts
@@ -4,7 +4,7 @@
  */
 import type { Router } from "express";
 
-import { parseBody } from "../../middleware/bodyGuard.ts";
+import { parseBody, isParseBodyError } from "../../middleware/bodyGuard.ts";
 
 import { callAI } from "../../services/ai/index.ts";
 import {
@@ -39,7 +39,7 @@ export function mountChatRoutes(router: Router): void {
       workspaceContext: { type: "unknown", required: false },
       state: { type: "unknown", required: false },
     });
-    if (!body.parsed) return res.status(400).json({ error: body.error });
+    if (isParseBodyError(body)) return res.status(400).json({ error: body.error });
     const { message, chatHistory, workspaceContext, state } = body.parsed;
     try {
       const scopeBlock = getChatScopeBlock(message);
@@ -101,7 +101,7 @@ export function mountChatRoutes(router: Router): void {
     const body = parseBody<{ recipe: unknown }>(req.body, {
       recipe: { type: "json", message: "Missing recipe" },
     });
-    if (!body.parsed) return res.status(400).json({ error: body.error });
+    if (isParseBodyError(body)) return res.status(400).json({ error: body.error });
     const { recipe } = body.parsed;
     try {
       const validation = validateOliveRecipeStructure(
@@ -127,7 +127,7 @@ export function mountChatRoutes(router: Router): void {
     const body = parseBody<{ state: UIState }>(req.body, {
       state: { type: "object", message: "Missing state" },
     });
-    if (!body.parsed) return res.status(400).json({ error: body.error });
+    if (isParseBodyError(body)) return res.status(400).json({ error: body.error });
     const { state } = body.parsed;
     try {
       const ctx = buildAiWorkspaceContext(state);

--- a/src/server/routes/ai/chatRoutes.ts
+++ b/src/server/routes/ai/chatRoutes.ts
@@ -22,7 +22,7 @@ import {
 import { CHAT_JSON_RESPONSE_CONTRACT, parseChatStructuredReply } from "../../../lib/chatActions.ts";
 import { getChatScopeBlock } from "../../../lib/chatScope.ts";
 import { validateOliveRecipeStructure } from "../../../lib/oliveRecipeSchema.ts";
-import type { UIState } from "../../../types.ts";
+import { parseUIStatePayload } from "../../../lib/pipelineValidation.ts";
 
 export function mountChatRoutes(router: Router): void {
   router.post("/ai/chat", async (req, res) => {
@@ -58,7 +58,8 @@ export function mountChatRoutes(router: Router): void {
         if (workspaceContext && typeof workspaceContext === "object") {
           workspace = workspaceContext as AiWorkspaceContext;
         } else if (state && typeof state === "object") {
-          workspace = buildAiWorkspaceContext(state as UIState);
+          const parsedState = parseUIStatePayload(state);
+          if (parsedState.ok) workspace = buildAiWorkspaceContext(parsedState.state);
         }
         workspaceBlock = workspace ? formatAiWorkspaceContextForPrompt(workspace) : null;
       } catch {
@@ -124,11 +125,13 @@ export function mountChatRoutes(router: Router): void {
   });
 
   router.post("/ai/analyze-state", async (req, res) => {
-    const body = parseBody<{ state: UIState }>(req.body, {
+    const body = parseBody<{ state: unknown }>(req.body, {
       state: { type: "object", message: "Missing state" },
     });
     if (isParseBodyError(body)) return res.status(400).json({ error: body.error });
-    const { state } = body.parsed;
+    const parsedState = parseUIStatePayload(body.parsed.state);
+    if (!parsedState.ok) return res.status(400).json({ error: parsedState.error });
+    const { state } = parsedState;
     try {
       const ctx = buildAiWorkspaceContext(state);
       // Cap context so small models still have room for full-sentence JSON.

--- a/src/server/routes/ai/codexRoutes.ts
+++ b/src/server/routes/ai/codexRoutes.ts
@@ -4,6 +4,7 @@ import type { Router } from "express";
 import { getCodexAppServer } from "../../../lib/codex/CodexAppServerClient.ts";
 import { codexAsk } from "../../../lib/codex/codexAgent.ts";
 import { authActionRateLimit } from "../../middleware/rateLimit.ts";
+import { parseBody } from "../../middleware/bodyGuard.ts";
 
 export function mountCodexRoutes(router: Router): void {
   router.get("/codex/account", async (_req, res) => {
@@ -35,12 +36,13 @@ export function mountCodexRoutes(router: Router): void {
   });
 
   router.post("/codex/login/cancel", authActionRateLimit, async (req, res) => {
+    const body = parseBody<{ loginId?: string }>(req.body, {
+      loginId: { type: "string", required: false },
+    });
+    if (!body.parsed) return res.status(400).json({ error: body.error });
     try {
       const server = getCodexAppServer();
-      if (server.isReady) {
-        const { loginId } = req.body ?? {};
-        if (loginId) await server.cancelLogin(loginId);
-      }
+      if (server.isReady && body.parsed.loginId) await server.cancelLogin(body.parsed.loginId);
       return res.json({ ok: true });
     } catch {
       return res.json({ ok: true });
@@ -69,10 +71,16 @@ export function mountCodexRoutes(router: Router): void {
   });
 
   router.post("/codex/ask", async (req, res) => {
-    const { prompt, model } = req.body ?? {};
-    if (!prompt) return res.status(400).json({ error: "Missing prompt" });
+    const body = parseBody<{ prompt: string; model?: string }>(req.body, {
+      prompt: { type: "string", message: "Missing prompt" },
+      model: { type: "string", required: false },
+    });
+    if (!body.parsed) return res.status(400).json({ error: body.error });
     try {
-      const reply = await codexAsk(prompt, { workingDirectory: process.cwd(), model: model || undefined });
+      const reply = await codexAsk(body.parsed.prompt, {
+        workingDirectory: process.cwd(),
+        model: body.parsed.model || undefined,
+      });
       return res.json({ reply });
     } catch (err: unknown) {
       return res.status(500).json({ error: err instanceof Error ? err.message : String(err) });

--- a/src/server/routes/ai/codexRoutes.ts
+++ b/src/server/routes/ai/codexRoutes.ts
@@ -4,7 +4,7 @@ import type { Router } from "express";
 import { getCodexAppServer } from "../../../lib/codex/CodexAppServerClient.ts";
 import { codexAsk } from "../../../lib/codex/codexAgent.ts";
 import { authActionRateLimit } from "../../middleware/rateLimit.ts";
-import { parseBody } from "../../middleware/bodyGuard.ts";
+import { parseBody, isParseBodyError } from "../../middleware/bodyGuard.ts";
 
 export function mountCodexRoutes(router: Router): void {
   router.get("/codex/account", async (_req, res) => {
@@ -39,7 +39,7 @@ export function mountCodexRoutes(router: Router): void {
     const body = parseBody<{ loginId?: string }>(req.body, {
       loginId: { type: "string", required: false },
     });
-    if (!body.parsed) return res.status(400).json({ error: body.error });
+    if (isParseBodyError(body)) return res.status(400).json({ error: body.error });
     try {
       const server = getCodexAppServer();
       if (server.isReady && body.parsed.loginId) await server.cancelLogin(body.parsed.loginId);
@@ -75,7 +75,7 @@ export function mountCodexRoutes(router: Router): void {
       prompt: { type: "string", message: "Missing prompt" },
       model: { type: "string", required: false },
     });
-    if (!body.parsed) return res.status(400).json({ error: body.error });
+    if (isParseBodyError(body)) return res.status(400).json({ error: body.error });
     try {
       const reply = await codexAsk(body.parsed.prompt, {
         workingDirectory: process.cwd(),

--- a/src/server/routes/ai/devinRoutes.ts
+++ b/src/server/routes/ai/devinRoutes.ts
@@ -25,7 +25,7 @@ export function mountDevinRoutes(router: Router): void {
     const body = parseBody<{ token: string }>(req.body, {
       token: { type: "string", message: "Missing token" },
     });
-    if (isParseBodyError(body)) return res.status(400).json({ error: body.error });
+    if (isParseBodyError(body)) return res.status(400).json({ ok: false, error: body.error });
     try {
       const result = await finishDevinLogin(body.parsed.token);
       return res.json({ ok: true, ...result });

--- a/src/server/routes/ai/devinRoutes.ts
+++ b/src/server/routes/ai/devinRoutes.ts
@@ -9,6 +9,7 @@ import {
   logoutDevin,
 } from "../../../lib/devin/client.ts";
 import { authActionRateLimit } from "../../middleware/rateLimit.ts";
+import { parseBody } from "../../middleware/bodyGuard.ts";
 
 export function mountDevinRoutes(router: Router): void {
   router.get("/devin/account", (_req, res) => {
@@ -21,10 +22,12 @@ export function mountDevinRoutes(router: Router): void {
   });
 
   router.post("/devin/login/complete", authActionRateLimit, async (req, res) => {
-    const { token } = req.body ?? {};
-    if (!token) return res.status(400).json({ ok: false, error: "Missing token" });
+    const body = parseBody<{ token: string }>(req.body, {
+      token: { type: "string", message: "Missing token" },
+    });
+    if (!body.parsed) return res.status(400).json({ error: body.error });
     try {
-      const result = await finishDevinLogin(token);
+      const result = await finishDevinLogin(body.parsed.token);
       return res.json({ ok: true, ...result });
     } catch (err: unknown) {
       return res.status(500).json({ ok: false, error: err instanceof Error ? err.message : String(err) });

--- a/src/server/routes/ai/devinRoutes.ts
+++ b/src/server/routes/ai/devinRoutes.ts
@@ -9,7 +9,7 @@ import {
   logoutDevin,
 } from "../../../lib/devin/client.ts";
 import { authActionRateLimit } from "../../middleware/rateLimit.ts";
-import { parseBody } from "../../middleware/bodyGuard.ts";
+import { parseBody, isParseBodyError } from "../../middleware/bodyGuard.ts";
 
 export function mountDevinRoutes(router: Router): void {
   router.get("/devin/account", (_req, res) => {
@@ -25,7 +25,7 @@ export function mountDevinRoutes(router: Router): void {
     const body = parseBody<{ token: string }>(req.body, {
       token: { type: "string", message: "Missing token" },
     });
-    if (!body.parsed) return res.status(400).json({ error: body.error });
+    if (isParseBodyError(body)) return res.status(400).json({ error: body.error });
     try {
       const result = await finishDevinLogin(body.parsed.token);
       return res.json({ ok: true, ...result });

--- a/src/server/routes/ai/installEngineRoutes.ts
+++ b/src/server/routes/ai/installEngineRoutes.ts
@@ -7,7 +7,7 @@ import rateLimit from "express-rate-limit";
 
 import { ensureOllamaReady, ensureLmsReady } from "./localEngines.ts";
 import { beginNdjsonStream, endNdjson, trackStreamClient } from "./streamHelpers.ts";
-import { parseBody } from "../../middleware/bodyGuard.ts";
+import { parseBody, isParseBodyError } from "../../middleware/bodyGuard.ts";
 
 const installEngineRateLimiter = rateLimit({
   windowMs: 5 * 60_000,
@@ -22,7 +22,7 @@ export function mountInstallEngineRoutes(router: Router): void {
     const body = parseBody<{ engine: string }>(req.body, {
       engine: { type: "string", message: "engine must be 'lms' or 'ollama'" },
     });
-    if (!body.parsed) return res.status(400).json({ error: body.error });
+    if (isParseBodyError(body)) return res.status(400).json({ error: body.error });
     const { engine } = body.parsed;
     if (engine !== "lms" && engine !== "ollama")
       return res.status(400).json({ error: "engine must be 'lms' or 'ollama'" });

--- a/src/server/routes/ai/installEngineRoutes.ts
+++ b/src/server/routes/ai/installEngineRoutes.ts
@@ -7,6 +7,7 @@ import rateLimit from "express-rate-limit";
 
 import { ensureOllamaReady, ensureLmsReady } from "./localEngines.ts";
 import { beginNdjsonStream, endNdjson, trackStreamClient } from "./streamHelpers.ts";
+import { parseBody } from "../../middleware/bodyGuard.ts";
 
 const installEngineRateLimiter = rateLimit({
   windowMs: 5 * 60_000,
@@ -18,7 +19,11 @@ const installEngineRateLimiter = rateLimit({
 
 export function mountInstallEngineRoutes(router: Router): void {
   router.post("/ai/install-engine", installEngineRateLimiter, async (req, res) => {
-    const { engine } = req.body ?? {};
+    const body = parseBody<{ engine: string }>(req.body, {
+      engine: { type: "string", message: "engine must be 'lms' or 'ollama'" },
+    });
+    if (!body.parsed) return res.status(400).json({ error: body.error });
+    const { engine } = body.parsed;
     if (engine !== "lms" && engine !== "ollama")
       return res.status(400).json({ error: "engine must be 'lms' or 'ollama'" });
     const guard = trackStreamClient(req, res);

--- a/src/server/routes/ai/lmStudioRoutes.ts
+++ b/src/server/routes/ai/lmStudioRoutes.ts
@@ -27,34 +27,7 @@ import {
   LMS_GET_MAX_MS,
 } from "./localEngines.ts";
 import { trackStreamClient, beginPullSse } from "./streamHelpers.ts";
-import { bodyGuard } from "../middleware/bodyGuard.ts";
-
-import type { Router } from "express";
-import { spawn } from "child_process";
-
-import { isValidLocalModelTag } from "../../../lib/localModelTag.ts";
-import {
-  hintForLmsPullFailure,
-  mapLmsDownloadPercent,
-  parseLmsGetPercent,
-  splitCliLines,
-} from "../../../lib/lmsPullProgress.ts";
-import { gateLocalPullDiskSpace } from "../../../lib/localEngineDisk.ts";
-import { heavyCommandRateLimit } from "../../middleware/rateLimit.ts";
-import { localEngineRuntime } from "../../services/ai/localEngineState.ts";
-import {
-  LM_STUDIO_PORT,
-  lmStudioFetchInit,
-  isLmsServerRunning,
-  findLmsCli,
-  listLmsInstalledModelKeys,
-  ensureLmsReady,
-  starterMetaForTag,
-  verifyInstalledAfterPull,
-  LMS_GET_MAX_MS,
-} from "./localEngines.ts";
-import { trackStreamClient, beginPullSse } from "./streamHelpers.ts";
-import { bodyGuard } from "../middleware/bodyGuard.ts";
+import { parseBody, isParseBodyError } from "../../middleware/bodyGuard.ts";
 
 export function mountLmStudioRoutes(router: Router): void {
   router.get("/ai/local-models", async (_req, res) => {
@@ -108,16 +81,12 @@ export function mountLmStudioRoutes(router: Router): void {
     return res.json({ healthy, lmsInstalled: !!lmsCli });
   });
 
-  router.post(
-    "/ai/local-load",
-    bodyGuard<{ modelTag: string }>({
-      modelTag: { type: "string", required: true },
-    }),
-    async (req, res) => {
-      const guardResult = req.body;
-      if ("error" in guardResult) return res.status(400).json({ error: guardResult.error });
-      const { modelTag } = guardResult.parsed;
-      if (!modelTag) return res.status(400).json({ error: "Missing modelTag" });
+  router.post("/ai/local-load", async (req, res) => {
+    const body = parseBody<{ modelTag: string }>(req.body, {
+      modelTag: { type: "string" },
+    });
+    if (isParseBodyError(body)) return res.status(400).json({ error: body.error });
+    const { modelTag } = body.parsed;
     try {
       const r = await fetch(`http://127.0.0.1:${LM_STUDIO_PORT}/v1/models/load`, {
         method: "POST",

--- a/src/server/routes/ai/localEngines.test.ts
+++ b/src/server/routes/ai/localEngines.test.ts
@@ -12,12 +12,13 @@ import {
   childProcessVitestMockFactory,
   createChildProcessTestHandles,
 } from "../../__tests__/childProcessTestMocks.ts";
-import { findLmsCli, ensureOllamaReady, ensureLmsReady } from "./localEngines.ts";
-import { localEngineRuntime, resetLocalEngineRuntime } from "../../services/ai/localEngineState.ts";
 
 const mocks = vi.hoisted(() => createChildProcessTestHandles());
 
 vi.mock("child_process", childProcessVitestMockFactory(mocks, { includeSpawn: true }));
+
+import { findLmsCli, ensureOllamaReady, ensureLmsReady } from "./localEngines.ts";
+import { localEngineRuntime, resetLocalEngineRuntime } from "../../services/ai/localEngineState.ts";
 
 // ── Helpers ────────────────────────────────────────────────────────────────
 

--- a/src/server/routes/ai/localEngines.test.ts
+++ b/src/server/routes/ai/localEngines.test.ts
@@ -8,14 +8,16 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import fs from "fs";
 
-import {
-  childProcessVitestMockFactory,
-  createChildProcessTestHandles,
-} from "../../__tests__/childProcessTestMocks.ts";
+const mocks = vi.hoisted(() => ({
+  execFileImpl: null as null | ((...args: unknown[]) => unknown),
+  spawnImpl: null as null | ((...args: unknown[]) => unknown),
+  execFileCalls: [] as unknown[][],
+}));
 
-const mocks = vi.hoisted(() => createChildProcessTestHandles());
-
-vi.mock("child_process", childProcessVitestMockFactory(mocks, { includeSpawn: true }));
+vi.mock("child_process", async (importOriginal) => {
+  const { childProcessVitestMockFactory } = await import("../../__tests__/childProcessTestMocks.ts");
+  return childProcessVitestMockFactory(mocks, { includeSpawn: true })(importOriginal);
+});
 
 import { findLmsCli, ensureOllamaReady, ensureLmsReady } from "./localEngines.ts";
 import { localEngineRuntime, resetLocalEngineRuntime } from "../../services/ai/localEngineState.ts";

--- a/src/server/routes/ai/ollamaRoutes.ts
+++ b/src/server/routes/ai/ollamaRoutes.ts
@@ -102,7 +102,7 @@ export function mountOllamaRoutes(router: Router): void {
 
       localEngineRuntime.ollamaPullBusyTag = tag;
       ownsBusy = true;
-      const ready = await ensureOllamaReady((evt) => send(evt));
+      const ready = await ensureOllamaReady((evt) => send(evt), guard.signal);
       if (guard.disconnected()) {
         releaseBusy();
         guard.endOnce();

--- a/src/server/routes/ai/ollamaRoutes.ts
+++ b/src/server/routes/ai/ollamaRoutes.ts
@@ -2,7 +2,21 @@
  * Ollama local model routes: /ai/ollama-models, /ai/ollama-model-sizes,
  * /ai/ollama-health, /ai/ollama-pull, /ai/ollama-load, /ai/ollama-unload.
  */
-import { bodyGuard } from "../middleware/bodyGuard.ts";
+import type { Router } from "express";
+
+import { isValidLocalModelTag } from "../../../lib/localModelTag.ts";
+import { gateLocalPullDiskSpace } from "../../../lib/localEngineDisk.ts";
+import { heavyCommandRateLimit } from "../../middleware/rateLimit.ts";
+import { localEngineRuntime } from "../../services/ai/localEngineState.ts";
+import {
+  OLLAMA_PORT,
+  isOllamaRunning,
+  ensureOllamaReady,
+  listOllamaInstalledNames,
+  verifyInstalledAfterPull,
+  OLLAMA_PULL_MAX_MS,
+} from "./localEngines.ts";
+import { trackStreamClient, beginPullSse } from "./streamHelpers.ts";
 
 export function mountOllamaRoutes(router: Router): void {
   router.get("/ai/ollama-models", async (_req, res) => {
@@ -88,9 +102,7 @@ export function mountOllamaRoutes(router: Router): void {
 
       localEngineRuntime.ollamaPullBusyTag = tag;
       ownsBusy = true;
-      // Waiter-based abort: disconnect removes this client; shared ensure continues
-      // while other clients are still waiting.
-      const ready = await ensureOllamaReady((evt) => send(evt), guard.signal);
+      const ready = await ensureOllamaReady((evt) => send(evt));
       if (guard.disconnected()) {
         releaseBusy();
         guard.endOnce();

--- a/src/server/routes/ai/ollamaRoutes.ts
+++ b/src/server/routes/ai/ollamaRoutes.ts
@@ -78,6 +78,8 @@ export function mountOllamaRoutes(router: Router): void {
     };
     let maxTimer: ReturnType<typeof setTimeout> | null = null;
     let timedOut = false;
+    /** Clears pull mutex as soon as the client disconnects (does not wait for shared readiness). */
+    let onClientAbort: (() => void) | undefined;
     try {
       if (!isValidLocalModelTag(tag)) {
         send({ type: "error", error: "Invalid modelTag." });
@@ -102,7 +104,26 @@ export function mountOllamaRoutes(router: Router): void {
 
       localEngineRuntime.ollamaPullBusyTag = tag;
       ownsBusy = true;
-      const ready = await ensureOllamaReady((evt) => send(evt), guard.signal);
+      // Shared ensure continues for other waiters; this pull must drop the mutex on abort
+      // so a second pull is not blocked while readiness is still in flight.
+      let settleAbortWait: (() => void) | undefined;
+      onClientAbort = () => {
+        releaseBusy();
+        settleAbortWait?.();
+      };
+      guard.signal.addEventListener("abort", onClientAbort);
+      if (guard.signal.aborted) {
+        onClientAbort();
+        guard.endOnce();
+        return;
+      }
+      const ready = await Promise.race([
+        ensureOllamaReady((evt) => send(evt), guard.signal),
+        new Promise<Awaited<ReturnType<typeof ensureOllamaReady>>>((resolve) => {
+          settleAbortWait = () =>
+            resolve({ ok: false, steps: [], cancelled: true, error: "Setup cancelled." });
+        }),
+      ]);
       if (guard.disconnected()) {
         releaseBusy();
         guard.endOnce();
@@ -252,6 +273,7 @@ export function mountOllamaRoutes(router: Router): void {
         }
       }
     } finally {
+      if (onClientAbort) guard.signal.removeEventListener("abort", onClientAbort);
       if (maxTimer) clearTimeout(maxTimer);
       releaseBusy();
       guard.endOnce();

--- a/src/server/routes/arena.ts
+++ b/src/server/routes/arena.ts
@@ -5,7 +5,7 @@
 import type { Request, Response, Router } from "express";
 import fs from "node:fs";
 import { resolveCloudTimeoutMs, ARENA_PROMPT_MAX_CHARS } from "../../lib/arenaConstants.ts";
-import { parseBody } from "../middleware/bodyGuard.ts";
+import { parseBody, isParseBodyError } from "../middleware/bodyGuard.ts";
 import { arenaLocalOnly, arenaStrictLocalOnly } from "../middleware/localOnly.ts";
 import { arenaProxyRateLimit } from "../middleware/rateLimit.ts";
 import {
@@ -109,7 +109,7 @@ export function mountArenaRoutes(router: Router): void {
       // Lenient by design: resolveCloudTimeoutMs clamps any raw value below.
       timeoutMs: { type: "unknown", required: false },
     });
-    if (!body.parsed) return res.status(400).json({ error: body.error });
+    if (isParseBodyError(body)) return res.status(400).json({ error: body.error });
     const { endpointUrl, apiKey, modelId, prompt } = body.parsed;
 
     if (prompt.length > ARENA_PROMPT_MAX_CHARS) {

--- a/src/server/routes/arena.ts
+++ b/src/server/routes/arena.ts
@@ -5,6 +5,7 @@
 import type { Request, Response, Router } from "express";
 import fs from "node:fs";
 import { resolveCloudTimeoutMs, ARENA_PROMPT_MAX_CHARS } from "../../lib/arenaConstants.ts";
+import { parseBody } from "../middleware/bodyGuard.ts";
 import { arenaLocalOnly, arenaStrictLocalOnly } from "../middleware/localOnly.ts";
 import { arenaProxyRateLimit } from "../middleware/rateLimit.ts";
 import {
@@ -94,21 +95,28 @@ export function mountArenaRoutes(router: Router): void {
   // Local-first access boundary (loopback) before rate limit / proxy work.
   // Override with OLIVE_ARENA_ALLOW_REMOTE=true when intentionally exposing the API.
   router.post("/arena/cloud-inference", arenaLocalOnly, arenaProxyRateLimit, async (req, res) => {
-    const { endpointUrl, apiKey, modelId, prompt, timeoutMs } = req.body ?? {};
+    const body = parseBody<{
+      endpointUrl: string;
+      prompt: string;
+      apiKey?: string;
+      modelId?: string;
+      timeoutMs?: unknown;
+    }>(req.body, {
+      endpointUrl: { type: "string", message: "endpointUrl is required" },
+      prompt: { type: "string", message: "prompt is required" },
+      apiKey: { type: "string", required: false },
+      modelId: { type: "string", required: false },
+      // Lenient by design: resolveCloudTimeoutMs clamps any raw value below.
+      timeoutMs: { type: "unknown", required: false },
+    });
+    if (!body.parsed) return res.status(400).json({ error: body.error });
+    const { endpointUrl, apiKey, modelId, prompt } = body.parsed;
 
-    if (!endpointUrl || typeof endpointUrl !== "string")
-      return res.status(400).json({ error: "endpointUrl is required" });
-    if (!prompt || typeof prompt !== "string")
-      return res.status(400).json({ error: "prompt is required" });
     if (prompt.length > ARENA_PROMPT_MAX_CHARS) {
       return res.status(400).json({
         error: `prompt must be at most ${ARENA_PROMPT_MAX_CHARS} characters`,
       });
     }
-    if (apiKey !== undefined && apiKey !== null && typeof apiKey !== "string")
-      return res.status(400).json({ error: "apiKey must be a string" });
-    if (modelId !== undefined && modelId !== null && typeof modelId !== "string")
-      return res.status(400).json({ error: "modelId must be a string" });
 
     let targetUrl: URL;
     try {
@@ -131,7 +139,7 @@ export function mountArenaRoutes(router: Router): void {
     // CodeQL js/resource-exhaustion treats any setTimeout/setInterval delay derived from
     // request body as tainted even after clamp; schedule with a fixed literal tick and
     // compare against a Date.now() deadline so the sink is not user-controlled.
-    const resolvedTimeoutMs = resolveCloudTimeoutMs(timeoutMs);
+    const resolvedTimeoutMs = resolveCloudTimeoutMs(body.parsed.timeoutMs);
     const ac = new AbortController();
     const timer = armCloudAbort(() => {
       if (!ac.signal.aborted) ac.abort();

--- a/src/server/routes/arena.ts
+++ b/src/server/routes/arena.ts
@@ -130,7 +130,7 @@ export function mountArenaRoutes(router: Router): void {
       headers["Authorization"] = `Bearer ${apiKey}`;
     }
 
-    const body = JSON.stringify({
+    const requestBody = JSON.stringify({
       model: typeof modelId === "string" && modelId.length > 0 ? modelId : undefined,
       messages: [{ role: "user", content: prompt }],
     });
@@ -168,7 +168,7 @@ export function mountArenaRoutes(router: Router): void {
       const upstream = await pinnedFetch(targetUrl, {
         method: "POST",
         headers,
-        body,
+        body: requestBody,
         signal: ac.signal,
       });
 

--- a/src/server/routes/env.ts
+++ b/src/server/routes/env.ts
@@ -19,6 +19,7 @@ import { ensureOnnxRuntimeGpu } from "../services/olive/cuda.ts";
 import { ensureDirectMl } from "../services/olive/directml.ts";
 import { ensureQnn, runQnnHtpDiagnostic } from "../services/olive/qnn.ts";
 import { fsWriteRateLimit, heavyCommandRateLimit } from "../middleware/rateLimit.ts";
+import { parseBody } from "../middleware/bodyGuard.ts";
 import { resolveAllowedPythonFile } from "../services/venv/pythonGuard.ts";
 
 /** Serialize all stack installs that mutate the shared venv via pip. */
@@ -85,11 +86,11 @@ export function mountEnvRoutes(router: Router): void {
   });
 
   router.post("/env/hf-token", (req, res) => {
-    const { token } = req.body ?? {};
-    if (!token || typeof token !== "string") {
-      return res.status(400).json({ error: "Missing token" });
-    }
-    setRuntimeHfToken(token);
+    const body = parseBody<{ token: string }>(req.body, {
+      token: { type: "string", message: "Missing token" },
+    });
+    if (!body.parsed) return res.status(400).json({ error: body.error });
+    setRuntimeHfToken(body.parsed.token);
     return res.json({ ok: true });
   });
 
@@ -142,8 +143,11 @@ export function mountEnvRoutes(router: Router): void {
 
   // ─── Python Path ──────────────────────────────────────────────────────
   router.post("/env/python-path", fsWriteRateLimit, async (req, res) => {
-    const { pythonPath } = req.body ?? {};
-    const safe = resolveAllowedPythonFile(pythonPath);
+    const body = parseBody<{ pythonPath: string }>(req.body, {
+      pythonPath: { type: "string", message: "Missing pythonPath" },
+    });
+    if (!body.parsed) return res.status(400).json({ error: body.error });
+    const safe = resolveAllowedPythonFile(body.parsed.pythonPath);
     if (!safe.ok) {
       return res.status(400).json({ ok: false, error: safe.error });
     }

--- a/src/server/routes/env.ts
+++ b/src/server/routes/env.ts
@@ -18,7 +18,7 @@ import { ensureOpenVino } from "../services/olive/openvino.ts";
 import { ensureOnnxRuntimeGpu } from "../services/olive/cuda.ts";
 import { ensureDirectMl } from "../services/olive/directml.ts";
 import { ensureQnn, runQnnHtpDiagnostic } from "../services/olive/qnn.ts";
-import { fsWriteRateLimit, heavyCommandRateLimit } from "../middleware/rateLimit.ts";
+import { authActionRateLimit, fsWriteRateLimit, heavyCommandRateLimit } from "../middleware/rateLimit.ts";
 import { parseBody, isParseBodyError } from "../middleware/bodyGuard.ts";
 import { resolveAllowedPythonFile } from "../services/venv/pythonGuard.ts";
 
@@ -85,7 +85,7 @@ export function mountEnvRoutes(router: Router): void {
     return res.json({ source: "none" });
   });
 
-  router.post("/env/hf-token", (req, res) => {
+  router.post("/env/hf-token", authActionRateLimit, (req, res) => {
     const body = parseBody<{ token: string }>(req.body, {
       token: { type: "string", message: "Missing token" },
     });

--- a/src/server/routes/env.ts
+++ b/src/server/routes/env.ts
@@ -19,7 +19,7 @@ import { ensureOnnxRuntimeGpu } from "../services/olive/cuda.ts";
 import { ensureDirectMl } from "../services/olive/directml.ts";
 import { ensureQnn, runQnnHtpDiagnostic } from "../services/olive/qnn.ts";
 import { fsWriteRateLimit, heavyCommandRateLimit } from "../middleware/rateLimit.ts";
-import { parseBody } from "../middleware/bodyGuard.ts";
+import { parseBody, isParseBodyError } from "../middleware/bodyGuard.ts";
 import { resolveAllowedPythonFile } from "../services/venv/pythonGuard.ts";
 
 /** Serialize all stack installs that mutate the shared venv via pip. */
@@ -89,7 +89,7 @@ export function mountEnvRoutes(router: Router): void {
     const body = parseBody<{ token: string }>(req.body, {
       token: { type: "string", message: "Missing token" },
     });
-    if (!body.parsed) return res.status(400).json({ error: body.error });
+    if (isParseBodyError(body)) return res.status(400).json({ error: body.error });
     setRuntimeHfToken(body.parsed.token);
     return res.json({ ok: true });
   });
@@ -146,7 +146,7 @@ export function mountEnvRoutes(router: Router): void {
     const body = parseBody<{ pythonPath: string }>(req.body, {
       pythonPath: { type: "string", message: "Missing pythonPath" },
     });
-    if (!body.parsed) return res.status(400).json({ error: body.error });
+    if (isParseBodyError(body)) return res.status(400).json({ error: body.error });
     const safe = resolveAllowedPythonFile(body.parsed.pythonPath);
     if (!safe.ok) {
       return res.status(400).json({ ok: false, error: safe.error });

--- a/src/server/routes/mcp.test.ts
+++ b/src/server/routes/mcp.test.ts
@@ -10,22 +10,24 @@
  * `child_process` is mocked via `src/server/__tests__/childProcessTestMocks.ts`.
  */
 import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach, vi } from "vitest";
-import express from "express";
-import type { Server } from "http";
-import fs from "fs";
-import { execFile } from "child_process";
 
 import {
   childProcessVitestMockFactory,
   createChildProcessTestHandles,
 } from "../__tests__/childProcessTestMocks.ts";
-import { mountMcpRoutes } from "./mcp.ts";
-import { setKbStatusCache } from "../services/mcp/state.ts";
-import mcpBreaker, { resetMcpBreaker } from "../services/mcp/breaker.ts";
 
 const mcpToolMocks = vi.hoisted(() => createChildProcessTestHandles());
 
 vi.mock("child_process", childProcessVitestMockFactory(mcpToolMocks, { trackExecFileCalls: true }));
+
+import express from "express";
+import type { Server } from "http";
+import fs from "fs";
+import { execFile } from "child_process";
+
+import { mountMcpRoutes } from "./mcp.ts";
+import { setKbStatusCache } from "../services/mcp/state.ts";
+import mcpBreaker, { resetMcpBreaker } from "../services/mcp/breaker.ts";
 
 const VALID_KB = JSON.stringify({
   version: "2.0",

--- a/src/server/routes/mcp.test.ts
+++ b/src/server/routes/mcp.test.ts
@@ -187,7 +187,7 @@ describe("POST /api/mcp/tool", () => {
     const res = await fetch(`${baseUrl}/api/mcp/tool`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ toolName: "x", args: {} }),
+      body: JSON.stringify({ toolName: "get_olive_passes", args: {} }),
     });
 
     expect(res.status).toBe(503);
@@ -197,14 +197,26 @@ describe("POST /api/mcp/tool", () => {
     expect(mcpToolMocks.execFileCalls).toHaveLength(0);
   });
 
+  it("returns 400 for an unknown toolName", async () => {
+    const res = await fetch(`${baseUrl}/api/mcp/tool`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ toolName: "not_a_real_tool", args: {} }),
+    });
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "Unknown toolName" });
+    expect(mcpToolMocks.execFileCalls).toHaveLength(0);
+  });
+
   it("returns 200 with the tool result when the closed breaker proxies valid JSON", async () => {
     mcpToolMocks.execFileImpl = () =>
-      Promise.resolve({ stdout: '[{"tool":"x","result":{"ok":true}}]', stderr: "" });
+      Promise.resolve({ stdout: '[{"tool":"get_olive_passes","result":{"ok":true}}]', stderr: "" });
 
     const res = await fetch(`${baseUrl}/api/mcp/tool`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ toolName: "x", args: {} }),
+      body: JSON.stringify({ toolName: "get_olive_passes", args: {} }),
     });
 
     expect(res.status).toBe(200);

--- a/src/server/routes/mcp.test.ts
+++ b/src/server/routes/mcp.test.ts
@@ -11,14 +11,16 @@
  */
 import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach, vi } from "vitest";
 
-import {
-  childProcessVitestMockFactory,
-  createChildProcessTestHandles,
-} from "../__tests__/childProcessTestMocks.ts";
+const mcpToolMocks = vi.hoisted(() => ({
+  execFileImpl: null as null | ((...args: unknown[]) => unknown),
+  spawnImpl: null as null | ((...args: unknown[]) => unknown),
+  execFileCalls: [] as unknown[][],
+}));
 
-const mcpToolMocks = vi.hoisted(() => createChildProcessTestHandles());
-
-vi.mock("child_process", childProcessVitestMockFactory(mcpToolMocks, { trackExecFileCalls: true }));
+vi.mock("child_process", async (importOriginal) => {
+  const { childProcessVitestMockFactory } = await import("../__tests__/childProcessTestMocks.ts");
+  return childProcessVitestMockFactory(mcpToolMocks, { trackExecFileCalls: true })(importOriginal);
+});
 
 import express from "express";
 import type { Server } from "http";

--- a/src/server/routes/mcp.test.ts
+++ b/src/server/routes/mcp.test.ts
@@ -25,11 +25,18 @@ vi.mock("child_process", async (importOriginal) => {
 import express from "express";
 import type { Server } from "http";
 import fs from "fs";
-import { execFile } from "child_process";
 
 import { mountMcpRoutes } from "./mcp.ts";
 import { setKbStatusCache } from "../services/mcp/state.ts";
 import mcpBreaker, { resetMcpBreaker } from "../services/mcp/breaker.ts";
+
+function tripMcpBreaker(): void {
+  for (let i = 0; i < 3; i += 1) {
+    const admission = mcpBreaker.beforeCall();
+    if (!admission) return;
+    mcpBreaker.recordFailure(admission.epoch);
+  }
+}
 
 const VALID_KB = JSON.stringify({
   version: "2.0",
@@ -175,11 +182,7 @@ describe("POST /api/mcp/sync-kb", () => {
 
 describe("POST /api/mcp/tool", () => {
   it("short-circuits with 503 when the breaker is open", async () => {
-    const execFileMock = vi.mocked(execFile);
-    // Trip the process-wide singleton breaker without spawning anything.
-    mcpBreaker.recordFailure(0);
-    mcpBreaker.recordFailure(0);
-    mcpBreaker.recordFailure(0);
+    tripMcpBreaker();
 
     const res = await fetch(`${baseUrl}/api/mcp/tool`, {
       method: "POST",
@@ -191,7 +194,7 @@ describe("POST /api/mcp/tool", () => {
     const body = await res.json();
     expect(body).toEqual({ available: false, error: expect.any(String) });
     // The short-circuit must not spawn a Python subprocess.
-    expect(execFileMock).not.toHaveBeenCalled();
+    expect(mcpToolMocks.execFileCalls).toHaveLength(0);
   });
 
   it("returns 200 with the tool result when the closed breaker proxies valid JSON", async () => {

--- a/src/server/routes/mcp.ts
+++ b/src/server/routes/mcp.ts
@@ -15,7 +15,7 @@ import {
 } from "../services/mcp/state.ts";
 import { callOliveMcpTool, MCP_UNAVAILABLE_ERROR } from "../services/mcp/client.ts";
 import { kbStatusRateLimit, kbSyncRateLimit } from "../middleware/rateLimit.ts";
-import { parseBody } from "../middleware/bodyGuard.ts";
+import { parseBody, isParseBodyError } from "../middleware/bodyGuard.ts";
 import { readStudioConfig, writeStudioConfig } from "../config.ts";
 import type { KbStatusCache } from "../types.ts";
 
@@ -199,7 +199,7 @@ export function mountMcpRoutes(router: Router): void {
       toolName: { type: "string", message: "Missing toolName" },
       args: { type: "object", required: false },
     });
-    if (!body.parsed) return res.status(400).json({ error: body.error });
+    if (isParseBodyError(body)) return res.status(400).json({ error: body.error });
     try {
       const out = await callOliveMcpTool(body.parsed.toolName, body.parsed.args ?? {});
       if (out.unavailable) {

--- a/src/server/routes/mcp.ts
+++ b/src/server/routes/mcp.ts
@@ -15,6 +15,7 @@ import {
 } from "../services/mcp/state.ts";
 import { callOliveMcpTool, MCP_UNAVAILABLE_ERROR } from "../services/mcp/client.ts";
 import { kbStatusRateLimit, kbSyncRateLimit } from "../middleware/rateLimit.ts";
+import { parseBody } from "../middleware/bodyGuard.ts";
 import { readStudioConfig, writeStudioConfig } from "../config.ts";
 import type { KbStatusCache } from "../types.ts";
 
@@ -194,12 +195,13 @@ export function performKbSync():
 export function mountMcpRoutes(router: Router): void {
   // ─── MCP Tool Proxy ───────────────────────────────────────────────────
   router.post("/mcp/tool", async (req, res) => {
-    const { toolName, args } = req.body as { toolName?: string; args?: Record<string, unknown> };
-    if (!toolName) {
-      return res.status(400).json({ error: "Missing toolName" });
-    }
+    const body = parseBody<{ toolName: string; args?: Record<string, unknown> }>(req.body, {
+      toolName: { type: "string", message: "Missing toolName" },
+      args: { type: "object", required: false },
+    });
+    if (!body.parsed) return res.status(400).json({ error: body.error });
     try {
-      const out = await callOliveMcpTool(toolName, args ?? {});
+      const out = await callOliveMcpTool(body.parsed.toolName, body.parsed.args ?? {});
       if (out.unavailable) {
         return res.status(503).json({ available: false, error: out.error ?? MCP_UNAVAILABLE_ERROR });
       }

--- a/src/server/routes/mcp.ts
+++ b/src/server/routes/mcp.ts
@@ -14,6 +14,7 @@ import {
   setKbSyncInProgress,
 } from "../services/mcp/state.ts";
 import { callOliveMcpTool, MCP_UNAVAILABLE_ERROR } from "../services/mcp/client.ts";
+import { isAllowedMcpToolName } from "../services/mcp/allowedTools.ts";
 import { kbStatusRateLimit, kbSyncRateLimit } from "../middleware/rateLimit.ts";
 import { parseBody, isParseBodyError } from "../middleware/bodyGuard.ts";
 import { readStudioConfig, writeStudioConfig } from "../config.ts";
@@ -200,6 +201,9 @@ export function mountMcpRoutes(router: Router): void {
       args: { type: "object", required: false },
     });
     if (isParseBodyError(body)) return res.status(400).json({ error: body.error });
+    if (!isAllowedMcpToolName(body.parsed.toolName)) {
+      return res.status(400).json({ error: "Unknown toolName" });
+    }
     try {
       const out = await callOliveMcpTool(body.parsed.toolName, body.parsed.args ?? {});
       if (out.unavailable) {

--- a/src/server/services/mcp/allowedTools.ts
+++ b/src/server/services/mcp/allowedTools.ts
@@ -1,0 +1,23 @@
+/** Pinned MCP tool names exposed by olive-mcp-server (see olive_mcp_server/mcp_server.py). */
+export const ALLOWED_MCP_TOOL_NAMES = new Set([
+  "get_olive_passes",
+  "get_pass_config_template",
+  "get_quantization_strategy",
+  "get_hardware_optimization_guide",
+  "get_pass_chain",
+  "troubleshoot_olive_error",
+  "diagnose_error",
+  "get_error_frequency_summary",
+  "get_model_compatibility",
+  "get_cli_command",
+  "get_data_config_template",
+  "search_olive_documentation",
+  "get_integration_recipe",
+  "get_pass_parameters",
+  "evaluate_optimization_tradeoff",
+  "get_context_for_pipeline",
+]);
+
+export function isAllowedMcpToolName(toolName: string): boolean {
+  return ALLOWED_MCP_TOOL_NAMES.has(toolName);
+}

--- a/src/server/services/mcp/breaker.test.ts
+++ b/src/server/services/mcp/breaker.test.ts
@@ -197,7 +197,6 @@ describe("createMcpCircuitBreaker", () => {
 
     // Late success from the pre-open admission must not clear half-open state.
     breaker.recordSuccess(stale.epoch);
-    expect(breaker.isOpen()).toBe(true);
     expect(breaker.beforeCall()).toBe(false);
 
     // The actual recovery probe failure must still reopen the breaker.

--- a/src/server/services/mcp/breaker.test.ts
+++ b/src/server/services/mcp/breaker.test.ts
@@ -7,6 +7,11 @@ import { createMcpCircuitBreaker } from "./breaker.ts";
 const FAILURE_THRESHOLD = 3;
 const COOLDOWN_MS = 30_000;
 
+function requireAdmission(admission: false | { epoch: number }): { epoch: number } {
+  if (admission === false) throw new Error("expected admission");
+  return admission;
+}
+
 describe("createMcpCircuitBreaker", () => {
   it("allows calls while closed", () => {
     const breaker = createMcpCircuitBreaker({ now: () => 0 });
@@ -133,7 +138,7 @@ describe("createMcpCircuitBreaker", () => {
       now: () => 0,
     });
 
-    const first = breaker.beforeCall();
+    const first = requireAdmission(breaker.beforeCall());
     expect(first).toEqual({ epoch: 0 });
 
     breaker.recordFailure(0);
@@ -141,7 +146,7 @@ describe("createMcpCircuitBreaker", () => {
     expect(breaker.isOpen()).toBe(true);
 
     // Late success from the pre-open admission must not close the breaker.
-    breaker.recordSuccess(first!.epoch);
+    breaker.recordSuccess(first.epoch);
     expect(breaker.isOpen()).toBe(true);
     expect(breaker.beforeCall()).toBe(false);
   });
@@ -154,18 +159,18 @@ describe("createMcpCircuitBreaker", () => {
       now: () => t,
     });
 
-    const stale = breaker.beforeCall();
-    breaker.recordFailure(stale!.epoch);
+    const stale = requireAdmission(breaker.beforeCall());
+    breaker.recordFailure(stale.epoch);
     expect(breaker.isOpen()).toBe(true);
 
     t += COOLDOWN_MS;
-    const probe = breaker.beforeCall();
+    const probe = requireAdmission(breaker.beforeCall());
     expect(probe).toEqual({ epoch: 1 });
-    breaker.recordFailure(probe!.epoch);
+    breaker.recordFailure(probe.epoch);
     expect(breaker.isOpen()).toBe(true);
 
     // Stale success from the original closed-state call must not clear the breaker.
-    breaker.recordSuccess(stale!.epoch);
+    breaker.recordSuccess(stale.epoch);
     expect(breaker.isOpen()).toBe(true);
     expect(breaker.beforeCall()).toBe(false);
   });
@@ -178,7 +183,7 @@ describe("createMcpCircuitBreaker", () => {
       now: () => t,
     });
 
-    const stale = breaker.beforeCall();
+    const stale = requireAdmission(breaker.beforeCall());
     expect(stale).toEqual({ epoch: 0 });
 
     breaker.recordFailure(0);
@@ -187,16 +192,16 @@ describe("createMcpCircuitBreaker", () => {
     expect(breaker.isOpen()).toBe(true);
 
     t += COOLDOWN_MS;
-    const probe = breaker.beforeCall();
+    const probe = requireAdmission(breaker.beforeCall());
     expect(probe).toEqual({ epoch: 1 });
 
     // Late success from the pre-open admission must not clear half-open state.
-    breaker.recordSuccess(stale!.epoch);
+    breaker.recordSuccess(stale.epoch);
     expect(breaker.isOpen()).toBe(true);
     expect(breaker.beforeCall()).toBe(false);
 
     // The actual recovery probe failure must still reopen the breaker.
-    breaker.recordFailure(probe!.epoch);
+    breaker.recordFailure(probe.epoch);
     expect(breaker.isOpen()).toBe(true);
     expect(breaker.beforeCall()).toBe(false);
   });

--- a/src/server/services/mcp/client.test.ts
+++ b/src/server/services/mcp/client.test.ts
@@ -5,14 +5,17 @@
  * `child_process` is mocked via `src/server/__tests__/childProcessTestMocks.ts`.
  */
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import {
-  childProcessVitestMockFactory,
-  createChildProcessTestHandles,
-} from "../../__tests__/childProcessTestMocks.ts";
 
-const mocks = vi.hoisted(() => createChildProcessTestHandles());
+const mocks = vi.hoisted(() => ({
+  execFileImpl: null as null | ((...args: unknown[]) => unknown),
+  spawnImpl: null as null | ((...args: unknown[]) => unknown),
+  execFileCalls: [] as unknown[][],
+}));
 
-vi.mock("child_process", childProcessVitestMockFactory(mocks));
+vi.mock("child_process", async (importOriginal) => {
+  const { childProcessVitestMockFactory } = await import("../../__tests__/childProcessTestMocks.ts");
+  return childProcessVitestMockFactory(mocks)(importOriginal);
+});
 
 import { callOliveMcpTools, callOliveMcpTool, MCP_UNAVAILABLE_ERROR } from "./client.ts";
 import mcpBreaker, { resetMcpBreaker } from "./breaker.ts";

--- a/src/server/services/mcp/client.test.ts
+++ b/src/server/services/mcp/client.test.ts
@@ -20,6 +20,15 @@ vi.mock("child_process", async (importOriginal) => {
 import { callOliveMcpTools, callOliveMcpTool, MCP_UNAVAILABLE_ERROR } from "./client.ts";
 import mcpBreaker, { resetMcpBreaker } from "./breaker.ts";
 
+/** Trip the process-wide breaker using the current admission epoch (safe after reset()). */
+function tripMcpBreaker(): void {
+  for (let i = 0; i < 3; i += 1) {
+    const admission = mcpBreaker.beforeCall();
+    if (!admission) return;
+    mcpBreaker.recordFailure(admission.epoch);
+  }
+}
+
 /** Makes the next execFile call resolve with the given stdout/stderr. */
 function mockExecFileResolve(stdout: string, stderr = ""): void {
   mocks.execFileImpl = (...args: unknown[]) => {
@@ -85,7 +94,7 @@ describe("callOliveMcpTools circuit-breaker integration", () => {
   });
 
   it("single-tool calls inherit the unavailable short-circuit", async () => {
-    for (let i = 0; i < 3; i += 1) mcpBreaker.recordFailure(0);
+    tripMcpBreaker();
 
     const out = await callOliveMcpTool("x", {});
 
@@ -136,6 +145,7 @@ describe("callOliveMcpTools circuit-breaker integration", () => {
     mockExecFileReject("spawn python ENOENT");
     await callOliveMcpTools([{ toolName: "x", args: {} }]);
     await callOliveMcpTools([{ toolName: "x", args: {} }]);
+    await callOliveMcpTools([{ toolName: "x", args: {} }]);
     expect(mcpBreaker.status().open).toBe(true);
 
     resolveExec!({ stdout: '[{"tool":"x","result":{"ok":true}}]', stderr: "" });
@@ -155,6 +165,7 @@ describe("callOliveMcpTools circuit-breaker integration", () => {
 
       const slow = callOliveMcpTools([{ toolName: "x", args: {} }]);
       mockExecFileReject("spawn python ENOENT");
+      await callOliveMcpTools([{ toolName: "x", args: {} }]);
       await callOliveMcpTools([{ toolName: "x", args: {} }]);
       await callOliveMcpTools([{ toolName: "x", args: {} }]);
       expect(mcpBreaker.status().open).toBe(true);

--- a/src/server/services/mcp/client.test.ts
+++ b/src/server/services/mcp/client.test.ts
@@ -5,9 +5,6 @@
  * `child_process` is mocked via `src/server/__tests__/childProcessTestMocks.ts`.
  */
 import { describe, it, expect, beforeEach, vi } from "vitest";
-
-import { callOliveMcpTools, callOliveMcpTool, MCP_UNAVAILABLE_ERROR } from "./client.ts";
-import mcpBreaker, { resetMcpBreaker } from "./breaker.ts";
 import {
   childProcessVitestMockFactory,
   createChildProcessTestHandles,
@@ -16,6 +13,9 @@ import {
 const mocks = vi.hoisted(() => createChildProcessTestHandles());
 
 vi.mock("child_process", childProcessVitestMockFactory(mocks));
+
+import { callOliveMcpTools, callOliveMcpTool, MCP_UNAVAILABLE_ERROR } from "./client.ts";
+import mcpBreaker, { resetMcpBreaker } from "./breaker.ts";
 
 /** Makes the next execFile call resolve with the given stdout/stderr. */
 function mockExecFileResolve(stdout: string, stderr = ""): void {


### PR DESCRIPTION
## Summary
- Add parseBody middleware for consistent, type-safe request parsing
- Adopt across AI, arena, env, and MCP routes

## Stack
- PR 3 of 4 (base: engines + MCP PR)
- Next: line-ending normalization

## Test plan
- [ ] pnpm test:server
- [ ] pnpm test:integration

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tonythethompson/Olive-Studio/pull/127?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

