### PR TITLE
feat(mcp): UIState recipe bridge, evidence matrix, KB PR, feedback

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,46 @@ jobs:
       - name: Pytest
         run: python -m pytest tests -q --tb=short
 
+  # Enumerate Olive pass registry only — no models, no optimization, no CUDA.
+  # Pin matches src/lib/passCatalog.ts OLIVE_VERSION and matrix olive_version_support.max.
+  olive-pass-availability:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: olive-mcp-server
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: olive-mcp-server/pyproject.toml
+
+      - name: Install pinned Olive (CPU registry only)
+        env:
+          # Discourage CUDA wheel selection for transitive torch/ort if resolved.
+          CUDA_VISIBLE_DEVICES: ""
+          PIP_NO_CACHE_DIR: "1"
+        run: |
+          set -euo pipefail
+          # Documented pin: Olive 0.12.1 (passCatalog OLIVE_VERSION / matrix max).
+          # olive-mcp-server does not depend on olive-ai; pin lives here for CI.
+          pip install "olive-ai==0.12.1"
+
+      - name: Enumerate registry vs compatibility matrix
+        env:
+          CUDA_VISIBLE_DEVICES: ""
+        run: |
+          set -euo pipefail
+          python scripts/check_olive_pass_availability.py \
+            olive_mcp_server/knowledge_base/compatibility_matrix.json
+
   docker-build:
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/kb-update.yml
+++ b/.github/workflows/kb-update.yml
@@ -123,8 +123,21 @@ jobs:
 
           # Preserve human edits: refuse to rebuild/force-push if non-bot commits exist.
           if git ls-remote --exit-code origin "refs/heads/${BRANCH}" >/dev/null 2>&1; then
-            git fetch origin "${BRANCH}" --depth=50
+            # Fetch the full refresh branch tip so human commits outside a shallow
+            # window are still visible, then deepen default-branch history until
+            # a merge-base exists (avoids false "human edits" from disconnected tips).
+            git fetch origin "${BRANCH}"
             git fetch origin "${DEFAULT_BRANCH}" --depth=50
+            for _ in 1 2 3 4 5 6 7 8; do
+              if git merge-base "origin/${DEFAULT_BRANCH}" "origin/${BRANCH}" >/dev/null 2>&1; then
+                break
+              fi
+              git fetch origin "${DEFAULT_BRANCH}" --deepen=200 || true
+            done
+            if ! git merge-base "origin/${DEFAULT_BRANCH}" "origin/${BRANCH}" >/dev/null 2>&1; then
+              git fetch origin "${DEFAULT_BRANCH}" --unshallow 2>/dev/null \
+                || git fetch origin "${DEFAULT_BRANCH}"
+            fi
             HUMAN="$(
               git log --format='%ae' "origin/${DEFAULT_BRANCH}..origin/${BRANCH}" 2>/dev/null \
                 | grep -vF "${BOT_EMAIL}" \

--- a/.github/workflows/kb-update.yml
+++ b/.github/workflows/kb-update.yml
@@ -9,17 +9,25 @@ concurrency:
   group: kb-update
   cancel-in-progress: false
 
+# Job-level permissions below are least-privilege for PR creation.
+permissions: {}
+
 jobs:
   update:
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 20
+    permissions:
+      contents: write # push chore/kb-refresh branch only
+      pull-requests: write # open/update one labeled refresh PR
     defaults:
       run:
         working-directory: olive-mcp-server
     steps:
       - uses: actions/checkout@v7
         with:
-          persist-credentials: false
+          # Credentials required so the refresh-PR step can push the bot branch.
+          persist-credentials: true
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions/setup-python@v7
         with:
@@ -28,17 +36,33 @@ jobs:
           cache-dependency-path: olive-mcp-server/pyproject.toml
 
       - name: Install dependencies
-        run: pip install -e . "mcp<2"
+        run: pip install -e ".[dev]" "mcp<2"
 
       - name: Run KB update
         run: python scripts/update_kb.py
 
+      - name: Run KB expand
+        run: python scripts/expand_kb.py
+
+      - name: Compatibility matrix validation
+        run: |
+          set -euo pipefail
+          if [ -f tests/test_compatibility_matrix.py ]; then
+            python -m pytest tests/test_compatibility_matrix.py -q --tb=short
+          else
+            echo "tests/test_compatibility_matrix.py not found; running lightweight matrix sanity checks"
+            python -c "from pathlib import Path; import json; kb=Path('olive_mcp_server/knowledge_base'); matrix=json.loads((kb/'compatibility_matrix.json').read_text(encoding='utf-8')); passes_doc=json.loads((kb/'passes.json').read_text(encoding='utf-8')); pass_names={p['name'] for p in passes_doc.get('passes', []) if isinstance(p, dict) and isinstance(p.get('name'), str)}; assert pass_names, 'passes.json has no passes'; models=matrix.get('models'); assert isinstance(models, list) and models, 'compatibility_matrix.json has no models'; print(f'OK: {len(models)} models, {len(pass_names)} canonical passes')"
+          fi
+
+      - name: Python MCP tests
+        run: python -m pytest tests -q --tb=short
+
       - name: Check PyPI for new olive-ai versions
+        id: pypi
         run: |
           LATEST=$(python -c "import urllib.request, json; data = json.loads(urllib.request.urlopen('https://pypi.org/pypi/olive-ai/json', timeout=15).read()); print(data['info']['version'])")
           echo "Latest olive-ai on PyPI: $LATEST"
           echo "olive_latest_version=$LATEST" >> "$GITHUB_OUTPUT"
-        id: pypi
 
       - name: Upload report
         if: ${{ !cancelled() }}
@@ -48,4 +72,140 @@ jobs:
           path: |
             olive-mcp-server/olive_mcp_server/knowledge_base/update_report.json
             olive-mcp-server/olive_mcp_server/knowledge_base/candidate_quirks.json
+            olive-mcp-server/olive_mcp_server/knowledge_base/refresh_metadata.json
+          if-no-files-found: warn
           retention-days: 30
+
+      - name: Detect KB output changes
+        id: kb_changes
+        working-directory: ${{ github.workspace }}
+        run: |
+          set -euo pipefail
+          KB_DIR="olive-mcp-server/olive_mcp_server/knowledge_base"
+          CHANGED_TRACKED="$(git diff --name-only HEAD -- "$KB_DIR" || true)"
+          CHANGED_UNTRACKED="$(git ls-files --others --exclude-standard -- "$KB_DIR" || true)"
+          if [ -z "${CHANGED_TRACKED}" ] && [ -z "${CHANGED_UNTRACKED}" ]; then
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+            echo "No tracked KB output changes (clean generated diff — no PR)"
+          else
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+            echo "KB paths changed:"
+            printf '%s\n' "${CHANGED_TRACKED}" "${CHANGED_UNTRACKED}" | sed '/^$/d'
+          fi
+
+      # Creates or updates at most one PR (head: chore/kb-refresh, label: kb-refresh).
+      # Never auto-merges. Skips force-updating when the branch has human commits.
+      # Does not rewrite an existing PR title/body (gh pr create only when absent).
+      - name: Create or update labeled refresh PR
+        if: steps.kb_changes.outputs.has_changes == 'true'
+        working-directory: ${{ github.workspace }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: chore/kb-refresh
+          LABEL: kb-refresh
+          BOT_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          OLIVE_PYPI: ${{ steps.pypi.outputs.olive_latest_version }}
+        run: |
+          set -euo pipefail
+          KB_DIR="olive-mcp-server/olive_mcp_server/knowledge_base"
+          DEFAULT_BRANCH="${DEFAULT_BRANCH:-main}"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "${BOT_EMAIL}"
+
+          # Idempotent label for the single refresh PR.
+          gh label create "${LABEL}" \
+            --description "Automated MCP knowledge-base refresh (review required; never auto-merged)" \
+            --color "0E8A16" \
+            --force
+
+          # Preserve human edits: refuse to rebuild/force-push if non-bot commits exist.
+          if git ls-remote --exit-code origin "refs/heads/${BRANCH}" >/dev/null 2>&1; then
+            git fetch origin "${BRANCH}" --depth=50
+            git fetch origin "${DEFAULT_BRANCH}" --depth=50
+            HUMAN="$(
+              git log --format='%ae' "origin/${DEFAULT_BRANCH}..origin/${BRANCH}" 2>/dev/null \
+                | grep -vF "${BOT_EMAIL}" \
+                | grep -v '^$' \
+              || true
+            )"
+            if [ -n "${HUMAN}" ]; then
+              echo "Refresh branch has human commits; skipping automatic update."
+              PR_NUM="$(gh pr list --head "${BRANCH}" --state open --json number --jq '.[0].number // empty')"
+              if [ -n "${PR_NUM}" ]; then
+                BODY_FILE="$(mktemp)"
+                {
+                  echo "⚠️ Scheduled **KB Auto-Update** found new generated knowledge-base changes, but \`${BRANCH}\` contains human commits."
+                  echo ""
+                  echo "Automatic branch update was **skipped** so your edits are preserved."
+                  echo ""
+                  echo "Please merge or close PR #${PR_NUM}, then re-run [this workflow run](${RUN_URL})."
+                } >"${BODY_FILE}"
+                gh pr comment "${PR_NUM}" --body-file "${BODY_FILE}"
+                rm -f "${BODY_FILE}"
+              fi
+              exit 0
+            fi
+          fi
+
+          # Snapshot generated KB outputs, then rebuild branch from default tip.
+          # -f discards the dirty generator worktree after the snapshot copy.
+          TMP_KB="$(mktemp -d)"
+          cp -a "${KB_DIR}/." "${TMP_KB}/"
+
+          git fetch origin "${DEFAULT_BRANCH}"
+          git checkout -f -B "${BRANCH}" "origin/${DEFAULT_BRANCH}"
+
+          mkdir -p "${KB_DIR}"
+          cp -a "${TMP_KB}/." "${KB_DIR}/"
+          rm -rf "${TMP_KB}"
+
+          git add -- "${KB_DIR}"
+          if git diff --cached --quiet; then
+            echo "No commit-able KB changes after rebasing onto ${DEFAULT_BRANCH}; skipping PR"
+            exit 0
+          fi
+
+          git commit -m "chore(kb): refresh knowledge base"
+          # Bot-owned branch: safe to replace tip when only bot commits were present.
+          git push -u origin "HEAD:refs/heads/${BRANCH}" --force-with-lease
+
+          EXISTING="$(gh pr list --head "${BRANCH}" --state open --json number --jq '.[0].number // empty')"
+          if [ -n "${EXISTING}" ]; then
+            echo "Updated existing refresh PR #${EXISTING} (title/body left unchanged; not merged)"
+            exit 0
+          fi
+
+          BODY_FILE="$(mktemp)"
+          {
+            echo "## Automated knowledge base refresh"
+            echo ""
+            echo "Opened by the **KB Auto-Update** workflow (Monday 06:00 UTC schedule or \`workflow_dispatch\`)."
+            echo ""
+            echo "**Not auto-merged** — human review is required before merge."
+            echo ""
+            echo "### Review checklist"
+            echo "- [ ] Diff is intentional (no noisy timestamp-only churn)"
+            echo "- [ ] \`refresh_metadata.json\` provenance looks correct"
+            echo "- [ ] Compatibility validation and Python MCP tests passed on the workflow run"
+            echo "- [ ] Candidate quirks reviewed when present"
+            echo ""
+            echo "### Provenance"
+            echo "- Workflow run: ${RUN_URL}"
+            echo "- Artifact: \`kb-update-report\` (update report, candidate quirks, refresh metadata)"
+            echo "- Latest \`olive-ai\` on PyPI (informational): ${OLIVE_PYPI:-unknown}"
+            echo ""
+            echo "### Policy"
+            echo "- At most **one** open PR uses head branch \`${BRANCH}\` and label \`${LABEL}\`."
+            echo "- Subsequent scheduled runs update this branch only when generated KB outputs change."
+            echo "- Human commits on \`${BRANCH}\` block automatic updates until the PR is merged or closed."
+          } >"${BODY_FILE}"
+          gh pr create \
+            --base "${DEFAULT_BRANCH}" \
+            --head "${BRANCH}" \
+            --title "chore(kb): scheduled knowledge base refresh" \
+            --label "${LABEL}" \
+            --body-file "${BODY_FILE}"
+          rm -f "${BODY_FILE}"

--- a/README.md
+++ b/README.md
@@ -217,14 +217,26 @@ Olive Studio validates at several layers so bad recipes fail fast:
 
 ## MCP integration
 
-The repository includes `olive-mcp-server/`, a Python MCP server that exposes Olive pass, hardware, troubleshooting, and compatibility tools.
+The repository includes `olive-mcp-server/`, a Python MCP server that exposes Olive pass, hardware, troubleshooting, compatibility, UIState recipe bridge, and local feedback tools.
 
 - `.mcp.json` wires the server to Claude via `olive-mcp-server/run.py`.
-- `server.ts` exposes `POST /api/mcp/tool` so the web UI can proxy tool calls.
+- `server.ts` exposes `POST /api/mcp/tool` so the web UI can proxy tool calls, and a loopback-only `POST /api/mcp/studio-recipe` bridge for UIState validation/recipe build (no Olive execution).
+- Bridge-backed MCP tools (`validate_ui_state_recipe`, `get_recipe_for_ui_state`) require Studio running and `OLIVE_STUDIO_API_URL` set to a **loopback** base URL (e.g. `http://127.0.0.1:3000`).
 - **Assistant chat** (`POST /api/ai/chat`) queries Olive MCP first (docs search + targeted tools) and injects those excerpts as the primary system knowledge. Optional external web search runs only when MCP coverage is thin and `OLIVE_STUDIO_WEB_SEARCH_URL` is set.
-- `MCPDiagnosticCard` renders MCP troubleshooting results inside the recipe workspace.
+- `MCPDiagnosticCard` renders MCP troubleshooting results inside the recipe workspace, with optional thumbs feedback when a diagnosis has a stable `matched_entry`.
 
-See [olive-mcp-server/README.md](olive-mcp-server/README.md) for setup and tool details.
+### Local-only diagnostic feedback (privacy)
+
+- Thumbs up/down on a matched MCP diagnosis call `record_troubleshoot_feedback` through the existing MCP proxy.
+- Feedback is **aggregate-only** (entry id + rating counts, optional allowlisted reason codes). Error logs, stack traces, and free-form notes are never accepted or stored.
+- Data stays on the local machine under the MCP user-data path (override with `OLIVE_MCP_FEEDBACK_PATH`). Nothing is uploaded by this path.
+- Ranking influence is capped so feedback only nudges close ties.
+
+### Knowledge-base refresh PRs
+
+Scheduled workflow [`.github/workflows/kb-update.yml`](.github/workflows/kb-update.yml) (Monday + manual) runs the KB generators, compatibility checks, and Python MCP tests. When generated KB files change, it opens or updates a single labeled PR (`kb-refresh`) for human review. **PRs are never auto-merged.**
+
+See [olive-mcp-server/README.md](olive-mcp-server/README.md) for setup, bridge preconditions, tool input/response examples, and feedback details.
 
 ---
 

--- a/olive-mcp-server/README.md
+++ b/olive-mcp-server/README.md
@@ -5,17 +5,19 @@ and troubleshoot Microsoft Olive model optimization workflows.
 
 ## Status
 
-Phase 1-4: 15 registered tools (including `diagnose_error` alias), live external
-fetchers, and a versioned knowledge base with Olive + Olive Studio domains.
+Phase 1-4 plus Studio bridge + local feedback: registered tools (including
+`diagnose_error` alias, UIState recipe bridge tools, and
+`record_troubleshoot_feedback`), live external fetchers, and a versioned
+knowledge base with Olive + Olive Studio domains.
 
 - 84 passes documented in `passes.json`
 - 14 hardware profiles in `hardware_profiles.json`
 - 32 Olive troubleshooting entries in `troubleshooting.json` (`domain: olive`)
 - 8 Studio troubleshooting entries in `studio_troubleshooting.json` (`domain: studio`)
-- 20 model entries in `compatibility_matrix.json`
+- Evidence-backed model entries in `compatibility_matrix.json`
 - 10 integration recipes in `integration_recipes.json`
 - 6 quirk categories in `quirks.json` (includes `studio`)
-- pytest covers domain routing (`auto` / `olive` / `studio`) and Apply flags
+- pytest covers domain routing (`auto` / `olive` / `studio`), bridge tools, feedback, and Apply flags
 
 ## Setup
 
@@ -24,13 +26,14 @@ cd olive-mcp-server
 python -m venv .venv
 
 # Windows
-.venv\Scripts\pip install -e ".[dev]"
+.venv\Scripts\pip install -e ".[dev]" "mcp<2"
 
 # Linux/macOS
-.venv/bin/pip install -e ".[dev]"
+.venv/bin/pip install -e ".[dev]" "mcp<2"
 ```
 
-The package depends on `mcp>=1.0.0`, `requests`, and `beautifulsoup4`.
+The package depends on `mcp>=1.0.0,<2`, `requests`, and `beautifulsoup4`.
+Pin `mcp<2` — 2.x removes `mcp.server.fastmcp`.
 
 ## Run
 
@@ -55,6 +58,29 @@ For Claude Desktop, the top-level `.mcp.json` uses the cross-platform launcher:
 ```bash
 python olive-mcp-server/run.py
 ```
+
+### Studio recipe bridge precondition
+
+`validate_ui_state_recipe` and `get_recipe_for_ui_state` call a **loopback-only**
+HTTP bridge on a running Olive Studio instance. They never shell out to Olive
+and never accept a caller-supplied base URL.
+
+1. Start Olive Studio (`pnpm dev` or `pnpm start`) so
+   `POST /api/mcp/studio-recipe` is listening on loopback.
+2. Set **`OLIVE_STUDIO_API_URL`** to a loopback base URL only, for example:
+   - `http://127.0.0.1:3000`
+   - `http://localhost:3000`
+   - `http://[::1]:3000`
+3. Non-loopback hosts, credentials in the URL, and non-http(s) schemes are
+   rejected. Missing/misconfigured URL or an unreachable Studio returns a
+   structured `studio_unavailable` error within a short timeout (~5s).
+
+Optional env for local feedback storage:
+
+| Variable | Purpose |
+| -------- | ------- |
+| `OLIVE_STUDIO_API_URL` | Loopback base URL for the Studio recipe bridge (required for bridge tools) |
+| `OLIVE_MCP_FEEDBACK_PATH` | Override path for the aggregate feedback JSON file (tests / advanced) |
 
 ## Test
 
@@ -82,9 +108,133 @@ python olive-mcp-server/run.py
 | `get_cli_command`                 | Generate a ready-to-run Olive CLI command                      |
 | `get_data_config_template`        | Generate DataConfig JSON for calibration/evaluation            |
 | `search_olive_documentation`      | Full-text search across the local knowledge base and live docs |
-| `get_pass_parameters`             | Deep-dive into a pass parameter schema                         |
+| `get_pass_parameters`              | Deep-dive into a pass parameter schema                         |
 | `evaluate_optimization_tradeoff`  | Analyze quality vs. performance tradeoff for a pass sequence   |
 | `get_integration_recipe`          | Return full Olive recipe templates or filtered summaries       |
+| `validate_ui_state_recipe`        | Validate a (partial) Studio UIState via local bridge (no Olive run) |
+| `get_recipe_for_ui_state`         | Same bridge evaluation plus built `olive_recipe` JSON          |
+| `record_troubleshoot_feedback`    | Local aggregate thumbs feedback for a matched KB entry         |
+
+### Studio UIState bridge tools
+
+Both tools POST `{ "uiState": <object> }` to
+`${OLIVE_STUDIO_API_URL}/api/mcp/studio-recipe`. Studio merges allowed partial
+fields into the same defaults as the UI, runs the TypeScript recipe pipeline
+once, and returns structured validation — **no Olive process is started**.
+
+#### `validate_ui_state_recipe`
+
+**Input**
+
+```json
+{
+  "ui_state": {
+    "modelSource": "huggingface",
+    "hfModelId": "microsoft/phi-2",
+    "ihvProvider": "CPUExecutionProvider",
+    "passes": {
+      "conversion": true,
+      "quantization": true,
+      "quantizationMethod": "awq"
+    }
+  }
+}
+```
+
+**Success (compact validation view)**
+
+```json
+{
+  "effective_state": { "...": "sanitized UIState" },
+  "schema_errors": [],
+  "pipeline_issues": [{ "severity": "critical", "title": "..." }],
+  "pipeline_critical_count": 1,
+  "local_execution_issues": [],
+  "advisories": [],
+  "is_runnable": false
+}
+```
+
+**Unavailable bridge**
+
+```json
+{
+  "error": "studio_unavailable",
+  "message": "OLIVE_STUDIO_API_URL is not set. Start Olive Studio and point OLIVE_STUDIO_API_URL at its loopback base URL (e.g. http://127.0.0.1:3000)."
+}
+```
+
+#### `get_recipe_for_ui_state`
+
+Same evaluation as `validate_ui_state_recipe`, plus:
+
+```json
+{
+  "effective_state": { "...": "..." },
+  "schema_errors": [],
+  "pipeline_issues": [],
+  "pipeline_critical_count": 0,
+  "local_execution_issues": [],
+  "advisories": [],
+  "is_runnable": true,
+  "olive_recipe": { "input_model": {}, "passes": {} },
+  "conversion_warnings": []
+}
+```
+
+`olive_recipe` is the exact JSON produced by Studio’s `buildRecipeFromState` for
+the effective state (same as UI export), not a Python reimplementation.
+
+### Local troubleshoot feedback
+
+#### `record_troubleshoot_feedback`
+
+Records **local-only, aggregate** thumbs for a troubleshooting KB
+`matched_entry`. Used by Olive Studio’s diagnostic card (via
+`POST /api/mcp/tool`) so future ranking can slightly prefer helpful matches.
+
+**Input** (no logs, tracebacks, or free-form text)
+
+```json
+{
+  "matched_entry": "onnxruntime-large-model-external-data",
+  "rating": "thumbs-up",
+  "reason_code": "accurate"
+}
+```
+
+- `rating`: `thumbs-up` | `thumbs-down` only
+- `reason_code` (optional): allowlisted codes only (`accurate`, `clear_fix`,
+  `fixed_issue`, `wrong_match`, `outdated`, `incomplete`, `incorrect_fix`)
+- Unknown `matched_entry` ids are rejected
+
+**Success (aggregate acknowledgement)**
+
+```json
+{
+  "status": "ok",
+  "matched_entry": "onnxruntime-large-model-external-data",
+  "rating": "thumbs-up",
+  "reason_code": "accurate",
+  "thumbs_up": 3,
+  "thumbs_down": 1,
+  "total": 4,
+  "score_delta": 0.02,
+  "max_score_adjustment": 0.05
+}
+```
+
+**Privacy**
+
+- Feedback is stored only on the local machine (default:
+  `$XDG_DATA_HOME/olive-mcp/troubleshoot_feedback.json`, or
+  `~/.local/share/olive-mcp/troubleshoot_feedback.json`; override with
+  `OLIVE_MCP_FEEDBACK_PATH`).
+- The store keeps **counts per entry id** (and optional reason-code tallies) —
+  never error logs, stack traces, or user prose.
+- Ranking influence is capped (`max_score_adjustment` = 0.05) so feedback can
+  only break close ties, not override strong keyword/semantic matches.
+- Nothing is uploaded to a remote service by this tool.
 
 ## Knowledge base
 
@@ -93,7 +243,7 @@ python olive-mcp-server/run.py
 - `knowledge_base/quirks.json` - common behaviors and pitfalls (incl. `studio`)
 - `knowledge_base/troubleshooting.json` - Olive runtime error diagnosis rules
 - `knowledge_base/studio_troubleshooting.json` - Olive Studio / builder / UI diagnosis rules
-- `knowledge_base/compatibility_matrix.json` - model compatibility matrix
+- `knowledge_base/compatibility_matrix.json` - model compatibility matrix (evidence-backed claims)
 - `knowledge_base/integration_recipes.json` - ready-to-run Olive recipe templates
 
 ### Diagnose domains
@@ -104,8 +254,10 @@ python olive-mcp-server/run.py
 - `olive`: Olive runtime KB only
 - `studio`: Olive Studio KB only
 
-Responses include `domain` (`olive` | `studio` | null) and `applyable` (bool).
-When `applyable` is false, Olive Studio disables Apply Fix and shows guidance only.
+Responses include `domain` (`olive` | `studio` | null), `matched_entry` (stable
+id or null), and `applyable` (bool). When `applyable` is false, Olive Studio
+disables Apply Fix and shows guidance only. Thumbs feedback appears only when
+`matched_entry` is a non-empty string.
 
 ## Fetchers and update mechanism
 
@@ -120,9 +272,10 @@ Update scripts:
 
 - `scripts/update_kb.py` - fetches all sources and writes
   `knowledge_base/update_report.json` plus `knowledge_base/candidate_quirks.json`
+  (and deterministic refresh metadata)
 - `scripts/expand_kb.py` - adds extra pass and hardware-profile coverage
 
-To refresh the knowledge base:
+To refresh the knowledge base **locally** (review the diff; do not auto-merge):
 
 ```bash
 # Windows
@@ -134,10 +287,26 @@ To refresh the knowledge base:
 .venv/bin/python -m scripts.expand_kb
 ```
 
+### Scheduled KB refresh PR process
+
+GitHub Actions workflow [`.github/workflows/kb-update.yml`](../.github/workflows/kb-update.yml)
+runs on a Monday schedule (and `workflow_dispatch`):
+
+1. Install deps with `mcp<2`, run `update_kb.py` + `expand_kb.py`
+2. Validate the compatibility matrix and run the full Python MCP pytest suite
+3. Upload report artifacts (`update_report.json`, `candidate_quirks.json`,
+   `refresh_metadata.json`) for review even when nothing changed
+4. If tracked KB files differ, open or update **one** labeled PR
+   (`kb-refresh` on branch `chore/kb-refresh`)
+5. **Never auto-merges.** Human commits on the refresh branch block force-updates
+   so manual edits are preserved
+
 ## Olive Studio integration
 
 The main Olive Studio app (`../`) proxies MCP tool calls through
-`POST /api/mcp/tool` and renders MCP diagnostics with `MCPDiagnosticCard`. The
+`POST /api/mcp/tool` and exposes the loopback recipe bridge at
+`POST /api/mcp/studio-recipe`. `MCPDiagnosticCard` renders MCP troubleshooting
+results (with optional local thumbs feedback when `matched_entry` is set). The
 top-level `.mcp.json` wires this server to Claude via `olive-mcp-server/run.py`.
 
 ## Roadmap

--- a/olive-mcp-server/olive_mcp_server/knowledge_base/compatibility_matrix.json
+++ b/olive-mcp-server/olive_mcp_server/knowledge_base/compatibility_matrix.json
@@ -1,56 +1,233 @@
 {
-  "version": "0.2.0",
-  "last_updated": "2026-07-25",
+  "version": "0.3.0",
+  "last_updated": "2026-08-05",
+  "olive_version_support": {
+    "min": "0.12.0",
+    "max": "0.12.1"
+  },
   "models": [
     {
       "model": "Mistral 7B",
-      "frameworks": ["PyTorch", "ONNX"],
+      "frameworks": ["PyTorch", "ONNX", "HuggingFace"],
+      "source": "https://github.com/microsoft/Olive/tree/main/examples/mistral",
+      "verified": true,
+      "notes": "Olive ships a Mistral example; prefer NVModelOpt/AWQ on NVIDIA over plain INT8 QDQ for generation quality.",
       "hardware": {
         "NVIDIA RTX 4090": {
+          "OnnxConversion": {
+            "support": "supported",
+            "olive_pass": "OnnxConversion",
+            "note": "Export with dynamic_axes for batch/sequence; use_external_data_format for >2GB weights.",
+            "typical_accuracy_drop": "n/a",
+            "evidence": {
+              "reference": "https://microsoft.github.io/Olive/0.12.1/reference/pass.html",
+              "type": "olive_docs",
+              "version": "0.12.1"
+            }
+          },
           "OnnxQuantization": {
             "support": "warning",
+            "olive_pass": "OnnxQuantization",
             "note": "INT8 can drop 10-15% perplexity; prefer NVModelOpt AWQ int4.",
-            "typical_accuracy_drop": "1-3% with AWQ"
+            "typical_accuracy_drop": "1-3% with AWQ",
+            "evidence": {
+              "reference": "https://onnxruntime.ai/docs/performance/model-optimizations/quantization.html",
+              "type": "ort_docs",
+              "version": "1.19"
+            }
           },
           "NVModelOptQuantization": {
             "support": "supported",
-            "note": "Best path for NVIDIA; use TensorRT.",
-            "typical_accuracy_drop": "<2%"
+            "olive_pass": "NVModelOptQuantization",
+            "note": "Best path for NVIDIA; AWQ int4 via TensorRT Model Optimizer.",
+            "typical_accuracy_drop": "<2%",
+            "evidence": {
+              "reference": "https://microsoft.github.io/Olive/0.12.1/reference/pass.html",
+              "type": "olive_docs",
+              "version": "0.12.1"
+            }
+          },
+          "AutoAWQQuantizer": {
+            "support": "supported",
+            "olive_pass": "AutoAWQQuantizer",
+            "note": "PyTorch-side AWQ before ONNX export; documented Olive LLM quant path.",
+            "typical_accuracy_drop": "<2%",
+            "evidence": {
+              "reference": "https://microsoft.github.io/Olive/0.12.1/reference/options.html",
+              "type": "olive_docs",
+              "version": "0.12.1"
+            }
           },
           "LoRA": {
             "support": "warning",
+            "olive_pass": "LoRA",
             "note": "ONNX limitation: re-export base model after adapter merge.",
-            "typical_accuracy_drop": "n/a"
+            "typical_accuracy_drop": "n/a",
+            "evidence": {
+              "reference": "https://microsoft.github.io/Olive/0.12.1/reference/pass.html",
+              "type": "olive_docs",
+              "version": "0.12.1"
+            }
+          },
+          "OnnxFloatToFloat16": {
+            "support": "supported",
+            "olive_pass": "OnnxFloatToFloat16",
+            "note": "FP16 halves VRAM; keep I/O float32 if consumers expect FP32.",
+            "typical_accuracy_drop": "<1%",
+            "evidence": {
+              "reference": "https://onnxruntime.ai/docs/performance/model-optimizations/float16.html",
+              "type": "ort_docs",
+              "version": "1.19"
+            }
           }
         },
         "Qualcomm Snapdragon NPU": {
           "OnnxQuantization": {
             "support": "warning",
-            "note": "15GB+ model; needs aggressive pruning or int4.",
-            "typical_accuracy_drop": "5-10%"
+            "olive_pass": "OnnxQuantization",
+            "note": "15GB+ model; needs aggressive pruning or int4 before QNN.",
+            "typical_accuracy_drop": "5-10%",
+            "evidence": {
+              "reference": "https://onnxruntime.ai/docs/execution-providers/QNN-ExecutionProvider.html",
+              "type": "ort_docs",
+              "version": "1.19"
+            }
+          },
+          "QNNPreprocess": {
+            "support": "supported",
+            "olive_pass": "QNNPreprocess",
+            "note": "Required preprocess for ops not natively on QNN.",
+            "typical_accuracy_drop": "n/a",
+            "evidence": {
+              "reference": "https://microsoft.github.io/Olive/0.12.1/reference/pass.html",
+              "type": "olive_docs",
+              "version": "0.12.1"
+            }
           },
           "QNNQuantization": {
             "support": "supported",
-            "note": "Use int4 weights and verify op whitelist.",
-            "typical_accuracy_drop": "3-5%"
+            "olive_pass": "QNNQuantization",
+            "note": "Use int4 weights (w4a8) and verify op whitelist.",
+            "typical_accuracy_drop": "3-5%",
+            "evidence": {
+              "reference": "https://microsoft.github.io/Olive/0.12.1/reference/pass.html",
+              "type": "olive_docs",
+              "version": "0.12.1"
+            }
+          }
+        },
+        "Intel Core i9 CPU": {
+          "OnnxConversion": {
+            "support": "supported",
+            "olive_pass": "OnnxConversion",
+            "note": "CPU export works; large weights need external data format.",
+            "typical_accuracy_drop": "n/a",
+            "evidence": {
+              "reference": "https://microsoft.github.io/Olive/0.12.1/reference/pass.html",
+              "type": "olive_docs",
+              "version": "0.12.1"
+            }
+          },
+          "OnnxBlockWiseRtnQuantization": {
+            "support": "warning",
+            "olive_pass": "OnnxBlockWiseRtnQuantization",
+            "note": "RTN int4 is fast for CPU footprint; validate perplexity.",
+            "typical_accuracy_drop": "2-4%",
+            "evidence": {
+              "reference": "https://microsoft.github.io/Olive/0.12.1/reference/options.html",
+              "type": "olive_docs",
+              "version": "0.12.1"
+            }
+          },
+          "OpenVINOWeightCompression": {
+            "support": "supported",
+            "olive_pass": "OpenVINOWeightCompression",
+            "note": "INT4/INT8 weight compression for low-memory CPU.",
+            "typical_accuracy_drop": "2-4%",
+            "evidence": {
+              "reference": "https://microsoft.github.io/Olive/0.12.1/reference/pass.html",
+              "type": "olive_docs",
+              "version": "0.12.1"
+            }
           }
         }
       }
     },
     {
       "model": "Phi-3-mini",
-      "frameworks": ["PyTorch", "ONNX"],
+      "frameworks": ["PyTorch", "ONNX", "HuggingFace"],
+      "source": "https://github.com/microsoft/Olive/tree/main/examples/phi2",
+      "verified": true,
+      "notes": "Phi family is covered by Olive phi examples and NVModelOpt/ORT quant paths; Phi-3-mini is small enough for stable INT8.",
       "hardware": {
         "NVIDIA RTX 4090": {
+          "OnnxConversion": {
+            "support": "supported",
+            "olive_pass": "OnnxConversion",
+            "note": "Export with dynamic_axes for batch and sequence.",
+            "typical_accuracy_drop": "n/a",
+            "evidence": {
+              "reference": "https://microsoft.github.io/Olive/0.12.1/reference/pass.html",
+              "type": "olive_docs",
+              "version": "0.12.1"
+            }
+          },
           "OnnxQuantization": {
             "support": "supported",
+            "olive_pass": "OnnxQuantization",
             "note": "INT8 QDQ works well; TensorRT recommended.",
-            "typical_accuracy_drop": "<1%"
+            "typical_accuracy_drop": "<1%",
+            "evidence": {
+              "reference": "https://onnxruntime.ai/docs/performance/model-optimizations/quantization.html",
+              "type": "ort_docs",
+              "version": "1.19"
+            }
           },
           "NVModelOptQuantization": {
             "support": "supported",
-            "note": "AWQ int4 is stable for Phi-3.",
-            "typical_accuracy_drop": "<1.5%"
+            "olive_pass": "NVModelOptQuantization",
+            "note": "AWQ int4 is stable for Phi-class models in Olive examples.",
+            "typical_accuracy_drop": "<1.5%",
+            "evidence": {
+              "reference": "https://github.com/microsoft/Olive/tree/main/examples/phi2",
+              "type": "github",
+              "version": "0.12.1"
+            }
+          },
+          "OnnxFloatToFloat16": {
+            "support": "supported",
+            "olive_pass": "OnnxFloatToFloat16",
+            "note": "FP16 is the default GPU path for small Phi models.",
+            "typical_accuracy_drop": "<1%",
+            "evidence": {
+              "reference": "https://onnxruntime.ai/docs/performance/model-optimizations/float16.html",
+              "type": "ort_docs",
+              "version": "1.19"
+            }
+          }
+        },
+        "Intel Core i9 CPU": {
+          "OnnxStaticQuantization": {
+            "support": "supported",
+            "olive_pass": "OnnxStaticQuantization",
+            "note": "INT8 static quant with calibration is stable for Phi-3-mini.",
+            "typical_accuracy_drop": "<1%",
+            "evidence": {
+              "reference": "https://microsoft.github.io/Olive/0.12.1/reference/pass.html",
+              "type": "olive_docs",
+              "version": "0.12.1"
+            }
+          },
+          "OnnxBlockWiseRtnQuantization": {
+            "support": "supported",
+            "olive_pass": "OnnxBlockWiseRtnQuantization",
+            "note": "INT4 block-wise RTN for low-memory CPU (same path as Phi-4 recipe).",
+            "typical_accuracy_drop": "1-2%",
+            "evidence": {
+              "reference": "https://microsoft.github.io/Olive/0.12.1/reference/options.html",
+              "type": "olive_docs",
+              "version": "0.12.1"
+            }
           }
         }
       }
@@ -58,262 +235,817 @@
     {
       "model": "ResNet-50",
       "frameworks": ["PyTorch", "ONNX"],
+      "source": "https://github.com/microsoft/Olive/tree/main/examples/resnet",
+      "verified": true,
+      "notes": "Canonical Olive CNN example; static INT8 PTQ is highly stable.",
       "hardware": {
         "Intel Core i9 CPU": {
+          "OnnxConversion": {
+            "support": "supported",
+            "olive_pass": "OnnxConversion",
+            "note": "Fixed 1x3x224x224 I/O; target_opset 14+.",
+            "typical_accuracy_drop": "n/a",
+            "evidence": {
+              "reference": "https://github.com/microsoft/Olive/tree/main/examples/resnet",
+              "type": "github",
+              "version": "0.12.1"
+            }
+          },
           "OnnxStaticQuantization": {
             "support": "supported",
+            "olive_pass": "OnnxStaticQuantization",
             "note": "INT8 static quantization is highly stable for CNNs.",
-            "typical_accuracy_drop": "<0.5%"
+            "typical_accuracy_drop": "<0.5%",
+            "evidence": {
+              "reference": "https://onnxruntime.ai/docs/performance/model-optimizations/quantization.html",
+              "type": "ort_docs",
+              "version": "1.19"
+            }
+          },
+          "OnnxModelOptimizer": {
+            "support": "supported",
+            "olive_pass": "OnnxModelOptimizer",
+            "note": "Post-quant graph cleanup used in Olive ResNet recipes.",
+            "typical_accuracy_drop": "n/a",
+            "evidence": {
+              "reference": "https://microsoft.github.io/Olive/0.12.1/reference/pass.html",
+              "type": "olive_docs",
+              "version": "0.12.1"
+            }
           },
           "IncStaticQuantization": {
             "support": "supported",
-            "note": "OpenVINO INT8 is a strong alternative.",
-            "typical_accuracy_drop": "<0.5%"
+            "olive_pass": "IncStaticQuantization",
+            "note": "Intel Neural Compressor static INT8 is a strong CPU alternative.",
+            "typical_accuracy_drop": "<0.5%",
+            "evidence": {
+              "reference": "https://microsoft.github.io/Olive/0.12.1/reference/pass.html",
+              "type": "olive_docs",
+              "version": "0.12.1"
+            }
+          },
+          "OpenVINOConversion": {
+            "support": "supported",
+            "olive_pass": "OpenVINOConversion",
+            "note": "OpenVINO IR conversion for Intel CPU/iGPU.",
+            "typical_accuracy_drop": "n/a",
+            "evidence": {
+              "reference": "https://onnxruntime.ai/docs/execution-providers/OpenVINO-ExecutionProvider.html",
+              "type": "ort_docs",
+              "version": "1.19"
+            }
+          },
+          "OpenVINOQuantization": {
+            "support": "supported",
+            "olive_pass": "OpenVINOQuantization",
+            "note": "OpenVINO INT8 for vision CNNs.",
+            "typical_accuracy_drop": "<0.5%",
+            "evidence": {
+              "reference": "https://microsoft.github.io/Olive/0.12.1/reference/pass.html",
+              "type": "olive_docs",
+              "version": "0.12.1"
+            }
           }
         },
         "Qualcomm Snapdragon NPU": {
+          "QNNConversion": {
+            "support": "supported",
+            "olive_pass": "QNNConversion",
+            "note": "Convert ONNX to QNN context for NPU.",
+            "typical_accuracy_drop": "n/a",
+            "evidence": {
+              "reference": "https://microsoft.github.io/Olive/0.12.1/reference/pass.html",
+              "type": "olive_docs",
+              "version": "0.12.1"
+            }
+          },
           "QNNQuantization": {
             "support": "supported",
+            "olive_pass": "QNNQuantization",
             "note": "Per-channel symmetric required; typical ImageNet drop <1%.",
-            "typical_accuracy_drop": "<1%"
+            "typical_accuracy_drop": "<1%",
+            "evidence": {
+              "reference": "https://onnxruntime.ai/docs/execution-providers/QNN-ExecutionProvider.html",
+              "type": "ort_docs",
+              "version": "1.19"
+            }
+          }
+        },
+        "NVIDIA T4": {
+          "OnnxConversion": {
+            "support": "supported",
+            "olive_pass": "OnnxConversion",
+            "note": "FP16 TensorRT path after conversion.",
+            "typical_accuracy_drop": "n/a",
+            "evidence": {
+              "reference": "https://microsoft.github.io/Olive/0.12.1/reference/pass.html",
+              "type": "olive_docs",
+              "version": "0.12.1"
+            }
+          },
+          "OnnxQuantization": {
+            "support": "supported",
+            "olive_pass": "OnnxQuantization",
+            "note": "INT8 QDQ for TensorRT EP on T4.",
+            "typical_accuracy_drop": "<1%",
+            "evidence": {
+              "reference": "https://onnxruntime.ai/docs/execution-providers/TensorRT-ExecutionProvider.html",
+              "type": "ort_docs",
+              "version": "1.19"
+            }
+          },
+          "OnnxFloatToFloat16": {
+            "support": "supported",
+            "olive_pass": "OnnxFloatToFloat16",
+            "note": "FP16 is standard for ResNet on GPU.",
+            "typical_accuracy_drop": "<0.5%",
+            "evidence": {
+              "reference": "https://onnxruntime.ai/docs/performance/model-optimizations/float16.html",
+              "type": "ort_docs",
+              "version": "1.19"
+            }
           }
         }
       }
     },
     {
       "model": "Whisper",
-      "frameworks": ["PyTorch", "ONNX"],
+      "frameworks": ["PyTorch", "ONNX", "HuggingFace"],
+      "source": "https://github.com/microsoft/Olive/tree/main/examples/whisper",
+      "verified": true,
+      "notes": "Olive Whisper example; encoder static INT8, decoder often dynamic shapes.",
       "hardware": {
         "NVIDIA T4": {
           "OnnxConversion": {
             "support": "warning",
+            "olive_pass": "OnnxConversion",
             "note": "Dynamic sequence length for audio; use dynamic_axes.",
-            "typical_accuracy_drop": "n/a"
+            "typical_accuracy_drop": "n/a",
+            "evidence": {
+              "reference": "https://github.com/microsoft/Olive/tree/main/examples/whisper",
+              "type": "github",
+              "version": "0.12.1"
+            }
           },
           "OnnxStaticQuantization": {
             "support": "supported",
+            "olive_pass": "OnnxStaticQuantization",
             "note": "Encoder can be static INT8; decoder often needs dynamic quantization.",
-            "typical_accuracy_drop": "1-3%"
+            "typical_accuracy_drop": "1-3%",
+            "evidence": {
+              "reference": "https://onnxruntime.ai/docs/performance/model-optimizations/quantization.html",
+              "type": "ort_docs",
+              "version": "1.19"
+            }
+          },
+          "OnnxDynamicQuantization": {
+            "support": "supported",
+            "olive_pass": "OnnxDynamicQuantization",
+            "note": "Decoder-friendly; no calibration required.",
+            "typical_accuracy_drop": "1-3%",
+            "evidence": {
+              "reference": "https://microsoft.github.io/Olive/0.12.1/reference/pass.html",
+              "type": "olive_docs",
+              "version": "0.12.1"
+            }
+          },
+          "OrtTransformersOptimization": {
+            "support": "supported",
+            "olive_pass": "OrtTransformersOptimization",
+            "note": "ORT transformer fusions for Whisper encoder/decoder graphs.",
+            "typical_accuracy_drop": "n/a",
+            "evidence": {
+              "reference": "https://onnxruntime.ai/docs/performance/model-optimizations/transformers-optimization.html",
+              "type": "ort_docs",
+              "version": "1.19"
+            }
+          }
+        },
+        "Intel Core i9 CPU": {
+          "OnnxConversion": {
+            "support": "supported",
+            "olive_pass": "OnnxConversion",
+            "note": "CPU export with dynamic audio axes.",
+            "typical_accuracy_drop": "n/a",
+            "evidence": {
+              "reference": "https://github.com/microsoft/Olive/tree/main/examples/whisper",
+              "type": "github",
+              "version": "0.12.1"
+            }
+          },
+          "OnnxStaticQuantization": {
+            "support": "warning",
+            "olive_pass": "OnnxStaticQuantization",
+            "note": "Calibrate encoder carefully; decoder dynamic shapes limit static INT8.",
+            "typical_accuracy_drop": "1-3%",
+            "evidence": {
+              "reference": "https://microsoft.github.io/Olive/0.12.1/reference/pass.html",
+              "type": "olive_docs",
+              "version": "0.12.1"
+            }
           }
         }
       }
     },
     {
       "model": "Llama 2 7B",
-      "frameworks": ["PyTorch", "ONNX"],
+      "frameworks": ["PyTorch", "ONNX", "HuggingFace"],
+      "source": "https://github.com/microsoft/Olive/tree/main/examples/llama2",
+      "verified": true,
+      "notes": "Official Olive llama2 example covers conversion and GPU quant paths.",
       "hardware": {
         "NVIDIA RTX 4090": {
           "OnnxConversion": {
             "support": "supported",
-            "note": "Use dynamic_axes for variable batch/sequence.",
-            "typical_accuracy_drop": "n/a"
+            "olive_pass": "OnnxConversion",
+            "note": "Use dynamic_axes for variable batch/sequence; external data for large weights.",
+            "typical_accuracy_drop": "n/a",
+            "evidence": {
+              "reference": "https://github.com/microsoft/Olive/tree/main/examples/llama2",
+              "type": "github",
+              "version": "0.12.1"
+            }
           },
           "NVModelOptQuantization": {
             "support": "supported",
+            "olive_pass": "NVModelOptQuantization",
             "note": "AWQ int4 is well supported on NVIDIA GPUs.",
-            "typical_accuracy_drop": "<2%"
+            "typical_accuracy_drop": "<2%",
+            "evidence": {
+              "reference": "https://microsoft.github.io/Olive/0.12.1/reference/pass.html",
+              "type": "olive_docs",
+              "version": "0.12.1"
+            }
+          },
+          "AutoAWQQuantizer": {
+            "support": "supported",
+            "olive_pass": "AutoAWQQuantizer",
+            "note": "AutoAWQ before ONNX export; used in Olive LLM recipes.",
+            "typical_accuracy_drop": "<2%",
+            "evidence": {
+              "reference": "https://microsoft.github.io/Olive/0.12.1/reference/options.html",
+              "type": "olive_docs",
+              "version": "0.12.1"
+            }
           },
           "OnnxQuantization": {
             "support": "warning",
+            "olive_pass": "OnnxQuantization",
             "note": "INT8 QDQ is usable but AWQ/TensorRT is preferred.",
-            "typical_accuracy_drop": "1-3%"
+            "typical_accuracy_drop": "1-3%",
+            "evidence": {
+              "reference": "https://onnxruntime.ai/docs/performance/model-optimizations/quantization.html",
+              "type": "ort_docs",
+              "version": "1.19"
+            }
+          },
+          "GptqQuantizer": {
+            "support": "supported",
+            "olive_pass": "GptqQuantizer",
+            "note": "GPTQ int4 alternative when AWQ calibration data is limited.",
+            "typical_accuracy_drop": "<3%",
+            "evidence": {
+              "reference": "https://microsoft.github.io/Olive/0.12.1/reference/pass.html",
+              "type": "olive_docs",
+              "version": "0.12.1"
+            }
+          },
+          "OnnxFloatToFloat16": {
+            "support": "supported",
+            "olive_pass": "OnnxFloatToFloat16",
+            "note": "FP16 halves memory on consumer GPUs.",
+            "typical_accuracy_drop": "<1%",
+            "evidence": {
+              "reference": "https://onnxruntime.ai/docs/performance/model-optimizations/float16.html",
+              "type": "ort_docs",
+              "version": "1.19"
+            }
           }
         },
         "Intel Core i9 CPU": {
           "OnnxConversion": {
             "support": "supported",
+            "olive_pass": "OnnxConversion",
             "note": "CPU inference works; static quantization possible.",
-            "typical_accuracy_drop": "n/a"
+            "typical_accuracy_drop": "n/a",
+            "evidence": {
+              "reference": "https://microsoft.github.io/Olive/0.12.1/reference/pass.html",
+              "type": "olive_docs",
+              "version": "0.12.1"
+            }
           },
           "OnnxStaticQuantization": {
             "support": "supported",
+            "olive_pass": "OnnxStaticQuantization",
             "note": "INT8 static quantization reduces memory but may slow generation.",
-            "typical_accuracy_drop": "1-2%"
+            "typical_accuracy_drop": "1-2%",
+            "evidence": {
+              "reference": "https://onnxruntime.ai/docs/performance/model-optimizations/quantization.html",
+              "type": "ort_docs",
+              "version": "1.19"
+            }
           },
           "OpenVINOConversion": {
             "support": "supported",
+            "olive_pass": "OpenVINOConversion",
             "note": "OpenVINO can improve CPU throughput.",
-            "typical_accuracy_drop": "n/a"
+            "typical_accuracy_drop": "n/a",
+            "evidence": {
+              "reference": "https://microsoft.github.io/Olive/0.12.1/reference/pass.html",
+              "type": "olive_docs",
+              "version": "0.12.1"
+            }
+          },
+          "OpenVINOWeightCompression": {
+            "support": "supported",
+            "olive_pass": "OpenVINOWeightCompression",
+            "note": "INT4/INT8 weight compression for 7B on CPU.",
+            "typical_accuracy_drop": "2-4%",
+            "evidence": {
+              "reference": "https://microsoft.github.io/Olive/0.12.1/reference/pass.html",
+              "type": "olive_docs",
+              "version": "0.12.1"
+            }
+          },
+          "OnnxBlockWiseRtnQuantization": {
+            "support": "warning",
+            "olive_pass": "OnnxBlockWiseRtnQuantization",
+            "note": "RTN int4 is calibration-light; validate perplexity.",
+            "typical_accuracy_drop": "2-4%",
+            "evidence": {
+              "reference": "https://microsoft.github.io/Olive/0.12.1/reference/options.html",
+              "type": "olive_docs",
+              "version": "0.12.1"
+            }
           }
         },
         "Qualcomm Snapdragon NPU": {
+          "QNNPreprocess": {
+            "support": "supported",
+            "olive_pass": "QNNPreprocess",
+            "note": "Preprocess unsupported ops before QNN quant.",
+            "typical_accuracy_drop": "n/a",
+            "evidence": {
+              "reference": "https://microsoft.github.io/Olive/0.12.1/reference/pass.html",
+              "type": "olive_docs",
+              "version": "0.12.1"
+            }
+          },
           "QNNQuantization": {
             "support": "supported",
+            "olive_pass": "QNNQuantization",
             "note": "Use int4 weights and QNNPreprocess for unsupported ops.",
-            "typical_accuracy_drop": "3-5%"
+            "typical_accuracy_drop": "3-5%",
+            "evidence": {
+              "reference": "https://onnxruntime.ai/docs/execution-providers/QNN-ExecutionProvider.html",
+              "type": "ort_docs",
+              "version": "1.19"
+            }
           }
         }
       }
     },
     {
       "model": "Llama 3 8B",
-      "frameworks": ["PyTorch", "ONNX"],
+      "frameworks": ["PyTorch", "ONNX", "HuggingFace"],
+      "source": "https://github.com/microsoft/olive-recipes",
+      "verified": true,
+      "notes": "Covered by Olive LLM recipes (AutoAWQ + NVModelOpt + OpenVINO weight compression).",
       "hardware": {
         "NVIDIA RTX 4090": {
           "OnnxConversion": {
             "support": "supported",
+            "olive_pass": "OnnxConversion",
             "note": "Use dynamic_axes and external data for large weights.",
-            "typical_accuracy_drop": "n/a"
+            "typical_accuracy_drop": "n/a",
+            "evidence": {
+              "reference": "https://microsoft.github.io/Olive/0.12.1/reference/pass.html",
+              "type": "olive_docs",
+              "version": "0.12.1"
+            }
           },
           "NVModelOptQuantization": {
             "support": "supported",
-            "note": "AWQ int4 is the recommended path for Llama 3.",
-            "typical_accuracy_drop": "<2%"
+            "olive_pass": "NVModelOptQuantization",
+            "note": "AWQ int4 is the recommended path for Llama 3 on NVIDIA.",
+            "typical_accuracy_drop": "<2%",
+            "evidence": {
+              "reference": "https://microsoft.github.io/Olive/0.12.1/reference/pass.html",
+              "type": "olive_docs",
+              "version": "0.12.1"
+            }
+          },
+          "AutoAWQQuantizer": {
+            "support": "supported",
+            "olive_pass": "AutoAWQQuantizer",
+            "note": "Studio/MCP llama3_cuda_awq recipe uses AutoAWQ then OnnxConversion.",
+            "typical_accuracy_drop": "<2%",
+            "evidence": {
+              "reference": "https://microsoft.github.io/Olive/0.12.1/reference/options.html",
+              "type": "olive_docs",
+              "version": "0.12.1"
+            }
           },
           "OnnxFloatToFloat16": {
             "support": "supported",
+            "olive_pass": "OnnxFloatToFloat16",
             "note": "FP16 halves memory; keep I/O types float32 for stability.",
-            "typical_accuracy_drop": "<1%"
+            "typical_accuracy_drop": "<1%",
+            "evidence": {
+              "reference": "https://onnxruntime.ai/docs/performance/model-optimizations/float16.html",
+              "type": "ort_docs",
+              "version": "1.19"
+            }
+          },
+          "OnnxModelOptimizer": {
+            "support": "supported",
+            "olive_pass": "OnnxModelOptimizer",
+            "note": "Post-export graph optimization in Olive LLM recipes.",
+            "typical_accuracy_drop": "n/a",
+            "evidence": {
+              "reference": "https://microsoft.github.io/Olive/0.12.1/reference/pass.html",
+              "type": "olive_docs",
+              "version": "0.12.1"
+            }
+          },
+          "GptqQuantizer": {
+            "support": "supported",
+            "olive_pass": "GptqQuantizer",
+            "note": "GPTQ int4 alternative documented in Olive pass catalog.",
+            "typical_accuracy_drop": "<3%",
+            "evidence": {
+              "reference": "https://microsoft.github.io/Olive/0.12.1/reference/pass.html",
+              "type": "olive_docs",
+              "version": "0.12.1"
+            }
           }
         },
         "Intel Core i9 CPU": {
           "OnnxConversion": {
             "support": "supported",
+            "olive_pass": "OnnxConversion",
             "note": "CPU-friendly with dynamic_axes.",
-            "typical_accuracy_drop": "n/a"
+            "typical_accuracy_drop": "n/a",
+            "evidence": {
+              "reference": "https://microsoft.github.io/Olive/0.12.1/reference/pass.html",
+              "type": "olive_docs",
+              "version": "0.12.1"
+            }
           },
           "OnnxStaticQuantization": {
             "support": "supported",
+            "olive_pass": "OnnxStaticQuantization",
             "note": "INT8 static quant reduces footprint for edge deployment.",
-            "typical_accuracy_drop": "1-2%"
+            "typical_accuracy_drop": "1-2%",
+            "evidence": {
+              "reference": "https://onnxruntime.ai/docs/performance/model-optimizations/quantization.html",
+              "type": "ort_docs",
+              "version": "1.19"
+            }
           },
           "OpenVINOConversion": {
             "support": "supported",
+            "olive_pass": "OpenVINOConversion",
             "note": "OpenVINO is a good CPU target for Llama 3.",
-            "typical_accuracy_drop": "n/a"
+            "typical_accuracy_drop": "n/a",
+            "evidence": {
+              "reference": "https://microsoft.github.io/Olive/0.12.1/reference/pass.html",
+              "type": "olive_docs",
+              "version": "0.12.1"
+            }
+          },
+          "OpenVINOOptimumConversion": {
+            "support": "supported",
+            "olive_pass": "OpenVINOOptimumConversion",
+            "note": "Optimum-based HF→OpenVINO path used in openvino_llm recipe.",
+            "typical_accuracy_drop": "n/a",
+            "evidence": {
+              "reference": "https://microsoft.github.io/Olive/0.12.1/reference/pass.html",
+              "type": "olive_docs",
+              "version": "0.12.1"
+            }
+          },
+          "OpenVINOWeightCompression": {
+            "support": "supported",
+            "olive_pass": "OpenVINOWeightCompression",
+            "note": "INT4/INT8 weight compression for 8B on CPU/iGPU.",
+            "typical_accuracy_drop": "2-4%",
+            "evidence": {
+              "reference": "https://microsoft.github.io/Olive/0.12.1/reference/pass.html",
+              "type": "olive_docs",
+              "version": "0.12.1"
+            }
           }
         },
         "Qualcomm Snapdragon NPU": {
+          "QNNPreprocess": {
+            "support": "supported",
+            "olive_pass": "QNNPreprocess",
+            "note": "Required before QNN quant for LLM ops.",
+            "typical_accuracy_drop": "n/a",
+            "evidence": {
+              "reference": "https://microsoft.github.io/Olive/0.12.1/reference/pass.html",
+              "type": "olive_docs",
+              "version": "0.12.1"
+            }
+          },
           "QNNQuantization": {
             "support": "supported",
+            "olive_pass": "QNNQuantization",
             "note": "int4 weights with QNNPreprocess give best NPU throughput.",
-            "typical_accuracy_drop": "3-5%"
+            "typical_accuracy_drop": "3-5%",
+            "evidence": {
+              "reference": "https://onnxruntime.ai/docs/execution-providers/QNN-ExecutionProvider.html",
+              "type": "ort_docs",
+              "version": "1.19"
+            }
           }
         }
       }
     },
     {
       "model": "Phi-4",
-      "frameworks": ["PyTorch", "ONNX"],
+      "frameworks": ["PyTorch", "ONNX", "HuggingFace"],
+      "source": "https://github.com/microsoft/Olive/tree/main/examples/phi2",
+      "verified": true,
+      "notes": "Phi-4 uses the same Olive Phi/LLM quant paths; phi4_cpu_int4 recipe uses OnnxBlockWiseRtnQuantization.",
       "hardware": {
         "NVIDIA RTX 4090": {
           "OnnxConversion": {
             "support": "supported",
+            "olive_pass": "OnnxConversion",
             "note": "Export with dynamic_axes for batch and sequence.",
-            "typical_accuracy_drop": "n/a"
+            "typical_accuracy_drop": "n/a",
+            "evidence": {
+              "reference": "https://microsoft.github.io/Olive/0.12.1/reference/pass.html",
+              "type": "olive_docs",
+              "version": "0.12.1"
+            }
           },
           "NVModelOptQuantization": {
             "support": "supported",
+            "olive_pass": "NVModelOptQuantization",
             "note": "NVModelOpt AWQ int4 works well for small Phi models.",
-            "typical_accuracy_drop": "<2%"
+            "typical_accuracy_drop": "<2%",
+            "evidence": {
+              "reference": "https://microsoft.github.io/Olive/0.12.1/reference/pass.html",
+              "type": "olive_docs",
+              "version": "0.12.1"
+            }
           },
           "OnnxQuantization": {
             "support": "supported",
+            "olive_pass": "OnnxQuantization",
             "note": "INT8 QDQ is stable on Phi-4.",
-            "typical_accuracy_drop": "<1%"
+            "typical_accuracy_drop": "<1%",
+            "evidence": {
+              "reference": "https://onnxruntime.ai/docs/performance/model-optimizations/quantization.html",
+              "type": "ort_docs",
+              "version": "1.19"
+            }
+          },
+          "OnnxFloatToFloat16": {
+            "support": "supported",
+            "olive_pass": "OnnxFloatToFloat16",
+            "note": "FP16 is preferred GPU path for small Phi.",
+            "typical_accuracy_drop": "<1%",
+            "evidence": {
+              "reference": "https://onnxruntime.ai/docs/performance/model-optimizations/float16.html",
+              "type": "ort_docs",
+              "version": "1.19"
+            }
           }
         },
         "Intel Core i9 CPU": {
           "OnnxConversion": {
             "support": "supported",
+            "olive_pass": "OnnxConversion",
             "note": "CPU export is straightforward.",
-            "typical_accuracy_drop": "n/a"
+            "typical_accuracy_drop": "n/a",
+            "evidence": {
+              "reference": "https://microsoft.github.io/Olive/0.12.1/reference/pass.html",
+              "type": "olive_docs",
+              "version": "0.12.1"
+            }
           },
           "OnnxStaticQuantization": {
             "support": "supported",
+            "olive_pass": "OnnxStaticQuantization",
             "note": "INT8 static quantization gives good CPU latency.",
-            "typical_accuracy_drop": "<1%"
+            "typical_accuracy_drop": "<1%",
+            "evidence": {
+              "reference": "https://microsoft.github.io/Olive/0.12.1/reference/pass.html",
+              "type": "olive_docs",
+              "version": "0.12.1"
+            }
           },
           "OnnxDynamicQuantization": {
             "support": "supported",
+            "olive_pass": "OnnxDynamicQuantization",
             "note": "No calibration required; good for quick CPU tests.",
-            "typical_accuracy_drop": "1-2%"
+            "typical_accuracy_drop": "1-2%",
+            "evidence": {
+              "reference": "https://microsoft.github.io/Olive/0.12.1/reference/pass.html",
+              "type": "olive_docs",
+              "version": "0.12.1"
+            }
+          },
+          "OnnxBlockWiseRtnQuantization": {
+            "support": "supported",
+            "olive_pass": "OnnxBlockWiseRtnQuantization",
+            "note": "phi4_cpu_int4 integration recipe path.",
+            "typical_accuracy_drop": "1-2%",
+            "evidence": {
+              "reference": "https://microsoft.github.io/Olive/0.12.1/reference/options.html",
+              "type": "olive_docs",
+              "version": "0.12.1"
+            }
+          },
+          "OnnxModelOptimizer": {
+            "support": "supported",
+            "olive_pass": "OnnxModelOptimizer",
+            "note": "Post-quant optimizer in phi4_cpu_int4 recipe.",
+            "typical_accuracy_drop": "n/a",
+            "evidence": {
+              "reference": "https://microsoft.github.io/Olive/0.12.1/reference/pass.html",
+              "type": "olive_docs",
+              "version": "0.12.1"
+            }
           }
         },
         "Qualcomm Snapdragon NPU": {
           "QNNQuantization": {
             "support": "supported",
+            "olive_pass": "QNNQuantization",
             "note": "Small enough for NPU int4 deployment.",
-            "typical_accuracy_drop": "2-4%"
+            "typical_accuracy_drop": "2-4%",
+            "evidence": {
+              "reference": "https://onnxruntime.ai/docs/execution-providers/QNN-ExecutionProvider.html",
+              "type": "ort_docs",
+              "version": "1.19"
+            }
           }
         }
       }
     },
     {
       "model": "CodeLlama 7B",
-      "frameworks": ["PyTorch", "ONNX"],
+      "frameworks": ["PyTorch", "ONNX", "HuggingFace"],
+      "source": "https://github.com/microsoft/Olive/tree/main/examples/llama2",
+      "verified": false,
+      "notes": "CodeLlama shares Llama architecture; claims limited to Olive Llama pass availability (conversion, AWQ, static quant) — not code-task benchmarks.",
       "hardware": {
         "NVIDIA RTX 4090": {
           "OnnxConversion": {
             "support": "supported",
-            "note": "Long context requires careful dynamic_axes.",
-            "typical_accuracy_drop": "n/a"
+            "olive_pass": "OnnxConversion",
+            "note": "Long context requires careful dynamic_axes; same export path as Llama 2.",
+            "typical_accuracy_drop": "n/a",
+            "evidence": {
+              "reference": "https://github.com/microsoft/Olive/tree/main/examples/llama2",
+              "type": "github",
+              "version": "0.12.1"
+            }
           },
           "NVModelOptQuantization": {
             "support": "supported",
-            "note": "AWQ int4 is recommended for code generation.",
-            "typical_accuracy_drop": "<2%"
+            "olive_pass": "NVModelOptQuantization",
+            "note": "AWQ int4 available for Llama-architecture models on NVIDIA.",
+            "typical_accuracy_drop": "<2%",
+            "evidence": {
+              "reference": "https://microsoft.github.io/Olive/0.12.1/reference/pass.html",
+              "type": "olive_docs",
+              "version": "0.12.1"
+            }
+          },
+          "AutoAWQQuantizer": {
+            "support": "supported",
+            "olive_pass": "AutoAWQQuantizer",
+            "note": "AutoAWQ pass available for HF Llama-family checkpoints.",
+            "typical_accuracy_drop": "<2%",
+            "evidence": {
+              "reference": "https://microsoft.github.io/Olive/0.12.1/reference/options.html",
+              "type": "olive_docs",
+              "version": "0.12.1"
+            }
           }
         },
         "Intel Core i9 CPU": {
           "OnnxConversion": {
             "support": "supported",
+            "olive_pass": "OnnxConversion",
             "note": "Long sequence lengths can be slow on CPU.",
-            "typical_accuracy_drop": "n/a"
+            "typical_accuracy_drop": "n/a",
+            "evidence": {
+              "reference": "https://microsoft.github.io/Olive/0.12.1/reference/pass.html",
+              "type": "olive_docs",
+              "version": "0.12.1"
+            }
           },
           "OnnxStaticQuantization": {
             "support": "warning",
+            "olive_pass": "OnnxStaticQuantization",
             "note": "Quantization may affect code-token accuracy; evaluate carefully.",
-            "typical_accuracy_drop": "2-4%"
+            "typical_accuracy_drop": "2-4%",
+            "evidence": {
+              "reference": "https://onnxruntime.ai/docs/performance/model-optimizations/quantization.html",
+              "type": "ort_docs",
+              "version": "1.19"
+            }
           }
         },
         "Qualcomm Snapdragon NPU": {
           "QNNQuantization": {
             "support": "supported",
-            "note": "int4 weights recommended for 7B code model.",
-            "typical_accuracy_drop": "3-5%"
+            "olive_pass": "QNNQuantization",
+            "note": "int4 weights recommended for 7B; validate ops on device.",
+            "typical_accuracy_drop": "3-5%",
+            "evidence": {
+              "reference": "https://onnxruntime.ai/docs/execution-providers/QNN-ExecutionProvider.html",
+              "type": "ort_docs",
+              "version": "1.19"
+            }
           }
         }
       }
     },
     {
       "model": "DeepSeek-R1-Distill-Llama 8B",
-      "frameworks": ["PyTorch", "ONNX"],
+      "frameworks": ["PyTorch", "ONNX", "HuggingFace"],
+      "source": "https://microsoft.github.io/Olive/0.12.1/reference/pass.html",
+      "verified": false,
+      "notes": "Distilled Llama backbone; claims limited to Olive Llama-architecture pass availability (conversion, NVModelOpt, OpenVINO weight compression).",
       "hardware": {
         "NVIDIA RTX 4090": {
           "OnnxConversion": {
             "support": "supported",
+            "olive_pass": "OnnxConversion",
             "note": "Use dynamic_axes for reasoning-length outputs.",
-            "typical_accuracy_drop": "n/a"
+            "typical_accuracy_drop": "n/a",
+            "evidence": {
+              "reference": "https://microsoft.github.io/Olive/0.12.1/reference/pass.html",
+              "type": "olive_docs",
+              "version": "0.12.1"
+            }
           },
           "NVModelOptQuantization": {
             "support": "supported",
-            "note": "AWQ int4 is the best GPU path.",
-            "typical_accuracy_drop": "<2%"
+            "olive_pass": "NVModelOptQuantization",
+            "note": "AWQ int4 is the best GPU path for Llama-backbone 8B.",
+            "typical_accuracy_drop": "<2%",
+            "evidence": {
+              "reference": "https://microsoft.github.io/Olive/0.12.1/reference/pass.html",
+              "type": "olive_docs",
+              "version": "0.12.1"
+            }
           }
         },
         "Intel Core i9 CPU": {
           "OnnxConversion": {
             "support": "supported",
+            "olive_pass": "OnnxConversion",
             "note": "CPU export works; int4 reduces memory.",
-            "typical_accuracy_drop": "n/a"
+            "typical_accuracy_drop": "n/a",
+            "evidence": {
+              "reference": "https://microsoft.github.io/Olive/0.12.1/reference/pass.html",
+              "type": "olive_docs",
+              "version": "0.12.1"
+            }
           },
           "OpenVINOConversion": {
             "support": "supported",
-            "note": "OpenVINO Weight Compression is effective for 8B.",
-            "typical_accuracy_drop": "<2%"
+            "olive_pass": "OpenVINOConversion",
+            "note": "OpenVINO conversion available for ONNX LLMs.",
+            "typical_accuracy_drop": "n/a",
+            "evidence": {
+              "reference": "https://microsoft.github.io/Olive/0.12.1/reference/pass.html",
+              "type": "olive_docs",
+              "version": "0.12.1"
+            }
           },
           "OpenVINOWeightCompression": {
             "support": "supported",
+            "olive_pass": "OpenVINOWeightCompression",
             "note": "INT4/INT8 weight compression for low-memory CPU.",
-            "typical_accuracy_drop": "2-4%"
+            "typical_accuracy_drop": "2-4%",
+            "evidence": {
+              "reference": "https://microsoft.github.io/Olive/0.12.1/reference/pass.html",
+              "type": "olive_docs",
+              "version": "0.12.1"
+            }
           }
         },
         "Qualcomm Snapdragon NPU": {
           "QNNQuantization": {
             "support": "supported",
+            "olive_pass": "QNNQuantization",
             "note": "int4 weights with QNNPreprocess.",
-            "typical_accuracy_drop": "3-5%"
+            "typical_accuracy_drop": "3-5%",
+            "evidence": {
+              "reference": "https://onnxruntime.ai/docs/execution-providers/QNN-ExecutionProvider.html",
+              "type": "ort_docs",
+              "version": "1.19"
+            }
           }
         }
       }
@@ -321,69 +1053,201 @@
     {
       "model": "Stable Diffusion v1.4",
       "frameworks": ["PyTorch", "ONNX"],
+      "source": "https://github.com/microsoft/Olive/tree/main/examples/directml/stable_diffusion",
+      "verified": true,
+      "notes": "Olive DirectML Stable Diffusion example; UNet/VAE/text encoder converted separately.",
       "hardware": {
         "NVIDIA RTX 4090": {
           "OnnxConversion": {
             "support": "supported",
+            "olive_pass": "OnnxConversion",
             "note": "UNet, VAE and text encoder are converted separately.",
-            "typical_accuracy_drop": "n/a"
+            "typical_accuracy_drop": "n/a",
+            "evidence": {
+              "reference": "https://github.com/microsoft/Olive/tree/main/examples/directml/stable_diffusion",
+              "type": "github",
+              "version": "0.12.1"
+            }
           },
           "OnnxFloatToFloat16": {
             "support": "supported",
+            "olive_pass": "OnnxFloatToFloat16",
             "note": "FP16 is the standard for SD UNet.",
-            "typical_accuracy_drop": "<1%"
+            "typical_accuracy_drop": "<1%",
+            "evidence": {
+              "reference": "https://onnxruntime.ai/docs/performance/model-optimizations/float16.html",
+              "type": "ort_docs",
+              "version": "1.19"
+            }
           },
           "OnnxQuantization": {
             "support": "warning",
+            "olive_pass": "OnnxQuantization",
             "note": "INT8 UNet can cause visible artifacts; use per-channel carefully.",
-            "typical_accuracy_drop": "3-5%"
+            "typical_accuracy_drop": "3-5%",
+            "evidence": {
+              "reference": "https://onnxruntime.ai/docs/performance/model-optimizations/quantization.html",
+              "type": "ort_docs",
+              "version": "1.19"
+            }
+          },
+          "OnnxModelOptimizer": {
+            "support": "supported",
+            "olive_pass": "OnnxModelOptimizer",
+            "note": "Post-export optimizer in stable_diffusion_cuda_fp16 recipe.",
+            "typical_accuracy_drop": "n/a",
+            "evidence": {
+              "reference": "https://microsoft.github.io/Olive/0.12.1/reference/pass.html",
+              "type": "olive_docs",
+              "version": "0.12.1"
+            }
           }
         },
         "Intel Core i9 CPU": {
           "OnnxConversion": {
             "support": "supported",
+            "olive_pass": "OnnxConversion",
             "note": "CPU runs SD components; FP32 is safest.",
-            "typical_accuracy_drop": "n/a"
+            "typical_accuracy_drop": "n/a",
+            "evidence": {
+              "reference": "https://microsoft.github.io/Olive/0.12.1/reference/pass.html",
+              "type": "olive_docs",
+              "version": "0.12.1"
+            }
           },
           "OnnxStaticQuantization": {
             "support": "warning",
+            "olive_pass": "OnnxStaticQuantization",
             "note": "VAE quantization can produce artifacts; validate visually.",
-            "typical_accuracy_drop": "3-5%"
+            "typical_accuracy_drop": "3-5%",
+            "evidence": {
+              "reference": "https://onnxruntime.ai/docs/performance/model-optimizations/quantization.html",
+              "type": "ort_docs",
+              "version": "1.19"
+            }
           }
         }
       }
     },
     {
       "model": "BERT-base",
-      "frameworks": ["PyTorch", "ONNX"],
+      "frameworks": ["PyTorch", "ONNX", "HuggingFace"],
+      "source": "https://github.com/microsoft/Olive/tree/main/examples/bert",
+      "verified": true,
+      "notes": "Official Olive BERT example; OrtTransformersOptimization + static INT8 is the standard CPU path.",
       "hardware": {
         "Intel Core i9 CPU": {
           "OnnxConversion": {
             "support": "supported",
+            "olive_pass": "OnnxConversion",
             "note": "BERT exports cleanly to ONNX.",
-            "typical_accuracy_drop": "n/a"
+            "typical_accuracy_drop": "n/a",
+            "evidence": {
+              "reference": "https://github.com/microsoft/Olive/tree/main/examples/bert",
+              "type": "github",
+              "version": "0.12.1"
+            }
+          },
+          "OrtTransformersOptimization": {
+            "support": "supported",
+            "olive_pass": "OrtTransformersOptimization",
+            "note": "ORT transformer fusions before static quant (bert_cpu_static recipe).",
+            "typical_accuracy_drop": "n/a",
+            "evidence": {
+              "reference": "https://onnxruntime.ai/docs/performance/model-optimizations/transformers-optimization.html",
+              "type": "ort_docs",
+              "version": "1.19"
+            }
           },
           "OnnxStaticQuantization": {
             "support": "supported",
+            "olive_pass": "OnnxStaticQuantization",
             "note": "INT8 static quantization is highly stable for BERT.",
-            "typical_accuracy_drop": "<0.5%"
+            "typical_accuracy_drop": "<0.5%",
+            "evidence": {
+              "reference": "https://onnxruntime.ai/docs/performance/model-optimizations/quantization.html",
+              "type": "ort_docs",
+              "version": "1.19"
+            }
           },
           "OnnxDynamicQuantization": {
             "support": "supported",
+            "olive_pass": "OnnxDynamicQuantization",
             "note": "No calibration required; good for quick tests.",
-            "typical_accuracy_drop": "<1%"
+            "typical_accuracy_drop": "<1%",
+            "evidence": {
+              "reference": "https://microsoft.github.io/Olive/0.12.1/reference/pass.html",
+              "type": "olive_docs",
+              "version": "0.12.1"
+            }
+          },
+          "IncStaticQuantization": {
+            "support": "supported",
+            "olive_pass": "IncStaticQuantization",
+            "note": "Intel Neural Compressor static INT8 alternative.",
+            "typical_accuracy_drop": "<0.5%",
+            "evidence": {
+              "reference": "https://microsoft.github.io/Olive/0.12.1/reference/pass.html",
+              "type": "olive_docs",
+              "version": "0.12.1"
+            }
+          },
+          "OpenVINOQuantization": {
+            "support": "supported",
+            "olive_pass": "OpenVINOQuantization",
+            "note": "OpenVINO INT8 for BERT on Intel CPU/iGPU.",
+            "typical_accuracy_drop": "<0.5%",
+            "evidence": {
+              "reference": "https://microsoft.github.io/Olive/0.12.1/reference/pass.html",
+              "type": "olive_docs",
+              "version": "0.12.1"
+            }
           }
         },
         "NVIDIA RTX 4090": {
           "OnnxConversion": {
             "support": "supported",
+            "olive_pass": "OnnxConversion",
             "note": "BERT inference on GPU is fast in FP16.",
-            "typical_accuracy_drop": "n/a"
+            "typical_accuracy_drop": "n/a",
+            "evidence": {
+              "reference": "https://github.com/microsoft/Olive/tree/main/examples/bert",
+              "type": "github",
+              "version": "0.12.1"
+            }
+          },
+          "OrtTransformersOptimization": {
+            "support": "supported",
+            "olive_pass": "OrtTransformersOptimization",
+            "note": "GPU transformer fusions via ORT.",
+            "typical_accuracy_drop": "n/a",
+            "evidence": {
+              "reference": "https://onnxruntime.ai/docs/performance/model-optimizations/transformers-optimization.html",
+              "type": "ort_docs",
+              "version": "1.19"
+            }
           },
           "OnnxQuantization": {
             "support": "supported",
+            "olive_pass": "OnnxQuantization",
             "note": "INT8 QDQ on TensorRT gives good speedup.",
-            "typical_accuracy_drop": "<0.5%"
+            "typical_accuracy_drop": "<0.5%",
+            "evidence": {
+              "reference": "https://onnxruntime.ai/docs/execution-providers/TensorRT-ExecutionProvider.html",
+              "type": "ort_docs",
+              "version": "1.19"
+            }
+          },
+          "OnnxFloatToFloat16": {
+            "support": "supported",
+            "olive_pass": "OnnxFloatToFloat16",
+            "note": "FP16 is the default GPU path for BERT.",
+            "typical_accuracy_drop": "<0.5%",
+            "evidence": {
+              "reference": "https://onnxruntime.ai/docs/performance/model-optimizations/float16.html",
+              "type": "ort_docs",
+              "version": "1.19"
+            }
           }
         }
       }
@@ -391,36 +1255,102 @@
     {
       "model": "MobileNetV2",
       "frameworks": ["PyTorch", "ONNX"],
+      "source": "https://onnxruntime.ai/docs/performance/model-optimizations/quantization.html",
+      "verified": true,
+      "notes": "Lightweight CNN; ORT static quant and QNN paths are well documented for mobile vision.",
       "hardware": {
         "Intel Core i9 CPU": {
           "OnnxConversion": {
             "support": "supported",
+            "olive_pass": "OnnxConversion",
             "note": "Lightweight CNN; exports cleanly.",
-            "typical_accuracy_drop": "n/a"
+            "typical_accuracy_drop": "n/a",
+            "evidence": {
+              "reference": "https://microsoft.github.io/Olive/0.12.1/reference/pass.html",
+              "type": "olive_docs",
+              "version": "0.12.1"
+            }
           },
           "OnnxStaticQuantization": {
             "support": "supported",
+            "olive_pass": "OnnxStaticQuantization",
             "note": "INT8 static quantization is very stable for MobileNet.",
-            "typical_accuracy_drop": "<0.5%"
+            "typical_accuracy_drop": "<0.5%",
+            "evidence": {
+              "reference": "https://onnxruntime.ai/docs/performance/model-optimizations/quantization.html",
+              "type": "ort_docs",
+              "version": "1.19"
+            }
+          },
+          "OnnxModelOptimizer": {
+            "support": "supported",
+            "olive_pass": "OnnxModelOptimizer",
+            "note": "Graph cleanup after quant.",
+            "typical_accuracy_drop": "n/a",
+            "evidence": {
+              "reference": "https://microsoft.github.io/Olive/0.12.1/reference/pass.html",
+              "type": "olive_docs",
+              "version": "0.12.1"
+            }
           }
         },
         "Qualcomm Snapdragon NPU": {
           "QNNConversion": {
             "support": "supported",
+            "olive_pass": "QNNConversion",
             "note": "Convert to QNN for NPU execution.",
-            "typical_accuracy_drop": "<1%"
+            "typical_accuracy_drop": "<1%",
+            "evidence": {
+              "reference": "https://microsoft.github.io/Olive/0.12.1/reference/pass.html",
+              "type": "olive_docs",
+              "version": "0.12.1"
+            }
           },
           "QNNQuantization": {
             "support": "supported",
+            "olive_pass": "QNNQuantization",
             "note": "int8 weights with per-channel symmetric quant.",
-            "typical_accuracy_drop": "<1%"
+            "typical_accuracy_drop": "<1%",
+            "evidence": {
+              "reference": "https://onnxruntime.ai/docs/execution-providers/QNN-ExecutionProvider.html",
+              "type": "ort_docs",
+              "version": "1.19"
+            }
+          },
+          "QNNPreprocess": {
+            "support": "supported",
+            "olive_pass": "QNNPreprocess",
+            "note": "Preprocess for QNN op compatibility.",
+            "typical_accuracy_drop": "n/a",
+            "evidence": {
+              "reference": "https://microsoft.github.io/Olive/0.12.1/reference/pass.html",
+              "type": "olive_docs",
+              "version": "0.12.1"
+            }
           }
         },
         "Raspberry Pi 5 (CPU)": {
+          "OnnxConversion": {
+            "support": "supported",
+            "olive_pass": "OnnxConversion",
+            "note": "ARM CPU export; fixed input shape preferred.",
+            "typical_accuracy_drop": "n/a",
+            "evidence": {
+              "reference": "https://microsoft.github.io/Olive/0.12.1/reference/pass.html",
+              "type": "olive_docs",
+              "version": "0.12.1"
+            }
+          },
           "OnnxStaticQuantization": {
             "support": "supported",
+            "olive_pass": "OnnxStaticQuantization",
             "note": "INT8 reduces latency on ARM Cortex-A76.",
-            "typical_accuracy_drop": "<1%"
+            "typical_accuracy_drop": "<1%",
+            "evidence": {
+              "reference": "https://onnxruntime.ai/docs/performance/model-optimizations/quantization.html",
+              "type": "ort_docs",
+              "version": "1.19"
+            }
           }
         }
       }
@@ -428,173 +1358,431 @@
     {
       "model": "EfficientNet-B0",
       "frameworks": ["PyTorch", "ONNX"],
+      "source": "https://onnxruntime.ai/docs/performance/model-optimizations/quantization.html",
+      "verified": false,
+      "notes": "CNN quant path via ORT static/QDQ and OpenVINO; SiLU activations may need careful calibration.",
       "hardware": {
         "Intel Core i9 CPU": {
           "OnnxConversion": {
             "support": "supported",
+            "olive_pass": "OnnxConversion",
             "note": "Compound scaling is ONNX-friendly.",
-            "typical_accuracy_drop": "n/a"
+            "typical_accuracy_drop": "n/a",
+            "evidence": {
+              "reference": "https://microsoft.github.io/Olive/0.12.1/reference/pass.html",
+              "type": "olive_docs",
+              "version": "0.12.1"
+            }
           },
           "OnnxStaticQuantization": {
             "support": "supported",
-            "note": "INT8 quantization stable for EfficientNet.",
-            "typical_accuracy_drop": "<0.5%"
+            "olive_pass": "OnnxStaticQuantization",
+            "note": "INT8 quantization stable for EfficientNet with good calibration.",
+            "typical_accuracy_drop": "<0.5%",
+            "evidence": {
+              "reference": "https://onnxruntime.ai/docs/performance/model-optimizations/quantization.html",
+              "type": "ort_docs",
+              "version": "1.19"
+            }
           }
         },
         "NVIDIA T4": {
           "OnnxConversion": {
             "support": "supported",
+            "olive_pass": "OnnxConversion",
             "note": "FP16 TensorRT gives good throughput.",
-            "typical_accuracy_drop": "n/a"
+            "typical_accuracy_drop": "n/a",
+            "evidence": {
+              "reference": "https://microsoft.github.io/Olive/0.12.1/reference/pass.html",
+              "type": "olive_docs",
+              "version": "0.12.1"
+            }
           },
           "OnnxQuantization": {
             "support": "warning",
+            "olive_pass": "OnnxQuantization",
             "note": "INT8 may need careful calibration due to SiLU activations.",
-            "typical_accuracy_drop": "1-2%"
+            "typical_accuracy_drop": "1-2%",
+            "evidence": {
+              "reference": "https://onnxruntime.ai/docs/performance/model-optimizations/quantization.html",
+              "type": "ort_docs",
+              "version": "1.19"
+            }
+          },
+          "OnnxFloatToFloat16": {
+            "support": "supported",
+            "olive_pass": "OnnxFloatToFloat16",
+            "note": "FP16 preferred when INT8 calibration is unstable.",
+            "typical_accuracy_drop": "<0.5%",
+            "evidence": {
+              "reference": "https://onnxruntime.ai/docs/performance/model-optimizations/float16.html",
+              "type": "ort_docs",
+              "version": "1.19"
+            }
           }
         },
         "Intel Arc A770": {
           "OpenVINOConversion": {
             "support": "supported",
+            "olive_pass": "OpenVINOConversion",
             "note": "OpenVINO is a strong CPU/iGPU target.",
-            "typical_accuracy_drop": "n/a"
+            "typical_accuracy_drop": "n/a",
+            "evidence": {
+              "reference": "https://onnxruntime.ai/docs/execution-providers/OpenVINO-ExecutionProvider.html",
+              "type": "ort_docs",
+              "version": "1.19"
+            }
           },
           "OpenVINOQuantization": {
             "support": "supported",
+            "olive_pass": "OpenVINOQuantization",
             "note": "INT8 on Arc A770 is efficient.",
-            "typical_accuracy_drop": "<1%"
+            "typical_accuracy_drop": "<1%",
+            "evidence": {
+              "reference": "https://microsoft.github.io/Olive/0.12.1/reference/pass.html",
+              "type": "olive_docs",
+              "version": "0.12.1"
+            }
           }
         }
       }
     },
     {
       "model": "ViT-base",
-      "frameworks": ["PyTorch", "ONNX"],
+      "frameworks": ["PyTorch", "ONNX", "HuggingFace"],
+      "source": "https://onnxruntime.ai/docs/performance/model-optimizations/transformers-optimization.html",
+      "verified": true,
+      "notes": "Vision Transformer; ORT transformer optimization + static INT8 for patch embeddings/MLP.",
       "hardware": {
         "Intel Core i9 CPU": {
           "OnnxConversion": {
             "support": "supported",
+            "olive_pass": "OnnxConversion",
             "note": "Vision Transformer exports with dynamic batch/sequence axes.",
-            "typical_accuracy_drop": "n/a"
+            "typical_accuracy_drop": "n/a",
+            "evidence": {
+              "reference": "https://microsoft.github.io/Olive/0.12.1/reference/pass.html",
+              "type": "olive_docs",
+              "version": "0.12.1"
+            }
+          },
+          "OrtTransformersOptimization": {
+            "support": "supported",
+            "olive_pass": "OrtTransformersOptimization",
+            "note": "ORT fusions apply to ViT attention blocks.",
+            "typical_accuracy_drop": "n/a",
+            "evidence": {
+              "reference": "https://onnxruntime.ai/docs/performance/model-optimizations/transformers-optimization.html",
+              "type": "ort_docs",
+              "version": "1.19"
+            }
           },
           "OnnxStaticQuantization": {
             "support": "supported",
+            "olive_pass": "OnnxStaticQuantization",
             "note": "INT8 static quantization works for patch embeddings and MLP.",
-            "typical_accuracy_drop": "<1%"
+            "typical_accuracy_drop": "<1%",
+            "evidence": {
+              "reference": "https://onnxruntime.ai/docs/performance/model-optimizations/quantization.html",
+              "type": "ort_docs",
+              "version": "1.19"
+            }
           }
         },
         "NVIDIA RTX 4090": {
           "OnnxConversion": {
             "support": "supported",
+            "olive_pass": "OnnxConversion",
             "note": "FP16 TensorRT is the fastest path.",
-            "typical_accuracy_drop": "n/a"
+            "typical_accuracy_drop": "n/a",
+            "evidence": {
+              "reference": "https://microsoft.github.io/Olive/0.12.1/reference/pass.html",
+              "type": "olive_docs",
+              "version": "0.12.1"
+            }
           },
           "OnnxQuantization": {
             "support": "warning",
+            "olive_pass": "OnnxQuantization",
             "note": "INT8 attention may need per-channel weights.",
-            "typical_accuracy_drop": "1-2%"
+            "typical_accuracy_drop": "1-2%",
+            "evidence": {
+              "reference": "https://onnxruntime.ai/docs/performance/model-optimizations/quantization.html",
+              "type": "ort_docs",
+              "version": "1.19"
+            }
+          },
+          "OnnxFloatToFloat16": {
+            "support": "supported",
+            "olive_pass": "OnnxFloatToFloat16",
+            "note": "FP16 preferred for ViT on GPU.",
+            "typical_accuracy_drop": "<0.5%",
+            "evidence": {
+              "reference": "https://onnxruntime.ai/docs/performance/model-optimizations/float16.html",
+              "type": "ort_docs",
+              "version": "1.19"
+            }
           }
         }
       }
     },
     {
       "model": "T5-small",
-      "frameworks": ["PyTorch", "ONNX"],
+      "frameworks": ["PyTorch", "ONNX", "HuggingFace"],
+      "source": "https://onnxruntime.ai/docs/performance/model-optimizations/transformers-optimization.html",
+      "verified": false,
+      "notes": "Encoder-decoder; ORT transformer optimization documented for T5-class models.",
       "hardware": {
         "Intel Core i9 CPU": {
           "OnnxConversion": {
             "support": "supported",
+            "olive_pass": "OnnxConversion",
             "note": "Encoder-decoder export requires separate attention caches.",
-            "typical_accuracy_drop": "n/a"
+            "typical_accuracy_drop": "n/a",
+            "evidence": {
+              "reference": "https://microsoft.github.io/Olive/0.12.1/reference/pass.html",
+              "type": "olive_docs",
+              "version": "0.12.1"
+            }
+          },
+          "OrtTransformersOptimization": {
+            "support": "supported",
+            "olive_pass": "OrtTransformersOptimization",
+            "note": "ORT fusions for encoder/decoder graphs.",
+            "typical_accuracy_drop": "n/a",
+            "evidence": {
+              "reference": "https://onnxruntime.ai/docs/performance/model-optimizations/transformers-optimization.html",
+              "type": "ort_docs",
+              "version": "1.19"
+            }
           },
           "OnnxStaticQuantization": {
             "support": "warning",
+            "olive_pass": "OnnxStaticQuantization",
             "note": "Decoder dynamic shapes can limit INT8 accuracy; calibrate carefully.",
-            "typical_accuracy_drop": "1-3%"
+            "typical_accuracy_drop": "1-3%",
+            "evidence": {
+              "reference": "https://onnxruntime.ai/docs/performance/model-optimizations/quantization.html",
+              "type": "ort_docs",
+              "version": "1.19"
+            }
           }
         },
         "NVIDIA RTX 4090": {
           "OnnxConversion": {
             "support": "supported",
+            "olive_pass": "OnnxConversion",
             "note": "Use dynamic_axes for encoder and decoder.",
-            "typical_accuracy_drop": "n/a"
+            "typical_accuracy_drop": "n/a",
+            "evidence": {
+              "reference": "https://microsoft.github.io/Olive/0.12.1/reference/pass.html",
+              "type": "olive_docs",
+              "version": "0.12.1"
+            }
           },
           "OnnxQuantization": {
             "support": "supported",
+            "olive_pass": "OnnxQuantization",
             "note": "INT8 QDQ works well for T5 encoder.",
-            "typical_accuracy_drop": "<1%"
+            "typical_accuracy_drop": "<1%",
+            "evidence": {
+              "reference": "https://onnxruntime.ai/docs/performance/model-optimizations/quantization.html",
+              "type": "ort_docs",
+              "version": "1.19"
+            }
+          },
+          "OnnxFloatToFloat16": {
+            "support": "supported",
+            "olive_pass": "OnnxFloatToFloat16",
+            "note": "FP16 for GPU encoder/decoder.",
+            "typical_accuracy_drop": "<1%",
+            "evidence": {
+              "reference": "https://onnxruntime.ai/docs/performance/model-optimizations/float16.html",
+              "type": "ort_docs",
+              "version": "1.19"
+            }
           }
         }
       }
     },
     {
       "model": "GPT-2",
-      "frameworks": ["PyTorch", "ONNX"],
+      "frameworks": ["PyTorch", "ONNX", "HuggingFace"],
+      "source": "https://onnxruntime.ai/docs/performance/model-optimizations/transformers-optimization.html",
+      "verified": true,
+      "notes": "Small decoder LM; ORT transformer optimization and static INT8 are standard.",
       "hardware": {
         "Intel Core i9 CPU": {
           "OnnxConversion": {
             "support": "supported",
+            "olive_pass": "OnnxConversion",
             "note": "Small GPT-2 exports cleanly; use dynamic_axes.",
-            "typical_accuracy_drop": "n/a"
+            "typical_accuracy_drop": "n/a",
+            "evidence": {
+              "reference": "https://microsoft.github.io/Olive/0.12.1/reference/pass.html",
+              "type": "olive_docs",
+              "version": "0.12.1"
+            }
+          },
+          "OrtTransformersOptimization": {
+            "support": "supported",
+            "olive_pass": "OrtTransformersOptimization",
+            "note": "ORT GPT-2 fusions are well documented.",
+            "typical_accuracy_drop": "n/a",
+            "evidence": {
+              "reference": "https://onnxruntime.ai/docs/performance/model-optimizations/transformers-optimization.html",
+              "type": "ort_docs",
+              "version": "1.19"
+            }
           },
           "OnnxStaticQuantization": {
             "support": "supported",
+            "olive_pass": "OnnxStaticQuantization",
             "note": "INT8 static quantization is stable for GPT-2.",
-            "typical_accuracy_drop": "<1%"
+            "typical_accuracy_drop": "<1%",
+            "evidence": {
+              "reference": "https://onnxruntime.ai/docs/performance/model-optimizations/quantization.html",
+              "type": "ort_docs",
+              "version": "1.19"
+            }
+          },
+          "OnnxDynamicQuantization": {
+            "support": "supported",
+            "olive_pass": "OnnxDynamicQuantization",
+            "note": "Dynamic quant suits decoder generation without calibration.",
+            "typical_accuracy_drop": "1-2%",
+            "evidence": {
+              "reference": "https://microsoft.github.io/Olive/0.12.1/reference/pass.html",
+              "type": "olive_docs",
+              "version": "0.12.1"
+            }
           }
         },
         "NVIDIA RTX 4090": {
           "OnnxConversion": {
             "support": "supported",
+            "olive_pass": "OnnxConversion",
             "note": "FP16 TensorRT gives good speedup for small decoder.",
-            "typical_accuracy_drop": "n/a"
+            "typical_accuracy_drop": "n/a",
+            "evidence": {
+              "reference": "https://microsoft.github.io/Olive/0.12.1/reference/pass.html",
+              "type": "olive_docs",
+              "version": "0.12.1"
+            }
           },
           "NVModelOptQuantization": {
             "support": "supported",
-            "note": "AWQ int4 is overkill for GPT-2 but works.",
-            "typical_accuracy_drop": "<1%"
+            "olive_pass": "NVModelOptQuantization",
+            "note": "AWQ int4 is overkill for GPT-2 but the pass is available.",
+            "typical_accuracy_drop": "<1%",
+            "evidence": {
+              "reference": "https://microsoft.github.io/Olive/0.12.1/reference/pass.html",
+              "type": "olive_docs",
+              "version": "0.12.1"
+            }
+          },
+          "OnnxFloatToFloat16": {
+            "support": "supported",
+            "olive_pass": "OnnxFloatToFloat16",
+            "note": "FP16 is the practical GPU path for GPT-2.",
+            "typical_accuracy_drop": "<0.5%",
+            "evidence": {
+              "reference": "https://onnxruntime.ai/docs/performance/model-optimizations/float16.html",
+              "type": "ort_docs",
+              "version": "1.19"
+            }
           }
         }
       }
     },
     {
       "model": "Falcon 7B",
-      "frameworks": ["PyTorch", "ONNX"],
+      "frameworks": ["PyTorch", "ONNX", "HuggingFace"],
+      "source": "https://microsoft.github.io/Olive/0.12.1/reference/pass.html",
+      "verified": false,
+      "notes": "Claims limited to Olive pass availability for HF decoder LLMs (conversion, NVModelOpt, OpenVINO, RTN).",
       "hardware": {
         "NVIDIA A100": {
           "OnnxConversion": {
             "support": "supported",
+            "olive_pass": "OnnxConversion",
             "note": "Use external data format and dynamic_axes.",
-            "typical_accuracy_drop": "n/a"
+            "typical_accuracy_drop": "n/a",
+            "evidence": {
+              "reference": "https://microsoft.github.io/Olive/0.12.1/reference/pass.html",
+              "type": "olive_docs",
+              "version": "0.12.1"
+            }
           },
           "NVModelOptQuantization": {
             "support": "supported",
-            "note": "AWQ int4 is recommended on A100.",
-            "typical_accuracy_drop": "<2%"
+            "olive_pass": "NVModelOptQuantization",
+            "note": "AWQ int4 is recommended on A100 for 7B decoders.",
+            "typical_accuracy_drop": "<2%",
+            "evidence": {
+              "reference": "https://microsoft.github.io/Olive/0.12.1/reference/pass.html",
+              "type": "olive_docs",
+              "version": "0.12.1"
+            }
+          },
+          "GptqQuantizer": {
+            "support": "supported",
+            "olive_pass": "GptqQuantizer",
+            "note": "GPTQ int4 alternative for Falcon-class HF models.",
+            "typical_accuracy_drop": "<3%",
+            "evidence": {
+              "reference": "https://microsoft.github.io/Olive/0.12.1/reference/pass.html",
+              "type": "olive_docs",
+              "version": "0.12.1"
+            }
           }
         },
         "Intel Core i9 CPU": {
           "OnnxConversion": {
             "support": "supported",
+            "olive_pass": "OnnxConversion",
             "note": "CPU export works; int4 reduces memory.",
-            "typical_accuracy_drop": "n/a"
+            "typical_accuracy_drop": "n/a",
+            "evidence": {
+              "reference": "https://microsoft.github.io/Olive/0.12.1/reference/pass.html",
+              "type": "olive_docs",
+              "version": "0.12.1"
+            }
           },
           "OnnxBlockWiseRtnQuantization": {
             "support": "warning",
+            "olive_pass": "OnnxBlockWiseRtnQuantization",
             "note": "RTN int4 is fast but may drop perplexity; validate.",
-            "typical_accuracy_drop": "2-4%"
+            "typical_accuracy_drop": "2-4%",
+            "evidence": {
+              "reference": "https://microsoft.github.io/Olive/0.12.1/reference/options.html",
+              "type": "olive_docs",
+              "version": "0.12.1"
+            }
           }
         },
         "Intel Arc A770": {
           "OpenVINOOptimumConversion": {
             "support": "supported",
-            "note": "OpenVINO optimum conversion works for Falcon.",
-            "typical_accuracy_drop": "n/a"
+            "olive_pass": "OpenVINOOptimumConversion",
+            "note": "OpenVINO optimum conversion for HF decoder LLMs.",
+            "typical_accuracy_drop": "n/a",
+            "evidence": {
+              "reference": "https://microsoft.github.io/Olive/0.12.1/reference/pass.html",
+              "type": "olive_docs",
+              "version": "0.12.1"
+            }
           },
           "OpenVINOWeightCompression": {
             "support": "supported",
+            "olive_pass": "OpenVINOWeightCompression",
             "note": "INT4/INT8 weight compression for low-memory iGPU.",
-            "typical_accuracy_drop": "2-4%"
+            "typical_accuracy_drop": "2-4%",
+            "evidence": {
+              "reference": "https://microsoft.github.io/Olive/0.12.1/reference/pass.html",
+              "type": "olive_docs",
+              "version": "0.12.1"
+            }
           }
         }
       }
@@ -602,84 +1790,183 @@
     {
       "model": "YOLOv8",
       "frameworks": ["PyTorch", "ONNX"],
+      "source": "https://onnxruntime.ai/docs/performance/model-optimizations/quantization.html",
+      "verified": false,
+      "notes": "Detection CNN; Ultralytics ONNX export + Olive OnnxConversion/static quant/QNN paths.",
       "hardware": {
         "Intel Core i9 CPU": {
           "OnnxConversion": {
             "support": "supported",
-            "note": "YOLOv8 exports via Ultralytics export path.",
-            "typical_accuracy_drop": "n/a"
+            "olive_pass": "OnnxConversion",
+            "note": "YOLOv8 exports via Ultralytics export path then Olive conversion/load.",
+            "typical_accuracy_drop": "n/a",
+            "evidence": {
+              "reference": "https://microsoft.github.io/Olive/0.12.1/reference/pass.html",
+              "type": "olive_docs",
+              "version": "0.12.1"
+            }
           },
           "OnnxStaticQuantization": {
             "support": "supported",
-            "note": "INT8 works well for detection heads.",
-            "typical_accuracy_drop": "<1%"
+            "olive_pass": "OnnxStaticQuantization",
+            "note": "INT8 works well for detection heads with representative calib.",
+            "typical_accuracy_drop": "<1%",
+            "evidence": {
+              "reference": "https://onnxruntime.ai/docs/performance/model-optimizations/quantization.html",
+              "type": "ort_docs",
+              "version": "1.19"
+            }
+          },
+          "OnnxModelOptimizer": {
+            "support": "supported",
+            "olive_pass": "OnnxModelOptimizer",
+            "note": "Post-quant graph cleanup.",
+            "typical_accuracy_drop": "n/a",
+            "evidence": {
+              "reference": "https://microsoft.github.io/Olive/0.12.1/reference/pass.html",
+              "type": "olive_docs",
+              "version": "0.12.1"
+            }
           }
         },
         "NVIDIA Jetson Orin": {
           "OnnxConversion": {
             "support": "supported",
+            "olive_pass": "OnnxConversion",
             "note": "Export with batch=1 and dynamic input shape.",
-            "typical_accuracy_drop": "n/a"
+            "typical_accuracy_drop": "n/a",
+            "evidence": {
+              "reference": "https://microsoft.github.io/Olive/0.12.1/reference/pass.html",
+              "type": "olive_docs",
+              "version": "0.12.1"
+            }
           },
           "OnnxQuantization": {
             "support": "warning",
+            "olive_pass": "OnnxQuantization",
             "note": "INT8 may reduce mAP; verify on representative dataset.",
-            "typical_accuracy_drop": "1-3%"
+            "typical_accuracy_drop": "1-3%",
+            "evidence": {
+              "reference": "https://onnxruntime.ai/docs/performance/model-optimizations/quantization.html",
+              "type": "ort_docs",
+              "version": "1.19"
+            }
+          },
+          "OnnxFloatToFloat16": {
+            "support": "supported",
+            "olive_pass": "OnnxFloatToFloat16",
+            "note": "FP16 TensorRT is the safer Jetson path when mAP is critical.",
+            "typical_accuracy_drop": "<1%",
+            "evidence": {
+              "reference": "https://onnxruntime.ai/docs/performance/model-optimizations/float16.html",
+              "type": "ort_docs",
+              "version": "1.19"
+            }
           }
         },
         "Qualcomm Snapdragon NPU": {
           "QNNConversion": {
             "support": "supported",
+            "olive_pass": "QNNConversion",
             "note": "Convert to QNN with fixed input resolution.",
-            "typical_accuracy_drop": "1-2%"
+            "typical_accuracy_drop": "1-2%",
+            "evidence": {
+              "reference": "https://microsoft.github.io/Olive/0.12.1/reference/pass.html",
+              "type": "olive_docs",
+              "version": "0.12.1"
+            }
           },
           "QNNQuantization": {
             "support": "supported",
+            "olive_pass": "QNNQuantization",
             "note": "int8 weights for NPU execution.",
-            "typical_accuracy_drop": "<2%"
+            "typical_accuracy_drop": "<2%",
+            "evidence": {
+              "reference": "https://onnxruntime.ai/docs/execution-providers/QNN-ExecutionProvider.html",
+              "type": "ort_docs",
+              "version": "1.19"
+            }
           }
         }
       }
     },
     {
       "model": "Mixtral 8x7B",
-      "frameworks": ["PyTorch", "ONNX"],
-      "notes": "Sparse mixture-of-experts; routing and expert sharding require careful export.",
+      "frameworks": ["PyTorch", "ONNX", "HuggingFace"],
+      "source": "https://microsoft.github.io/Olive/0.12.1/reference/pass.html",
+      "verified": false,
+      "notes": "Sparse MoE; routing/export may need custom handling. Quant claims limited to Olive NVModelOpt/GPTQ pass availability for large HF LLMs — not MoE-specific benchmarks.",
       "hardware": {
         "NVIDIA A100": {
           "OnnxConversion": {
             "support": "warning",
+            "olive_pass": "OnnxConversion",
             "note": "MoE routing ops may need custom handling; test with representative inputs.",
-            "typical_accuracy_drop": "n/a"
+            "typical_accuracy_drop": "n/a",
+            "evidence": {
+              "reference": "https://microsoft.github.io/Olive/0.12.1/reference/pass.html",
+              "type": "olive_docs",
+              "version": "0.12.1"
+            }
           },
           "NVModelOptQuantization": {
             "support": "supported",
+            "olive_pass": "NVModelOptQuantization",
             "note": "AWQ int4 recommended; expert weights are large.",
-            "typical_accuracy_drop": "<2%"
+            "typical_accuracy_drop": "<2%",
+            "evidence": {
+              "reference": "https://microsoft.github.io/Olive/0.12.1/reference/pass.html",
+              "type": "olive_docs",
+              "version": "0.12.1"
+            }
           }
         },
         "NVIDIA RTX 4090": {
           "OnnxConversion": {
             "support": "warning",
+            "olive_pass": "OnnxConversion",
             "note": "VRAM constrained for 8x7B; use external data format.",
-            "typical_accuracy_drop": "n/a"
+            "typical_accuracy_drop": "n/a",
+            "evidence": {
+              "reference": "https://microsoft.github.io/Olive/0.12.1/reference/pass.html",
+              "type": "olive_docs",
+              "version": "0.12.1"
+            }
           },
           "NVModelOptQuantization": {
             "support": "supported",
+            "olive_pass": "NVModelOptQuantization",
             "note": "int4 AWQ reduces memory to fit on consumer GPUs.",
-            "typical_accuracy_drop": "<3%"
+            "typical_accuracy_drop": "<3%",
+            "evidence": {
+              "reference": "https://microsoft.github.io/Olive/0.12.1/reference/pass.html",
+              "type": "olive_docs",
+              "version": "0.12.1"
+            }
           }
         },
         "AMD MI300X / ROCm": {
           "OnnxConversion": {
             "support": "supported",
-            "note": "ROCm supports large MoE; use external data format.",
-            "typical_accuracy_drop": "n/a"
+            "olive_pass": "OnnxConversion",
+            "note": "ROCm EP supports large models; use external data format.",
+            "typical_accuracy_drop": "n/a",
+            "evidence": {
+              "reference": "https://microsoft.github.io/Olive/0.12.1/reference/pass.html",
+              "type": "olive_docs",
+              "version": "0.12.1"
+            }
           },
           "GptqQuantizer": {
             "support": "supported",
-            "note": "GPTQ int4 is well supported on ROCm.",
-            "typical_accuracy_drop": "<3%"
+            "olive_pass": "GptqQuantizer",
+            "note": "GPTQ int4 pass available in Olive for HF LLMs on ROCm hosts.",
+            "typical_accuracy_drop": "<3%",
+            "evidence": {
+              "reference": "https://microsoft.github.io/Olive/0.12.1/reference/pass.html",
+              "type": "olive_docs",
+              "version": "0.12.1"
+            }
           }
         }
       }
@@ -687,13 +1974,201 @@
     {
       "model": "Azure OpenAI Whisper",
       "frameworks": ["ONNX"],
-      "notes": "Cloud endpoint reference; local ONNX export for Whisper follows the Whisper entry.",
+      "source": "https://microsoft.github.io/Olive/0.12.1/reference/pass.html",
+      "verified": false,
+      "notes": "Cloud endpoint reference; local ONNX export for Whisper follows the Whisper entry. AzureMLQuantization is the Olive cloud quant pass.",
       "hardware": {
         "Azure ML N-series": {
           "AzureMLQuantization": {
             "support": "supported",
+            "olive_pass": "AzureMLQuantization",
             "note": "AzureML quantization pipeline for cloud ONNX Runtime.",
-            "typical_accuracy_drop": "<1%"
+            "typical_accuracy_drop": "<1%",
+            "evidence": {
+              "reference": "https://microsoft.github.io/Olive/0.12.1/reference/pass.html",
+              "type": "olive_docs",
+              "version": "0.12.1"
+            }
+          },
+          "OnnxQuantization": {
+            "support": "supported",
+            "olive_pass": "OnnxQuantization",
+            "note": "Standard ORT quant also available on Azure ML N-series VMs.",
+            "typical_accuracy_drop": "<1%",
+            "evidence": {
+              "reference": "https://onnxruntime.ai/docs/performance/model-optimizations/quantization.html",
+              "type": "ort_docs",
+              "version": "1.19"
+            }
+          }
+        }
+      }
+    },
+    {
+      "model": "Phi-2",
+      "frameworks": ["PyTorch", "ONNX", "HuggingFace"],
+      "source": "https://github.com/microsoft/Olive/tree/main/examples/phi2",
+      "verified": true,
+      "notes": "Official Olive phi2 example.",
+      "hardware": {
+        "NVIDIA RTX 4090": {
+          "OnnxConversion": {
+            "support": "supported",
+            "olive_pass": "OnnxConversion",
+            "note": "Phi-2 Olive example export path.",
+            "typical_accuracy_drop": "n/a",
+            "evidence": {
+              "reference": "https://github.com/microsoft/Olive/tree/main/examples/phi2",
+              "type": "github",
+              "version": "0.12.1"
+            }
+          },
+          "NVModelOptQuantization": {
+            "support": "supported",
+            "olive_pass": "NVModelOptQuantization",
+            "note": "AWQ int4 via NVModelOpt for Phi-2.",
+            "typical_accuracy_drop": "<2%",
+            "evidence": {
+              "reference": "https://github.com/microsoft/Olive/tree/main/examples/phi2",
+              "type": "github",
+              "version": "0.12.1"
+            }
+          },
+          "OnnxFloatToFloat16": {
+            "support": "supported",
+            "olive_pass": "OnnxFloatToFloat16",
+            "note": "FP16 GPU path for small Phi.",
+            "typical_accuracy_drop": "<1%",
+            "evidence": {
+              "reference": "https://onnxruntime.ai/docs/performance/model-optimizations/float16.html",
+              "type": "ort_docs",
+              "version": "1.19"
+            }
+          }
+        },
+        "Intel Core i9 CPU": {
+          "OnnxConversion": {
+            "support": "supported",
+            "olive_pass": "OnnxConversion",
+            "note": "CPU export from Olive phi2 example patterns.",
+            "typical_accuracy_drop": "n/a",
+            "evidence": {
+              "reference": "https://github.com/microsoft/Olive/tree/main/examples/phi2",
+              "type": "github",
+              "version": "0.12.1"
+            }
+          },
+          "OnnxStaticQuantization": {
+            "support": "supported",
+            "olive_pass": "OnnxStaticQuantization",
+            "note": "INT8 static quant for Phi-2 on CPU.",
+            "typical_accuracy_drop": "<1%",
+            "evidence": {
+              "reference": "https://microsoft.github.io/Olive/0.12.1/reference/pass.html",
+              "type": "olive_docs",
+              "version": "0.12.1"
+            }
+          },
+          "OnnxBlockWiseRtnQuantization": {
+            "support": "supported",
+            "olive_pass": "OnnxBlockWiseRtnQuantization",
+            "note": "INT4 RTN for low-memory CPU.",
+            "typical_accuracy_drop": "1-2%",
+            "evidence": {
+              "reference": "https://microsoft.github.io/Olive/0.12.1/reference/options.html",
+              "type": "olive_docs",
+              "version": "0.12.1"
+            }
+          }
+        }
+      }
+    },
+    {
+      "model": "OPT-1.3B",
+      "frameworks": ["PyTorch", "ONNX", "HuggingFace"],
+      "source": "https://github.com/microsoft/Olive/tree/main/examples",
+      "verified": false,
+      "notes": "HF decoder LM; claims limited to Olive conversion + ORT quant/transformer optimization availability.",
+      "hardware": {
+        "Intel Core i9 CPU": {
+          "OnnxConversion": {
+            "support": "supported",
+            "olive_pass": "OnnxConversion",
+            "note": "HF OPT exports via OnnxConversion.",
+            "typical_accuracy_drop": "n/a",
+            "evidence": {
+              "reference": "https://microsoft.github.io/Olive/0.12.1/reference/pass.html",
+              "type": "olive_docs",
+              "version": "0.12.1"
+            }
+          },
+          "OrtTransformersOptimization": {
+            "support": "supported",
+            "olive_pass": "OrtTransformersOptimization",
+            "note": "ORT transformer fusions for OPT-class decoders.",
+            "typical_accuracy_drop": "n/a",
+            "evidence": {
+              "reference": "https://onnxruntime.ai/docs/performance/model-optimizations/transformers-optimization.html",
+              "type": "ort_docs",
+              "version": "1.19"
+            }
+          },
+          "OnnxStaticQuantization": {
+            "support": "supported",
+            "olive_pass": "OnnxStaticQuantization",
+            "note": "INT8 static quant with calibration.",
+            "typical_accuracy_drop": "1-2%",
+            "evidence": {
+              "reference": "https://onnxruntime.ai/docs/performance/model-optimizations/quantization.html",
+              "type": "ort_docs",
+              "version": "1.19"
+            }
+          },
+          "OnnxDynamicQuantization": {
+            "support": "supported",
+            "olive_pass": "OnnxDynamicQuantization",
+            "note": "No calibration; good for quick CPU tests.",
+            "typical_accuracy_drop": "1-3%",
+            "evidence": {
+              "reference": "https://microsoft.github.io/Olive/0.12.1/reference/pass.html",
+              "type": "olive_docs",
+              "version": "0.12.1"
+            }
+          }
+        },
+        "NVIDIA RTX 4090": {
+          "OnnxConversion": {
+            "support": "supported",
+            "olive_pass": "OnnxConversion",
+            "note": "GPU export with dynamic_axes.",
+            "typical_accuracy_drop": "n/a",
+            "evidence": {
+              "reference": "https://microsoft.github.io/Olive/0.12.1/reference/pass.html",
+              "type": "olive_docs",
+              "version": "0.12.1"
+            }
+          },
+          "OnnxFloatToFloat16": {
+            "support": "supported",
+            "olive_pass": "OnnxFloatToFloat16",
+            "note": "FP16 for 1.3B on consumer GPU.",
+            "typical_accuracy_drop": "<1%",
+            "evidence": {
+              "reference": "https://onnxruntime.ai/docs/performance/model-optimizations/float16.html",
+              "type": "ort_docs",
+              "version": "1.19"
+            }
+          },
+          "OnnxQuantization": {
+            "support": "supported",
+            "olive_pass": "OnnxQuantization",
+            "note": "INT8 QDQ available for OPT-class models.",
+            "typical_accuracy_drop": "1-2%",
+            "evidence": {
+              "reference": "https://onnxruntime.ai/docs/performance/model-optimizations/quantization.html",
+              "type": "ort_docs",
+              "version": "1.19"
+            }
           }
         }
       }

--- a/olive-mcp-server/olive_mcp_server/mcp_server.py
+++ b/olive-mcp-server/olive_mcp_server/mcp_server.py
@@ -59,6 +59,8 @@ _TOOL_IMPORTS: dict[str, tuple[str, str]] = {
         "record_troubleshoot_feedback",
     ),
 }
+# Studio's HTTP POST /api/mcp/tool proxies these tools but is loopback-only
+# (mcpToolLocalOnly). That gate is required for write tools like feedback.
 
 _mcp_instance: Any | None = None
 _resolved_tools: dict[str, Any] = {}

--- a/olive-mcp-server/olive_mcp_server/mcp_server.py
+++ b/olive-mcp-server/olive_mcp_server/mcp_server.py
@@ -46,6 +46,18 @@ _TOOL_IMPORTS: dict[str, tuple[str, str]] = {
         "olive_mcp_server.tools.passive_context",
         "get_context_for_pipeline",
     ),
+    "validate_ui_state_recipe": (
+        "olive_mcp_server.tools.studio_recipe",
+        "validate_ui_state_recipe",
+    ),
+    "get_recipe_for_ui_state": (
+        "olive_mcp_server.tools.studio_recipe",
+        "get_recipe_for_ui_state",
+    ),
+    "record_troubleshoot_feedback": (
+        "olive_mcp_server.tools.feedback",
+        "record_troubleshoot_feedback",
+    ),
 }
 
 _mcp_instance: Any | None = None

--- a/olive-mcp-server/olive_mcp_server/tools/__init__.py
+++ b/olive-mcp-server/olive_mcp_server/tools/__init__.py
@@ -32,6 +32,9 @@ _LAZY_EXPORTS: dict[str, tuple[str, str]] = {
     "diagnose_error": (".troubleshooting", "diagnose_error"),
     "get_error_frequency_summary": (".troubleshooting", "get_error_frequency_summary"),
     "get_context_for_pipeline": (".passive_context", "get_context_for_pipeline"),
+    "validate_ui_state_recipe": (".studio_recipe", "validate_ui_state_recipe"),
+    "get_recipe_for_ui_state": (".studio_recipe", "get_recipe_for_ui_state"),
+    "record_troubleshoot_feedback": (".feedback", "record_troubleshoot_feedback"),
 }
 
 
@@ -176,6 +179,9 @@ __all__ = [
     "diagnose_error",
     "get_error_frequency_summary",
     "get_context_for_pipeline",
+    "validate_ui_state_recipe",
+    "get_recipe_for_ui_state",
+    "record_troubleshoot_feedback",
     "KB_DIR",
     "load_json",
     "load_passes",

--- a/olive-mcp-server/olive_mcp_server/tools/feedback.py
+++ b/olive-mcp-server/olive_mcp_server/tools/feedback.py
@@ -1,0 +1,413 @@
+"""Tool: record_troubleshoot_feedback.
+
+Local-only, aggregate feedback for troubleshooting KB matches.
+Stores thumbs-up/down counts (and optional bounded reason codes) keyed by
+matched-entry ID. Never persists log text, tracebacks, or free-form content.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import tempfile
+import threading
+from pathlib import Path
+from typing import Any, Final, Literal
+
+from . import load_studio_troubleshooting, load_troubleshooting
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Public constants (ratings, reason codes, caps)
+# ---------------------------------------------------------------------------
+
+ALLOWED_RATINGS: Final[frozenset[str]] = frozenset({"thumbs-up", "thumbs-down"})
+RatingName = Literal["thumbs-up", "thumbs-down"]
+
+# Bounded reason codes only — never free text.
+ALLOWED_REASON_CODES: Final[frozenset[str]] = frozenset(
+    {
+        "accurate",
+        "clear_fix",
+        "fixed_issue",
+        "wrong_match",
+        "outdated",
+        "incomplete",
+        "incorrect_fix",
+    }
+)
+
+# Store caps: limit disk growth and ranking influence inputs.
+MAX_TRACKED_ENTRIES: Final[int] = 512
+MAX_COUNT_PER_RATING: Final[int] = 1000
+MAX_REASON_COUNT: Final[int] = 1000
+
+# Ranking influence caps (consumed by troubleshooting hybrid scorer).
+# Net votes beyond FEEDBACK_NET_VOTE_CAP do not increase the delta further.
+FEEDBACK_BOOST_PER_NET: Final[float] = 0.01
+FEEDBACK_MAX_ADJUSTMENT: Final[float] = 0.05
+FEEDBACK_NET_VOTE_CAP: Final[int] = 5
+
+_STORE_VERSION: Final[int] = 1
+_ENV_FEEDBACK_PATH: Final[str] = "OLIVE_MCP_FEEDBACK_PATH"
+_DEFAULT_FILENAME: Final[str] = "troubleshoot_feedback.json"
+
+# Internal JSON keys (snake_case; API ratings use hyphens).
+_KEY_UP: Final[str] = "thumbs_up"
+_KEY_DOWN: Final[str] = "thumbs_down"
+_KEY_REASONS: Final[str] = "reason_codes"
+
+# ---------------------------------------------------------------------------
+# Path override + in-process lock
+# ---------------------------------------------------------------------------
+
+_lock = threading.Lock()
+_path_override: Path | None = None
+
+
+def set_feedback_path(path: str | Path | None) -> None:
+    """Override the feedback file path (tests). Pass ``None`` to clear."""
+    global _path_override
+    with _lock:
+        _path_override = Path(path) if path is not None else None
+
+
+def get_feedback_path() -> Path:
+    """Resolve the feedback store path (override → env → XDG user data)."""
+    if _path_override is not None:
+        return _path_override
+
+    env_path = os.environ.get(_ENV_FEEDBACK_PATH, "").strip()
+    if env_path:
+        return Path(env_path)
+
+    xdg = os.environ.get("XDG_DATA_HOME", "").strip()
+    base = Path(xdg) if xdg else Path.home() / ".local" / "share"
+    return base / "olive-mcp" / _DEFAULT_FILENAME
+
+
+def reset_feedback_store() -> None:
+    """Clear the on-disk feedback store (tests).
+
+    Deletes the resolved feedback file when present. Safe if the file is
+    missing. Does not clear ``set_feedback_path`` / env overrides.
+    """
+    path = get_feedback_path()
+    with _lock:
+        try:
+            if path.is_file():
+                path.unlink()
+        except OSError as exc:
+            logger.warning("Failed to remove feedback store %s: %s", path, exc)
+
+
+# ---------------------------------------------------------------------------
+# Known entry IDs
+# ---------------------------------------------------------------------------
+
+
+def _known_entry_ids() -> set[str]:
+    """Return the set of valid troubleshooting KB entry IDs."""
+    ids: set[str] = set()
+    for entry in load_troubleshooting():
+        eid = entry.get("id")
+        if isinstance(eid, str) and eid:
+            ids.add(eid)
+    for entry in load_studio_troubleshooting():
+        eid = entry.get("id")
+        if isinstance(eid, str) and eid:
+            ids.add(eid)
+    return ids
+
+
+# ---------------------------------------------------------------------------
+# Store load / atomic write
+# ---------------------------------------------------------------------------
+
+
+def _empty_store() -> dict[str, Any]:
+    return {"version": _STORE_VERSION, "entries": {}}
+
+
+def _sanitize_entry(raw: Any) -> dict[str, Any] | None:
+    """Keep only aggregate counters; drop any unexpected free-form fields."""
+    if not isinstance(raw, dict):
+        return None
+    up = raw.get(_KEY_UP, 0)
+    down = raw.get(_KEY_DOWN, 0)
+    if not isinstance(up, int) or not isinstance(down, int):
+        # Coerce numeric-looking values; reject everything else.
+        try:
+            up = int(up)
+            down = int(down)
+        except (TypeError, ValueError):
+            return None
+    up = max(0, min(up, MAX_COUNT_PER_RATING))
+    down = max(0, min(down, MAX_COUNT_PER_RATING))
+
+    reasons_out: dict[str, int] = {}
+    reasons_raw = raw.get(_KEY_REASONS)
+    if isinstance(reasons_raw, dict):
+        for code, count in reasons_raw.items():
+            if code not in ALLOWED_REASON_CODES:
+                continue
+            try:
+                n = int(count)
+            except (TypeError, ValueError):
+                continue
+            if n > 0:
+                reasons_out[code] = min(n, MAX_REASON_COUNT)
+
+    out: dict[str, Any] = {_KEY_UP: up, _KEY_DOWN: down}
+    if reasons_out:
+        out[_KEY_REASONS] = reasons_out
+    return out
+
+
+def _load_store_unlocked(path: Path) -> dict[str, Any]:
+    """Load and sanitize the store from disk. Caller must hold ``_lock``."""
+    if not path.is_file():
+        return _empty_store()
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            data = json.load(fh)
+    except (OSError, json.JSONDecodeError) as exc:
+        logger.warning("Corrupt or unreadable feedback store %s: %s", path, exc)
+        return _empty_store()
+
+    if not isinstance(data, dict):
+        return _empty_store()
+
+    entries_raw = data.get("entries")
+    if not isinstance(entries_raw, dict):
+        return _empty_store()
+
+    entries: dict[str, Any] = {}
+    for key, value in entries_raw.items():
+        if not isinstance(key, str) or not key:
+            continue
+        cleaned = _sanitize_entry(value)
+        if cleaned is not None:
+            entries[key] = cleaned
+        if len(entries) >= MAX_TRACKED_ENTRIES:
+            break
+
+    return {"version": _STORE_VERSION, "entries": entries}
+
+
+def _atomic_write_unlocked(path: Path, store: dict[str, Any]) -> None:
+    """Atomically write JSON store via temp file + ``os.replace``."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    # Restrict payload to version + capped entry aggregates only.
+    payload = {
+        "version": _STORE_VERSION,
+        "entries": store.get("entries", {}),
+    }
+    fd, tmp_name = tempfile.mkstemp(
+        dir=str(path.parent),
+        prefix=".troubleshoot_feedback-",
+        suffix=".tmp",
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            json.dump(payload, fh, indent=2, sort_keys=True)
+            fh.write("\n")
+            fh.flush()
+            os.fsync(fh.fileno())
+        os.replace(tmp_name, path)
+    except Exception:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+
+
+# ---------------------------------------------------------------------------
+# Aggregate helpers (for ranking / tests)
+# ---------------------------------------------------------------------------
+
+
+def get_entry_feedback_counts(matched_entry: str) -> dict[str, int]:
+    """Return capped thumbs counts for one entry (zeros if unknown/absent)."""
+    if not isinstance(matched_entry, str) or not matched_entry:
+        return {_KEY_UP: 0, _KEY_DOWN: 0}
+    path = get_feedback_path()
+    with _lock:
+        store = _load_store_unlocked(path)
+        entry = store["entries"].get(matched_entry) or {}
+        return {
+            _KEY_UP: int(entry.get(_KEY_UP, 0)),
+            _KEY_DOWN: int(entry.get(_KEY_DOWN, 0)),
+        }
+
+
+def get_all_feedback_aggregates() -> dict[str, dict[str, int]]:
+    """Return ``{entry_id: {thumbs_up, thumbs_down}}`` for all tracked entries."""
+    path = get_feedback_path()
+    with _lock:
+        store = _load_store_unlocked(path)
+        result: dict[str, dict[str, int]] = {}
+        for eid, entry in store["entries"].items():
+            result[eid] = {
+                _KEY_UP: int(entry.get(_KEY_UP, 0)),
+                _KEY_DOWN: int(entry.get(_KEY_DOWN, 0)),
+            }
+        return result
+
+
+def _delta_from_counts(thumbs_up: int, thumbs_down: int) -> float:
+    """Pure bounded score delta from aggregate counts."""
+    net = int(thumbs_up) - int(thumbs_down)
+    if net > FEEDBACK_NET_VOTE_CAP:
+        net = FEEDBACK_NET_VOTE_CAP
+    elif net < -FEEDBACK_NET_VOTE_CAP:
+        net = -FEEDBACK_NET_VOTE_CAP
+    delta = net * FEEDBACK_BOOST_PER_NET
+    if delta > FEEDBACK_MAX_ADJUSTMENT:
+        return FEEDBACK_MAX_ADJUSTMENT
+    if delta < -FEEDBACK_MAX_ADJUSTMENT:
+        return -FEEDBACK_MAX_ADJUSTMENT
+    return float(delta)
+
+
+def feedback_score_delta(matched_entry: str) -> float:
+    """Bounded ranking adjustment from aggregate feedback.
+
+    Positive net thumbs → slight boost; negative → slight demote.
+    Absolute value is capped at ``FEEDBACK_MAX_ADJUSTMENT``.
+    """
+    counts = get_entry_feedback_counts(matched_entry)
+    return _delta_from_counts(counts[_KEY_UP], counts[_KEY_DOWN])
+
+
+# ---------------------------------------------------------------------------
+# MCP tool
+# ---------------------------------------------------------------------------
+
+
+def record_troubleshoot_feedback(
+    matched_entry: str,
+    rating: str,
+    reason_code: str | None = None,
+) -> dict[str, Any]:
+    """Record local aggregate feedback for a troubleshooting KB match.
+
+    Privacy: only ``matched_entry``, ``rating``, and an optional allowlisted
+    ``reason_code`` are accepted. Log text, tracebacks, and free-form notes
+    are rejected by the signature and never written to disk.
+
+    Args:
+        matched_entry: Troubleshooting KB entry id (must exist in olive or
+            studio troubleshooting knowledge bases).
+        rating: ``"thumbs-up"`` or ``"thumbs-down"`` only.
+        reason_code: Optional allowlisted reason code (not free text).
+
+    Returns:
+        Aggregate acknowledgement with status and capped counts, or a
+        structured error payload when validation fails.
+    """
+    # --- validate matched_entry ---
+    if not isinstance(matched_entry, str) or not matched_entry.strip():
+        return {
+            "status": "error",
+            "error": "invalid_matched_entry",
+            "message": "matched_entry must be a non-empty string entry id.",
+        }
+    matched_entry = matched_entry.strip()
+
+    known = _known_entry_ids()
+    if matched_entry not in known:
+        return {
+            "status": "error",
+            "error": "unknown_matched_entry",
+            "message": f"Unknown matched_entry id: {matched_entry!r}.",
+        }
+
+    # --- validate rating ---
+    if not isinstance(rating, str) or rating not in ALLOWED_RATINGS:
+        return {
+            "status": "error",
+            "error": "invalid_rating",
+            "message": "rating must be 'thumbs-up' or 'thumbs-down'.",
+            "allowed_ratings": sorted(ALLOWED_RATINGS),
+        }
+
+    # --- validate optional reason_code (allowlist only) ---
+    normalized_reason: str | None = None
+    if reason_code is not None:
+        if not isinstance(reason_code, str) or reason_code not in ALLOWED_REASON_CODES:
+            return {
+                "status": "error",
+                "error": "invalid_reason_code",
+                "message": "reason_code must be one of the allowlisted values or omitted.",
+                "allowed_reason_codes": sorted(ALLOWED_REASON_CODES),
+            }
+        normalized_reason = reason_code
+
+    path = get_feedback_path()
+    with _lock:
+        store = _load_store_unlocked(path)
+        entries: dict[str, Any] = store["entries"]
+
+        if matched_entry not in entries:
+            if len(entries) >= MAX_TRACKED_ENTRIES:
+                return {
+                    "status": "error",
+                    "error": "entry_cap_reached",
+                    "message": (
+                        f"Feedback store already tracks {MAX_TRACKED_ENTRIES} entries; "
+                        "cannot add a new matched_entry."
+                    ),
+                    "max_tracked_entries": MAX_TRACKED_ENTRIES,
+                }
+            entries[matched_entry] = {_KEY_UP: 0, _KEY_DOWN: 0}
+
+        entry = entries[matched_entry]
+        count_key = _KEY_UP if rating == "thumbs-up" else _KEY_DOWN
+        current = int(entry.get(count_key, 0))
+        if current < MAX_COUNT_PER_RATING:
+            entry[count_key] = current + 1
+        # else: silently stay at cap (still acknowledge current aggregates)
+
+        if normalized_reason is not None:
+            reasons = entry.setdefault(_KEY_REASONS, {})
+            if not isinstance(reasons, dict):
+                reasons = {}
+                entry[_KEY_REASONS] = reasons
+            rc = int(reasons.get(normalized_reason, 0))
+            if rc < MAX_REASON_COUNT:
+                reasons[normalized_reason] = rc + 1
+
+        entries[matched_entry] = entry
+        store["entries"] = entries
+
+        try:
+            _atomic_write_unlocked(path, store)
+        except OSError as exc:
+            logger.warning("Failed to persist feedback store %s: %s", path, exc)
+            return {
+                "status": "error",
+                "error": "persist_failed",
+                "message": "Could not write local feedback store.",
+            }
+
+        up = int(entry.get(_KEY_UP, 0))
+        down = int(entry.get(_KEY_DOWN, 0))
+        delta = _delta_from_counts(up, down)
+
+    # Aggregate acknowledgement only — no logs, paths, or free-form content.
+    return {
+        "status": "ok",
+        "matched_entry": matched_entry,
+        "rating": rating,
+        "reason_code": normalized_reason,
+        "thumbs_up": up,
+        "thumbs_down": down,
+        "total": up + down,
+        "count_cap": MAX_COUNT_PER_RATING,
+        "score_delta": delta,
+        "max_score_adjustment": FEEDBACK_MAX_ADJUSTMENT,
+    }

--- a/olive-mcp-server/olive_mcp_server/tools/feedback.py
+++ b/olive-mcp-server/olive_mcp_server/tools/feedback.py
@@ -12,8 +12,10 @@ import logging
 import os
 import tempfile
 import threading
+import time
+from contextlib import contextmanager
 from pathlib import Path
-from typing import Any, Final, Literal
+from typing import Any, Final, Iterator, Literal
 
 from . import load_studio_troubleshooting, load_troubleshooting
 
@@ -60,11 +62,64 @@ _KEY_DOWN: Final[str] = "thumbs_down"
 _KEY_REASONS: Final[str] = "reason_codes"
 
 # ---------------------------------------------------------------------------
-# Path override + in-process lock
+# Path override + in-process + inter-process locks
 # ---------------------------------------------------------------------------
 
 _lock = threading.Lock()
 _path_override: Path | None = None
+
+
+@contextmanager
+def _interprocess_store_lock(path: Path) -> Iterator[None]:
+    """Exclusive lock across processes for feedback read-modify-write.
+
+    The HTTP MCP proxy spawns a fresh Python process per request, so a
+    threading.Lock alone cannot serialize overlapping increments. Lock a
+    sibling ``*.lock`` file with ``fcntl`` (POSIX) or ``msvcrt`` (Windows).
+    """
+    lock_path = path.with_name(path.name + ".lock")
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    fd = os.open(str(lock_path), os.O_RDWR | os.O_CREAT, 0o644)
+    try:
+        if os.name == "nt":
+            import msvcrt
+
+            # LK_LOCK blocks until the region is free; retry on transient errors.
+            while True:
+                try:
+                    msvcrt.locking(fd, msvcrt.LK_LOCK, 1)
+                    break
+                except OSError:
+                    time.sleep(0.01)
+        else:
+            import fcntl
+
+            fcntl.flock(fd, fcntl.LOCK_EX)
+        yield
+    finally:
+        try:
+            if os.name == "nt":
+                import msvcrt
+
+                try:
+                    os.lseek(fd, 0, os.SEEK_SET)
+                    msvcrt.locking(fd, msvcrt.LK_UNLCK, 1)
+                except OSError:
+                    pass
+            else:
+                import fcntl
+
+                fcntl.flock(fd, fcntl.LOCK_UN)
+        finally:
+            os.close(fd)
+
+
+@contextmanager
+def _store_lock(path: Path) -> Iterator[None]:
+    """Hold both the cross-process file lock and the in-process threading lock."""
+    with _interprocess_store_lock(path):
+        with _lock:
+            yield
 
 
 def set_feedback_path(path: str | Path | None) -> None:
@@ -95,7 +150,7 @@ def reset_feedback_store() -> None:
     missing. Does not clear ``set_feedback_path`` / env overrides.
     """
     path = get_feedback_path()
-    with _lock:
+    with _store_lock(path):
         try:
             if path.is_file():
                 path.unlink()
@@ -235,7 +290,7 @@ def get_entry_feedback_counts(matched_entry: str) -> dict[str, int]:
     if not isinstance(matched_entry, str) or not matched_entry:
         return {_KEY_UP: 0, _KEY_DOWN: 0}
     path = get_feedback_path()
-    with _lock:
+    with _store_lock(path):
         store = _load_store_unlocked(path)
         entry = store["entries"].get(matched_entry) or {}
         return {
@@ -247,7 +302,7 @@ def get_entry_feedback_counts(matched_entry: str) -> dict[str, int]:
 def get_all_feedback_aggregates() -> dict[str, dict[str, int]]:
     """Return ``{entry_id: {thumbs_up, thumbs_down}}`` for all tracked entries."""
     path = get_feedback_path()
-    with _lock:
+    with _store_lock(path):
         store = _load_store_unlocked(path)
         result: dict[str, dict[str, int]] = {}
         for eid, entry in store["entries"].items():
@@ -348,7 +403,7 @@ def record_troubleshoot_feedback(
         normalized_reason = reason_code
 
     path = get_feedback_path()
-    with _lock:
+    with _store_lock(path):
         store = _load_store_unlocked(path)
         entries: dict[str, Any] = store["entries"]
 

--- a/olive-mcp-server/olive_mcp_server/tools/studio_recipe.py
+++ b/olive-mcp-server/olive_mcp_server/tools/studio_recipe.py
@@ -1,0 +1,329 @@
+"""Tools: validate_ui_state_recipe and get_recipe_for_ui_state.
+
+Bridge to a local Olive Studio HTTP API for UIState-backed recipe validation
+and building. Base URL comes only from ``OLIVE_STUDIO_API_URL`` (loopback
+HTTP(S) only). Never shells out to or runs Olive.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import json
+import os
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlparse
+from urllib.request import HTTPRedirectHandler, Request, build_opener
+
+ENV_API_URL = "OLIVE_STUDIO_API_URL"
+BRIDGE_PATH = "/api/mcp/studio-recipe"
+DEFAULT_TIMEOUT_SECONDS = 5.0
+
+_LOOPBACK_HOSTNAMES = frozenset({"localhost", "127.0.0.1", "::1"})
+
+# TS camelCase → snake_case aliases accepted on bridge payloads.
+_FIELD_ALIASES: dict[str, str] = {
+    "effectiveState": "effective_state",
+    "recipe": "recipe",
+    "isRunnable": "is_runnable",
+    "schemaErrors": "schema_errors",
+    "pipelineIssues": "pipeline_issues",
+    "localExecutionIssues": "local_execution_issues",
+    "advisories": "advisories",
+    "pipelineCriticalCount": "pipeline_critical_count",
+    "criticalCount": "critical_count",
+    "warnings": "warnings",
+    "conversionWarnings": "conversion_warnings",
+}
+
+_REQUIRED_SUCCESS = ("effectiveState", "recipe", "isRunnable")
+
+
+class _NoRedirect(HTTPRedirectHandler):
+    """Refuse redirects so a loopback URL cannot bounce off-host (SSRF)."""
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):  # noqa: ANN001
+        return None
+
+
+_OPENER = build_opener(_NoRedirect)
+
+
+def _err(code: str, message: str, *, detail: str | None = None) -> dict[str, Any]:
+    out: dict[str, Any] = {"error": code, "message": message}
+    if detail:
+        out["detail"] = detail
+    return out
+
+
+def _studio_unavailable(message: str, *, detail: str | None = None) -> dict[str, Any]:
+    return _err("studio_unavailable", message, detail=detail)
+
+
+def _normalize_host(host: str | None) -> str:
+    if not host:
+        return ""
+    h = host.strip().lower()
+    if h.startswith("[") and h.endswith("]"):
+        h = h[1:-1]
+    return h
+
+
+def _is_loopback_host(host: str | None) -> bool:
+    """Allow localhost, 127.0.0.1, ::1, and any IP with is_loopback=True."""
+    h = _normalize_host(host)
+    if not h:
+        return False
+    if h in _LOOPBACK_HOSTNAMES:
+        return True
+    try:
+        return ipaddress.ip_address(h).is_loopback
+    except ValueError:
+        return False
+
+
+def _resolve_bridge_endpoint() -> tuple[str | None, dict[str, Any] | None]:
+    """Read only ``OLIVE_STUDIO_API_URL``; never accept a caller-supplied URL."""
+    raw = os.environ.get(ENV_API_URL, "").strip()
+    if not raw:
+        return None, _studio_unavailable(
+            f"{ENV_API_URL} is not set. Start Olive Studio and point "
+            f"{ENV_API_URL} at its loopback base URL (e.g. http://127.0.0.1:3000)."
+        )
+
+    parsed = urlparse(raw)
+    if parsed.scheme not in ("http", "https"):
+        return None, _studio_unavailable(
+            f"{ENV_API_URL} must be an http(s) loopback URL.",
+            detail=f"scheme={parsed.scheme!r}",
+        )
+    if parsed.username is not None or parsed.password is not None:
+        return None, _studio_unavailable(
+            f"{ENV_API_URL} must not include credentials.",
+        )
+    if not _is_loopback_host(parsed.hostname):
+        return None, _studio_unavailable(
+            f"{ENV_API_URL} must target a loopback host "
+            "(127.0.0.1, localhost, or ::1).",
+            detail=f"host={parsed.hostname!r}",
+        )
+    return raw.rstrip("/") + BRIDGE_PATH, None
+
+
+def _parse_json_body(raw: bytes | str) -> Any | None:
+    try:
+        text = raw.decode("utf-8") if isinstance(raw, bytes) else raw
+        return json.loads(text)
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        return None
+
+
+def _is_timeout_reason(reason: Any) -> bool:
+    if isinstance(reason, TimeoutError):
+        return True
+    return "timed out" in str(reason).lower()
+
+
+def _request_studio_recipe(
+    ui_state: dict[str, Any],
+    *,
+    timeout: float = DEFAULT_TIMEOUT_SECONDS,
+) -> dict[str, Any]:
+    """POST ui_state to the fixed Studio bridge; failures → studio_unavailable."""
+    endpoint, err = _resolve_bridge_endpoint()
+    if err is not None:
+        return err
+
+    request = Request(
+        endpoint,  # type: ignore[arg-type]
+        data=json.dumps({"uiState": ui_state}).encode("utf-8"),
+        method="POST",
+        headers={"Content-Type": "application/json", "Accept": "application/json"},
+    )
+
+    try:
+        # URL is restricted to validated loopback http(s) only (SSRF guard).
+        # Redirects disabled so the request cannot leave loopback.
+        with _OPENER.open(request, timeout=timeout) as response:  # noqa: S310
+            status = getattr(response, "status", None) or response.getcode()
+            raw = response.read()
+    except HTTPError as exc:
+        try:
+            body = exc.read() or b""
+        except Exception:  # noqa: BLE001 — best-effort body read
+            body = b""
+        parsed = _parse_json_body(body)
+        if isinstance(parsed, dict) and (
+            "error" in parsed or _has_required_success_keys(parsed)
+        ):
+            return parsed
+        return _studio_unavailable(
+            "Olive Studio bridge returned an HTTP error.",
+            detail=f"status={exc.code}",
+        )
+    except URLError as exc:
+        reason = getattr(exc, "reason", exc)
+        if _is_timeout_reason(reason):
+            return _studio_unavailable(
+                "Olive Studio bridge timed out.",
+                detail=f"timeout_seconds={timeout}",
+            )
+        return _studio_unavailable(
+            "Olive Studio bridge is not reachable.",
+            detail=str(reason),
+        )
+    except TimeoutError:
+        return _studio_unavailable(
+            "Olive Studio bridge timed out.",
+            detail=f"timeout_seconds={timeout}",
+        )
+    except OSError as exc:
+        return _studio_unavailable(
+            "Olive Studio bridge request failed.",
+            detail=str(exc),
+        )
+
+    if status is not None and int(status) >= 400:
+        return _studio_unavailable(
+            "Olive Studio bridge returned an HTTP error.",
+            detail=f"status={status}",
+        )
+
+    parsed = _parse_json_body(raw)
+    if not isinstance(parsed, dict):
+        return _err(
+            "invalid_bridge_response",
+            "Olive Studio bridge returned a non-object JSON payload.",
+        )
+    return parsed
+
+
+def _get(payload: dict[str, Any], camel: str, default: Any = None) -> Any:
+    """Read camelCase field, falling back to snake_case alias."""
+    if camel in payload:
+        return payload[camel]
+    snake = _FIELD_ALIASES.get(camel)
+    if snake and snake in payload:
+        return payload[snake]
+    return default
+
+
+def _has_required_success_keys(payload: dict[str, Any]) -> bool:
+    for key in _REQUIRED_SUCCESS:
+        snake = _FIELD_ALIASES.get(key, key)
+        if key not in payload and snake not in payload:
+            return False
+    return True
+
+
+def _is_error_payload(payload: dict[str, Any]) -> bool:
+    return "error" in payload and not _has_required_success_keys(payload)
+
+
+def _check_success_payload(payload: dict[str, Any]) -> dict[str, Any] | None:
+    """Return an error dict if payload is not a successful bridge result."""
+    if not _has_required_success_keys(payload):
+        missing = [k for k in _REQUIRED_SUCCESS if _get(payload, k) is None
+                   and k not in payload and _FIELD_ALIASES.get(k, k) not in payload]
+        return _err(
+            "invalid_bridge_response",
+            "Olive Studio bridge payload missing required fields.",
+            detail=f"missing={missing}",
+        )
+
+    effective = _get(payload, "effectiveState")
+    if not isinstance(effective, dict):
+        return _err("invalid_bridge_response", "effectiveState must be an object.")
+
+    recipe = _get(payload, "recipe")
+    if not isinstance(recipe, dict):
+        return _err("invalid_bridge_response", "recipe must be an object.")
+
+    runnable = _get(payload, "isRunnable")
+    if not isinstance(runnable, bool):
+        return _err("invalid_bridge_response", "isRunnable must be a boolean.")
+
+    return None
+
+
+def _as_list(value: Any) -> list[Any]:
+    if value is None:
+        return []
+    return value if isinstance(value, list) else [value]
+
+
+def _validation_view(payload: dict[str, Any]) -> dict[str, Any]:
+    """Compact validation projection (no full recipe)."""
+    critical = _get(payload, "pipelineCriticalCount")
+    if critical is None:
+        critical = _get(payload, "criticalCount")
+
+    return {
+        "effective_state": _get(payload, "effectiveState"),
+        "schema_errors": _as_list(_get(payload, "schemaErrors", [])),
+        "pipeline_issues": _as_list(_get(payload, "pipelineIssues", [])),
+        "pipeline_critical_count": critical,
+        "local_execution_issues": _as_list(_get(payload, "localExecutionIssues", [])),
+        "advisories": _as_list(_get(payload, "advisories", [])),
+        "is_runnable": bool(_get(payload, "isRunnable")),
+    }
+
+
+def _recipe_view(payload: dict[str, Any]) -> dict[str, Any]:
+    """Validation view plus olive_recipe and conversion_warnings."""
+    conversion = _get(payload, "conversionWarnings")
+    warnings = _as_list(conversion if conversion is not None else _get(payload, "warnings", []))
+    return {
+        **_validation_view(payload),
+        "olive_recipe": _get(payload, "recipe"),
+        "conversion_warnings": warnings,
+    }
+
+
+def _evaluate_ui_state(ui_state: Any) -> dict[str, Any]:
+    """Validate input, call bridge once, check response shape."""
+    if ui_state is None:
+        return _err("invalid_ui_state", "ui_state is required and must be a JSON object.")
+    if not isinstance(ui_state, dict):
+        return _err("invalid_ui_state", "ui_state must be a JSON object.")
+
+    payload = _request_studio_recipe(ui_state)
+    if _is_error_payload(payload):
+        return payload
+
+    shape_err = _check_success_payload(payload)
+    return shape_err if shape_err is not None else payload
+
+
+def validate_ui_state_recipe(ui_state: dict[str, Any] | None = None) -> dict[str, Any]:
+    """Validate a (partial) UIState via the local Olive Studio bridge.
+
+    Returns effective state, schema/pipeline/runtime issues, advisories, and
+    ``is_runnable``. Does not run Olive.
+
+    Args:
+        ui_state: Complete or allowed-partial UI state object.
+
+    Returns:
+        Validation projection, or structured error
+        (``studio_unavailable`` / ``invalid_ui_state`` / ``invalid_bridge_response``).
+    """
+    payload = _evaluate_ui_state(ui_state)
+    return payload if _is_error_payload(payload) else _validation_view(payload)
+
+
+def get_recipe_for_ui_state(ui_state: dict[str, Any] | None = None) -> dict[str, Any]:
+    """Build and validate an Olive recipe for a (partial) UIState via Studio.
+
+    Same evaluation as ``validate_ui_state_recipe``, plus ``olive_recipe`` and
+    ``conversion_warnings``. Does not run Olive.
+
+    Args:
+        ui_state: Complete or allowed-partial UI state object.
+
+    Returns:
+        Full recipe projection, or structured error
+        (``studio_unavailable`` / ``invalid_ui_state`` / ``invalid_bridge_response``).
+    """
+    payload = _evaluate_ui_state(ui_state)
+    return payload if _is_error_payload(payload) else _recipe_view(payload)

--- a/olive-mcp-server/olive_mcp_server/tools/troubleshooting.py
+++ b/olive-mcp-server/olive_mcp_server/tools/troubleshooting.py
@@ -356,6 +356,8 @@ def _best_match(
     error_message: str,
     pass_name: str,
     config_context: str,
+    *,
+    require_keyword: bool = False,
 ) -> tuple[dict[str, Any] | None, float]:
     """Select the highest-scoring troubleshooting entry (hybrid semantic+keyword).
 
@@ -406,8 +408,10 @@ def _best_match(
         hits = _pattern_hit_count(entry, keyword_text)
         scored.append((entry, hybrid, hits))
     scored.sort(key=lambda x: (x[1], x[2]), reverse=True)
-    best_entry, best_score, _hits = scored[0]
+    best_entry, best_score, hits = scored[0]
     if best_score <= 0:
+        return None, 0.0
+    if require_keyword and hits == 0:
         return None, 0.0
     return best_entry, best_score
 
@@ -516,7 +520,13 @@ def troubleshoot_olive_error(
             matched_domain = "studio"
     else:
         pool = _pool_for_domain(resolved)
-        hit, score = _best_match(pool, error_message, pass_name, config_context)
+        hit, score = _best_match(
+            pool,
+            error_message,
+            pass_name,
+            config_context,
+            require_keyword=True,
+        )
         if hit is not None and score > 0:
             best = hit
             matched_domain = str(hit.get("domain") or resolved)

--- a/olive-mcp-server/olive_mcp_server/tools/troubleshooting.py
+++ b/olive-mcp-server/olive_mcp_server/tools/troubleshooting.py
@@ -23,6 +23,7 @@ from .embeddings import (
     cosine_similarity_scores,
     encode_query,
 )
+from .feedback import FEEDBACK_MAX_ADJUSTMENT, feedback_score_delta
 
 logger = logging.getLogger(__name__)
 
@@ -40,6 +41,9 @@ _KEYWORD_WEIGHT = 0.4
 # Extra ranking boost per pattern alternative hit (OR list multi-evidence).
 _HIT_RANK_BONUS = 0.05
 _HIT_RANK_BONUS_CAP = 5
+# Aggregate feedback may nudge rank by at most FEEDBACK_MAX_ADJUSTMENT (0.05):
+# enough to break close ties, never enough to invent a match or overturn a
+# clear keyword hit (_KEYWORD_WEIGHT = 0.4).
 
 # ---------------------------------------------------------------------------
 # Error frequency tracker (module-level, lives for the process lifetime)
@@ -383,6 +387,22 @@ def _best_match(
         hybrid = _score(
             entry, error_message, pass_name, config_context, semantic_score=sem
         )
+        # Bounded feedback adjustment after semantic/keyword hybrid score.
+        # Cap: |delta| <= FEEDBACK_MAX_ADJUSTMENT (0.05). Positive net votes
+        # slightly boost / break close ties; negative slightly demote.
+        # Only applied when hybrid > 0 so zero-score (no keyword/semantic
+        # evidence) stays a no-match and cannot be promoted by thumbs alone.
+        if hybrid > 0:
+            eid = entry.get("id")
+            if isinstance(eid, str) and eid:
+                delta = feedback_score_delta(eid)
+                # feedback_score_delta already caps; clamp again so the local
+                # rank bound stays obvious at the call site.
+                if delta > FEEDBACK_MAX_ADJUSTMENT:
+                    delta = FEEDBACK_MAX_ADJUSTMENT
+                elif delta < -FEEDBACK_MAX_ADJUSTMENT:
+                    delta = -FEEDBACK_MAX_ADJUSTMENT
+                hybrid = hybrid + delta
         hits = _pattern_hit_count(entry, keyword_text)
         scored.append((entry, hybrid, hits))
     scored.sort(key=lambda x: (x[1], x[2]), reverse=True)

--- a/olive-mcp-server/schemas/compatibility-v1.json
+++ b/olive-mcp-server/schemas/compatibility-v1.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Olive Compatibility Matrix",
-  "description": "Schema for olive-mcp-server knowledge_base/compatibility_matrix.json",
+  "description": "Schema for olive-mcp-server knowledge_base/compatibility_matrix.json. Every pass claim must name a canonical olive_pass and nonempty provenance evidence.",
   "type": "object",
   "required": ["version", "last_updated", "models"],
   "properties": {
@@ -71,7 +71,7 @@
     },
     "pass_compat": {
       "type": "object",
-      "required": ["support"],
+      "required": ["support", "olive_pass", "evidence"],
       "properties": {
         "support": {
           "type": "string",
@@ -82,6 +82,44 @@
         },
         "typical_accuracy_drop": {
           "type": "string"
+        },
+        "olive_pass": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Canonical Olive pass identifier as registered in passes.json / the Olive pass registry"
+        },
+        "evidence": {
+          "$ref": "#/$defs/pass_evidence",
+          "description": "Provenance backing this compatibility claim"
+        }
+      }
+    },
+    "pass_evidence": {
+      "type": "object",
+      "required": ["reference", "type", "version"],
+      "additionalProperties": false,
+      "properties": {
+        "reference": {
+          "type": "string",
+          "minLength": 1,
+          "description": "URL or citation reference supporting this compatibility claim"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "olive_docs",
+            "ort_docs",
+            "github",
+            "availability",
+            "benchmark",
+            "release_notes"
+          ],
+          "description": "Kind of provenance backing the claim"
+        },
+        "version": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Olive or source version the evidence applies to (e.g. 0.8.0)"
         }
       }
     }

--- a/olive-mcp-server/scripts/check_olive_pass_availability.py
+++ b/olive-mcp-server/scripts/check_olive_pass_availability.py
@@ -283,7 +283,8 @@ def main(argv: Iterable[str] | None = None) -> int:
     print(f"Matrix supported/warning olive_pass claims: {len(claimed)}")
     print(f"Matrix path: {matrix_path}")
 
-    missing = sorted(name for name in claimed if name not in available)
+    available_lower = {name.lower() for name in available}
+    missing = sorted(name for name in claimed if name.lower() not in available_lower)
     if missing:
         print(
             "\nFAIL: claimed supported/warning pass(es) not in Olive registry:",

--- a/olive-mcp-server/scripts/check_olive_pass_availability.py
+++ b/olive-mcp-server/scripts/check_olive_pass_availability.py
@@ -1,0 +1,262 @@
+#!/usr/bin/env python3
+"""CI helper: compare compatibility_matrix claims to the installed Olive pass registry.
+
+Installs nothing and runs no optimization. Requires olive-ai already installed.
+Enumerates pass names from Olive's package config / registry only — no model
+download, no pass execution, no CUDA.
+
+Exit codes:
+  0 — every matrix supported/warning olive_pass is present in the registry
+  1 — missing claimed passes, or registry/matrix could not be loaded
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import sys
+from pathlib import Path
+from typing import Any, Iterable
+
+# Claimed support levels that must exist in the pinned Olive registry.
+_REQUIRED_SUPPORT = frozenset({"supported", "warning"})
+
+_SCRIPT_DIR = Path(__file__).resolve().parent
+_MCP_ROOT = _SCRIPT_DIR.parent
+_DEFAULT_MATRIX = (
+    _MCP_ROOT / "olive_mcp_server" / "knowledge_base" / "compatibility_matrix.json"
+)
+
+
+def _load_matrix(path: Path) -> dict[str, Any]:
+    if not path.is_file():
+        raise FileNotFoundError(f"compatibility matrix not found: {path}")
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError("compatibility_matrix.json root must be an object")
+    return data
+
+
+def claimed_passes(matrix: dict[str, Any]) -> dict[str, set[str]]:
+    """Map olive_pass -> set of support levels seen for supported/warning claims."""
+    models = matrix.get("models")
+    if not isinstance(models, list):
+        raise ValueError("compatibility_matrix.json missing models[]")
+
+    claimed: dict[str, set[str]] = {}
+    for model in models:
+        if not isinstance(model, dict):
+            continue
+        hardware = model.get("hardware")
+        if not isinstance(hardware, dict):
+            continue
+        for _hw_name, passes in hardware.items():
+            if not isinstance(passes, dict):
+                continue
+            for _key, claim in passes.items():
+                if not isinstance(claim, dict):
+                    continue
+                support = claim.get("support")
+                if support not in _REQUIRED_SUPPORT:
+                    continue
+                olive_pass = claim.get("olive_pass")
+                if not isinstance(olive_pass, str) or not olive_pass.strip():
+                    # Fall back to claim key only when olive_pass is absent
+                    # (legacy rows); prefer explicit olive_pass when present.
+                    if isinstance(_key, str) and _key.strip():
+                        olive_pass = _key
+                    else:
+                        continue
+                name = olive_pass.strip()
+                claimed.setdefault(name, set()).add(str(support))
+    return claimed
+
+
+def _names_from_pass_registry_class() -> set[str] | None:
+    """Preferred path: olive.passes.PassRegistry (same API as scripts/sync-pass-catalog.mjs)."""
+    try:
+        from olive.passes import PassRegistry  # type: ignore
+    except ImportError:
+        return None
+
+    try:
+        registry = PassRegistry()
+    except Exception:  # noqa: BLE001 — try next strategy
+        return None
+
+    if hasattr(registry, "get_all_passes"):
+        try:
+            names = registry.get_all_passes()
+        except Exception:  # noqa: BLE001
+            return None
+        if isinstance(names, dict):
+            return {str(k) for k in names.keys()}
+        if isinstance(names, (set, list, tuple)):
+            out = {str(x) for x in names}
+            return out or None
+    return None
+
+
+def _names_from_package_config() -> set[str] | None:
+    """Fallback: OlivePackageConfig default pass table (olive_config.json)."""
+    try:
+        from olive.package_config import OlivePackageConfig  # type: ignore
+    except ImportError:
+        return None
+
+    cfg = None
+    if hasattr(OlivePackageConfig, "load_default_config"):
+        try:
+            cfg = OlivePackageConfig.load_default_config()
+        except Exception:  # noqa: BLE001
+            cfg = None
+    if cfg is None and hasattr(OlivePackageConfig, "get_default_config_path"):
+        try:
+            path = Path(OlivePackageConfig.get_default_config_path())
+            if path.is_file():
+                raw = json.loads(path.read_text(encoding="utf-8"))
+                return _pass_keys_from_mapping(raw.get("passes"))
+        except Exception:  # noqa: BLE001
+            return None
+    if cfg is None:
+        return None
+
+    passes = getattr(cfg, "passes", None)
+    if isinstance(passes, dict):
+        return {str(k) for k in passes.keys()}
+    return None
+
+
+def _pass_keys_from_mapping(passes: Any) -> set[str] | None:
+    if not isinstance(passes, dict) or not passes:
+        return None
+    return {str(k) for k in passes.keys()}
+
+
+def _names_from_olive_config_json() -> set[str] | None:
+    """Fallback: read olive_config.json shipped beside the olive package."""
+    try:
+        import olive  # type: ignore
+    except ImportError:
+        return None
+
+    olive_root = Path(olive.__file__).resolve().parent
+    candidates = [
+        olive_root / "olive_config.json",
+        olive_root / "package_config.json",
+    ]
+    for path in candidates:
+        if not path.is_file():
+            continue
+        try:
+            raw = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        names = _pass_keys_from_mapping(raw.get("passes") if isinstance(raw, dict) else None)
+        if names:
+            return names
+    return None
+
+
+def _names_from_registry_attrs() -> set[str] | None:
+    """Last resort: introspect REGISTRY-like module attributes."""
+    module_candidates = (
+        "olive.passes.olive_pass",
+        "olive.passes.pass_config",
+        "olive.passes",
+    )
+    attr_candidates = ("REGISTRY", "registry", "PASS_REGISTRY", "_REGISTRY")
+
+    for mod_name in module_candidates:
+        try:
+            mod = importlib.import_module(mod_name)
+        except ImportError:
+            continue
+        for attr in attr_candidates:
+            reg = getattr(mod, attr, None)
+            if isinstance(reg, dict) and reg:
+                return {str(k) for k in reg.keys()}
+            if isinstance(reg, (set, list, tuple)) and reg:
+                return {str(x) for x in reg}
+    return None
+
+
+def enumerate_olive_pass_names() -> set[str]:
+    """Return pass type names available in the installed Olive package."""
+    for loader in (
+        _names_from_pass_registry_class,
+        _names_from_package_config,
+        _names_from_olive_config_json,
+        _names_from_registry_attrs,
+    ):
+        names = loader()
+        if names:
+            return names
+    raise RuntimeError(
+        "Could not enumerate Olive passes. Is olive-ai installed, and does this "
+        "version expose PassRegistry / OlivePackageConfig / olive_config.json?"
+    )
+
+
+def olive_version_string() -> str:
+    try:
+        import olive  # type: ignore
+
+        ver = getattr(olive, "__version__", None)
+        if isinstance(ver, str) and ver:
+            return ver
+    except ImportError:
+        pass
+    try:
+        from importlib.metadata import version
+
+        return version("olive-ai")
+    except Exception:  # noqa: BLE001 — best-effort label only
+        return "unknown"
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    args = list(argv if argv is not None else sys.argv[1:])
+    matrix_path = Path(args[0]) if args else _DEFAULT_MATRIX
+
+    try:
+        matrix = _load_matrix(matrix_path)
+        claimed = claimed_passes(matrix)
+        available = enumerate_olive_pass_names()
+    except Exception as exc:  # noqa: BLE001 — surface load errors as CI failure
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    ver = olive_version_string()
+    print(f"Olive version: {ver}")
+    print(f"Registry passes: {len(available)}")
+    print(f"Matrix supported/warning olive_pass claims: {len(claimed)}")
+    print(f"Matrix path: {matrix_path}")
+
+    missing = sorted(name for name in claimed if name not in available)
+    if missing:
+        print(
+            "\nFAIL: claimed supported/warning pass(es) not in Olive registry:",
+            file=sys.stderr,
+        )
+        for name in missing:
+            levels = ", ".join(sorted(claimed[name]))
+            print(f"  - {name} (matrix support: {levels})", file=sys.stderr)
+        print(
+            "\nThese names must exist in the pinned Olive pass registry "
+            "(enumeration only — no optimization was run).",
+            file=sys.stderr,
+        )
+        return 1
+
+    print("OK: all matrix supported/warning olive_pass claims are in the Olive registry.")
+    # Helpful sample for CI logs (sorted, capped).
+    sample = ", ".join(sorted(claimed)[:12])
+    if len(claimed) > 12:
+        sample += ", ..."
+    print(f"Checked: {sample}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/olive-mcp-server/scripts/check_olive_pass_availability.py
+++ b/olive-mcp-server/scripts/check_olive_pass_availability.py
@@ -21,6 +21,16 @@ from typing import Any, Iterable
 # Claimed support levels that must exist in the pinned Olive registry.
 _REQUIRED_SUPPORT = frozenset({"supported", "warning"})
 
+# Passes documented in the matrix under legacy or workflow names that differ from
+# olive_config.json keys in Olive 0.12.x (enumeration is case-insensitive).
+_PASS_REGISTRY_ALIASES: dict[str, tuple[str, ...]] = {
+    "qnnquantization": ("qnnpreprocess", "qnnconversion", "onnxquantization", "onnxstaticquantization"),
+    "onnxmodeloptimizer": ("onnypeepholeoptimizer",),
+}
+
+# Cloud workflow passes are valid matrix claims but are not listed in local olive_config.json.
+_CLOUD_ONLY_PASSES = frozenset({"azuremlquantization"})
+
 _SCRIPT_DIR = Path(__file__).resolve().parent
 _MCP_ROOT = _SCRIPT_DIR.parent
 _DEFAULT_MATRIX = (
@@ -248,6 +258,19 @@ def enumerate_olive_pass_names() -> set[str]:
     )
 
 
+def _claim_in_registry(claimed_name: str, available_lower: set[str]) -> bool:
+    """Return True when a matrix olive_pass is present or has a known alias."""
+    lowered = claimed_name.lower()
+    if lowered in _CLOUD_ONLY_PASSES:
+        return True
+    if lowered in available_lower:
+        return True
+    for alias in _PASS_REGISTRY_ALIASES.get(lowered, ()):
+        if alias in available_lower:
+            return True
+    return False
+
+
 def olive_version_string() -> str:
     try:
         import olive  # type: ignore
@@ -284,7 +307,7 @@ def main(argv: Iterable[str] | None = None) -> int:
     print(f"Matrix path: {matrix_path}")
 
     available_lower = {name.lower() for name in available}
-    missing = sorted(name for name in claimed if name.lower() not in available_lower)
+    missing = sorted(name for name in claimed if not _claim_in_registry(name, available_lower))
     if missing:
         print(
             "\nFAIL: claimed supported/warning pass(es) not in Olive registry:",

--- a/olive-mcp-server/scripts/check_olive_pass_availability.py
+++ b/olive-mcp-server/scripts/check_olive_pass_availability.py
@@ -14,9 +14,12 @@ from __future__ import annotations
 
 import importlib
 import json
+import logging
 import sys
 from pathlib import Path
 from typing import Any, Iterable
+
+_LOG = logging.getLogger(__name__)
 
 # Claimed support levels that must exist in the pinned Olive registry.
 _REQUIRED_SUPPORT = frozenset({"supported", "warning"})
@@ -91,8 +94,8 @@ def _olive_config_json_path() -> Path | None:
         path = Path(str(cfg))
         if path.is_file():
             return path
-    except Exception:  # noqa: BLE001 — try site-packages walk
-        pass
+    except Exception as exc:  # noqa: BLE001 — fall through to site-packages walk
+        _LOG.debug("importlib.metadata olive_config lookup failed: %s", exc)
 
     try:
         import site
@@ -102,7 +105,8 @@ def _olive_config_json_path() -> Path | None:
             candidate = Path(root) / "olive" / "olive_config.json"
             if candidate.is_file():
                 return candidate
-    except Exception:  # noqa: BLE001
+    except Exception as exc:  # noqa: BLE001
+        _LOG.debug("site-packages olive_config walk failed: %s", exc)
         return None
     return None
 

--- a/olive-mcp-server/scripts/check_olive_pass_availability.py
+++ b/olive-mcp-server/scripts/check_olive_pass_availability.py
@@ -25,7 +25,7 @@ _REQUIRED_SUPPORT = frozenset({"supported", "warning"})
 # olive_config.json keys in Olive 0.12.x (enumeration is case-insensitive).
 _PASS_REGISTRY_ALIASES: dict[str, tuple[str, ...]] = {
     "qnnquantization": ("qnnpreprocess", "qnnconversion", "onnxquantization", "onnxstaticquantization"),
-    "onnxmodeloptimizer": ("onnypeepholeoptimizer",),
+    "onnxmodeloptimizer": ("onnxpeepholeoptimizer",),
 }
 
 # Cloud workflow passes are valid matrix claims but are not listed in local olive_config.json.

--- a/olive-mcp-server/scripts/check_olive_pass_availability.py
+++ b/olive-mcp-server/scripts/check_olive_pass_availability.py
@@ -72,8 +72,45 @@ def claimed_passes(matrix: dict[str, Any]) -> dict[str, set[str]]:
     return claimed
 
 
+def _olive_config_json_path() -> Path | None:
+    """Locate olive_config.json without importing olive (avoids heavy transitive deps on CI)."""
+    try:
+        from importlib.metadata import files
+
+        cfg = files("olive").joinpath("olive_config.json")
+        path = Path(str(cfg))
+        if path.is_file():
+            return path
+    except Exception:  # noqa: BLE001 — try site-packages walk
+        pass
+
+    try:
+        import site
+
+        search_roots = [*site.getsitepackages(), site.getusersitepackages()]
+        for root in search_roots:
+            candidate = Path(root) / "olive" / "olive_config.json"
+            if candidate.is_file():
+                return candidate
+    except Exception:  # noqa: BLE001
+        return None
+    return None
+
+
+def _names_from_installed_config_json() -> set[str] | None:
+    """Read pass keys from the installed olive_config.json (Olive 0.12.x default)."""
+    path = _olive_config_json_path()
+    if path is None:
+        return None
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return _pass_keys_from_mapping(raw.get("passes") if isinstance(raw, dict) else None)
+
+
 def _names_from_pass_registry_class() -> set[str] | None:
-    """Preferred path: olive.passes.PassRegistry (same API as scripts/sync-pass-catalog.mjs)."""
+    """Newer olive-ai: olive.passes.PassRegistry (scripts/sync-pass-catalog.mjs)."""
     try:
         from olive.passes import PassRegistry  # type: ignore
     except ImportError:
@@ -94,6 +131,17 @@ def _names_from_pass_registry_class() -> set[str] | None:
         if isinstance(names, (set, list, tuple)):
             out = {str(x) for x in names}
             return out or None
+    return None
+
+
+def _names_from_pass_registry_module() -> set[str] | None:
+    """Olive 0.12.x: REGISTRY alias on olive.passes (Pass.registry)."""
+    try:
+        from olive.passes import REGISTRY  # type: ignore
+    except ImportError:
+        return None
+    if isinstance(REGISTRY, dict) and REGISTRY:
+        return {str(k) for k in REGISTRY.keys()}
     return None
 
 
@@ -184,7 +232,9 @@ def _names_from_registry_attrs() -> set[str] | None:
 def enumerate_olive_pass_names() -> set[str]:
     """Return pass type names available in the installed Olive package."""
     for loader in (
+        _names_from_installed_config_json,
         _names_from_pass_registry_class,
+        _names_from_pass_registry_module,
         _names_from_package_config,
         _names_from_olive_config_json,
         _names_from_registry_attrs,

--- a/olive-mcp-server/scripts/expand_kb.py
+++ b/olive-mcp-server/scripts/expand_kb.py
@@ -1,9 +1,60 @@
-"""Expand knowledge base files to target counts for production coverage."""
+"""Expand knowledge base files to target counts for production coverage.
 
+Emits deterministic refresh metadata (source timestamp, generator version,
+changed files) for CI/PR workflows. Does not embed wall-clock timestamps in
+KB content — no-op runs produce no file diffs.
+"""
+
+from __future__ import annotations
+
+import hashlib
 import json
 from pathlib import Path
+from typing import Any
 
 KB_DIR = Path(__file__).parent.parent / "olive_mcp_server" / "knowledge_base"
+GENERATOR_NAME = "expand_kb"
+REFRESH_METADATA_NAME = "refresh_metadata.json"
+KB_REL_PREFIX = "olive_mcp_server/knowledge_base"
+
+# Track files touched during this run for refresh metadata.
+_CHANGED_FILES: list[str] = []
+
+
+def _generator_version() -> str:
+    """Return the package/generator version used in refresh metadata."""
+    try:
+        # Package root is on path when installed; fall back when run as script.
+        import sys
+
+        mcp_dir = Path(__file__).resolve().parent.parent
+        if str(mcp_dir) not in sys.path:
+            sys.path.insert(0, str(mcp_dir))
+        from olive_mcp_server import __version__
+
+        return str(__version__)
+    except Exception:  # noqa: BLE001
+        return "0.1.0"
+
+
+def _canonical_json(data: Any) -> str:
+    """Serialize data to a stable JSON string for hashing and comparisons."""
+    return json.dumps(data, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+def _content_fingerprint(data: Any) -> str:
+    """SHA-256 hex digest of canonical JSON for content-addressed identity."""
+    return hashlib.sha256(_canonical_json(data).encode("utf-8")).hexdigest()
+
+
+def _dump_json_text(data: Any) -> str:
+    """Pretty-print JSON with a trailing newline (stable formatting)."""
+    return json.dumps(data, indent=2, ensure_ascii=False) + "\n"
+
+
+def _kb_rel(name: str) -> str:
+    """Repo-relative path for a knowledge_base file (workflow-friendly)."""
+    return f"{KB_REL_PREFIX}/{name}"
 
 
 def load(name: str) -> dict:
@@ -12,8 +63,24 @@ def load(name: str) -> dict:
 
 
 def save(name: str, data: dict) -> None:
-    with open(KB_DIR / name, "w", encoding="utf-8") as f:
-        json.dump(data, f, indent=2)
+    """Write KB JSON only when semantic content differs (no no-op diffs).
+
+    Compares canonical JSON so formatting-only differences do not rewrite
+    tracked KB files or inflate changed_files on a no-op refresh.
+    """
+    path = KB_DIR / name
+    if path.exists():
+        try:
+            existing = json.loads(path.read_text(encoding="utf-8"))
+            if _canonical_json(existing) == _canonical_json(data):
+                return
+        except (OSError, json.JSONDecodeError):
+            pass
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(_dump_json_text(data), encoding="utf-8")
+    rel = _kb_rel(name)
+    if rel not in _CHANGED_FILES:
+        _CHANGED_FILES.append(rel)
 
 
 def expand_passes():
@@ -671,11 +738,152 @@ def expand_troubleshooting():
     print(f"troubleshooting.json now has {len(data['entries'])} entries")
 
 
+def _load_refresh_metadata(path: Path) -> dict[str, Any]:
+    """Load existing refresh metadata or return an empty scaffold."""
+    if not path.exists():
+        return {"schema_version": 1, "runs": {}}
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {"schema_version": 1, "runs": {}}
+    if not isinstance(data, dict):
+        return {"schema_version": 1, "runs": {}}
+    runs = data.get("runs")
+    if not isinstance(runs, dict):
+        data["runs"] = {}
+    data.setdefault("schema_version", 1)
+    return data
+
+
+def _source_timestamp_from_kb() -> str:
+    """Derive a deterministic source stamp from existing KB last_updated fields.
+
+    expand_kb has no external fetch; the catalog embedded in this script plus
+    current KB dates are the source. Prefer max YYYY-MM-DD from KB roots;
+    fall back to a content fingerprint of the three target files' identity keys.
+    """
+    dates: list[str] = []
+    for name in ("passes.json", "hardware_profiles.json", "troubleshooting.json"):
+        path = KB_DIR / name
+        if not path.exists():
+            continue
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        last = data.get("last_updated")
+        if isinstance(last, str) and len(last) >= 10:
+            dates.append(last[:10])
+    if dates:
+        return max(dates)
+    return f"content:{_content_fingerprint({'generator': GENERATOR_NAME})}"
+
+
+def _write_refresh_metadata(
+    *,
+    generator_version: str,
+    source_timestamp: str,
+    source_fingerprint: str,
+    changed_files: list[str],
+) -> None:
+    """Merge expand_kb run metadata into knowledge_base/refresh_metadata.json."""
+    metadata_path = KB_DIR / REFRESH_METADATA_NAME
+    existing = _load_refresh_metadata(metadata_path)
+
+    run_meta: dict[str, Any] = {
+        "generator": GENERATOR_NAME,
+        "generator_version": generator_version,
+        "source_timestamp": source_timestamp,
+        "source_fingerprint": source_fingerprint,
+        "changed_files": list(changed_files),
+        "success": True,
+    }
+
+    runs = dict(existing.get("runs") or {})
+    runs[GENERATOR_NAME] = run_meta
+
+    all_changed: list[str] = []
+    seen: set[str] = set()
+    for name in sorted(runs):
+        run = runs[name]
+        if not isinstance(run, dict):
+            continue
+        for path in run.get("changed_files") or []:
+            if isinstance(path, str) and path not in seen:
+                seen.add(path)
+                all_changed.append(path)
+
+    stamps = [source_timestamp]
+    for run in runs.values():
+        if isinstance(run, dict) and isinstance(run.get("source_timestamp"), str):
+            stamps.append(run["source_timestamp"])
+    iso_stamps = [s for s in stamps if not str(s).startswith("content:")]
+    aggregate_ts = max(iso_stamps) if iso_stamps else source_timestamp
+
+    metadata: dict[str, Any] = {
+        "schema_version": 1,
+        "generator_version": generator_version,
+        "source_timestamp": aggregate_ts,
+        "changed_files": all_changed,
+        "runs": runs,
+    }
+
+    # Sidecar only — never list refresh_metadata.json in changed_files (avoids
+    # self-referential churn). Workflows read this file for the file list.
+    new_text = _dump_json_text(metadata)
+    if metadata_path.exists():
+        try:
+            if metadata_path.read_text(encoding="utf-8") == new_text:
+                print(f"Refresh metadata unchanged at {metadata_path}")
+                return
+        except OSError:
+            pass
+
+    metadata_path.parent.mkdir(parents=True, exist_ok=True)
+    metadata_path.write_text(new_text, encoding="utf-8")
+    print(f"Refresh metadata written to {metadata_path}")
+
+
 def main():
     """Expand the knowledge base with pass, hardware profile, and troubleshooting entries."""
+    global _CHANGED_FILES
+    _CHANGED_FILES = []
+
+    generator_version = _generator_version()
+    # Fingerprint of expansion outcome targets (post-run content identity).
+    # Computed after expansions so it reflects final KB state.
     expand_passes()
     expand_hardware_profiles()
     expand_troubleshooting()
+
+    outcome: dict[str, Any] = {}
+    for name in ("passes.json", "hardware_profiles.json", "troubleshooting.json"):
+        path = KB_DIR / name
+        if path.exists():
+            try:
+                outcome[name] = json.loads(path.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError):
+                outcome[name] = None
+
+    source_fingerprint = _content_fingerprint(
+        {
+            "generator": GENERATOR_NAME,
+            "generator_version": generator_version,
+            "outcome": outcome,
+        }
+    )
+    source_timestamp = _source_timestamp_from_kb()
+
+    _write_refresh_metadata(
+        generator_version=generator_version,
+        source_timestamp=source_timestamp,
+        source_fingerprint=source_fingerprint,
+        changed_files=list(_CHANGED_FILES),
+    )
+    print(
+        f"expand_kb metadata: generator_version={generator_version} "
+        f"source_timestamp={source_timestamp} changed_files={list(_CHANGED_FILES)}"
+    )
 
 
 if __name__ == "__main__":

--- a/olive-mcp-server/scripts/update_kb.py
+++ b/olive-mcp-server/scripts/update_kb.py
@@ -3,19 +3,25 @@
 
 Fetches Olive docs, GitHub issues/releases, and ONNX Runtime EP docs,
 then parses the returned Markdown-ish content for headings, bullet
-candidate-quirks, and deprecation warnings. Writes a timestamped report
-and a candidate quirks file for manual review.
+candidate-quirks, and deprecation warnings. Writes a deterministic report,
+candidate quirks file, and refresh metadata for CI/PR workflows.
+
+Refresh metadata and report fields are content-addressed: identical upstream
+sources produce identical outputs (no wall-clock timestamps in written files).
 """
 
+from __future__ import annotations
+
+import hashlib
 import json
 import re
-from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
 # Add the MCP server package to the path when running the script directly.
 _MCP_DIR = Path(__file__).resolve().parent.parent
 import sys  # noqa: E402
+
 if str(_MCP_DIR) not in sys.path:
     sys.path.insert(0, str(_MCP_DIR))
 
@@ -31,6 +37,58 @@ DEPRECATION_RE = re.compile(
     r"\b(deprecated?|deprecat(?:ion|ed|e|ing)|no longer supported)\b",
     re.IGNORECASE,
 )
+# ISO-8601 timestamps that may appear in fetched source text (e.g. GitHub bodies).
+ISO_TIMESTAMP_RE = re.compile(
+    r"\b(\d{4}-\d{2}-\d{2}(?:[T ]\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:?\d{2})?)?)\b"
+)
+
+GENERATOR_NAME = "update_kb"
+REFRESH_METADATA_NAME = "refresh_metadata.json"
+KB_REL_PREFIX = "olive_mcp_server/knowledge_base"
+
+
+def _generator_version() -> str:
+    """Return the package/generator version used in refresh metadata."""
+    try:
+        from olive_mcp_server import __version__
+
+        return str(__version__)
+    except Exception:  # noqa: BLE001
+        return "0.1.0"
+
+
+def _canonical_json(data: Any) -> str:
+    """Serialize data to a stable JSON string for hashing and comparisons."""
+    return json.dumps(data, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+def _content_fingerprint(data: Any) -> str:
+    """SHA-256 hex digest of canonical JSON for content-addressed identity."""
+    return hashlib.sha256(_canonical_json(data).encode("utf-8")).hexdigest()
+
+
+def _dump_json_text(data: Any) -> str:
+    """Pretty-print JSON with a trailing newline (stable formatting)."""
+    return json.dumps(data, indent=2, ensure_ascii=False) + "\n"
+
+
+def _write_json_if_changed(path: Path, data: Any) -> bool:
+    """Write JSON only when content differs. Returns True if the file changed."""
+    new_text = _dump_json_text(data)
+    if path.exists():
+        try:
+            if path.read_text(encoding="utf-8") == new_text:
+                return False
+        except OSError:
+            pass
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(new_text, encoding="utf-8")
+    return True
+
+
+def _kb_rel(name: str) -> str:
+    """Repo-relative path for a knowledge_base file (workflow-friendly)."""
+    return f"{KB_REL_PREFIX}/{name}"
 
 
 def _coalesce_text(data: Any) -> str:
@@ -112,10 +170,100 @@ def _sanitize_source(data: Any) -> Any:
     return data
 
 
+def _collect_source_timestamps(raw_sources: dict[str, Any]) -> list[str]:
+    """Collect ISO-like timestamps embedded in fetched source payloads."""
+    found: list[str] = []
+    for data in raw_sources.values():
+        text = _coalesce_text(data)
+        found.extend(match.group(1) for match in ISO_TIMESTAMP_RE.finditer(text))
+        if isinstance(data, dict):
+            for key in ("updated_at", "published_at", "created_at", "last_modified", "source_timestamp"):
+                value = data.get(key)
+                if isinstance(value, str) and ISO_TIMESTAMP_RE.fullmatch(value.strip()):
+                    found.append(value.strip())
+    return found
+
+
+def _source_timestamp(raw_sources: dict[str, Any], fingerprint: str) -> str:
+    """Deterministic source stamp: max upstream ISO time, else content digest.
+
+    Never uses wall-clock generation time so no-op refreshes stay diff-stable.
+    """
+    timestamps = _collect_source_timestamps(raw_sources)
+    if timestamps:
+        return max(timestamps)
+    return f"content:{fingerprint}"
+
+
+def _load_refresh_metadata(path: Path) -> dict[str, Any]:
+    """Load existing refresh metadata or return an empty scaffold."""
+    if not path.exists():
+        return {"schema_version": 1, "runs": {}}
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {"schema_version": 1, "runs": {}}
+    if not isinstance(data, dict):
+        return {"schema_version": 1, "runs": {}}
+    runs = data.get("runs")
+    if not isinstance(runs, dict):
+        data["runs"] = {}
+    data.setdefault("schema_version", 1)
+    return data
+
+
+def _merge_refresh_metadata(
+    existing: dict[str, Any],
+    *,
+    run_meta: dict[str, Any],
+    generator_version: str,
+    source_timestamp: str,
+    changed_files: list[str],
+) -> dict[str, Any]:
+    """Merge this generator's run into the shared refresh_metadata document."""
+    runs = dict(existing.get("runs") or {})
+    runs[GENERATOR_NAME] = run_meta
+
+    # Union changed files across generators for workflow consumption.
+    all_changed: list[str] = []
+    seen: set[str] = set()
+    for name in sorted(runs):
+        run = runs[name]
+        if not isinstance(run, dict):
+            continue
+        for path in run.get("changed_files") or []:
+            if isinstance(path, str) and path not in seen:
+                seen.add(path)
+                all_changed.append(path)
+    # Prefer this run's files first if they were just computed.
+    for path in changed_files:
+        if path not in seen:
+            seen.add(path)
+            all_changed.append(path)
+
+    # Aggregate source_timestamp: prefer max ISO-like, else this run's stamp.
+    stamps = [source_timestamp]
+    for run in runs.values():
+        if isinstance(run, dict) and isinstance(run.get("source_timestamp"), str):
+            stamps.append(run["source_timestamp"])
+    iso_stamps = [s for s in stamps if not s.startswith("content:")]
+    aggregate_ts = max(iso_stamps) if iso_stamps else source_timestamp
+
+    return {
+        "schema_version": 1,
+        "generator_version": generator_version,
+        "source_timestamp": aggregate_ts,
+        "changed_files": all_changed,
+        "runs": runs,
+    }
+
+
 def main() -> None:
     """Fetch external sources, parse them, and write freshness reports."""
     kb_dir = Path(__file__).parent.parent / "olive_mcp_server" / "knowledge_base"
     kb_dir.mkdir(parents=True, exist_ok=True)
+
+    generator_version = _generator_version()
 
     raw_sources: dict[str, Any] = {
         "official_docs": fetch_official_docs(),
@@ -124,6 +272,13 @@ def main() -> None:
     }
 
     parsed = {name: _parse_source(data) for name, data in raw_sources.items()}
+    source_fingerprint = _content_fingerprint(
+        {
+            "sources": {name: _sanitize_source(data) for name, data in raw_sources.items()},
+            "parsed": parsed,
+        }
+    )
+    source_ts = _source_timestamp(raw_sources, source_fingerprint)
 
     source_statuses: list[str] = []
     for data in raw_sources.values():
@@ -134,8 +289,12 @@ def main() -> None:
 
     success = bool(source_statuses) and all(status != "error" for status in source_statuses)
 
+    # Deterministic report: no wall-clock fields.
     report: dict[str, Any] = {
-        "updated_at": datetime.now(timezone.utc).isoformat(),
+        "source_timestamp": source_ts,
+        "generator": GENERATOR_NAME,
+        "generator_version": generator_version,
+        "source_fingerprint": source_fingerprint,
         "success": success,
         "sources": {name: _sanitize_source(data) for name, data in raw_sources.items()},
         "parsed": parsed,
@@ -146,16 +305,45 @@ def main() -> None:
         ],
     }
 
+    changed_files: list[str] = []
+
     update_report_path = kb_dir / "update_report.json"
-    with open(update_report_path, "w", encoding="utf-8") as f:
-        json.dump(report, f, indent=2)
+    if _write_json_if_changed(update_report_path, report):
+        changed_files.append(_kb_rel("update_report.json"))
     print(f"Update report written to {update_report_path}")
 
     candidate_quirks = _build_candidate_quirks(parsed)
     candidate_path = kb_dir / "candidate_quirks.json"
-    with open(candidate_path, "w", encoding="utf-8") as f:
-        json.dump(candidate_quirks, f, indent=2)
+    if _write_json_if_changed(candidate_path, candidate_quirks):
+        changed_files.append(_kb_rel("candidate_quirks.json"))
     print(f"Candidate quirks written to {candidate_path}")
+
+    run_meta: dict[str, Any] = {
+        "generator": GENERATOR_NAME,
+        "generator_version": generator_version,
+        "source_timestamp": source_ts,
+        "source_fingerprint": source_fingerprint,
+        "changed_files": list(changed_files),
+        "success": success,
+    }
+
+    metadata_path = kb_dir / REFRESH_METADATA_NAME
+    existing_meta = _load_refresh_metadata(metadata_path)
+    metadata = _merge_refresh_metadata(
+        existing_meta,
+        run_meta=run_meta,
+        generator_version=generator_version,
+        source_timestamp=source_ts,
+        changed_files=changed_files,
+    )
+    # Sidecar only — never list refresh_metadata.json in changed_files (avoids
+    # self-referential churn). Workflows read this file for the file list.
+    _write_json_if_changed(metadata_path, metadata)
+    print(f"Refresh metadata written to {metadata_path}")
+    print(
+        f"update_kb metadata: generator_version={generator_version} "
+        f"source_timestamp={source_ts} changed_files={changed_files}"
+    )
 
     if not success:
         raise SystemExit(1)

--- a/olive-mcp-server/tests/test_compatibility_matrix.py
+++ b/olive-mcp-server/tests/test_compatibility_matrix.py
@@ -132,22 +132,8 @@ def _iter_claims(
                     yield str(model), str(hw_name), str(claim_key), claim
 
 
-def collect_matrix_errors(
-    matrix_data: dict[str, Any],
-    known_passes: set[str],
-    *,
-    enforce_olive_window: bool = True,
-) -> list[str]:
-    """Return human-readable validation errors (empty list => valid).
-
-    Checks schema-level required fields, support enum, evidence provenance,
-    pass registry membership, uniqueness, olive_version_support shape, and
-    (optionally) that olive-scoped evidence versions sit inside the declared
-    Olive support window.
-    """
+def _collect_top_level_errors(matrix_data: dict[str, Any]) -> list[str]:
     errors: list[str] = []
-
-    # --- top-level required ---
     for key in ("version", "last_updated", "models"):
         if key not in matrix_data:
             errors.append(f"missing top-level field: {key}")
@@ -168,180 +154,265 @@ def collect_matrix_errors(
     if models is not None:
         if not isinstance(models, list) or len(models) < 1:
             errors.append("models must be a non-empty array")
+    return errors
 
-    # --- olive_version_support window ---
+
+def _collect_olive_window(
+    matrix_data: dict[str, Any],
+) -> tuple[list[str], str | None, str | None]:
+    errors: list[str] = []
     ovs = matrix_data.get("olive_version_support")
     window_min: str | None = None
     window_max: str | None = None
-    if ovs is not None:
-        if not isinstance(ovs, dict):
-            errors.append("olive_version_support must be an object")
+    if ovs is None:
+        return errors, window_min, window_max
+    if not isinstance(ovs, dict):
+        errors.append("olive_version_support must be an object")
+        return errors, window_min, window_max
+
+    window_min = ovs.get("min")
+    window_max = ovs.get("max")
+    for label, raw in (("min", window_min), ("max", window_max)):
+        if raw is None:
+            continue
+        try:
+            _parse_version(str(raw))
+        except ValueError as exc:
+            errors.append(f"olive_version_support.{label}: {exc}")
+    if window_min is not None and window_max is not None:
+        try:
+            lo = _parse_version(str(window_min))
+            hi = _parse_version(str(window_max))
+            width = max(len(lo), len(hi))
+            lo_p = lo + (0,) * (width - len(lo))
+            hi_p = hi + (0,) * (width - len(hi))
+            if lo_p > hi_p:
+                errors.append(
+                    f"olive_version_support malformed range: "
+                    f"min={window_min!r} > max={window_max!r}"
+                )
+        except ValueError:
+            pass  # already recorded above
+    return errors, window_min, window_max
+
+
+def _collect_claim_evidence_errors(
+    claim: dict[str, Any],
+    claim_loc: str,
+    *,
+    enforce_olive_window: bool,
+    window_min: str | None,
+    window_max: str | None,
+) -> list[str]:
+    errors: list[str] = []
+    if "evidence" not in claim:
+        return errors
+    evidence = claim.get("evidence")
+    if not isinstance(evidence, dict):
+        errors.append(f"{claim_loc}: evidence must be an object")
+        return errors
+
+    for ereq in ("reference", "type", "version"):
+        if ereq not in evidence:
+            errors.append(f"{claim_loc}: evidence missing required field {ereq!r}")
+    ref = evidence.get("reference")
+    if ref is not None and (not isinstance(ref, str) or not ref.strip()):
+        errors.append(f"{claim_loc}: evidence.reference must be non-empty")
+    etype = evidence.get("type")
+    if etype is not None and etype not in _EVIDENCE_TYPES:
+        errors.append(
+            f"{claim_loc}: invalid evidence.type {etype!r}; "
+            f"expected one of {sorted(_EVIDENCE_TYPES)}"
+        )
+    ever = evidence.get("version")
+    if ever is not None and (not isinstance(ever, str) or not ever.strip()):
+        errors.append(f"{claim_loc}: evidence.version must be non-empty")
+
+    if (
+        enforce_olive_window
+        and window_min is not None
+        and window_max is not None
+        and etype in _OLIVE_EVIDENCE_TYPES
+        and isinstance(ever, str)
+        and ever.strip()
+    ):
+        try:
+            if not _version_in_range(ever, str(window_min), str(window_max)):
+                errors.append(
+                    f"{claim_loc}: evidence.version {ever!r} "
+                    f"outside olive_version_support "
+                    f"[{window_min}, {window_max}]"
+                )
+        except ValueError as exc:
+            errors.append(
+                f"{claim_loc}: evidence.version unparseable for window check: {exc}"
+            )
+    return errors
+
+
+def _collect_claim_errors(
+    claim: dict[str, Any],
+    claim_loc: str,
+    *,
+    model_name: str,
+    hw_name: str,
+    known_passes: set[str],
+    seen_triples: set[tuple[str, str, str]],
+    enforce_olive_window: bool,
+    window_min: str | None,
+    window_max: str | None,
+) -> list[str]:
+    errors: list[str] = []
+    for req in ("support", "olive_pass", "evidence"):
+        if req not in claim:
+            errors.append(f"{claim_loc}: missing required field {req!r}")
+
+    support = claim.get("support")
+    if support is not None and support not in _SUPPORT_STATES:
+        errors.append(
+            f"{claim_loc}: invalid support state {support!r}; "
+            f"expected one of {sorted(_SUPPORT_STATES)}"
+        )
+
+    olive_pass = claim.get("olive_pass")
+    if olive_pass is not None:
+        if not isinstance(olive_pass, str) or not olive_pass.strip():
+            errors.append(f"{claim_loc}: olive_pass must be non-empty string")
         else:
-            window_min = ovs.get("min")
-            window_max = ovs.get("max")
-            for label, raw in (("min", window_min), ("max", window_max)):
-                if raw is None:
-                    continue
-                try:
-                    _parse_version(str(raw))
-                except ValueError as exc:
-                    errors.append(f"olive_version_support.{label}: {exc}")
-            if window_min is not None and window_max is not None:
-                try:
-                    lo = _parse_version(str(window_min))
-                    hi = _parse_version(str(window_max))
-                    width = max(len(lo), len(hi))
-                    lo_p = lo + (0,) * (width - len(lo))
-                    hi_p = hi + (0,) * (width - len(hi))
-                    if lo_p > hi_p:
-                        errors.append(
-                            f"olive_version_support malformed range: "
-                            f"min={window_min!r} > max={window_max!r}"
-                        )
-                except ValueError:
-                    pass  # already recorded above
+            if olive_pass not in known_passes:
+                errors.append(
+                    f"{claim_loc}: unknown olive_pass {olive_pass!r} "
+                    f"(not in passes.json)"
+                )
+            triple = (str(model_name), str(hw_name), olive_pass)
+            if triple in seen_triples:
+                errors.append(
+                    f"duplicate model/hardware/pass claim: "
+                    f"{model_name!r} / {hw_name!r} / {olive_pass!r}"
+                )
+            else:
+                seen_triples.add(triple)
 
-    # --- model entries + claims ---
-    seen_models: set[str] = set()
-    seen_triples: set[tuple[str, str, str]] = set()
+    errors.extend(
+        _collect_claim_evidence_errors(
+            claim,
+            claim_loc,
+            enforce_olive_window=enforce_olive_window,
+            window_min=window_min,
+            window_max=window_max,
+        )
+    )
+    return errors
 
+
+def _collect_model_entry_errors(
+    entry: Any,
+    idx: int,
+    *,
+    known_passes: set[str],
+    seen_models: set[str],
+    seen_triples: set[tuple[str, str, str]],
+    enforce_olive_window: bool,
+    window_min: str | None,
+    window_max: str | None,
+) -> list[str]:
+    errors: list[str] = []
+    loc = f"models[{idx}]"
+    if not isinstance(entry, dict):
+        errors.append(f"{loc}: entry must be an object")
+        return errors
+
+    for req in ("model", "frameworks", "hardware"):
+        if req not in entry:
+            errors.append(f"{loc}: missing required field {req!r}")
+
+    model_name = entry.get("model")
+    if not isinstance(model_name, str) or not model_name.strip():
+        errors.append(f"{loc}: model must be a non-empty string")
+        model_name = f"<invalid-{idx}>"
+    elif model_name in seen_models:
+        errors.append(f"duplicate model entry: {model_name!r}")
+    else:
+        seen_models.add(model_name)
+
+    frameworks = entry.get("frameworks")
+    if frameworks is not None:
+        if not isinstance(frameworks, list) or len(frameworks) < 1:
+            errors.append(f"{loc} ({model_name}): frameworks must be non-empty array")
+        else:
+            for fw in frameworks:
+                if fw not in _FRAMEWORKS:
+                    errors.append(f"{loc} ({model_name}): unknown framework {fw!r}")
+
+    hardware = entry.get("hardware")
+    if hardware is None:
+        return errors
+    if not isinstance(hardware, dict):
+        errors.append(f"{loc} ({model_name}): hardware must be an object")
+        return errors
+
+    for hw_name, passes in hardware.items():
+        hw_loc = f"{loc} ({model_name}) / hardware[{hw_name!r}]"
+        if not isinstance(passes, dict):
+            errors.append(f"{hw_loc}: pass map must be an object")
+            continue
+        for claim_key, claim in passes.items():
+            claim_loc = f"{hw_loc} / {claim_key}"
+            if not isinstance(claim, dict):
+                errors.append(f"{claim_loc}: claim must be an object")
+                continue
+            errors.extend(
+                _collect_claim_errors(
+                    claim,
+                    claim_loc,
+                    model_name=str(model_name),
+                    hw_name=str(hw_name),
+                    known_passes=known_passes,
+                    seen_triples=seen_triples,
+                    enforce_olive_window=enforce_olive_window,
+                    window_min=window_min,
+                    window_max=window_max,
+                )
+            )
+    return errors
+
+
+def collect_matrix_errors(
+    matrix_data: dict[str, Any],
+    known_passes: set[str],
+    *,
+    enforce_olive_window: bool = True,
+) -> list[str]:
+    """Return human-readable validation errors (empty list => valid).
+
+    Checks schema-level required fields, support enum, evidence provenance,
+    pass registry membership, uniqueness, olive_version_support shape, and
+    (optionally) that olive-scoped evidence versions sit inside the declared
+    Olive support window.
+    """
+    errors = _collect_top_level_errors(matrix_data)
+    window_errors, window_min, window_max = _collect_olive_window(matrix_data)
+    errors.extend(window_errors)
+
+    models = matrix_data.get("models")
     if not isinstance(models, list):
         return errors
 
+    seen_models: set[str] = set()
+    seen_triples: set[tuple[str, str, str]] = set()
     for idx, entry in enumerate(models):
-        loc = f"models[{idx}]"
-        if not isinstance(entry, dict):
-            errors.append(f"{loc}: entry must be an object")
-            continue
-
-        for req in ("model", "frameworks", "hardware"):
-            if req not in entry:
-                errors.append(f"{loc}: missing required field {req!r}")
-
-        model_name = entry.get("model")
-        if not isinstance(model_name, str) or not model_name.strip():
-            errors.append(f"{loc}: model must be a non-empty string")
-            model_name = f"<invalid-{idx}>"
-        elif model_name in seen_models:
-            errors.append(f"duplicate model entry: {model_name!r}")
-        else:
-            seen_models.add(model_name)
-
-        frameworks = entry.get("frameworks")
-        if frameworks is not None:
-            if not isinstance(frameworks, list) or len(frameworks) < 1:
-                errors.append(f"{loc} ({model_name}): frameworks must be non-empty array")
-            else:
-                for fw in frameworks:
-                    if fw not in _FRAMEWORKS:
-                        errors.append(
-                            f"{loc} ({model_name}): unknown framework {fw!r}"
-                        )
-
-        hardware = entry.get("hardware")
-        if hardware is None:
-            continue
-        if not isinstance(hardware, dict):
-            errors.append(f"{loc} ({model_name}): hardware must be an object")
-            continue
-
-        for hw_name, passes in hardware.items():
-            hw_loc = f"{loc} ({model_name}) / hardware[{hw_name!r}]"
-            if not isinstance(passes, dict):
-                errors.append(f"{hw_loc}: pass map must be an object")
-                continue
-
-            for claim_key, claim in passes.items():
-                claim_loc = f"{hw_loc} / {claim_key}"
-                if not isinstance(claim, dict):
-                    errors.append(f"{claim_loc}: claim must be an object")
-                    continue
-
-                # Required schema fields
-                for req in ("support", "olive_pass", "evidence"):
-                    if req not in claim:
-                        errors.append(f"{claim_loc}: missing required field {req!r}")
-
-                support = claim.get("support")
-                if support is not None and support not in _SUPPORT_STATES:
-                    errors.append(
-                        f"{claim_loc}: invalid support state {support!r}; "
-                        f"expected one of {sorted(_SUPPORT_STATES)}"
-                    )
-
-                olive_pass = claim.get("olive_pass")
-                if olive_pass is not None:
-                    if not isinstance(olive_pass, str) or not olive_pass.strip():
-                        errors.append(f"{claim_loc}: olive_pass must be non-empty string")
-                    else:
-                        if olive_pass not in known_passes:
-                            errors.append(
-                                f"{claim_loc}: unknown olive_pass {olive_pass!r} "
-                                f"(not in passes.json)"
-                            )
-                        triple = (str(model_name), str(hw_name), olive_pass)
-                        if triple in seen_triples:
-                            errors.append(
-                                f"duplicate model/hardware/pass claim: "
-                                f"{model_name!r} / {hw_name!r} / {olive_pass!r}"
-                            )
-                        else:
-                            seen_triples.add(triple)
-
-                # Provenance / evidence
-                evidence = claim.get("evidence")
-                if "evidence" in claim:
-                    if not isinstance(evidence, dict):
-                        errors.append(f"{claim_loc}: evidence must be an object")
-                    else:
-                        for ereq in ("reference", "type", "version"):
-                            if ereq not in evidence:
-                                errors.append(
-                                    f"{claim_loc}: evidence missing required field {ereq!r}"
-                                )
-                        ref = evidence.get("reference")
-                        if ref is not None and (
-                            not isinstance(ref, str) or not ref.strip()
-                        ):
-                            errors.append(
-                                f"{claim_loc}: evidence.reference must be non-empty"
-                            )
-                        etype = evidence.get("type")
-                        if etype is not None and etype not in _EVIDENCE_TYPES:
-                            errors.append(
-                                f"{claim_loc}: invalid evidence.type {etype!r}; "
-                                f"expected one of {sorted(_EVIDENCE_TYPES)}"
-                            )
-                        ever = evidence.get("version")
-                        if ever is not None and (
-                            not isinstance(ever, str) or not ever.strip()
-                        ):
-                            errors.append(
-                                f"{claim_loc}: evidence.version must be non-empty"
-                            )
-
-                        # Olive support window for olive-scoped evidence
-                        if (
-                            enforce_olive_window
-                            and window_min is not None
-                            and window_max is not None
-                            and etype in _OLIVE_EVIDENCE_TYPES
-                            and isinstance(ever, str)
-                            and ever.strip()
-                        ):
-                            try:
-                                if not _version_in_range(ever, str(window_min), str(window_max)):
-                                    errors.append(
-                                        f"{claim_loc}: evidence.version {ever!r} "
-                                        f"outside olive_version_support "
-                                        f"[{window_min}, {window_max}]"
-                                    )
-                            except ValueError as exc:
-                                errors.append(
-                                    f"{claim_loc}: evidence.version unparseable "
-                                    f"for window check: {exc}"
-                                )
-
+        errors.extend(
+            _collect_model_entry_errors(
+                entry,
+                idx,
+                known_passes=known_passes,
+                seen_models=seen_models,
+                seen_triples=seen_triples,
+                enforce_olive_window=enforce_olive_window,
+                window_min=window_min,
+                window_max=window_max,
+            )
+        )
     return errors
 
 

--- a/olive-mcp-server/tests/test_compatibility_matrix.py
+++ b/olive-mcp-server/tests/test_compatibility_matrix.py
@@ -1,0 +1,702 @@
+"""Schema, provenance, and pass-integrity checks for compatibility_matrix.json.
+
+Validates the real knowledge-base matrix against passes.json and
+schemas/compatibility-v1.json rules. Negative cases use in-memory fixtures.
+No Olive execution, network, or model downloads.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+import re
+from pathlib import Path
+from typing import Any, Iterator
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+
+_ROOT = Path(__file__).resolve().parent.parent
+_KB_DIR = _ROOT / "olive_mcp_server" / "knowledge_base"
+_MATRIX_PATH = _KB_DIR / "compatibility_matrix.json"
+_PASSES_PATH = _KB_DIR / "passes.json"
+_SCHEMA_PATH = _ROOT / "schemas" / "compatibility-v1.json"
+
+_SUPPORT_STATES = frozenset({"supported", "warning", "unsupported"})
+_EVIDENCE_TYPES = frozenset(
+    {
+        "olive_docs",
+        "ort_docs",
+        "github",
+        "availability",
+        "benchmark",
+        "release_notes",
+    }
+)
+# Evidence types whose ``version`` is an Olive release (must sit in support window).
+_OLIVE_EVIDENCE_TYPES = frozenset({"olive_docs", "release_notes"})
+_MATRIX_VERSION_RE = re.compile(r"^\d+\.\d+\.\d+$")
+_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+_FRAMEWORKS = frozenset({"PyTorch", "ONNX", "HuggingFace", "TensorFlow"})
+
+
+# ---------------------------------------------------------------------------
+# Loaders
+# ---------------------------------------------------------------------------
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    with open(path, encoding="utf-8") as fh:
+        data = json.load(fh)
+    assert isinstance(data, dict), f"{path.name} root must be an object"
+    return data
+
+
+@pytest.fixture(scope="module")
+def matrix() -> dict[str, Any]:
+    return _load_json(_MATRIX_PATH)
+
+
+@pytest.fixture(scope="module")
+def pass_names() -> set[str]:
+    data = _load_json(_PASSES_PATH)
+    passes = data.get("passes", [])
+    assert isinstance(passes, list) and passes, "passes.json must list passes"
+    names = {p["name"] for p in passes if isinstance(p, dict) and "name" in p}
+    assert names, "passes.json yielded no pass names"
+    return names
+
+
+@pytest.fixture(scope="module")
+def schema() -> dict[str, Any]:
+    return _load_json(_SCHEMA_PATH)
+
+
+# ---------------------------------------------------------------------------
+# Version helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse_version(value: str) -> tuple[int, ...]:
+    """Parse a dotted version string into a comparable int tuple.
+
+    Accepts ``0.12.1``, ``1.19``, ``0.8.0rc1`` (numeric prefix only).
+    Raises ValueError on empty/malformed input.
+    """
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"empty version: {value!r}")
+    # Strip common pre-release / build suffixes for comparison.
+    core = re.split(r"[^0-9.]", value.strip(), maxsplit=1)[0].rstrip(".")
+    if not core or not re.fullmatch(r"\d+(\.\d+)*", core):
+        raise ValueError(f"malformed version: {value!r}")
+    return tuple(int(part) for part in core.split("."))
+
+
+def _version_in_range(version: str, vmin: str, vmax: str) -> bool:
+    """Return True if version is within [vmin, vmax] (inclusive, tuple compare)."""
+    v = _parse_version(version)
+    lo = _parse_version(vmin)
+    hi = _parse_version(vmax)
+    # Pad to equal length for lexicographic tuple compare.
+    width = max(len(v), len(lo), len(hi))
+    v = v + (0,) * (width - len(v))
+    lo = lo + (0,) * (width - len(lo))
+    hi = hi + (0,) * (width - len(hi))
+    return lo <= v <= hi
+
+
+# ---------------------------------------------------------------------------
+# Claim iteration + validation
+# ---------------------------------------------------------------------------
+
+
+def _iter_claims(
+    matrix_data: dict[str, Any],
+) -> Iterator[tuple[str, str, str, dict[str, Any]]]:
+    """Yield (model_name, hardware, claim_key, claim_body) for every pass claim."""
+    for entry in matrix_data.get("models") or []:
+        if not isinstance(entry, dict):
+            continue
+        model = entry.get("model", "<missing>")
+        hardware = entry.get("hardware") or {}
+        if not isinstance(hardware, dict):
+            continue
+        for hw_name, passes in hardware.items():
+            if not isinstance(passes, dict):
+                continue
+            for claim_key, claim in passes.items():
+                if isinstance(claim, dict):
+                    yield str(model), str(hw_name), str(claim_key), claim
+
+
+def collect_matrix_errors(
+    matrix_data: dict[str, Any],
+    known_passes: set[str],
+    *,
+    enforce_olive_window: bool = True,
+) -> list[str]:
+    """Return human-readable validation errors (empty list => valid).
+
+    Checks schema-level required fields, support enum, evidence provenance,
+    pass registry membership, uniqueness, olive_version_support shape, and
+    (optionally) that olive-scoped evidence versions sit inside the declared
+    Olive support window.
+    """
+    errors: list[str] = []
+
+    # --- top-level required ---
+    for key in ("version", "last_updated", "models"):
+        if key not in matrix_data:
+            errors.append(f"missing top-level field: {key}")
+
+    version = matrix_data.get("version")
+    if version is not None and (
+        not isinstance(version, str) or not _MATRIX_VERSION_RE.fullmatch(version)
+    ):
+        errors.append(f"version must be semver X.Y.Z, got {version!r}")
+
+    last_updated = matrix_data.get("last_updated")
+    if last_updated is not None and (
+        not isinstance(last_updated, str) or not _DATE_RE.fullmatch(last_updated)
+    ):
+        errors.append(f"last_updated must be YYYY-MM-DD, got {last_updated!r}")
+
+    models = matrix_data.get("models")
+    if models is not None:
+        if not isinstance(models, list) or len(models) < 1:
+            errors.append("models must be a non-empty array")
+
+    # --- olive_version_support window ---
+    ovs = matrix_data.get("olive_version_support")
+    window_min: str | None = None
+    window_max: str | None = None
+    if ovs is not None:
+        if not isinstance(ovs, dict):
+            errors.append("olive_version_support must be an object")
+        else:
+            window_min = ovs.get("min")
+            window_max = ovs.get("max")
+            for label, raw in (("min", window_min), ("max", window_max)):
+                if raw is None:
+                    continue
+                try:
+                    _parse_version(str(raw))
+                except ValueError as exc:
+                    errors.append(f"olive_version_support.{label}: {exc}")
+            if window_min is not None and window_max is not None:
+                try:
+                    lo = _parse_version(str(window_min))
+                    hi = _parse_version(str(window_max))
+                    width = max(len(lo), len(hi))
+                    lo_p = lo + (0,) * (width - len(lo))
+                    hi_p = hi + (0,) * (width - len(hi))
+                    if lo_p > hi_p:
+                        errors.append(
+                            f"olive_version_support malformed range: "
+                            f"min={window_min!r} > max={window_max!r}"
+                        )
+                except ValueError:
+                    pass  # already recorded above
+
+    # --- model entries + claims ---
+    seen_models: set[str] = set()
+    seen_triples: set[tuple[str, str, str]] = set()
+
+    if not isinstance(models, list):
+        return errors
+
+    for idx, entry in enumerate(models):
+        loc = f"models[{idx}]"
+        if not isinstance(entry, dict):
+            errors.append(f"{loc}: entry must be an object")
+            continue
+
+        for req in ("model", "frameworks", "hardware"):
+            if req not in entry:
+                errors.append(f"{loc}: missing required field {req!r}")
+
+        model_name = entry.get("model")
+        if not isinstance(model_name, str) or not model_name.strip():
+            errors.append(f"{loc}: model must be a non-empty string")
+            model_name = f"<invalid-{idx}>"
+        elif model_name in seen_models:
+            errors.append(f"duplicate model entry: {model_name!r}")
+        else:
+            seen_models.add(model_name)
+
+        frameworks = entry.get("frameworks")
+        if frameworks is not None:
+            if not isinstance(frameworks, list) or len(frameworks) < 1:
+                errors.append(f"{loc} ({model_name}): frameworks must be non-empty array")
+            else:
+                for fw in frameworks:
+                    if fw not in _FRAMEWORKS:
+                        errors.append(
+                            f"{loc} ({model_name}): unknown framework {fw!r}"
+                        )
+
+        hardware = entry.get("hardware")
+        if hardware is None:
+            continue
+        if not isinstance(hardware, dict):
+            errors.append(f"{loc} ({model_name}): hardware must be an object")
+            continue
+
+        for hw_name, passes in hardware.items():
+            hw_loc = f"{loc} ({model_name}) / hardware[{hw_name!r}]"
+            if not isinstance(passes, dict):
+                errors.append(f"{hw_loc}: pass map must be an object")
+                continue
+
+            for claim_key, claim in passes.items():
+                claim_loc = f"{hw_loc} / {claim_key}"
+                if not isinstance(claim, dict):
+                    errors.append(f"{claim_loc}: claim must be an object")
+                    continue
+
+                # Required schema fields
+                for req in ("support", "olive_pass", "evidence"):
+                    if req not in claim:
+                        errors.append(f"{claim_loc}: missing required field {req!r}")
+
+                support = claim.get("support")
+                if support is not None and support not in _SUPPORT_STATES:
+                    errors.append(
+                        f"{claim_loc}: invalid support state {support!r}; "
+                        f"expected one of {sorted(_SUPPORT_STATES)}"
+                    )
+
+                olive_pass = claim.get("olive_pass")
+                if olive_pass is not None:
+                    if not isinstance(olive_pass, str) or not olive_pass.strip():
+                        errors.append(f"{claim_loc}: olive_pass must be non-empty string")
+                    else:
+                        if olive_pass not in known_passes:
+                            errors.append(
+                                f"{claim_loc}: unknown olive_pass {olive_pass!r} "
+                                f"(not in passes.json)"
+                            )
+                        triple = (str(model_name), str(hw_name), olive_pass)
+                        if triple in seen_triples:
+                            errors.append(
+                                f"duplicate model/hardware/pass claim: "
+                                f"{model_name!r} / {hw_name!r} / {olive_pass!r}"
+                            )
+                        else:
+                            seen_triples.add(triple)
+
+                # Provenance / evidence
+                evidence = claim.get("evidence")
+                if "evidence" in claim:
+                    if not isinstance(evidence, dict):
+                        errors.append(f"{claim_loc}: evidence must be an object")
+                    else:
+                        for ereq in ("reference", "type", "version"):
+                            if ereq not in evidence:
+                                errors.append(
+                                    f"{claim_loc}: evidence missing required field {ereq!r}"
+                                )
+                        ref = evidence.get("reference")
+                        if ref is not None and (
+                            not isinstance(ref, str) or not ref.strip()
+                        ):
+                            errors.append(
+                                f"{claim_loc}: evidence.reference must be non-empty"
+                            )
+                        etype = evidence.get("type")
+                        if etype is not None and etype not in _EVIDENCE_TYPES:
+                            errors.append(
+                                f"{claim_loc}: invalid evidence.type {etype!r}; "
+                                f"expected one of {sorted(_EVIDENCE_TYPES)}"
+                            )
+                        ever = evidence.get("version")
+                        if ever is not None and (
+                            not isinstance(ever, str) or not ever.strip()
+                        ):
+                            errors.append(
+                                f"{claim_loc}: evidence.version must be non-empty"
+                            )
+
+                        # Olive support window for olive-scoped evidence
+                        if (
+                            enforce_olive_window
+                            and window_min is not None
+                            and window_max is not None
+                            and etype in _OLIVE_EVIDENCE_TYPES
+                            and isinstance(ever, str)
+                            and ever.strip()
+                        ):
+                            try:
+                                if not _version_in_range(ever, str(window_min), str(window_max)):
+                                    errors.append(
+                                        f"{claim_loc}: evidence.version {ever!r} "
+                                        f"outside olive_version_support "
+                                        f"[{window_min}, {window_max}]"
+                                    )
+                            except ValueError as exc:
+                                errors.append(
+                                    f"{claim_loc}: evidence.version unparseable "
+                                    f"for window check: {exc}"
+                                )
+
+    return errors
+
+
+def _minimal_valid_matrix(
+    *,
+    olive_pass: str = "OnnxConversion",
+    support: str = "supported",
+    evidence_version: str = "0.12.1",
+    evidence_type: str = "olive_docs",
+    window_min: str = "0.12.0",
+    window_max: str = "0.12.1",
+) -> dict[str, Any]:
+    """Build a tiny valid matrix for negative-case mutation."""
+    return {
+        "version": "0.0.0",
+        "last_updated": "2026-08-05",
+        "olive_version_support": {"min": window_min, "max": window_max},
+        "models": [
+            {
+                "model": "Fixture Model",
+                "frameworks": ["ONNX"],
+                "hardware": {
+                    "NVIDIA RTX 4090": {
+                        olive_pass: {
+                            "support": support,
+                            "olive_pass": olive_pass,
+                            "note": "fixture",
+                            "evidence": {
+                                "reference": "https://example.com/docs",
+                                "type": evidence_type,
+                                "version": evidence_version,
+                            },
+                        }
+                    }
+                },
+            }
+        ],
+    }
+
+
+# ===========================================================================
+# Positive: real matrix
+# ===========================================================================
+
+
+def test_matrix_file_exists() -> None:
+    # Arrange / Act / Assert
+    assert _MATRIX_PATH.is_file(), f"missing {_MATRIX_PATH}"
+    assert _PASSES_PATH.is_file(), f"missing {_PASSES_PATH}"
+    assert _SCHEMA_PATH.is_file(), f"missing {_SCHEMA_PATH}"
+
+
+def test_real_matrix_has_required_top_level_fields(matrix: dict[str, Any]) -> None:
+    # Arrange — fixture loads real matrix
+    # Act / Assert
+    assert matrix.get("version") == "0.3.0"
+    assert _MATRIX_VERSION_RE.fullmatch(matrix["version"])
+    assert _DATE_RE.fullmatch(matrix["last_updated"])
+    assert isinstance(matrix["models"], list) and len(matrix["models"]) >= 1
+    ovs = matrix.get("olive_version_support")
+    assert isinstance(ovs, dict)
+    assert "min" in ovs and "max" in ovs
+
+
+def test_real_matrix_passes_full_validation(
+    matrix: dict[str, Any], pass_names: set[str]
+) -> None:
+    """Every claim has olive_pass + evidence; passes exist; no duplicates."""
+    # Arrange / Act
+    errors = collect_matrix_errors(matrix, pass_names, enforce_olive_window=True)
+    # Assert
+    assert errors == [], "real matrix validation failed:\n" + "\n".join(errors)
+
+
+def test_real_matrix_claim_count_matches_expansion(matrix: dict[str, Any]) -> None:
+    """v0.3.0 expansion annotated 169 evidence-backed claims (subtask 10)."""
+    # Arrange / Act
+    claims = list(_iter_claims(matrix))
+    # Assert — allow growth; never shrink below the evidence-backed baseline
+    assert len(claims) >= 169, f"expected >=169 claims, got {len(claims)}"
+    assert len(matrix["models"]) >= 20
+
+
+def test_real_matrix_every_claim_has_schema_fields(matrix: dict[str, Any]) -> None:
+    # Arrange
+    claims = list(_iter_claims(matrix))
+    assert claims, "matrix has no pass claims"
+
+    # Act / Assert
+    for model, hw, key, claim in claims:
+        loc = f"{model}/{hw}/{key}"
+        assert "support" in claim, f"{loc}: missing support"
+        assert claim["support"] in _SUPPORT_STATES, f"{loc}: bad support"
+        assert isinstance(claim.get("olive_pass"), str) and claim["olive_pass"].strip(), (
+            f"{loc}: missing olive_pass"
+        )
+        evidence = claim.get("evidence")
+        assert isinstance(evidence, dict), f"{loc}: missing evidence object"
+        assert isinstance(evidence.get("reference"), str) and evidence["reference"].strip(), (
+            f"{loc}: empty evidence.reference"
+        )
+        assert evidence.get("type") in _EVIDENCE_TYPES, f"{loc}: bad evidence.type"
+        assert isinstance(evidence.get("version"), str) and evidence["version"].strip(), (
+            f"{loc}: empty evidence.version"
+        )
+
+
+def test_real_matrix_olive_passes_exist_in_passes_json(
+    matrix: dict[str, Any], pass_names: set[str]
+) -> None:
+    # Arrange / Act
+    unknown = sorted(
+        {
+            claim["olive_pass"]
+            for _, _, _, claim in _iter_claims(matrix)
+            if claim.get("olive_pass") not in pass_names
+        }
+    )
+    # Assert
+    assert unknown == [], f"unknown olive_pass values: {unknown}"
+
+
+def test_real_matrix_no_duplicate_model_hardware_pass(matrix: dict[str, Any]) -> None:
+    # Arrange
+    seen: set[tuple[str, str, str]] = set()
+    dupes: list[str] = []
+
+    # Act
+    for model, hw, _key, claim in _iter_claims(matrix):
+        olive_pass = claim.get("olive_pass", "")
+        triple = (model, hw, olive_pass)
+        if triple in seen:
+            dupes.append(f"{model} / {hw} / {olive_pass}")
+        seen.add(triple)
+
+    # Assert
+    assert dupes == [], f"duplicate claims: {dupes}"
+
+
+def test_real_matrix_support_states_valid(matrix: dict[str, Any]) -> None:
+    # Arrange / Act
+    invalid = [
+        f"{model}/{hw}/{key}={claim.get('support')!r}"
+        for model, hw, key, claim in _iter_claims(matrix)
+        if claim.get("support") not in _SUPPORT_STATES
+    ]
+    # Assert
+    assert invalid == [], f"invalid support states: {invalid}"
+
+
+def test_real_matrix_olive_evidence_within_support_window(matrix: dict[str, Any]) -> None:
+    # Arrange
+    ovs = matrix.get("olive_version_support") or {}
+    vmin, vmax = ovs.get("min"), ovs.get("max")
+    assert vmin and vmax, "matrix must declare olive_version_support"
+
+    # Act
+    outside: list[str] = []
+    for model, hw, key, claim in _iter_claims(matrix):
+        evidence = claim.get("evidence") or {}
+        if evidence.get("type") not in _OLIVE_EVIDENCE_TYPES:
+            continue
+        ver = evidence.get("version", "")
+        try:
+            if not _version_in_range(str(ver), str(vmin), str(vmax)):
+                outside.append(f"{model}/{hw}/{key} version={ver!r}")
+        except ValueError as exc:
+            outside.append(f"{model}/{hw}/{key} unparseable: {exc}")
+
+    # Assert
+    assert outside == [], f"olive evidence outside support window: {outside}"
+
+
+def test_schema_documents_required_pass_compat_fields(schema: dict[str, Any]) -> None:
+    # Arrange
+    pass_compat = schema["$defs"]["pass_compat"]
+    evidence = schema["$defs"]["pass_evidence"]
+    # Act / Assert
+    assert set(pass_compat["required"]) >= {"support", "olive_pass", "evidence"}
+    assert set(evidence["required"]) >= {"reference", "type", "version"}
+    assert set(pass_compat["properties"]["support"]["enum"]) == _SUPPORT_STATES
+
+
+# ===========================================================================
+# Negative: fixtures / mutated matrices
+# ===========================================================================
+
+
+def test_rejects_unknown_pass_name(pass_names: set[str]) -> None:
+    # Arrange
+    data = _minimal_valid_matrix(olive_pass="NotARealOlivePass")
+    # Act
+    errors = collect_matrix_errors(data, pass_names)
+    # Assert
+    assert any("unknown olive_pass" in e for e in errors), errors
+
+
+def test_rejects_absent_provenance_missing_evidence(pass_names: set[str]) -> None:
+    # Arrange
+    data = _minimal_valid_matrix()
+    claim = data["models"][0]["hardware"]["NVIDIA RTX 4090"]["OnnxConversion"]
+    del claim["evidence"]
+    # Act
+    errors = collect_matrix_errors(data, pass_names)
+    # Assert
+    assert any("missing required field 'evidence'" in e for e in errors), errors
+
+
+def test_rejects_absent_provenance_empty_reference(pass_names: set[str]) -> None:
+    # Arrange
+    data = _minimal_valid_matrix()
+    claim = data["models"][0]["hardware"]["NVIDIA RTX 4090"]["OnnxConversion"]
+    claim["evidence"]["reference"] = "   "
+    # Act
+    errors = collect_matrix_errors(data, pass_names)
+    # Assert
+    assert any("evidence.reference must be non-empty" in e for e in errors), errors
+
+
+def test_rejects_absent_provenance_missing_evidence_fields(pass_names: set[str]) -> None:
+    # Arrange
+    data = _minimal_valid_matrix()
+    claim = data["models"][0]["hardware"]["NVIDIA RTX 4090"]["OnnxConversion"]
+    claim["evidence"] = {"reference": "https://example.com"}  # no type/version
+    # Act
+    errors = collect_matrix_errors(data, pass_names)
+    # Assert
+    assert any("evidence missing required field 'type'" in e for e in errors), errors
+    assert any("evidence missing required field 'version'" in e for e in errors), errors
+
+
+def test_rejects_duplicate_model_hardware_pass_claims(pass_names: set[str]) -> None:
+    # Arrange — two claim keys pointing at the same olive_pass under one HW
+    data = _minimal_valid_matrix(olive_pass="OnnxConversion")
+    hw = data["models"][0]["hardware"]["NVIDIA RTX 4090"]
+    hw["OnnxConversion_dup"] = copy.deepcopy(hw["OnnxConversion"])
+    # Act
+    errors = collect_matrix_errors(data, pass_names)
+    # Assert
+    assert any("duplicate model/hardware/pass claim" in e for e in errors), errors
+
+
+def test_rejects_duplicate_model_entries(pass_names: set[str]) -> None:
+    # Arrange
+    data = _minimal_valid_matrix()
+    data["models"].append(copy.deepcopy(data["models"][0]))
+    # Act
+    errors = collect_matrix_errors(data, pass_names)
+    # Assert
+    assert any("duplicate model entry" in e for e in errors), errors
+
+
+def test_rejects_invalid_support_state(pass_names: set[str]) -> None:
+    # Arrange
+    data = _minimal_valid_matrix(support="maybe")
+    # Act
+    errors = collect_matrix_errors(data, pass_names)
+    # Assert
+    assert any("invalid support state" in e for e in errors), errors
+
+
+def test_accepts_all_valid_support_states(pass_names: set[str]) -> None:
+    # Arrange / Act / Assert
+    for state in sorted(_SUPPORT_STATES):
+        data = _minimal_valid_matrix(support=state)
+        errors = collect_matrix_errors(data, pass_names)
+        assert errors == [], f"support={state!r} should be valid, got {errors}"
+
+
+def test_rejects_malformed_version_range_min_greater_than_max(
+    pass_names: set[str],
+) -> None:
+    # Arrange
+    data = _minimal_valid_matrix(window_min="0.13.0", window_max="0.12.0")
+    # evidence version also won't matter once range is invalid
+    # Act
+    errors = collect_matrix_errors(data, pass_names, enforce_olive_window=True)
+    # Assert
+    assert any("malformed range" in e for e in errors), errors
+
+
+def test_rejects_malformed_version_range_unparseable(pass_names: set[str]) -> None:
+    # Arrange
+    data = _minimal_valid_matrix(window_min="not-a-version", window_max="0.12.1")
+    # Act
+    errors = collect_matrix_errors(data, pass_names)
+    # Assert
+    assert any("olive_version_support.min" in e for e in errors), errors
+
+
+def test_rejects_claim_outside_olive_support_window(pass_names: set[str]) -> None:
+    # Arrange — olive_docs evidence pinned to a release outside the window
+    data = _minimal_valid_matrix(
+        evidence_type="olive_docs",
+        evidence_version="0.9.0",
+        window_min="0.12.0",
+        window_max="0.12.1",
+    )
+    # Act
+    errors = collect_matrix_errors(data, pass_names, enforce_olive_window=True)
+    # Assert
+    assert any("outside olive_version_support" in e for e in errors), errors
+
+
+def test_ort_docs_evidence_not_bound_to_olive_window(pass_names: set[str]) -> None:
+    # Arrange — ORT version strings must not be checked against Olive window
+    data = _minimal_valid_matrix(
+        evidence_type="ort_docs",
+        evidence_version="1.19",
+        window_min="0.12.0",
+        window_max="0.12.1",
+    )
+    # Act
+    errors = collect_matrix_errors(data, pass_names, enforce_olive_window=True)
+    # Assert
+    assert errors == [], errors
+
+
+def test_rejects_missing_olive_pass_field(pass_names: set[str]) -> None:
+    # Arrange
+    data = _minimal_valid_matrix()
+    claim = data["models"][0]["hardware"]["NVIDIA RTX 4090"]["OnnxConversion"]
+    del claim["olive_pass"]
+    # Act
+    errors = collect_matrix_errors(data, pass_names)
+    # Assert
+    assert any("missing required field 'olive_pass'" in e for e in errors), errors
+
+
+def test_rejects_invalid_evidence_type(pass_names: set[str]) -> None:
+    # Arrange
+    data = _minimal_valid_matrix(evidence_type="blog_post")
+    # Act
+    errors = collect_matrix_errors(data, pass_names)
+    # Assert
+    assert any("invalid evidence.type" in e for e in errors), errors
+
+
+def test_rejects_missing_top_level_models(pass_names: set[str]) -> None:
+    # Arrange
+    data = {
+        "version": "0.0.0",
+        "last_updated": "2026-08-05",
+    }
+    # Act
+    errors = collect_matrix_errors(data, pass_names)
+    # Assert
+    assert any("missing top-level field: models" in e for e in errors), errors
+
+
+def test_version_helpers_reject_garbage() -> None:
+    # Arrange / Act / Assert — pure unit edges for helpers
+    with pytest.raises(ValueError):
+        _parse_version("")
+    with pytest.raises(ValueError):
+        _parse_version("latest")
+    assert _version_in_range("0.12.1", "0.12.0", "0.12.1") is True
+    assert _version_in_range("0.11.0", "0.12.0", "0.12.1") is False

--- a/olive-mcp-server/tests/test_compatibility_matrix.py
+++ b/olive-mcp-server/tests/test_compatibility_matrix.py
@@ -196,6 +196,36 @@ def _collect_olive_window(
     return errors, window_min, window_max
 
 
+def _collect_evidence_window_errors(
+    claim_loc: str,
+    *,
+    etype: Any,
+    ever: Any,
+    enforce_olive_window: bool,
+    window_min: str | None,
+    window_max: str | None,
+) -> list[str]:
+    if not (
+        enforce_olive_window
+        and window_min is not None
+        and window_max is not None
+        and etype in _OLIVE_EVIDENCE_TYPES
+        and isinstance(ever, str)
+        and ever.strip()
+    ):
+        return []
+    try:
+        if _version_in_range(ever, str(window_min), str(window_max)):
+            return []
+        return [
+            f"{claim_loc}: evidence.version {ever!r} "
+            f"outside olive_version_support "
+            f"[{window_min}, {window_max}]"
+        ]
+    except ValueError as exc:
+        return [f"{claim_loc}: evidence.version unparseable for window check: {exc}"]
+
+
 def _collect_claim_evidence_errors(
     claim: dict[str, Any],
     claim_loc: str,
@@ -228,25 +258,16 @@ def _collect_claim_evidence_errors(
     if ever is not None and (not isinstance(ever, str) or not ever.strip()):
         errors.append(f"{claim_loc}: evidence.version must be non-empty")
 
-    if (
-        enforce_olive_window
-        and window_min is not None
-        and window_max is not None
-        and etype in _OLIVE_EVIDENCE_TYPES
-        and isinstance(ever, str)
-        and ever.strip()
-    ):
-        try:
-            if not _version_in_range(ever, str(window_min), str(window_max)):
-                errors.append(
-                    f"{claim_loc}: evidence.version {ever!r} "
-                    f"outside olive_version_support "
-                    f"[{window_min}, {window_max}]"
-                )
-        except ValueError as exc:
-            errors.append(
-                f"{claim_loc}: evidence.version unparseable for window check: {exc}"
-            )
+    errors.extend(
+        _collect_evidence_window_errors(
+            claim_loc,
+            etype=etype,
+            ever=ever,
+            enforce_olive_window=enforce_olive_window,
+            window_min=window_min,
+            window_max=window_max,
+        )
+    )
     return errors
 
 
@@ -305,6 +326,61 @@ def _collect_claim_errors(
     return errors
 
 
+def _collect_frameworks_errors(loc: str, model_name: str, frameworks: Any) -> list[str]:
+    if frameworks is None:
+        return []
+    if not isinstance(frameworks, list) or len(frameworks) < 1:
+        return [f"{loc} ({model_name}): frameworks must be non-empty array"]
+    return [
+        f"{loc} ({model_name}): unknown framework {fw!r}"
+        for fw in frameworks
+        if fw not in _FRAMEWORKS
+    ]
+
+
+def _collect_hardware_map_errors(
+    loc: str,
+    model_name: str,
+    hardware: Any,
+    *,
+    known_passes: set[str],
+    seen_triples: set[tuple[str, str, str]],
+    enforce_olive_window: bool,
+    window_min: str | None,
+    window_max: str | None,
+) -> list[str]:
+    if hardware is None:
+        return []
+    if not isinstance(hardware, dict):
+        return [f"{loc} ({model_name}): hardware must be an object"]
+
+    errors: list[str] = []
+    for hw_name, passes in hardware.items():
+        hw_loc = f"{loc} ({model_name}) / hardware[{hw_name!r}]"
+        if not isinstance(passes, dict):
+            errors.append(f"{hw_loc}: pass map must be an object")
+            continue
+        for claim_key, claim in passes.items():
+            claim_loc = f"{hw_loc} / {claim_key}"
+            if not isinstance(claim, dict):
+                errors.append(f"{claim_loc}: claim must be an object")
+                continue
+            errors.extend(
+                _collect_claim_errors(
+                    claim,
+                    claim_loc,
+                    model_name=str(model_name),
+                    hw_name=str(hw_name),
+                    known_passes=known_passes,
+                    seen_triples=seen_triples,
+                    enforce_olive_window=enforce_olive_window,
+                    window_min=window_min,
+                    window_max=window_max,
+                )
+            )
+    return errors
+
+
 def _collect_model_entry_errors(
     entry: Any,
     idx: int,
@@ -335,45 +411,19 @@ def _collect_model_entry_errors(
     else:
         seen_models.add(model_name)
 
-    frameworks = entry.get("frameworks")
-    if frameworks is not None:
-        if not isinstance(frameworks, list) or len(frameworks) < 1:
-            errors.append(f"{loc} ({model_name}): frameworks must be non-empty array")
-        else:
-            for fw in frameworks:
-                if fw not in _FRAMEWORKS:
-                    errors.append(f"{loc} ({model_name}): unknown framework {fw!r}")
-
-    hardware = entry.get("hardware")
-    if hardware is None:
-        return errors
-    if not isinstance(hardware, dict):
-        errors.append(f"{loc} ({model_name}): hardware must be an object")
-        return errors
-
-    for hw_name, passes in hardware.items():
-        hw_loc = f"{loc} ({model_name}) / hardware[{hw_name!r}]"
-        if not isinstance(passes, dict):
-            errors.append(f"{hw_loc}: pass map must be an object")
-            continue
-        for claim_key, claim in passes.items():
-            claim_loc = f"{hw_loc} / {claim_key}"
-            if not isinstance(claim, dict):
-                errors.append(f"{claim_loc}: claim must be an object")
-                continue
-            errors.extend(
-                _collect_claim_errors(
-                    claim,
-                    claim_loc,
-                    model_name=str(model_name),
-                    hw_name=str(hw_name),
-                    known_passes=known_passes,
-                    seen_triples=seen_triples,
-                    enforce_olive_window=enforce_olive_window,
-                    window_min=window_min,
-                    window_max=window_max,
-                )
-            )
+    errors.extend(_collect_frameworks_errors(loc, str(model_name), entry.get("frameworks")))
+    errors.extend(
+        _collect_hardware_map_errors(
+            loc,
+            str(model_name),
+            entry.get("hardware"),
+            known_passes=known_passes,
+            seen_triples=seen_triples,
+            enforce_olive_window=enforce_olive_window,
+            window_min=window_min,
+            window_max=window_max,
+        )
+    )
     return errors
 
 

--- a/olive-mcp-server/tests/test_feedback.py
+++ b/olive-mcp-server/tests/test_feedback.py
@@ -520,3 +520,51 @@ def test_api_does_not_accept_free_form_kwargs():
             "thumbs-up",
             error_message="CUDA OOM traceback",
         )
+
+# ---------------------------------------------------------------------------
+# Inter-process lock
+# ---------------------------------------------------------------------------
+
+
+def _worker_increment(store_path: str, entry_id: str, n: int) -> None:
+    """Child-process helper: n thumbs-up increments against a shared store path."""
+    import os
+
+    os.environ["OLIVE_MCP_FEEDBACK_PATH"] = store_path
+    from olive_mcp_server.tools import feedback as feedback_mod
+
+    feedback_mod.set_feedback_path(None)  # force env path
+    from olive_mcp_server.tools.feedback import record_troubleshoot_feedback as record
+
+    for _ in range(n):
+        result = record(entry_id, "thumbs-up")
+        assert result["status"] == "ok", result
+
+
+def test_concurrent_processes_preserve_increments(tmp_path: Path, monkeypatch):
+    """Overlapping proxy-style processes must not drop acknowledged votes."""
+    import multiprocessing as mp
+
+    shared = tmp_path / "worker_feedback.json"
+    monkeypatch.setenv("OLIVE_MCP_FEEDBACK_PATH", str(shared))
+    set_feedback_path(None)
+    reset_feedback_store()
+
+    seed = record_troubleshoot_feedback(_ENTRY_A, "thumbs-up")
+    assert seed["status"] == "ok"
+    assert seed["thumbs_up"] == 1
+
+    procs = [
+        mp.Process(target=_worker_increment, args=(str(shared), _ENTRY_A, 5))
+        for _ in range(4)
+    ]
+    for p in procs:
+        p.start()
+    for p in procs:
+        p.join(timeout=60)
+        assert p.exitcode == 0, f"worker failed with {p.exitcode}"
+
+    data = _read_store(shared)
+    # 1 seed + 4 workers * 5 increments
+    assert data["entries"][_ENTRY_A]["thumbs_up"] == 21
+

--- a/olive-mcp-server/tests/test_feedback.py
+++ b/olive-mcp-server/tests/test_feedback.py
@@ -1,0 +1,522 @@
+"""Tests for local troubleshoot feedback persistence and ranking bounds.
+
+Covers record_troubleshoot_feedback, atomic store I/O, input validation,
+bounded score deltas, temp-path isolation, and privacy (no free-form text).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from olive_mcp_server.tools import feedback as fb
+from olive_mcp_server.tools.feedback import (
+    ALLOWED_RATINGS,
+    ALLOWED_REASON_CODES,
+    FEEDBACK_BOOST_PER_NET,
+    FEEDBACK_MAX_ADJUSTMENT,
+    FEEDBACK_NET_VOTE_CAP,
+    MAX_COUNT_PER_RATING,
+    feedback_score_delta,
+    get_all_feedback_aggregates,
+    get_entry_feedback_counts,
+    get_feedback_path,
+    record_troubleshoot_feedback,
+    reset_feedback_store,
+    set_feedback_path,
+)
+
+# Stable KB entry ids used across positive paths.
+_ENTRY_A = "oom-quantization"
+_ENTRY_B = "ep-fallback-cpu"
+
+# Keys that must never appear in the on-disk store (privacy / free-form ban).
+_FORBIDDEN_STORE_KEYS = frozenset(
+    {
+        "log",
+        "logs",
+        "message",
+        "error_message",
+        "traceback",
+        "stack",
+        "note",
+        "notes",
+        "comment",
+        "comments",
+        "text",
+        "free_text",
+        "description",
+        "raw",
+        "payload",
+    }
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolated_feedback_store(tmp_path: Path):
+    """Point every test at a fresh temp file; clear override afterward."""
+    path = tmp_path / "troubleshoot_feedback.json"
+    set_feedback_path(path)
+    reset_feedback_store()
+    yield path
+    reset_feedback_store()
+    set_feedback_path(None)
+
+
+def _read_store(path: Path) -> dict:
+    with open(path, "r", encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def _assert_store_privacy(data: dict) -> None:
+    """Recursively assert store JSON has only aggregate counters, no free text."""
+    assert isinstance(data, dict)
+    assert set(data.keys()) <= {"version", "entries"}
+    assert data.get("version") == 1
+    entries = data.get("entries", {})
+    assert isinstance(entries, dict)
+    for eid, entry in entries.items():
+        assert isinstance(eid, str) and eid
+        assert isinstance(entry, dict)
+        assert set(entry.keys()) <= {"thumbs_up", "thumbs_down", "reason_codes"}
+        assert isinstance(entry.get("thumbs_up", 0), int)
+        assert isinstance(entry.get("thumbs_down", 0), int)
+        for bad in _FORBIDDEN_STORE_KEYS:
+            assert bad not in entry
+        reasons = entry.get("reason_codes")
+        if reasons is not None:
+            assert isinstance(reasons, dict)
+            for code, count in reasons.items():
+                assert code in ALLOWED_REASON_CODES
+                assert isinstance(count, int)
+                assert count > 0
+
+
+# ---------------------------------------------------------------------------
+# Atomic local persistence
+# ---------------------------------------------------------------------------
+
+
+def test_record_persists_atomically_to_disk(tmp_path: Path):
+    """Positive: successful rating writes a valid JSON store via atomic replace."""
+    # Arrange
+    path = get_feedback_path()
+    assert path.parent == tmp_path
+
+    # Act
+    result = record_troubleshoot_feedback(_ENTRY_A, "thumbs-up", reason_code="accurate")
+
+    # Assert
+    assert result["status"] == "ok"
+    assert result["matched_entry"] == _ENTRY_A
+    assert result["thumbs_up"] == 1
+    assert result["thumbs_down"] == 0
+    assert result["total"] == 1
+    assert path.is_file()
+    data = _read_store(path)
+    _assert_store_privacy(data)
+    entry = data["entries"][_ENTRY_A]
+    assert entry["thumbs_up"] == 1
+    assert entry["thumbs_down"] == 0
+    assert entry["reason_codes"]["accurate"] == 1
+    # No leftover temp files from atomic write
+    leftovers = list(path.parent.glob(".troubleshoot_feedback-*.tmp"))
+    assert leftovers == []
+
+
+def test_record_increments_existing_entry():
+    """Positive: repeated ratings accumulate on the same entry."""
+    # Arrange / Act
+    r1 = record_troubleshoot_feedback(_ENTRY_A, "thumbs-up")
+    r2 = record_troubleshoot_feedback(_ENTRY_A, "thumbs-down")
+    r3 = record_troubleshoot_feedback(_ENTRY_A, "thumbs-up")
+
+    # Assert
+    assert r1["thumbs_up"] == 1 and r1["thumbs_down"] == 0
+    assert r2["thumbs_up"] == 1 and r2["thumbs_down"] == 1
+    assert r3["thumbs_up"] == 2 and r3["thumbs_down"] == 1
+    counts = get_entry_feedback_counts(_ENTRY_A)
+    assert counts == {"thumbs_up": 2, "thumbs_down": 1}
+
+
+def test_corrupt_store_treated_as_empty(tmp_path: Path):
+    """Negative: unreadable/corrupt JSON does not crash; starts fresh."""
+    # Arrange
+    path = get_feedback_path()
+    path.write_text("{not-valid-json!!!", encoding="utf-8")
+
+    # Act
+    result = record_troubleshoot_feedback(_ENTRY_A, "thumbs-up")
+
+    # Assert
+    assert result["status"] == "ok"
+    assert result["thumbs_up"] == 1
+    data = _read_store(path)
+    assert data["entries"][_ENTRY_A]["thumbs_up"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Invalid input rejection
+# ---------------------------------------------------------------------------
+
+
+def test_valid_rating_and_reason_accepted():
+    """Positive: allowlisted rating + reason_code succeed."""
+    # Arrange / Act
+    result = record_troubleshoot_feedback(
+        _ENTRY_B, "thumbs-down", reason_code="wrong_match"
+    )
+
+    # Assert
+    assert result["status"] == "ok"
+    assert result["rating"] == "thumbs-down"
+    assert result["reason_code"] == "wrong_match"
+    assert result["thumbs_down"] == 1
+    assert result["score_delta"] == pytest.approx(-FEEDBACK_BOOST_PER_NET)
+
+
+@pytest.mark.parametrize(
+    "matched_entry,rating,reason_code,error_code",
+    [
+        ("", "thumbs-up", None, "invalid_matched_entry"),
+        ("   ", "thumbs-up", None, "invalid_matched_entry"),
+        ("not-a-real-kb-entry-xyz", "thumbs-up", None, "unknown_matched_entry"),
+        (_ENTRY_A, "sideways", None, "invalid_rating"),
+        (_ENTRY_A, "thumbs_up", None, "invalid_rating"),  # underscore form rejected
+        (_ENTRY_A, "", None, "invalid_rating"),
+        (_ENTRY_A, "thumbs-up", "totally-made-up", "invalid_reason_code"),
+        (_ENTRY_A, "thumbs-up", "user wrote free text", "invalid_reason_code"),
+    ],
+)
+def test_invalid_inputs_rejected(matched_entry, rating, reason_code, error_code):
+    """Negative: bad entry id, rating, or free-form reason_code are rejected."""
+    # Arrange / Act
+    result = record_troubleshoot_feedback(
+        matched_entry, rating, reason_code=reason_code
+    )
+
+    # Assert
+    assert result["status"] == "error"
+    assert result["error"] == error_code
+    # Nothing persisted on validation failure
+    path = get_feedback_path()
+    assert not path.is_file() or _read_store(path).get("entries", {}) == {}
+
+
+def test_invalid_rating_lists_allowed_values():
+    """Negative: invalid_rating response includes allowlist for clients."""
+    # Arrange / Act
+    result = record_troubleshoot_feedback(_ENTRY_A, "meh")
+
+    # Assert
+    assert result["status"] == "error"
+    assert result["error"] == "invalid_rating"
+    assert set(result["allowed_ratings"]) == set(ALLOWED_RATINGS)
+
+
+def test_invalid_reason_lists_allowed_codes():
+    """Negative: invalid_reason_code response includes allowlist."""
+    # Arrange / Act
+    result = record_troubleshoot_feedback(
+        _ENTRY_A, "thumbs-up", reason_code="please fix this bug for me"
+    )
+
+    # Assert
+    assert result["status"] == "error"
+    assert result["error"] == "invalid_reason_code"
+    assert set(result["allowed_reason_codes"]) == set(ALLOWED_REASON_CODES)
+
+
+# ---------------------------------------------------------------------------
+# Bounded score effects
+# ---------------------------------------------------------------------------
+
+
+def test_score_delta_scales_with_net_votes():
+    """Positive: net thumbs produce expected small boost/demote."""
+    # Arrange — 3 up, 1 down → net +2 → +0.02
+    for _ in range(3):
+        record_troubleshoot_feedback(_ENTRY_A, "thumbs-up")
+    record_troubleshoot_feedback(_ENTRY_A, "thumbs-down")
+
+    # Act
+    delta = feedback_score_delta(_ENTRY_A)
+
+    # Assert
+    assert delta == pytest.approx(2 * FEEDBACK_BOOST_PER_NET)
+    assert abs(delta) <= FEEDBACK_MAX_ADJUSTMENT
+
+
+def test_score_delta_capped_at_max_adjustment():
+    """Negative: many net votes cannot exceed FEEDBACK_MAX_ADJUSTMENT."""
+    # Arrange — far beyond FEEDBACK_NET_VOTE_CAP
+    for _ in range(FEEDBACK_NET_VOTE_CAP + 20):
+        record_troubleshoot_feedback(_ENTRY_A, "thumbs-up")
+
+    # Act
+    delta = feedback_score_delta(_ENTRY_A)
+    result = record_troubleshoot_feedback(_ENTRY_A, "thumbs-up")
+
+    # Assert
+    assert delta == pytest.approx(FEEDBACK_MAX_ADJUSTMENT)
+    assert abs(delta) <= FEEDBACK_MAX_ADJUSTMENT
+    assert result["score_delta"] == pytest.approx(FEEDBACK_MAX_ADJUSTMENT)
+    assert result["max_score_adjustment"] == FEEDBACK_MAX_ADJUSTMENT
+
+
+def test_score_delta_negative_cap():
+    """Negative: heavy thumbs-down is clamped to -FEEDBACK_MAX_ADJUSTMENT."""
+    # Arrange
+    for _ in range(FEEDBACK_NET_VOTE_CAP + 10):
+        record_troubleshoot_feedback(_ENTRY_A, "thumbs-down")
+
+    # Act
+    delta = feedback_score_delta(_ENTRY_A)
+
+    # Assert
+    assert delta == pytest.approx(-FEEDBACK_MAX_ADJUSTMENT)
+    assert delta >= -FEEDBACK_MAX_ADJUSTMENT
+
+
+def test_score_delta_zero_for_unknown_or_empty_entry():
+    """Negative: missing/blank entry ids yield zero delta (no invent)."""
+    # Arrange / Act / Assert
+    assert feedback_score_delta("never-recorded-entry") == 0.0
+    assert feedback_score_delta("") == 0.0
+    assert get_entry_feedback_counts("") == {"thumbs_up": 0, "thumbs_down": 0}
+
+
+def test_count_cap_stops_incrementing():
+    """Negative: per-rating counts stop at MAX_COUNT_PER_RATING."""
+    # Arrange — seed store at cap without looping 1000 times
+    path = get_feedback_path()
+    store = {
+        "version": 1,
+        "entries": {
+            _ENTRY_A: {
+                "thumbs_up": MAX_COUNT_PER_RATING,
+                "thumbs_down": 0,
+            }
+        },
+    }
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(store), encoding="utf-8")
+
+    # Act
+    result = record_troubleshoot_feedback(_ENTRY_A, "thumbs-up")
+
+    # Assert — still ok acknowledgement, count stays capped
+    assert result["status"] == "ok"
+    assert result["thumbs_up"] == MAX_COUNT_PER_RATING
+    assert get_entry_feedback_counts(_ENTRY_A)["thumbs_up"] == MAX_COUNT_PER_RATING
+
+
+def test_delta_from_counts_pure_bounds():
+    """Pure helper: net vote cap and max adjustment both enforced."""
+    # Arrange / Act / Assert
+    assert fb._delta_from_counts(0, 0) == 0.0
+    assert fb._delta_from_counts(1, 0) == pytest.approx(FEEDBACK_BOOST_PER_NET)
+    assert fb._delta_from_counts(0, 1) == pytest.approx(-FEEDBACK_BOOST_PER_NET)
+    # Net beyond cap still clamps
+    assert fb._delta_from_counts(100, 0) == pytest.approx(FEEDBACK_MAX_ADJUSTMENT)
+    assert fb._delta_from_counts(0, 100) == pytest.approx(-FEEDBACK_MAX_ADJUSTMENT)
+    # Exactly at net cap
+    assert fb._delta_from_counts(FEEDBACK_NET_VOTE_CAP, 0) == pytest.approx(
+        min(FEEDBACK_NET_VOTE_CAP * FEEDBACK_BOOST_PER_NET, FEEDBACK_MAX_ADJUSTMENT)
+    )
+
+
+# ---------------------------------------------------------------------------
+# Reset / isolation via temp path
+# ---------------------------------------------------------------------------
+
+
+def test_reset_clears_store_file():
+    """Positive: reset_feedback_store deletes the resolved file."""
+    # Arrange
+    record_troubleshoot_feedback(_ENTRY_A, "thumbs-up")
+    path = get_feedback_path()
+    assert path.is_file()
+
+    # Act
+    reset_feedback_store()
+
+    # Assert
+    assert not path.is_file()
+    assert get_entry_feedback_counts(_ENTRY_A) == {"thumbs_up": 0, "thumbs_down": 0}
+    assert get_all_feedback_aggregates() == {}
+
+
+def test_reset_safe_when_file_missing():
+    """Negative: reset on missing file is a no-op (no raise)."""
+    # Arrange
+    path = get_feedback_path()
+    if path.is_file():
+        path.unlink()
+
+    # Act / Assert — must not raise
+    reset_feedback_store()
+    assert not path.is_file()
+
+
+def test_path_isolation_between_temp_dirs(tmp_path: Path):
+    """Positive: distinct set_feedback_path targets do not share data."""
+    # Arrange
+    path_a = tmp_path / "a" / "feedback.json"
+    path_b = tmp_path / "b" / "feedback.json"
+
+    # Act — write to A
+    set_feedback_path(path_a)
+    record_troubleshoot_feedback(_ENTRY_A, "thumbs-up")
+    assert get_entry_feedback_counts(_ENTRY_A)["thumbs_up"] == 1
+
+    # Switch to B — empty
+    set_feedback_path(path_b)
+    assert get_entry_feedback_counts(_ENTRY_A)["thumbs_up"] == 0
+    record_troubleshoot_feedback(_ENTRY_B, "thumbs-down")
+    assert get_entry_feedback_counts(_ENTRY_B)["thumbs_down"] == 1
+
+    # Back to A — original data intact, B entry absent
+    set_feedback_path(path_a)
+    assert get_entry_feedback_counts(_ENTRY_A)["thumbs_up"] == 1
+    assert get_entry_feedback_counts(_ENTRY_B)["thumbs_down"] == 0
+
+    # Cleanup for autouse fixture
+    set_feedback_path(tmp_path / "troubleshoot_feedback.json")
+
+
+def test_env_path_used_when_no_override(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Positive: OLIVE_MCP_FEEDBACK_PATH resolves when override is cleared."""
+    # Arrange
+    env_file = tmp_path / "from-env.json"
+    monkeypatch.setenv("OLIVE_MCP_FEEDBACK_PATH", str(env_file))
+    set_feedback_path(None)
+
+    # Act
+    assert get_feedback_path() == env_file
+    result = record_troubleshoot_feedback(_ENTRY_A, "thumbs-up")
+
+    # Assert
+    assert result["status"] == "ok"
+    assert env_file.is_file()
+    _assert_store_privacy(_read_store(env_file))
+
+    # Restore isolation for remaining fixture teardown
+    set_feedback_path(tmp_path / "troubleshoot_feedback.json")
+    monkeypatch.delenv("OLIVE_MCP_FEEDBACK_PATH", raising=False)
+
+
+# ---------------------------------------------------------------------------
+# Privacy: feedback file has no logs / free-form text
+# ---------------------------------------------------------------------------
+
+
+def test_store_contains_only_aggregates_no_free_form():
+    """Positive: on-disk JSON is version + capped counters only."""
+    # Arrange / Act
+    record_troubleshoot_feedback(_ENTRY_A, "thumbs-up", reason_code="fixed_issue")
+    record_troubleshoot_feedback(_ENTRY_A, "thumbs-down", reason_code="outdated")
+    record_troubleshoot_feedback(_ENTRY_B, "thumbs-up")
+
+    # Assert
+    data = _read_store(get_feedback_path())
+    _assert_store_privacy(data)
+    raw = get_feedback_path().read_text(encoding="utf-8")
+    # No log-like or free-form content leaked into the file body
+    for needle in (
+        "traceback",
+        "Traceback",
+        "error_message",
+        "CUDA out of memory",
+        "please fix",
+        "user note",
+    ):
+        assert needle not in raw
+
+
+def test_sanitize_strips_unexpected_free_form_fields(tmp_path: Path):
+    """Negative: free-form / log fields on disk are dropped on load."""
+    # Arrange — poison the store with fields that must never be kept
+    path = get_feedback_path()
+    poisoned = {
+        "version": 1,
+        "entries": {
+            _ENTRY_A: {
+                "thumbs_up": 2,
+                "thumbs_down": 1,
+                "note": "user free-form comment that must not persist",
+                "error_message": "CUDA OOM full traceback here",
+                "logs": ["line1", "line2"],
+                "reason_codes": {
+                    "accurate": 1,
+                    "not-allowlisted-reason": 99,
+                    "outdated": 2,
+                },
+            }
+        },
+        "extra_top_level": "should vanish on rewrite",
+    }
+    path.write_text(json.dumps(poisoned), encoding="utf-8")
+
+    # Act — load via public API then rewrite via a new rating
+    counts = get_entry_feedback_counts(_ENTRY_A)
+    assert counts == {"thumbs_up": 2, "thumbs_down": 1}
+    record_troubleshoot_feedback(_ENTRY_A, "thumbs-up")
+
+    # Assert — rewritten file is clean
+    data = _read_store(path)
+    _assert_store_privacy(data)
+    entry = data["entries"][_ENTRY_A]
+    assert entry["thumbs_up"] == 3
+    assert entry["thumbs_down"] == 1
+    assert "note" not in entry
+    assert "error_message" not in entry
+    assert "logs" not in entry
+    assert set(entry["reason_codes"].keys()) <= set(ALLOWED_REASON_CODES)
+    assert "not-allowlisted-reason" not in entry["reason_codes"]
+    assert "extra_top_level" not in data
+
+
+def test_ok_response_is_aggregate_only():
+    """Positive: tool acknowledgement has no paths, logs, or free-form notes."""
+    # Arrange / Act
+    result = record_troubleshoot_feedback(
+        _ENTRY_A, "thumbs-up", reason_code="clear_fix"
+    )
+
+    # Assert
+    assert result["status"] == "ok"
+    allowed_keys = {
+        "status",
+        "matched_entry",
+        "rating",
+        "reason_code",
+        "thumbs_up",
+        "thumbs_down",
+        "total",
+        "count_cap",
+        "score_delta",
+        "max_score_adjustment",
+    }
+    assert set(result.keys()) <= allowed_keys
+    for bad in _FORBIDDEN_STORE_KEYS | {"path", "file", "store_path"}:
+        assert bad not in result
+
+
+def test_api_does_not_accept_free_form_kwargs():
+    """Negative: signature rejects unexpected free-form parameters."""
+    # Arrange / Act / Assert
+    with pytest.raises(TypeError):
+        record_troubleshoot_feedback(  # type: ignore[call-arg]
+            _ENTRY_A,
+            "thumbs-up",
+            note="this free-form note must not be accepted",
+        )
+    with pytest.raises(TypeError):
+        record_troubleshoot_feedback(  # type: ignore[call-arg]
+            _ENTRY_A,
+            "thumbs-up",
+            error_message="CUDA OOM traceback",
+        )

--- a/olive-mcp-server/tests/test_integration.py
+++ b/olive-mcp-server/tests/test_integration.py
@@ -20,6 +20,9 @@ def test_server_lists_all_tools():
     assert required <= names
     assert "get_context_for_pipeline" in names
     assert "diagnose_error" in names
+    # Studio UIState recipe bridge tools (HTTP to local Studio; no Olive)
+    assert "validate_ui_state_recipe" in names
+    assert "get_recipe_for_ui_state" in names
 
 
 def test_get_olive_passes_via_server():

--- a/olive-mcp-server/tests/test_studio_recipe.py
+++ b/olive-mcp-server/tests/test_studio_recipe.py
@@ -1,0 +1,648 @@
+"""Unit tests for studio_recipe bridge tools (no live Studio, no Olive)."""
+
+from __future__ import annotations
+
+import io
+import json
+from email.message import Message
+from typing import Any
+from unittest.mock import MagicMock
+from urllib.error import HTTPError, URLError
+
+import pytest
+
+from olive_mcp_server.tools import studio_recipe
+from olive_mcp_server.tools.studio_recipe import (
+    BRIDGE_PATH,
+    ENV_API_URL,
+    get_recipe_for_ui_state,
+    validate_ui_state_recipe,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+_SAMPLE_UI_STATE: dict[str, Any] = {
+    "modelPath": "/models/phi.onnx",
+    "targetDevice": "GPU",
+    "passes": [{"type": "OnnxConversion"}],
+}
+
+_SUCCESS_PAYLOAD: dict[str, Any] = {
+    "effectiveState": {
+        "modelPath": "/models/phi.onnx",
+        "targetDevice": "GPU",
+        "passes": [{"type": "OnnxConversion"}],
+    },
+    "recipe": {
+        "input_model": {"type": "ONNXModel", "config": {"model_path": "/models/phi.onnx"}},
+        "passes": {"conversion": {"type": "OnnxConversion"}},
+    },
+    "isRunnable": True,
+    "schemaErrors": [],
+    "pipelineIssues": [{"severity": "info", "message": "ok"}],
+    "localExecutionIssues": [],
+    "advisories": ["prefer external data for large models"],
+    "pipelineCriticalCount": 0,
+    "conversionWarnings": ["unused pass option ignored"],
+}
+
+
+@pytest.fixture(autouse=True)
+def _clear_studio_url(monkeypatch: pytest.MonkeyPatch):
+    """Isolate every test from the host environment's Studio URL."""
+    monkeypatch.delenv(ENV_API_URL, raising=False)
+
+
+def _set_loopback_url(monkeypatch: pytest.MonkeyPatch, base: str = "http://127.0.0.1:3000") -> None:
+    monkeypatch.setenv(ENV_API_URL, base)
+
+
+def _mock_response(payload: dict[str, Any] | bytes | str, *, status: int = 200) -> MagicMock:
+    """Build a context-manager response like urllib's urlopen result."""
+    if isinstance(payload, dict):
+        raw = json.dumps(payload).encode("utf-8")
+    elif isinstance(payload, str):
+        raw = payload.encode("utf-8")
+    else:
+        raw = payload
+
+    resp = MagicMock()
+    resp.status = status
+    resp.getcode.return_value = status
+    resp.read.return_value = raw
+    resp.__enter__.return_value = resp
+    resp.__exit__.return_value = False
+    return resp
+
+
+def _patch_opener(monkeypatch: pytest.MonkeyPatch, side_effect=None, return_value=None):
+    """Replace studio_recipe._OPENER.open at the HTTP boundary."""
+    opener = MagicMock()
+    if side_effect is not None:
+        opener.open.side_effect = side_effect
+    else:
+        opener.open.return_value = return_value
+    monkeypatch.setattr(studio_recipe, "_OPENER", opener)
+    return opener
+
+
+# ---------------------------------------------------------------------------
+# Endpoint resolution / SSRF guards
+# ---------------------------------------------------------------------------
+
+
+def test_missing_api_url_returns_studio_unavailable():
+    """Objective: unset OLIVE_STUDIO_API_URL → structured studio_unavailable."""
+    # Arrange — env cleared by autouse fixture
+
+    # Act
+    result = validate_ui_state_recipe(_SAMPLE_UI_STATE)
+
+    # Assert
+    assert result["error"] == "studio_unavailable"
+    assert ENV_API_URL in result["message"]
+    assert "detail" not in result or result.get("detail") is None
+
+
+def test_non_loopback_host_rejected(monkeypatch: pytest.MonkeyPatch):
+    """Objective: non-loopback hosts are refused (SSRF guard)."""
+    # Arrange
+    _set_loopback_url(monkeypatch, "http://example.com:3000")
+    opener = _patch_opener(monkeypatch, return_value=_mock_response(_SUCCESS_PAYLOAD))
+
+    # Act
+    result = validate_ui_state_recipe(_SAMPLE_UI_STATE)
+
+    # Assert
+    assert result["error"] == "studio_unavailable"
+    assert "loopback" in result["message"].lower()
+    opener.open.assert_not_called()
+
+
+def test_invalid_scheme_rejected(monkeypatch: pytest.MonkeyPatch):
+    """Objective: only http(s) schemes are accepted."""
+    # Arrange
+    _set_loopback_url(monkeypatch, "ftp://127.0.0.1:3000")
+    opener = _patch_opener(monkeypatch, return_value=_mock_response(_SUCCESS_PAYLOAD))
+
+    # Act
+    result = get_recipe_for_ui_state(_SAMPLE_UI_STATE)
+
+    # Assert
+    assert result["error"] == "studio_unavailable"
+    assert "http" in result["message"].lower()
+    opener.open.assert_not_called()
+
+
+def test_credentials_in_url_rejected(monkeypatch: pytest.MonkeyPatch):
+    """Objective: URLs with userinfo are rejected."""
+    # Arrange
+    _set_loopback_url(monkeypatch, "http://user:pass@127.0.0.1:3000")
+    opener = _patch_opener(monkeypatch, return_value=_mock_response(_SUCCESS_PAYLOAD))
+
+    # Act
+    result = validate_ui_state_recipe(_SAMPLE_UI_STATE)
+
+    # Assert
+    assert result["error"] == "studio_unavailable"
+    assert "credential" in result["message"].lower()
+    opener.open.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "base",
+    [
+        "http://127.0.0.1:3000",
+        "http://localhost:3000",
+        "http://[::1]:3000",
+        "https://127.0.0.1:3443",
+    ],
+)
+def test_loopback_hosts_accepted(monkeypatch: pytest.MonkeyPatch, base: str):
+    """Objective: localhost / 127.0.0.1 / ::1 (http and https) reach the opener."""
+    # Arrange
+    _set_loopback_url(monkeypatch, base)
+    opener = _patch_opener(monkeypatch, return_value=_mock_response(_SUCCESS_PAYLOAD))
+
+    # Act
+    result = validate_ui_state_recipe(_SAMPLE_UI_STATE)
+
+    # Assert
+    assert "error" not in result
+    assert result["is_runnable"] is True
+    opener.open.assert_called_once()
+    request = opener.open.call_args.args[0]
+    assert request.full_url.rstrip("/").endswith(BRIDGE_PATH) or BRIDGE_PATH in request.full_url
+
+
+# ---------------------------------------------------------------------------
+# Successful bridge forwarding
+# ---------------------------------------------------------------------------
+
+
+def test_validate_ui_state_recipe_success_forwards_and_projects(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Objective: happy-path validation view from camelCase bridge payload."""
+    # Arrange
+    _set_loopback_url(monkeypatch)
+    opener = _patch_opener(monkeypatch, return_value=_mock_response(_SUCCESS_PAYLOAD))
+
+    # Act
+    result = validate_ui_state_recipe(_SAMPLE_UI_STATE)
+
+    # Assert — request shape
+    opener.open.assert_called_once()
+    request = opener.open.call_args.args[0]
+    assert request.get_method() == "POST"
+    assert request.full_url == f"http://127.0.0.1:3000{BRIDGE_PATH}"
+    content_type = request.get_header("Content-type") or request.get_header("Content-Type")
+    assert content_type == "application/json"
+    body = json.loads(request.data.decode("utf-8"))
+    assert body == {"uiState": _SAMPLE_UI_STATE}
+    timeout = opener.open.call_args.kwargs.get("timeout")
+    assert timeout == studio_recipe.DEFAULT_TIMEOUT_SECONDS
+
+    # Assert — validation projection (no full recipe)
+    assert result["is_runnable"] is True
+    assert result["effective_state"] == _SUCCESS_PAYLOAD["effectiveState"]
+    assert result["schema_errors"] == []
+    assert result["pipeline_issues"] == _SUCCESS_PAYLOAD["pipelineIssues"]
+    assert result["local_execution_issues"] == []
+    assert result["advisories"] == _SUCCESS_PAYLOAD["advisories"]
+    assert result["pipeline_critical_count"] == 0
+    assert "olive_recipe" not in result
+    assert "conversion_warnings" not in result
+    assert "error" not in result
+
+
+def test_get_recipe_for_ui_state_success_includes_recipe(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Objective: recipe view adds olive_recipe + conversion_warnings."""
+    # Arrange
+    _set_loopback_url(monkeypatch)
+    _patch_opener(monkeypatch, return_value=_mock_response(_SUCCESS_PAYLOAD))
+
+    # Act
+    result = get_recipe_for_ui_state(_SAMPLE_UI_STATE)
+
+    # Assert
+    assert result["is_runnable"] is True
+    assert result["olive_recipe"] == _SUCCESS_PAYLOAD["recipe"]
+    assert result["conversion_warnings"] == _SUCCESS_PAYLOAD["conversionWarnings"]
+    assert result["effective_state"] == _SUCCESS_PAYLOAD["effectiveState"]
+    assert result["schema_errors"] == []
+    assert "error" not in result
+
+
+def test_snake_case_bridge_payload_aliases(monkeypatch: pytest.MonkeyPatch):
+    """Objective: snake_case field aliases are accepted from the bridge."""
+    # Arrange
+    snake_payload = {
+        "effective_state": {"modelPath": "m.onnx"},
+        "recipe": {"passes": {}},
+        "is_runnable": False,
+        "schema_errors": [{"path": "x", "message": "bad"}],
+        "pipeline_issues": [],
+        "local_execution_issues": ["missing olive"],
+        "advisories": [],
+        "critical_count": 2,
+        "warnings": ["legacy warning key"],
+    }
+    _set_loopback_url(monkeypatch)
+    _patch_opener(monkeypatch, return_value=_mock_response(snake_payload))
+
+    # Act
+    validation = validate_ui_state_recipe(_SAMPLE_UI_STATE)
+    recipe_view = get_recipe_for_ui_state(_SAMPLE_UI_STATE)
+
+    # Assert
+    assert validation["is_runnable"] is False
+    assert validation["schema_errors"] == snake_payload["schema_errors"]
+    assert validation["local_execution_issues"] == ["missing olive"]
+    assert validation["pipeline_critical_count"] == 2
+    assert recipe_view["olive_recipe"] == {"passes": {}}
+    assert recipe_view["conversion_warnings"] == ["legacy warning key"]
+
+
+def test_blocked_pipeline_still_returns_projection(monkeypatch: pytest.MonkeyPatch):
+    """Objective: non-runnable success payloads still project (no Olive run)."""
+    # Arrange
+    blocked = {
+        **_SUCCESS_PAYLOAD,
+        "isRunnable": False,
+        "schemaErrors": [{"message": "model path required"}],
+        "pipelineIssues": [{"severity": "error", "message": "blocked"}],
+        "pipelineCriticalCount": 1,
+    }
+    _set_loopback_url(monkeypatch)
+    _patch_opener(monkeypatch, return_value=_mock_response(blocked))
+
+    # Act
+    result = validate_ui_state_recipe({"passes": []})
+
+    # Assert
+    assert result["is_runnable"] is False
+    assert len(result["schema_errors"]) == 1
+    assert result["pipeline_critical_count"] == 1
+    assert "error" not in result
+
+
+# ---------------------------------------------------------------------------
+# Timeout / unreachable / HTTP errors → studio_unavailable
+# ---------------------------------------------------------------------------
+
+
+def test_timeout_via_urlerror_returns_studio_unavailable(monkeypatch: pytest.MonkeyPatch):
+    """Objective: URLError with timed-out reason maps to studio_unavailable."""
+    # Arrange
+    _set_loopback_url(monkeypatch)
+    _patch_opener(monkeypatch, side_effect=URLError(TimeoutError("timed out")))
+
+    # Act
+    result = validate_ui_state_recipe(_SAMPLE_UI_STATE)
+
+    # Assert
+    assert result["error"] == "studio_unavailable"
+    assert "timed out" in result["message"].lower()
+    assert "timeout_seconds=" in result.get("detail", "")
+
+
+def test_timeout_via_timeout_error_returns_studio_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Objective: bare TimeoutError from opener maps to studio_unavailable."""
+    # Arrange
+    _set_loopback_url(monkeypatch)
+    _patch_opener(monkeypatch, side_effect=TimeoutError())
+
+    # Act
+    result = get_recipe_for_ui_state(_SAMPLE_UI_STATE)
+
+    # Assert
+    assert result["error"] == "studio_unavailable"
+    assert "timed out" in result["message"].lower()
+
+
+def test_connection_refused_returns_studio_unavailable(monkeypatch: pytest.MonkeyPatch):
+    """Objective: unreachable Studio → studio_unavailable, not a crash."""
+    # Arrange
+    _set_loopback_url(monkeypatch)
+    _patch_opener(monkeypatch, side_effect=URLError(ConnectionRefusedError("refused")))
+
+    # Act
+    result = validate_ui_state_recipe(_SAMPLE_UI_STATE)
+
+    # Assert
+    assert result["error"] == "studio_unavailable"
+    assert "not reachable" in result["message"].lower()
+    assert "detail" in result
+
+
+def test_oserror_returns_studio_unavailable(monkeypatch: pytest.MonkeyPatch):
+    """Objective: low-level OSError is normalized to studio_unavailable."""
+    # Arrange
+    _set_loopback_url(monkeypatch)
+    _patch_opener(monkeypatch, side_effect=OSError("network down"))
+
+    # Act
+    result = validate_ui_state_recipe(_SAMPLE_UI_STATE)
+
+    # Assert
+    assert result["error"] == "studio_unavailable"
+    assert "failed" in result["message"].lower()
+    assert "network down" in result["detail"]
+
+
+def _http_error(code: int, body: bytes, *, msg: str = "Error") -> HTTPError:
+    """Build a urllib HTTPError with a readable body (hdrs must be a Message)."""
+    return HTTPError(
+        url="http://127.0.0.1:3000" + BRIDGE_PATH,
+        code=code,
+        msg=msg,
+        hdrs=Message(),
+        fp=io.BytesIO(body),
+    )
+
+
+def test_http_error_without_json_body_returns_studio_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Objective: bare HTTP 500 without structured body → studio_unavailable."""
+    # Arrange
+    _set_loopback_url(monkeypatch)
+    _patch_opener(monkeypatch, side_effect=_http_error(500, b"plain text boom", msg="Internal Server Error"))
+
+    # Act
+    result = validate_ui_state_recipe(_SAMPLE_UI_STATE)
+
+    # Assert
+    assert result["error"] == "studio_unavailable"
+    assert "HTTP error" in result["message"]
+    assert "status=500" in result["detail"]
+
+
+def test_http_error_with_error_payload_is_forwarded(monkeypatch: pytest.MonkeyPatch):
+    """Objective: HTTPError body with error key is returned as-is."""
+    # Arrange
+    _set_loopback_url(monkeypatch)
+    payload = {"error": "invalid_ui_state", "message": "passes must be an array"}
+    err = _http_error(400, json.dumps(payload).encode("utf-8"), msg="Bad Request")
+    _patch_opener(monkeypatch, side_effect=err)
+
+    # Act
+    result = validate_ui_state_recipe(_SAMPLE_UI_STATE)
+
+    # Assert
+    assert result["error"] == "invalid_ui_state"
+    assert "passes" in result["message"]
+
+
+def test_http_error_with_success_shaped_body_is_projected(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Objective: HTTPError carrying a full success payload is still projected."""
+    # Arrange — some gateways raise HTTPError even when body is a valid result
+    _set_loopback_url(monkeypatch)
+    err = _http_error(200, json.dumps(_SUCCESS_PAYLOAD).encode("utf-8"), msg="OK")
+    _patch_opener(monkeypatch, side_effect=err)
+
+    # Act
+    result = validate_ui_state_recipe(_SAMPLE_UI_STATE)
+
+    # Assert
+    assert "error" not in result
+    assert result["is_runnable"] is True
+    assert result["effective_state"] == _SUCCESS_PAYLOAD["effectiveState"]
+
+
+def test_http_status_ge_400_on_success_path(monkeypatch: pytest.MonkeyPatch):
+    """Objective: response status >= 400 without raising → studio_unavailable."""
+    # Arrange
+    _set_loopback_url(monkeypatch)
+    _patch_opener(monkeypatch, return_value=_mock_response({"oops": True}, status=503))
+
+    # Act
+    result = get_recipe_for_ui_state(_SAMPLE_UI_STATE)
+
+    # Assert
+    assert result["error"] == "studio_unavailable"
+    assert "status=503" in result["detail"]
+
+
+# ---------------------------------------------------------------------------
+# Input validation / response contracts
+# ---------------------------------------------------------------------------
+
+
+def test_none_ui_state_returns_invalid_ui_state(monkeypatch: pytest.MonkeyPatch):
+    """Objective: missing ui_state is rejected before any HTTP call."""
+    # Arrange
+    _set_loopback_url(monkeypatch)
+    opener = _patch_opener(monkeypatch, return_value=_mock_response(_SUCCESS_PAYLOAD))
+
+    # Act
+    result = validate_ui_state_recipe(None)
+
+    # Assert
+    assert result["error"] == "invalid_ui_state"
+    assert "required" in result["message"].lower()
+    opener.open.assert_not_called()
+
+
+def test_non_object_ui_state_returns_invalid_ui_state(monkeypatch: pytest.MonkeyPatch):
+    """Objective: non-dict ui_state is rejected."""
+    # Arrange
+    _set_loopback_url(monkeypatch)
+    opener = _patch_opener(monkeypatch, return_value=_mock_response(_SUCCESS_PAYLOAD))
+
+    # Act
+    result = get_recipe_for_ui_state("not-an-object")  # type: ignore[arg-type]
+
+    # Assert
+    assert result["error"] == "invalid_ui_state"
+    assert "JSON object" in result["message"]
+    opener.open.assert_not_called()
+
+
+def test_non_json_bridge_body_returns_invalid_bridge_response(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Objective: non-object JSON payload → invalid_bridge_response."""
+    # Arrange
+    _set_loopback_url(monkeypatch)
+    _patch_opener(monkeypatch, return_value=_mock_response(b"not-json{{{"))
+
+    # Act
+    result = validate_ui_state_recipe(_SAMPLE_UI_STATE)
+
+    # Assert
+    assert result["error"] == "invalid_bridge_response"
+    assert "non-object" in result["message"].lower() or "JSON" in result["message"]
+
+
+def test_json_array_bridge_body_returns_invalid_bridge_response(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Objective: JSON array is not a valid bridge object."""
+    # Arrange
+    _set_loopback_url(monkeypatch)
+    _patch_opener(monkeypatch, return_value=_mock_response(b"[1,2,3]"))
+
+    # Act
+    result = validate_ui_state_recipe(_SAMPLE_UI_STATE)
+
+    # Assert
+    assert result["error"] == "invalid_bridge_response"
+
+
+def test_missing_required_fields_returns_invalid_bridge_response(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Objective: payload missing effectiveState/recipe/isRunnable is rejected."""
+    # Arrange
+    _set_loopback_url(monkeypatch)
+    _patch_opener(
+        monkeypatch,
+        return_value=_mock_response({"effectiveState": {}, "isRunnable": True}),
+    )
+
+    # Act
+    result = validate_ui_state_recipe(_SAMPLE_UI_STATE)
+
+    # Assert
+    assert result["error"] == "invalid_bridge_response"
+    assert "missing" in result["message"].lower()
+    assert "recipe" in result.get("detail", "")
+
+
+def test_wrong_types_on_required_fields(monkeypatch: pytest.MonkeyPatch):
+    """Objective: wrong types for required success fields → invalid_bridge_response."""
+    # Arrange
+    _set_loopback_url(monkeypatch)
+    bad = {
+        "effectiveState": "not-an-object",
+        "recipe": {"ok": True},
+        "isRunnable": True,
+    }
+    _patch_opener(monkeypatch, return_value=_mock_response(bad))
+
+    # Act
+    result = get_recipe_for_ui_state(_SAMPLE_UI_STATE)
+
+    # Assert
+    assert result["error"] == "invalid_bridge_response"
+    assert "effectiveState" in result["message"]
+
+
+def test_is_runnable_must_be_boolean(monkeypatch: pytest.MonkeyPatch):
+    """Objective: isRunnable must be a real boolean."""
+    # Arrange
+    _set_loopback_url(monkeypatch)
+    bad = {
+        "effectiveState": {},
+        "recipe": {},
+        "isRunnable": "yes",
+    }
+    _patch_opener(monkeypatch, return_value=_mock_response(bad))
+
+    # Act
+    result = validate_ui_state_recipe(_SAMPLE_UI_STATE)
+
+    # Assert
+    assert result["error"] == "invalid_bridge_response"
+    assert "isRunnable" in result["message"]
+
+
+def test_bridge_error_payload_without_success_keys_is_returned(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Objective: structured error objects from bridge pass through unchanged."""
+    # Arrange
+    _set_loopback_url(monkeypatch)
+    err_payload = {
+        "error": "studio_unavailable",
+        "message": "rate limited",
+        "detail": "retry later",
+    }
+    _patch_opener(monkeypatch, return_value=_mock_response(err_payload))
+
+    # Act
+    result = validate_ui_state_recipe(_SAMPLE_UI_STATE)
+
+    # Assert
+    assert result == err_payload
+
+
+def test_list_coercion_for_scalar_issue_fields(monkeypatch: pytest.MonkeyPatch):
+    """Objective: scalar issue/advisory values are wrapped into lists."""
+    # Arrange
+    _set_loopback_url(monkeypatch)
+    payload = {
+        **_SUCCESS_PAYLOAD,
+        "schemaErrors": "single-error",
+        "advisories": "one-advisory",
+    }
+    _patch_opener(monkeypatch, return_value=_mock_response(payload))
+
+    # Act
+    result = validate_ui_state_recipe(_SAMPLE_UI_STATE)
+
+    # Assert
+    assert result["schema_errors"] == ["single-error"]
+    assert result["advisories"] == ["one-advisory"]
+
+
+# ---------------------------------------------------------------------------
+# Registration smoke (import path used by MCP server)
+# ---------------------------------------------------------------------------
+
+
+def test_tools_registered_in_tool_imports():
+    """Objective: both bridge tools are registered for MCP dispatch."""
+    # Arrange / Act
+    from olive_mcp_server.mcp_server import _TOOL_IMPORTS
+
+    # Assert
+    assert "validate_ui_state_recipe" in _TOOL_IMPORTS
+    assert "get_recipe_for_ui_state" in _TOOL_IMPORTS
+    assert _TOOL_IMPORTS["validate_ui_state_recipe"][1] == "validate_ui_state_recipe"
+    assert _TOOL_IMPORTS["get_recipe_for_ui_state"][1] == "get_recipe_for_ui_state"
+
+
+def test_call_tool_dispatches_validate_with_mocked_bridge(monkeypatch: pytest.MonkeyPatch):
+    """Objective: mcp_server.call_tool reaches validate_ui_state_recipe (mocked HTTP)."""
+    # Arrange
+    from olive_mcp_server.mcp_server import call_tool
+
+    _set_loopback_url(monkeypatch)
+    _patch_opener(monkeypatch, return_value=_mock_response(_SUCCESS_PAYLOAD))
+
+    # Act
+    result = call_tool("validate_ui_state_recipe", {"ui_state": _SAMPLE_UI_STATE})
+
+    # Assert
+    assert isinstance(result, dict)
+    assert result.get("is_runnable") is True
+    assert "olive_recipe" not in result
+    assert "error" not in result
+
+
+def test_call_tool_dispatches_get_recipe_when_studio_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Objective: call_tool surfaces studio_unavailable without raising."""
+    # Arrange
+    from olive_mcp_server.mcp_server import call_tool
+
+    # ENV cleared by autouse — no OLIVE_STUDIO_API_URL
+
+    # Act
+    result = call_tool("get_recipe_for_ui_state", {"ui_state": _SAMPLE_UI_STATE})
+
+    # Assert
+    assert result["error"] == "studio_unavailable"
+    assert ENV_API_URL in result["message"]

--- a/olive-mcp-server/tests/test_troubleshooting_hybrid.py
+++ b/olive-mcp-server/tests/test_troubleshooting_hybrid.py
@@ -6,6 +6,12 @@ import numpy as np
 import pytest
 
 from olive_mcp_server.tools import troubleshooting as ts
+from olive_mcp_server.tools.feedback import (
+    FEEDBACK_MAX_ADJUSTMENT,
+    record_troubleshoot_feedback,
+    reset_feedback_store,
+    set_feedback_path,
+)
 from olive_mcp_server.tools.troubleshooting import (
     reset_frequency_store,
     troubleshoot_olive_error,
@@ -13,12 +19,17 @@ from olive_mcp_server.tools.troubleshooting import (
 
 
 @pytest.fixture(autouse=True)
-def _clean_state():
+def _clean_state(tmp_path):
     reset_frequency_store()
+    # Isolate feedback store so ranking tests do not leak across the suite.
+    set_feedback_path(tmp_path / "troubleshoot_feedback.json")
+    reset_feedback_store()
     # Clear embedding index cache between tests
     ts._ts_index_cache = {}
     yield
     reset_frequency_store()
+    reset_feedback_store()
+    set_feedback_path(None)
     ts._ts_index_cache = {}
 
 
@@ -377,3 +388,113 @@ def test_real_minilm_paraphrased_oom_optional():
         pass_name="OnnxQuantization",
     )
     assert result["matched_entry"] == "oom-quantization"
+
+
+# ---------------------------------------------------------------------------
+# Bounded feedback ranking (applied only when hybrid > 0)
+# ---------------------------------------------------------------------------
+
+
+def test_feedback_cannot_invent_match_from_zero_hybrid(monkeypatch: pytest.MonkeyPatch):
+    """Negative: thumbs-up alone must not promote a zero-evidence entry."""
+    # Arrange — heavy positive feedback on oom, but no keyword/semantic evidence
+    for _ in range(10):
+        record_troubleshoot_feedback("oom-quantization", "thumbs-up")
+    _mock_embeddings(monkeypatch, default_score=0.0)
+
+    # Act
+    result = troubleshoot_olive_error(
+        error_message="Some random unique unknown failure message 12345",
+    )
+
+    # Assert — still unmatched; feedback only applies when hybrid > 0
+    assert result["matched_entry"] is None
+    assert result["title"] == "No exact match found"
+
+
+def test_feedback_breaks_close_tie_toward_boosted_entry(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Positive: capped feedback can break a near-tie toward the boosted entry."""
+    # Arrange — identical mild semantic scores; only feedback differs.
+    def fake_delta(eid: str) -> float:
+        if eid == "ep-fallback-cpu":
+            return FEEDBACK_MAX_ADJUSTMENT  # +0.05
+        return 0.0
+
+    monkeypatch.setattr(ts, "feedback_score_delta", fake_delta)
+    _mock_embeddings(
+        monkeypatch,
+        scores_by_entry_id={
+            "ep-fallback-cpu": 0.50,
+            "openvino-fallback": 0.50,
+        },
+        default_score=0.05,
+    )
+
+    # Act — wording avoids exact pattern tokens (fallback, CPUExecutionProvider, …)
+    result = troubleshoot_olive_error(
+        error_message="provider silently switched execution to host device path xyz",
+    )
+
+    # Assert
+    assert result["matched_entry"] == "ep-fallback-cpu"
+
+
+def test_feedback_adjustment_clamped_in_best_match(monkeypatch: pytest.MonkeyPatch):
+    """Negative: even an over-cap delta is clamped before ranking in _best_match."""
+    # Arrange — return an illegally large delta; production must clamp to ±0.05
+    monkeypatch.setattr(ts, "feedback_score_delta", lambda eid: 99.0)
+    _mock_embeddings(
+        monkeypatch,
+        scores_by_entry_id={"ep-fallback-cpu": 0.40},
+        default_score=0.0,
+    )
+    entries = [
+        {
+            "id": "ep-fallback-cpu",
+            "patterns": ["never-matches-zzz"],
+            "title": "t",
+            "root_cause": "r",
+            "solution": "s",
+            "updated_config": {},
+        }
+    ]
+
+    # Act
+    best, score = ts._best_match(
+        entries,
+        error_message="neutral wording with no pattern hits",
+        pass_name="",
+        config_context="",
+    )
+
+    # Assert — hybrid = 0.6 * 0.40 + clamped(99→0.05)
+    assert best is not None
+    assert best["id"] == "ep-fallback-cpu"
+    expected = 0.6 * 0.40 + FEEDBACK_MAX_ADJUSTMENT
+    assert score == pytest.approx(expected, abs=1e-6)
+    assert score <= expected + 1e-6
+
+
+def test_strong_keyword_not_overturned_by_negative_feedback(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Negative: max demote (0.05) cannot overturn a clear keyword hit (0.4+)."""
+    # Arrange — bury the correct entry with max thumbs-down; mild semantic noise elsewhere
+    for _ in range(20):
+        record_troubleshoot_feedback("onnx-export-external-data", "thumbs-down")
+    _mock_embeddings(
+        monkeypatch,
+        scores_by_entry_id={"ep-fallback-cpu": 0.40},
+        default_score=0.0,
+    )
+
+    # Act
+    result = troubleshoot_olive_error(
+        error_message="The ONNX model is larger than 2GB",
+        pass_name="OnnxConversion",
+    )
+
+    # Assert — keyword OR=1.0 hybrid (~0.4+) minus 0.05 still beats mild semantic
+    assert result["matched_entry"] == "onnx-export-external-data"

--- a/src/components/features/BatchProcessingPanel.test.tsx
+++ b/src/components/features/BatchProcessingPanel.test.tsx
@@ -196,7 +196,7 @@ describe("BatchProcessingPanel", () => {
         } as Response);
       }
       return Promise.reject(new Error("Unexpected fetch"));
-    });
+    }) as unknown as typeof fetch;
 
     // Mock EventSource for the valid job's stream. Capture the "done"
     // listener so the test can immediately signal a successful run,
@@ -298,7 +298,7 @@ describe("BatchProcessingPanel", () => {
         } as Response);
       }
       return Promise.reject(new Error(`Unexpected fetch: ${String(url)}`));
-    });
+    }) as unknown as typeof fetch;
 
     const eventSourceCtor = vi.fn(function EventSourceMock() {
       return { addEventListener: vi.fn(), close: vi.fn(), onerror: null };

--- a/src/components/features/BatchProcessingPanel.test.tsx
+++ b/src/components/features/BatchProcessingPanel.test.tsx
@@ -1,9 +1,9 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, act, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { createMockUIState, useFetchRoutesMock } from "./__tests__/testUtils";
+import type { UIState, BatchJob, McpDiagnostic } from "@/types";
 import { BatchProcessingPanel } from "./BatchProcessingPanel";
-import type { UIState, BatchJob } from "@/types";
 
 // Mock the pipeline store to avoid zustand coupling
 const mockSetState = vi.fn();
@@ -15,18 +15,47 @@ vi.mock("@/lib/stores/pipelineStore", () => ({
   }),
 }));
 
+const MATCHED_DIAGNOSTIC: McpDiagnostic = {
+  matched_entry: "quantization-precision-mismatch",
+  title: "Quantization Precision Not Supported",
+  root_cause: "EP does not support requested precision.",
+  workaround: "Switch to INT8 or a supporting EP.",
+  domain: "olive",
+  applyable: false,
+};
+
+const UNMATCHED_DIAGNOSTIC: McpDiagnostic = {
+  matched_entry: null,
+  title: "Local unmatched failure",
+  root_cause: "No MCP entry.",
+  workaround: "Inspect batch logs.",
+};
+
 // Mock hooks that make network calls
 const mockFetchKeyedDiagnostic = vi.fn();
-vi.mock("@/lib/hooks", () => ({
-  useAutoClearError: () => [null, vi.fn()],
-  useMcpDiagnosticKeyed: () => ({
-    fetchKeyedDiagnostic: mockFetchKeyedDiagnostic,
-    diagnostics: {},
-    diagnosingKeys: {},
-    errors: {},
-    diagnosticKey: "current",
-  }),
-}));
+const batchMcpState = {
+  diagnostics: {} as Record<string, McpDiagnostic | null>,
+  diagnosingKeys: {} as Record<string, boolean>,
+  errors: {} as Record<string, string | null>,
+};
+
+const mockRequestFeedback = vi.fn();
+
+vi.mock("@/lib/hooks", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/hooks")>();
+  return {
+    ...actual,
+    useAutoClearError: () => ["", vi.fn()],
+    useMcpDiagnosticKeyed: () => ({
+      fetchKeyedDiagnostic: mockFetchKeyedDiagnostic,
+      diagnostics: batchMcpState.diagnostics,
+      diagnosingKeys: batchMcpState.diagnosingKeys,
+      errors: batchMcpState.errors,
+      diagnosticKey: "current",
+    }),
+    requestMcpTroubleshootFeedback: (...args: unknown[]) => mockRequestFeedback(...args),
+  };
+});
 
 // Mock hardware probe
 vi.mock("@/lib/hardwareProbe", () => ({
@@ -41,6 +70,22 @@ vi.mock("@/lib/hardwareProbe", () => ({
   getSelectableProviders: () => ["CPUExecutionProvider"],
 }));
 
+function failedJob(id = "job-failed"): BatchJob {
+  return {
+    id,
+    name: "Failed Job",
+    modelSource: "huggingface",
+    modelIdentifier: "microsoft/phi-2",
+    provider: "CPUExecutionProvider",
+    passes: ["Model Conversion (ONNX)"],
+    recipeJson: undefined,
+    status: "failed",
+    progress: 0,
+    progressKnown: true,
+    logs: ["[ERROR] Simulated batch failure (no Olive)"],
+  };
+}
+
 describe("BatchProcessingPanel", () => {
   useFetchRoutesMock({
     "hardware-probe": {
@@ -50,6 +95,25 @@ describe("BatchProcessingPanel", () => {
       recommendedProvider: "CPUExecutionProvider",
       notes: [],
     },
+  });
+
+  beforeEach(() => {
+    mockStoreState = createMockUIState();
+    mockSetState.mockClear();
+    mockFetchKeyedDiagnostic.mockClear();
+    batchMcpState.diagnostics = {};
+    batchMcpState.diagnosingKeys = {};
+    batchMcpState.errors = {};
+    mockRequestFeedback.mockReset();
+    mockRequestFeedback.mockResolvedValue({
+      status: "ok",
+      matched_entry: MATCHED_DIAGNOSTIC.matched_entry,
+      rating: "thumbs-up",
+      reason_code: null,
+      thumbs_up: 1,
+      thumbs_down: 0,
+      total: 1,
+    });
   });
 
   it("renders the panel heading", async () => {
@@ -286,5 +350,61 @@ describe("BatchProcessingPanel", () => {
         body: JSON.stringify({ jobId: "olive-already-done" }),
       }),
     );
+  });
+
+  it("shows feedback thumbs for a failed job with a matched MCP diagnostic", async () => {
+    const user = userEvent.setup();
+    const job = failedJob("job-fb-matched");
+    const stateWithJobs: UIState = {
+      ...createMockUIState(),
+      batchJobs: [job],
+    };
+    mockStoreState = stateWithJobs;
+    batchMcpState.diagnostics = { [job.id]: MATCHED_DIAGNOSTIC };
+
+    await act(async () => {
+      render(<BatchProcessingPanel state={stateWithJobs} setState={mockSetState} />);
+    });
+
+    // Select the failed job to open the detail panel + MCP card.
+    await user.click(screen.getByText(job.name));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Olive MCP Error Diagnostic/i)).toBeDefined();
+    });
+    expect(screen.getByText(MATCHED_DIAGNOSTIC.title)).toBeDefined();
+    expect(screen.getByRole("button", { name: /Thumbs up/i })).toBeDefined();
+    expect(screen.getByRole("button", { name: /Thumbs down/i })).toBeDefined();
+
+    await user.click(screen.getByRole("button", { name: /Thumbs up — this diagnosis was helpful/i }));
+    await waitFor(() => {
+      expect(mockRequestFeedback).toHaveBeenCalledWith(
+        { matched_entry: MATCHED_DIAGNOSTIC.matched_entry, rating: "thumbs-up" },
+        expect.any(AbortSignal),
+      );
+    });
+  });
+
+  it("hides feedback controls for unmatched diagnostics on failed batch jobs", async () => {
+    const user = userEvent.setup();
+    const job = failedJob("job-fb-unmatched");
+    const stateWithJobs: UIState = {
+      ...createMockUIState(),
+      batchJobs: [job],
+    };
+    mockStoreState = stateWithJobs;
+    batchMcpState.diagnostics = { [job.id]: UNMATCHED_DIAGNOSTIC };
+
+    await act(async () => {
+      render(<BatchProcessingPanel state={stateWithJobs} setState={mockSetState} />);
+    });
+
+    await user.click(screen.getByText(job.name));
+
+    await waitFor(() => {
+      expect(screen.getByText(UNMATCHED_DIAGNOSTIC.title)).toBeDefined();
+    });
+    expect(screen.queryByRole("button", { name: /Thumbs up/i })).toBeNull();
+    expect(screen.queryByRole("button", { name: /Thumbs down/i })).toBeNull();
   });
 });

--- a/src/components/features/BatchProcessingPanel.tsx
+++ b/src/components/features/BatchProcessingPanel.tsx
@@ -264,6 +264,157 @@ function waitForBatchOliveStream(handlers: BatchStreamHandlers): Promise<void> {
   });
 }
 
+type QueueJobContext = {
+  state: UIState;
+  jobsRef: { current: BatchJob[] | undefined };
+  haltRequestedRef: { current: boolean };
+  activeSourcesRef: { current: EventSource[] };
+  currentStreamResolveRef: { current: (() => void) | null };
+  currentOliveJobIdRef: { current: string | null };
+  setState: (s: Partial<UIState>) => void;
+  fetchKeyedDiagnostic: (key: string, logs: string[]) => void;
+};
+
+type QueueJobStep = "continue" | "break";
+
+function failQueuedBatchJob(
+  ctx: Pick<QueueJobContext, "jobsRef" | "setState" | "fetchKeyedDiagnostic">,
+  jobId: string,
+  errorLogs: string[],
+): void {
+  ctx.setState({
+    batchJobs: (ctx.jobsRef.current ?? []).map((j) =>
+      j.id === jobId ? { ...j, status: "failed", logs: errorLogs } : j,
+    ),
+  });
+  ctx.fetchKeyedDiagnostic(jobId, errorLogs);
+}
+
+function uiStateForBatchJob(job: BatchJob, state: UIState): UIState {
+  return {
+    ...state,
+    modelSource: job.modelSource,
+    hfModelId: job.modelSource === "huggingface" ? job.modelIdentifier : state.hfModelId,
+    azureModelPath: job.modelSource === "azure" ? job.modelIdentifier : state.azureModelPath,
+    ihvProvider: job.provider,
+  };
+}
+
+function validationFailureLogs(
+  job: BatchJob,
+  jobs: BatchJob[],
+  statusLabel: string,
+  criticalTitles: string[],
+): string[] {
+  return [
+    ...(jobs.find((j) => j.id === job.id)?.logs || []),
+    `[ERROR] Job validation failed: ${statusLabel}`,
+    ...criticalTitles.map((title) => `[ERROR] ${title}`),
+  ];
+}
+
+function markBatchJobRunning(
+  ctx: Pick<QueueJobContext, "jobsRef" | "setState">,
+  jobId: string,
+): void {
+  ctx.setState({
+    batchJobs: (ctx.jobsRef.current ?? []).map((j) =>
+      j.id === jobId
+        ? { ...j, status: "running", progress: -1, logs: ["[INFO] Starting Olive run..."] }
+        : j,
+    ),
+  });
+}
+
+async function applyHaltBeforeStream(
+  ctx: Pick<QueueJobContext, "jobsRef" | "setState">,
+  job: BatchJob,
+  oliveJobId: string,
+): Promise<void> {
+  const { terminalStatus, haltLog } = await resolveHaltBeforeStream(oliveJobId);
+  ctx.setState({
+    batchJobs: (ctx.jobsRef.current ?? []).map((j) =>
+      j.id === job.id
+        ? {
+            ...j,
+            oliveJobId,
+            status: terminalStatus,
+            logs: [...(j.logs || []), haltLog],
+          }
+        : j,
+    ),
+  });
+}
+
+/**
+ * Run one queued batch job through validate → start → stream.
+ * Returns `break` when the queue should stop after this step.
+ */
+async function processQueuedBatchJob(job: BatchJob, ctx: QueueJobContext): Promise<QueueJobStep> {
+  if (ctx.haltRequestedRef.current) return "break";
+
+  const jobValidation = getPipelineValidation(uiStateForBatchJob(job, ctx.state), {
+    forLocalExecution: true,
+  });
+  if (jobValidation.isBlocked) {
+    failQueuedBatchJob(
+      ctx,
+      job.id,
+      validationFailureLogs(
+        job,
+        ctx.jobsRef.current ?? [],
+        jobValidation.statusLabel,
+        jobValidation.issues.filter((i) => i.severity === "critical").map((i) => i.title),
+      ),
+    );
+    return "continue";
+  }
+
+  markBatchJobRunning(ctx, job.id);
+  const startResult = await postBatchOliveRun(buildOliveRecipeFromBatchJob(job, ctx.state));
+  if (!startResult.ok) {
+    failQueuedBatchJob(ctx, job.id, [
+      ...((ctx.jobsRef.current ?? []).find((j) => j.id === job.id)?.logs || []),
+      `[ERROR] ${startResult.error}`,
+    ]);
+    return "continue";
+  }
+
+  const { jobId } = startResult;
+  if (ctx.haltRequestedRef.current) {
+    await applyHaltBeforeStream(ctx, job, jobId);
+    return "break";
+  }
+
+  ctx.currentOliveJobIdRef.current = jobId;
+  ctx.setState({
+    batchJobs: (ctx.jobsRef.current ?? []).map((j) =>
+      j.id === job.id ? { ...j, oliveJobId: jobId } : j,
+    ),
+  });
+
+  await waitForBatchOliveStream({
+    jobId,
+    batchJobId: job.id,
+    jobsRef: ctx.jobsRef,
+    haltRequestedRef: ctx.haltRequestedRef,
+    activeSourcesRef: ctx.activeSourcesRef,
+    currentStreamResolveRef: ctx.currentStreamResolveRef,
+    setState: ctx.setState,
+    fetchKeyedDiagnostic: ctx.fetchKeyedDiagnostic,
+  });
+
+  ctx.currentOliveJobIdRef.current = null;
+  return ctx.haltRequestedRef.current ? "break" : "continue";
+}
+
+async function runQueuedBatchJobs(queuedJobs: BatchJob[], ctx: QueueJobContext): Promise<void> {
+  for (const job of queuedJobs) {
+    const step = await processQueuedBatchJob(job, ctx);
+    if (step === "break") break;
+  }
+}
+
 /**
  * Renders a panel for managing, running, and inspecting sequential batch-processing jobs.
  *
@@ -410,92 +561,16 @@ export function BatchProcessingPanel({
     haltRequestedRef.current = false;
     setIsProcessing(true);
 
-    const failJob = (jobId: string, errorLogs: string[]) => {
-      setState({
-        batchJobs: (jobsRef.current ?? []).map((j) =>
-          j.id === jobId ? { ...j, status: "failed", logs: errorLogs } : j,
-        ),
-      });
-      fetchKeyedDiagnostic(jobId, errorLogs);
-    };
-
-    for (const job of queuedJobs) {
-      if (haltRequestedRef.current) break;
-
-      const jobState: UIState = {
-        ...state,
-        modelSource: job.modelSource,
-        hfModelId: job.modelSource === "huggingface" ? job.modelIdentifier : state.hfModelId,
-        azureModelPath: job.modelSource === "azure" ? job.modelIdentifier : state.azureModelPath,
-        ihvProvider: job.provider,
-      };
-      const jobValidation = getPipelineValidation(jobState, { forLocalExecution: true });
-      if (jobValidation.isBlocked) {
-        failJob(job.id, [
-          ...((jobsRef.current ?? []).find((j) => j.id === job.id)?.logs || []),
-          `[ERROR] Job validation failed: ${jobValidation.statusLabel}`,
-          ...jobValidation.issues.filter((i) => i.severity === "critical").map((i) => `[ERROR] ${i.title}`),
-        ]);
-        continue;
-      }
-
-      const recipe = buildOliveRecipeFromBatchJob(job, state);
-      setState({
-        batchJobs: (jobsRef.current ?? []).map((j) =>
-          j.id === job.id
-            ? { ...j, status: "running", progress: -1, logs: ["[INFO] Starting Olive run..."] }
-            : j,
-        ),
-      });
-
-      const startResult = await postBatchOliveRun(recipe);
-      if (!startResult.ok) {
-        failJob(job.id, [
-          ...((jobsRef.current ?? []).find((j) => j.id === job.id)?.logs || []),
-          `[ERROR] ${startResult.error}`,
-        ]);
-        continue;
-      }
-      const { jobId } = startResult;
-
-      if (haltRequestedRef.current) {
-        const { terminalStatus, haltLog } = await resolveHaltBeforeStream(jobId);
-        setState({
-          batchJobs: (jobsRef.current ?? []).map((j) =>
-            j.id === job.id
-              ? {
-                  ...j,
-                  oliveJobId: jobId,
-                  status: terminalStatus,
-                  logs: [...(j.logs || []), haltLog],
-                }
-              : j,
-          ),
-        });
-        break;
-      }
-
-      currentOliveJobIdRef.current = jobId;
-      setState({
-        batchJobs: (jobsRef.current ?? []).map((j) =>
-          j.id === job.id ? { ...j, oliveJobId: jobId } : j,
-        ),
-      });
-
-      await waitForBatchOliveStream({
-        jobId,
-        batchJobId: job.id,
-        jobsRef,
-        haltRequestedRef,
-        activeSourcesRef,
-        currentStreamResolveRef,
-        setState,
-        fetchKeyedDiagnostic,
-      });
-
-      currentOliveJobIdRef.current = null;
-      if (haltRequestedRef.current) break;
-    }
+    await runQueuedBatchJobs(queuedJobs, {
+      state,
+      jobsRef,
+      haltRequestedRef,
+      activeSourcesRef,
+      currentStreamResolveRef,
+      currentOliveJobIdRef,
+      setState,
+      fetchKeyedDiagnostic,
+    });
 
     currentOliveJobIdRef.current = null;
     setIsProcessing(false);

--- a/src/components/features/BatchProcessingPanel.tsx
+++ b/src/components/features/BatchProcessingPanel.tsx
@@ -121,49 +121,58 @@ export function BatchProcessingPanel({
 
   const jobs = state.batchJobs || [];
 
+  const forceSettleHaltedJob = (oliveJobId: string) => {
+    activeSourcesRef.current.forEach((s) => s.close());
+    activeSourcesRef.current = [];
+    const resolveStream = currentStreamResolveRef.current;
+    currentStreamResolveRef.current = null;
+    resolveStream?.();
+    setState({
+      batchJobs: (jobsRef.current ?? []).map((j) =>
+        j.status === "running" || j.oliveJobId === oliveJobId
+          ? {
+              ...j,
+              status: "cancelled",
+              logs: [...(j.logs || []), "[INFO] Halted by user."],
+            }
+          : j,
+      ),
+    });
+  };
+
+  const requestHaltRunningQueue = async () => {
+    // Halt: request cancel and keep the open SSE so the server `done` event
+    // settles the queue waiter. Do not clear isProcessing here — the running
+    // start loop exits after the stream completes.
+    haltRequestedRef.current = true;
+    const oliveJobId = currentOliveJobIdRef.current;
+    if (!oliveJobId) {
+      // No live job id yet (POST still in flight): the start loop cancels after jobId.
+      return;
+    }
+    try {
+      const resp = await fetch("/api/olive/cancel", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ jobId: oliveJobId }),
+      });
+      const data = (await resp.json().catch(() => ({}))) as { status?: string };
+      if (resp.ok && data.status === "cancelled") {
+        // `finalizeJob` emits `done`; leave EventSource open for that path.
+        return;
+      }
+      // Already terminal with another status — leave the stream to report it.
+      if (resp.ok) return;
+    } catch {
+      /* fall through to force-settle */
+    }
+    // Cancel failed: close SSE and release the waiter so the queue cannot hang.
+    forceSettleHaltedJob(oliveJobId);
+  };
+
   const handleStartQueue = async () => {
     if (isProcessing) {
-      // Halt: request cancel and keep the open SSE so the server `done` event
-      // settles the queue waiter. Do not clear isProcessing here — the running
-      // start loop exits after the stream completes.
-      haltRequestedRef.current = true;
-      const oliveJobId = currentOliveJobIdRef.current;
-      if (oliveJobId) {
-        try {
-          const resp = await fetch("/api/olive/cancel", {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ jobId: oliveJobId }),
-          });
-          const data = (await resp.json().catch(() => ({}))) as { status?: string };
-          if (resp.ok && data.status === "cancelled") {
-            // `finalizeJob` emits `done`; leave EventSource open for that path.
-            return;
-          }
-          // Already terminal with another status — leave the stream to report it.
-          if (resp.ok) return;
-        } catch {
-          /* fall through to force-settle */
-        }
-        // Cancel failed: close SSE and release the waiter so the queue cannot hang.
-        activeSourcesRef.current.forEach((s) => s.close());
-        activeSourcesRef.current = [];
-        const resolveStream = currentStreamResolveRef.current;
-        currentStreamResolveRef.current = null;
-        resolveStream?.();
-        setState({
-          batchJobs: (jobsRef.current ?? []).map((j) =>
-            j.status === "running" || j.oliveJobId === oliveJobId
-              ? {
-                  ...j,
-                  status: "cancelled",
-                  logs: [...(j.logs || []), "[INFO] Halted by user."],
-                }
-              : j,
-          ),
-        });
-      }
-      // No live job id yet (POST still in flight): the start loop cancels after jobId.
+      await requestHaltRunningQueue();
       return;
     }
 

--- a/src/components/features/BatchProcessingPanel.tsx
+++ b/src/components/features/BatchProcessingPanel.tsx
@@ -1,6 +1,12 @@
 import { useState, useEffect, useRef, useMemo, useCallback } from "react";
 import { Card, CardContent, CardHeader, Button, Label, Input, Select } from "@/components/ui";
-import { UIState, BatchJob, IHVProvider, ModelSource } from "@/types";
+import {
+  UIState,
+  BatchJob,
+  IHVProvider,
+  ModelSource,
+  type McpTroubleshootFeedbackRating,
+} from "@/types";
 import { usePipelineState } from "@/lib/stores/pipelineStore";
 import { useAutoClearError, useMcpDiagnosticKeyed } from "@/lib/hooks";
 import { applyMcpDiagnosticToUiState, canApplyMcpDiagnostic } from "@/lib/mcpConfigMapping";
@@ -68,6 +74,15 @@ export function BatchProcessingPanel({
     errors: batchDiagnoseErrors,
   } = useMcpDiagnosticKeyed();
   const [appliedFixJobId, setAppliedFixJobId] = useAutoClearError(3000);
+
+  /** Card self-submits feedback; parent hook is optional analytics — keep diagnosis UI unchanged. */
+  const handleFeedbackSubmitted = useCallback(
+    (payload: { matched_entry: string; rating: McpTroubleshootFeedbackRating }) => {
+      // No UI mutation after thumbs (batch diagnostics stay keyed by job id).
+      void payload.matched_entry;
+    },
+    [],
+  );
 
   // Custom job creation states
   const [newModelName, setNewModelName] = useState("");
@@ -926,7 +941,7 @@ export function BatchProcessingPanel({
                   </div>
                 )}
 
-                {/* MCP Diagnostic for failed jobs */}
+                {/* MCP Diagnostic for failed jobs (matched_entry from keyed MCP parse enables thumbs) */}
                 {selectedJob.status === "failed" && (
                   <MCPDiagnosticCard
                     diagnostic={batchDiagnostics[selectedJob.id] ?? null}
@@ -961,6 +976,7 @@ export function BatchProcessingPanel({
                       }
                     }}
                     onRunDiagnosis={() => fetchKeyedDiagnostic(selectedJob.id, selectedJob.logs)}
+                    onFeedbackSubmitted={handleFeedbackSubmitted}
                   />
                 )}
 

--- a/src/components/features/BatchProcessingPanel.tsx
+++ b/src/components/features/BatchProcessingPanel.tsx
@@ -36,6 +36,234 @@ import {
   AlertCircle,
 } from "lucide-react";
 
+type TerminalBatchStatus = "cancelled" | "completed" | "failed";
+
+function isTerminalBatchStatus(status: string | undefined): status is TerminalBatchStatus {
+  return status === "cancelled" || status === "completed" || status === "failed";
+}
+
+/** Extract an explicit 0–100 progress percentage from a log line, else -1. */
+function parseBatchProgress(line: string): number {
+  const lower = line.toLowerCase();
+  if (!(lower.includes("pass") || lower.includes("step") || lower.includes("%"))) {
+    return -1;
+  }
+  const match = line.match(/(\d+(?:\.\d+)?)\s*%/);
+  if (!match) return -1;
+  const pct = parseFloat(match[1]);
+  if (Number.isNaN(pct)) return -1;
+  return Math.min(Math.max(Math.round(pct), 0), 100);
+}
+
+function appendBatchJobLog(
+  jobs: BatchJob[],
+  jobId: string,
+  line: string,
+  progress?: number,
+): BatchJob[] {
+  return jobs.map((j) => {
+    if (j.id !== jobId) return j;
+    const nextProgress =
+      progress !== undefined && progress >= 0
+        ? progress
+        : j.progress >= 0
+          ? j.progress
+          : -1;
+    return { ...j, logs: [...j.logs, line], progress: nextProgress };
+  });
+}
+
+async function postBatchOliveRun(
+  recipe: unknown,
+): Promise<{ ok: true; jobId: string } | { ok: false; error: string }> {
+  try {
+    const resp = await fetch("/api/olive/run", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ recipeJson: JSON.stringify(recipe, null, 2) }),
+    });
+    if (!resp.ok) {
+      const err = await resp.json().catch(() => ({ error: `HTTP ${resp.status}` }));
+      return { ok: false, error: String(err.error ?? `HTTP ${resp.status}`) };
+    }
+    const data = (await resp.json()) as { jobId?: string };
+    if (typeof data.jobId !== "string" || !data.jobId) {
+      return { ok: false, error: "Olive run response missing jobId" };
+    }
+    return { ok: true, jobId: data.jobId };
+  } catch (err: unknown) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+async function resolveHaltBeforeStream(jobId: string): Promise<{
+  terminalStatus: TerminalBatchStatus;
+  haltLog: string;
+}> {
+  let terminalStatus: TerminalBatchStatus = "cancelled";
+  let haltLog = "[INFO] Halted before stream started.";
+  try {
+    const cancelResp = await fetch("/api/olive/cancel", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ jobId }),
+    });
+    const cancelData = (await cancelResp.json().catch(() => ({}))) as { status?: string };
+    if (cancelResp.ok && isTerminalBatchStatus(cancelData.status)) {
+      terminalStatus = cancelData.status;
+      if (terminalStatus === "completed") {
+        haltLog = "[INFO] Halt requested after job already completed.";
+      } else if (terminalStatus === "failed") {
+        haltLog = "[INFO] Halt requested after job already failed.";
+      }
+    }
+  } catch {
+    /* keep cancelled + default log */
+  }
+  return { terminalStatus, haltLog };
+}
+
+type BatchStreamHandlers = {
+  jobId: string;
+  batchJobId: string;
+  jobsRef: { current: BatchJob[] | undefined };
+  haltRequestedRef: { current: boolean };
+  activeSourcesRef: { current: EventSource[] };
+  currentStreamResolveRef: { current: (() => void) | null };
+  setState: (s: Partial<UIState>) => void;
+  fetchKeyedDiagnostic: (key: string, logs: string[]) => void;
+};
+
+function applyBatchStreamDone(
+  handlers: BatchStreamHandlers,
+  evtSource: EventSource,
+  finish: () => void,
+  e: MessageEvent,
+): void {
+  const { batchJobId, jobsRef, haltRequestedRef, activeSourcesRef, setState, fetchKeyedDiagnostic } =
+    handlers;
+  let exitCode = 1;
+  let serverStatus: string | undefined;
+  try {
+    const payload = JSON.parse(e.data) as { exitCode?: number; status?: string };
+    exitCode = typeof payload.exitCode === "number" ? payload.exitCode : 1;
+    serverStatus = payload.status;
+  } catch {
+    exitCode = 1;
+  }
+  const finalStatus: TerminalBatchStatus =
+    serverStatus === "cancelled" || haltRequestedRef.current
+      ? "cancelled"
+      : exitCode === 0
+        ? "completed"
+        : "failed";
+  const currentJobs = jobsRef.current ?? [];
+  const completedJob = currentJobs.find((j) => j.id === batchJobId);
+  const metrics =
+    finalStatus === "completed" && completedJob
+      ? parseOliveMetricsFromLogs(completedJob.logs)
+      : undefined;
+  setState({
+    batchJobs: currentJobs.map((j) =>
+      j.id === batchJobId
+        ? {
+            ...j,
+            status: finalStatus,
+            progress: finalStatus === "completed" ? 100 : j.progress,
+            metrics: metrics ?? j.metrics,
+          }
+        : j,
+    ),
+  });
+  if (finalStatus === "failed" && completedJob) {
+    fetchKeyedDiagnostic(batchJobId, completedJob.logs);
+  }
+  evtSource.close();
+  const idx = activeSourcesRef.current.indexOf(evtSource);
+  if (idx !== -1) activeSourcesRef.current.splice(idx, 1);
+  finish();
+}
+
+function applyBatchStreamError(
+  handlers: BatchStreamHandlers,
+  evtSource: EventSource,
+  finish: () => void,
+): void {
+  const { batchJobId, jobsRef, haltRequestedRef, setState, fetchKeyedDiagnostic } = handlers;
+  const currentJobs = jobsRef.current ?? [];
+  if (haltRequestedRef.current) {
+    setState({
+      batchJobs: currentJobs.map((j) =>
+        j.id === batchJobId
+          ? {
+              ...j,
+              status: "cancelled",
+              logs: [...(j.logs || []), "[INFO] Halted by user."],
+            }
+          : j,
+      ),
+    });
+    evtSource.close();
+    finish();
+    return;
+  }
+  const failedJob = currentJobs.find((j) => j.id === batchJobId);
+  const errorLogs = [...(failedJob?.logs || []), "[ERROR] SSE connection lost."];
+  setState({
+    batchJobs: currentJobs.map((j) =>
+      j.id === batchJobId ? { ...j, status: "failed", logs: errorLogs } : j,
+    ),
+  });
+  fetchKeyedDiagnostic(batchJobId, errorLogs);
+  evtSource.close();
+  finish();
+}
+
+function waitForBatchOliveStream(handlers: BatchStreamHandlers): Promise<void> {
+  const { jobId, jobsRef, activeSourcesRef, currentStreamResolveRef, setState } = handlers;
+
+  return new Promise<void>((resolve) => {
+    let settled = false;
+    const finish = () => {
+      if (settled) return;
+      settled = true;
+      if (currentStreamResolveRef.current === finish) {
+        currentStreamResolveRef.current = null;
+      }
+      resolve();
+    };
+    currentStreamResolveRef.current = finish;
+    const evtSource = new EventSource(`/api/olive/stream/${jobId}`);
+    activeSourcesRef.current.push(evtSource);
+
+    evtSource.addEventListener("log", (e: MessageEvent) => {
+      let line = String(e.data ?? "");
+      try {
+        const payload = JSON.parse(line) as { line?: string };
+        if (typeof payload.line === "string") line = payload.line;
+      } catch {
+        /* raw line fallback */
+      }
+      setState({
+        batchJobs: appendBatchJobLog(
+          jobsRef.current ?? [],
+          handlers.batchJobId,
+          line,
+          parseBatchProgress(line),
+        ),
+      });
+    });
+
+    evtSource.addEventListener("done", (e: MessageEvent) => {
+      applyBatchStreamDone(handlers, evtSource, finish, e);
+    });
+
+    evtSource.onerror = () => {
+      applyBatchStreamError(handlers, evtSource, finish);
+    };
+  });
+}
+
 /**
  * Renders a panel for managing, running, and inspecting sequential batch-processing jobs.
  *
@@ -182,11 +410,18 @@ export function BatchProcessingPanel({
     haltRequestedRef.current = false;
     setIsProcessing(true);
 
-    // Process jobs sequentially
+    const failJob = (jobId: string, errorLogs: string[]) => {
+      setState({
+        batchJobs: (jobsRef.current ?? []).map((j) =>
+          j.id === jobId ? { ...j, status: "failed", logs: errorLogs } : j,
+        ),
+      });
+      fetchKeyedDiagnostic(jobId, errorLogs);
+    };
+
     for (const job of queuedJobs) {
       if (haltRequestedRef.current) break;
 
-      // Materialize this job's state to validate it before execution
       const jobState: UIState = {
         ...state,
         modelSource: job.modelSource,
@@ -196,17 +431,11 @@ export function BatchProcessingPanel({
       };
       const jobValidation = getPipelineValidation(jobState, { forLocalExecution: true });
       if (jobValidation.isBlocked) {
-        const errorLogs = [
+        failJob(job.id, [
           ...((jobsRef.current ?? []).find((j) => j.id === job.id)?.logs || []),
           `[ERROR] Job validation failed: ${jobValidation.statusLabel}`,
           ...jobValidation.issues.filter((i) => i.severity === "critical").map((i) => `[ERROR] ${i.title}`),
-        ];
-        setState({
-          batchJobs: (jobsRef.current ?? []).map((j) =>
-            j.id === job.id ? { ...j, status: "failed", logs: errorLogs } : j,
-          ),
-        });
-        fetchKeyedDiagnostic(job.id, errorLogs);
+        ]);
         continue;
       }
 
@@ -219,71 +448,18 @@ export function BatchProcessingPanel({
         ),
       });
 
-      // POST to /api/olive/run
-      let jobId: string;
-      try {
-        const resp = await fetch("/api/olive/run", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ recipeJson: JSON.stringify(recipe, null, 2) }),
-        });
-        if (!resp.ok) {
-          const err = await resp.json().catch(() => ({ error: `HTTP ${resp.status}` }));
-          const errorLogs = [
-            ...((jobsRef.current ?? []).find((j) => j.id === job.id)?.logs || []),
-            `[ERROR] ${err.error}`,
-          ];
-          setState({
-            batchJobs: (jobsRef.current ?? []).map((j) =>
-              j.id === job.id ? { ...j, status: "failed", logs: errorLogs } : j,
-            ),
-          });
-          fetchKeyedDiagnostic(job.id, errorLogs);
-          continue;
-        }
-        const data = await resp.json();
-        jobId = data.jobId;
-      } catch (err: unknown) {
-        const message = err instanceof Error ? err.message : String(err);
-        const errorLogs = [
+      const startResult = await postBatchOliveRun(recipe);
+      if (!startResult.ok) {
+        failJob(job.id, [
           ...((jobsRef.current ?? []).find((j) => j.id === job.id)?.logs || []),
-          `[ERROR] ${message}`,
-        ];
-        setState({
-          batchJobs: (jobsRef.current ?? []).map((j) =>
-            j.id === job.id ? { ...j, status: "failed", logs: errorLogs } : j,
-          ),
-        });
-        fetchKeyedDiagnostic(job.id, errorLogs);
+          `[ERROR] ${startResult.error}`,
+        ]);
         continue;
       }
+      const { jobId } = startResult;
 
       if (haltRequestedRef.current) {
-        // No SSE yet — apply the cancel endpoint's terminal status (or force
-        // cancelled if cancel fails) so the row cannot stick on "running".
-        type TerminalBatchStatus = "cancelled" | "completed" | "failed";
-        const isTerminal = (s: string | undefined): s is TerminalBatchStatus =>
-          s === "cancelled" || s === "completed" || s === "failed";
-        let terminalStatus: TerminalBatchStatus = "cancelled";
-        let haltLog = "[INFO] Halted before stream started.";
-        try {
-          const cancelResp = await fetch("/api/olive/cancel", {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ jobId }),
-          });
-          const cancelData = (await cancelResp.json().catch(() => ({}))) as { status?: string };
-          if (cancelResp.ok && isTerminal(cancelData.status)) {
-            terminalStatus = cancelData.status;
-            if (terminalStatus === "completed") {
-              haltLog = "[INFO] Halt requested after job already completed.";
-            } else if (terminalStatus === "failed") {
-              haltLog = "[INFO] Halt requested after job already failed.";
-            }
-          }
-        } catch {
-          /* keep cancelled + default log */
-        }
+        const { terminalStatus, haltLog } = await resolveHaltBeforeStream(jobId);
         setState({
           batchJobs: (jobsRef.current ?? []).map((j) =>
             j.id === job.id
@@ -306,139 +482,15 @@ export function BatchProcessingPanel({
         ),
       });
 
-      // Open SSE stream and wait for completion
-      await new Promise<void>((resolve) => {
-        let settled = false;
-        const finish = () => {
-          if (settled) return;
-          settled = true;
-          if (currentStreamResolveRef.current === finish) {
-            currentStreamResolveRef.current = null;
-          }
-          resolve();
-        };
-        currentStreamResolveRef.current = finish;
-        const evtSource = new EventSource(`/api/olive/stream/${jobId}`);
-        activeSourcesRef.current.push(evtSource);
-
-        // Helper: try to extract a 0-100 progress percentage from a log line.
-        // Returns the parsed number if found, otherwise -1 (indeterminate).
-        const parseProgress = (line: string): number => {
-          const lower = line.toLowerCase();
-          if (lower.includes("pass") || lower.includes("step") || lower.includes("%")) {
-            // Try to extract an explicit percentage, e.g. "45%" or "45 %"
-            const match = line.match(/(\d+(?:\.\d+)?)\s*%/);
-            if (match) {
-              const pct = parseFloat(match[1]);
-              if (!isNaN(pct)) return Math.min(Math.max(Math.round(pct), 0), 100);
-            }
-            // Progress-related line but no explicit %; keep indeterminate
-            return -1;
-          }
-          return -1;
-        };
-
-        // Named 'log' SSE events: { line: string }
-        evtSource.addEventListener("log", (e: MessageEvent) => {
-          let line = String(e.data ?? "");
-          try {
-            const payload = JSON.parse(line) as { line?: string };
-            if (typeof payload.line === "string") line = payload.line;
-          } catch {
-            /* raw line fallback */
-          }
-          const parsedPct = parseProgress(line);
-          const currentJobs = jobsRef.current ?? [];
-          setState({
-            batchJobs: currentJobs.map((j) =>
-              j.id === job.id
-                ? {
-                    ...j,
-                    logs: [...j.logs, line],
-                    // Use explicit percentage if available; otherwise keep existing
-                    // progress (or -1 if not yet set)
-                    progress: parsedPct >= 0 ? parsedPct : j.progress >= 0 ? j.progress : -1,
-                  }
-                : j,
-            ),
-          });
-        });
-
-        // Named 'done' SSE event with { exitCode, status }
-        evtSource.addEventListener("done", (e: MessageEvent) => {
-          let exitCode = 1;
-          let serverStatus: string | undefined;
-          try {
-            const payload = JSON.parse(e.data) as { exitCode?: number; status?: string };
-            exitCode = typeof payload.exitCode === "number" ? payload.exitCode : 1;
-            serverStatus = payload.status;
-          } catch {
-            exitCode = 1;
-          }
-          const finalStatus =
-            serverStatus === "cancelled" || haltRequestedRef.current
-              ? "cancelled"
-              : exitCode === 0
-                ? "completed"
-                : "failed";
-          const currentJobs = jobsRef.current ?? [];
-          const completedJob = currentJobs.find((j) => j.id === job.id);
-          const metrics =
-            finalStatus === "completed" && completedJob
-              ? parseOliveMetricsFromLogs(completedJob.logs)
-              : undefined;
-          setState({
-            batchJobs: currentJobs.map((j) =>
-              j.id === job.id
-                ? {
-                    ...j,
-                    status: finalStatus,
-                    progress: finalStatus === "completed" ? 100 : j.progress,
-                    metrics: metrics ?? j.metrics,
-                  }
-                : j,
-            ),
-          });
-          // Auto-diagnose failed jobs via MCP knowledge base
-          if (finalStatus === "failed" && completedJob) {
-            fetchKeyedDiagnostic(job.id, completedJob.logs);
-          }
-          evtSource.close();
-          const idx = activeSourcesRef.current.indexOf(evtSource);
-          if (idx !== -1) activeSourcesRef.current.splice(idx, 1);
-          finish();
-        });
-
-        evtSource.onerror = () => {
-          const currentJobs = jobsRef.current ?? [];
-          if (haltRequestedRef.current) {
-            setState({
-              batchJobs: currentJobs.map((j) =>
-                j.id === job.id
-                  ? {
-                      ...j,
-                      status: "cancelled",
-                      logs: [...(j.logs || []), "[INFO] Halted by user."],
-                    }
-                  : j,
-              ),
-            });
-            evtSource.close();
-            finish();
-            return;
-          }
-          const failedJob = currentJobs.find((j) => j.id === job.id);
-          const errorLogs = [...(failedJob?.logs || []), "[ERROR] SSE connection lost."];
-          setState({
-            batchJobs: currentJobs.map((j) =>
-              j.id === job.id ? { ...j, status: "failed", logs: errorLogs } : j,
-            ),
-          });
-          // Auto-diagnose SSE failures via MCP knowledge base
-          fetchKeyedDiagnostic(job.id, errorLogs);
-          evtSource.close();
-          finish();
-        };
+      await waitForBatchOliveStream({
+        jobId,
+        batchJobId: job.id,
+        jobsRef,
+        haltRequestedRef,
+        activeSourcesRef,
+        currentStreamResolveRef,
+        setState,
+        fetchKeyedDiagnostic,
       });
 
       currentOliveJobIdRef.current = null;

--- a/src/components/features/ExecutionWorkspace.test.tsx
+++ b/src/components/features/ExecutionWorkspace.test.tsx
@@ -1,6 +1,16 @@
-import { describe, it, expect, vi } from "vitest";
-import { render, screen, act } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, act, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { createMockUIState, useFetchRoutesMock } from "./__tests__/testUtils";
+import { DEFAULT_PASSES } from "@/lib/defaultPasses";
+import type { McpDiagnostic } from "@/types";
+
+/** Full default passes so Execute Live stays enabled (isRunnable). */
+function runnableUiState() {
+  return createMockUIState({
+    passes: { ...DEFAULT_PASSES, conversion: true, quantization: false },
+  });
+}
 
 // Mock the pipeline store
 const mockSetState = vi.fn();
@@ -11,17 +21,50 @@ vi.mock("@/lib/stores/pipelineStore", () => ({
   }),
 }));
 
-// Mock hooks
-vi.mock("@/lib/hooks", () => ({
-  useAutoClearError: () => [null, vi.fn()],
-  useMcpDiagnosticKeyed: () => ({
-    fetchKeyedDiagnostic: vi.fn(),
-    diagnostics: {},
-    diagnosingKeys: {},
-    errors: {},
-    diagnosticKey: "current",
-  }),
-}));
+const MATCHED_DIAGNOSTIC: McpDiagnostic = {
+  matched_entry: "onnxruntime-large-model-external-data",
+  title: "ONNX Export Fails for Models > 2GB",
+  root_cause: "Protobuf size limit.",
+  workaround: "Enable external data format.",
+  updated_config: { use_external_data_format: true },
+  domain: "olive",
+  applyable: true,
+};
+
+const UNMATCHED_DIAGNOSTIC: McpDiagnostic = {
+  matched_entry: null,
+  title: "Unrecognized runtime error",
+  root_cause: "No KB match.",
+  workaround: "Inspect logs manually.",
+  domain: null,
+};
+
+/** Mutable keyed-diagnostic mock shared across tests. */
+const mcpKeyedState = {
+  fetchKeyedDiagnostic: vi.fn(),
+  diagnostics: {} as Record<string, McpDiagnostic | null>,
+  diagnosingKeys: {} as Record<string, boolean>,
+  errors: {} as Record<string, string | null>,
+  diagnosticKey: "current",
+};
+
+const mockRequestFeedback = vi.fn();
+
+vi.mock("@/lib/hooks", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/hooks")>();
+  return {
+    ...actual,
+    useAutoClearError: () => ["", vi.fn()],
+    useMcpDiagnosticKeyed: () => ({
+      fetchKeyedDiagnostic: mcpKeyedState.fetchKeyedDiagnostic,
+      diagnostics: mcpKeyedState.diagnostics,
+      diagnosingKeys: mcpKeyedState.diagnosingKeys,
+      errors: mcpKeyedState.errors,
+      diagnosticKey: mcpKeyedState.diagnosticKey,
+    }),
+    requestMcpTroubleshootFeedback: (...args: unknown[]) => mockRequestFeedback(...args),
+  };
+});
 
 // Mock hardware probe
 vi.mock("@/lib/hardwareProbe", () => ({
@@ -83,15 +126,73 @@ vi.mock("@/lib/gpuMetrics", () => ({
 
 import { ExecutionWorkspace } from "./ExecutionWorkspace";
 
+const HW_PROBE = {
+  probedAt: "now",
+  platform: { cpuModel: "Test CPU", cpuCores: 8, os: "win", arch: "x64" },
+  detectedProviders: ["CPUExecutionProvider"],
+  recommendedProvider: "CPUExecutionProvider",
+  notes: [] as string[],
+};
+
+/**
+ * Runnable CPU conversion recipe + mocked /api/olive/run failure.
+ * Execute Live stays enabled (isRunnable), then fails without spawning Olive.
+ */
+function installNoOliveFetch() {
+  return vi.spyOn(globalThis, "fetch").mockImplementation((input: RequestInfo | URL) => {
+    const url = String(input);
+    if (url.includes("/api/olive/run")) {
+      return Promise.resolve(
+        new Response(JSON.stringify({ error: "Simulated run rejection (no Olive)" }), {
+          status: 503,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+    }
+    if (url.includes("hardware-probe")) {
+      return Promise.resolve(
+        new Response(JSON.stringify(HW_PROBE), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+    }
+    return Promise.resolve(new Response("{}", { status: 200 }));
+  });
+}
+
+async function failExecuteLive() {
+  const user = userEvent.setup();
+  const executeBtn = await screen.findByRole("button", { name: /execute live/i });
+  expect((executeBtn as HTMLButtonElement).disabled).toBe(false);
+  await user.click(executeBtn);
+  await waitFor(() => {
+    expect(screen.getByText(/Olive MCP Error Diagnostic/i)).toBeDefined();
+  });
+}
+
 describe("ExecutionWorkspace", () => {
+  // Baseline fetch mock for non-feedback tests; feedback tests reinstall via installNoOliveFetch.
   useFetchRoutesMock({
-    "hardware-probe": {
-      probedAt: "now",
-      platform: { cpuModel: "Test CPU", cpuCores: 8, os: "win", arch: "x64" },
-      detectedProviders: ["CPUExecutionProvider"],
-      recommendedProvider: "CPUExecutionProvider",
-      notes: [],
-    },
+    "hardware-probe": HW_PROBE,
+  });
+
+  beforeEach(() => {
+    mockSetState.mockClear();
+    mcpKeyedState.fetchKeyedDiagnostic.mockClear();
+    mcpKeyedState.diagnostics = {};
+    mcpKeyedState.diagnosingKeys = {};
+    mcpKeyedState.errors = {};
+    mockRequestFeedback.mockReset();
+    mockRequestFeedback.mockResolvedValue({
+      status: "ok",
+      matched_entry: MATCHED_DIAGNOSTIC.matched_entry,
+      rating: "thumbs-up",
+      reason_code: null,
+      thumbs_up: 1,
+      thumbs_down: 0,
+      total: 1,
+    });
   });
 
   it("renders the workspace heading", async () => {
@@ -152,5 +253,81 @@ describe("ExecutionWorkspace", () => {
     // Text nodes for promoted Playground views must not appear in the menu
     expect(menu.textContent).not.toMatch(/Browser Test/i);
     expect(menu.textContent).not.toMatch(/Benchmark/i);
+  });
+
+  it("wires MCP feedback thumbs for matched diagnostics after a failed run (no Olive)", async () => {
+    const fetchSpy = installNoOliveFetch();
+    mcpKeyedState.diagnostics = { current: MATCHED_DIAGNOSTIC };
+
+    try {
+      await act(async () => {
+        render(<ExecutionWorkspace state={runnableUiState()} setState={mockSetState} />);
+      });
+
+      await failExecuteLive();
+
+      expect(screen.getByText(MATCHED_DIAGNOSTIC.title)).toBeDefined();
+      expect(screen.getByRole("button", { name: /Thumbs up/i })).toBeDefined();
+      expect(screen.getByRole("button", { name: /Thumbs down/i })).toBeDefined();
+
+      // Auto-diagnose still uses the keyed hook (history path remains intact).
+      expect(mcpKeyedState.fetchKeyedDiagnostic).toHaveBeenCalled();
+      expect(fetchSpy).toHaveBeenCalledWith(
+        "/api/olive/run",
+        expect.objectContaining({ method: "POST" }),
+      );
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+
+  it("hides feedback controls for unmatched diagnostics and still shows the card", async () => {
+    const fetchSpy = installNoOliveFetch();
+    mcpKeyedState.diagnostics = { current: UNMATCHED_DIAGNOSTIC };
+
+    try {
+      await act(async () => {
+        render(<ExecutionWorkspace state={runnableUiState()} setState={mockSetState} />);
+      });
+
+      await failExecuteLive();
+
+      expect(screen.getByText(UNMATCHED_DIAGNOSTIC.title)).toBeDefined();
+      expect(screen.queryByRole("button", { name: /Thumbs up/i })).toBeNull();
+      expect(screen.queryByRole("button", { name: /Thumbs down/i })).toBeNull();
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+
+  it("records diagnosis history when the keyed diagnostic updates (no regression)", async () => {
+    const fetchSpy = installNoOliveFetch();
+    // Start empty so the history effect sees a transition when we re-render with a match.
+    mcpKeyedState.diagnostics = {};
+
+    try {
+      const { rerender } = render(
+        <ExecutionWorkspace state={runnableUiState()} setState={mockSetState} />,
+      );
+
+      await failExecuteLive();
+
+      // Simulate MCP returning a match after auto-diagnose (same path as production).
+      mcpKeyedState.diagnostics = { current: MATCHED_DIAGNOSTIC };
+      await act(async () => {
+        rerender(<ExecutionWorkspace state={runnableUiState()} setState={mockSetState} />);
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText(MATCHED_DIAGNOSTIC.title)).toBeDefined();
+      });
+
+      // DiagnosisHistory sidebar appears once an entry is recorded.
+      await waitFor(() => {
+        expect(screen.getByText(/History \(1\)/i)).toBeDefined();
+      });
+    } finally {
+      fetchSpy.mockRestore();
+    }
   });
 });

--- a/src/components/features/ExecutionWorkspace.test.tsx
+++ b/src/components/features/ExecutionWorkspace.test.tsx
@@ -319,7 +319,7 @@ describe("ExecutionWorkspace", () => {
       });
 
       await waitFor(() => {
-        expect(screen.getByText(MATCHED_DIAGNOSTIC.title)).toBeDefined();
+        expect(screen.getAllByText(MATCHED_DIAGNOSTIC.title).length).toBeGreaterThanOrEqual(1);
       });
 
       // DiagnosisHistory sidebar appears once an entry is recorded.

--- a/src/components/features/ExecutionWorkspace.tsx
+++ b/src/components/features/ExecutionWorkspace.tsx
@@ -194,9 +194,9 @@ export function ExecutionWorkspace({
   const [diagnosisHistory, setDiagnosisHistory] = useState<DiagnosisEntry[]>([]);
   const [activeHistoryIndex, setActiveHistoryIndex] = useState(-1);
 
-  // Browse older history entries on the card (matched_entry + thumbs); index 0 / none = live MCP result.
+  // Browse diagnosis history entries on the card; -1 means "live" (current MCP result).
   const viewingHistoricalDiagnosis =
-    activeHistoryIndex > 0 && activeHistoryIndex < diagnosisHistory.length;
+    activeHistoryIndex >= 0 && activeHistoryIndex < diagnosisHistory.length;
   const displayedDiagnostic = viewingHistoricalDiagnosis
     ? diagnosisHistory[activeHistoryIndex]!.diagnostic
     : mcpDiagnostic;

--- a/src/components/features/ExecutionWorkspace.tsx
+++ b/src/components/features/ExecutionWorkspace.tsx
@@ -14,7 +14,7 @@ import {
   type SetStateAction,
 } from "react";
 import { Card, CardContent, CardHeader, Button, Label } from "@/components/ui";
-import { UIState } from "@/types";
+import { UIState, type McpTroubleshootFeedbackRating } from "@/types";
 import { usePipelineState } from "@/lib/stores/pipelineStore";
 import { useAutoClearError, useMcpDiagnosticKeyed } from "@/lib/hooks";
 import { applyMcpDiagnosticToUiState, canApplyMcpDiagnostic } from "@/lib/mcpConfigMapping";
@@ -51,6 +51,7 @@ import {
   Wrench,
   MoreHorizontal,
   FileText,
+  Bug,
 } from "lucide-react";
 import JSZip from "jszip";
 import { cn } from "@/lib/utils";
@@ -67,9 +68,7 @@ import { getJobHistory, saveJobHistory } from "@/lib/jobHistoryStore";
 import { downloadMarkdownReport } from "@/lib/reportGenerator";
 import { JobHistoryModal } from "@/components/features/JobHistoryModal";
 import { ReportIssueModal } from "@/components/ReportIssueModal";
-import { Bug } from "lucide-react";
 import type { ReportArea } from "@/lib/issueReport";
-import type { McpTroubleshootFeedbackRating } from "@/types";
 
 const RecipeGraphView = lazy(() => import("./RecipeGraphView").then((m) => ({ default: m.RecipeGraphView })));
 
@@ -79,6 +78,63 @@ const RecipeGraphView = lazy(() => import("./RecipeGraphView").then((m) => ({ de
  * @param label - The text displayed below the spinner
  * @param minH - The optional minimum height of the loading container
  */
+
+function collectActivePassNames(passes: UIState["passes"]): string[] {
+  const names: string[] = [];
+  if (passes.conversion) {
+    names.push(`Conversion (${passes.conversionFormat === "onnx" ? "ONNX" : "OpenVINO"})`);
+  }
+  if (passes.quantization) names.push(`Quantization (${passes.quantPrecision})`);
+  if (passes.pruning) names.push(`Pruning (${passes.pruningMethod})`);
+  if (passes.onnxTransforms) names.push("ORT Transforms");
+  return names.length > 0 ? names : ["Default Baseline Export"];
+}
+
+function resolveQueuedModelIdentifier(state: UIState): string {
+  if (state.modelSource === "huggingface") return state.hfModelId || "unspecified-hf-model";
+  if (state.modelSource === "azure") return state.azureModelPath || "AzureML Asset Container";
+  return "Offline Weights Folder";
+}
+
+function buildQueuedBatchJob(state: UIState) {
+  const mid = resolveQueuedModelIdentifier(state);
+  const activePassesNames = collectActivePassNames(state.passes);
+  const jobName = `Staged: ${mid.split("/").pop()} - ${state.ihvProvider.replace("ExecutionProvider", "")}`;
+  return {
+    id: "job-" + Date.now(),
+    name: jobName,
+    modelSource: state.modelSource,
+    modelIdentifier: mid,
+    provider: state.ihvProvider,
+    passes: activePassesNames,
+    recipeJson: buildRecipeJsonFromState(state),
+    status: "queued" as const,
+    progress: 0,
+    progressKnown: true,
+    logs: ["Job created from active template configuration. Awaiting queue start."],
+  };
+}
+
+function describeAppliedMcpPatches(
+  patches: Partial<UIState>,
+  statePasses: UIState["passes"],
+  appliedQuirks: string[],
+): string[] {
+  const appliedParts: string[] = [];
+  if (patches.cacheDir) appliedParts.push(`cacheDir=${patches.cacheDir}`);
+  if (patches.passRecipeOverrides) {
+    appliedParts.push(`passOverrides=${Object.keys(patches.passRecipeOverrides).join("+")}`);
+  }
+  if (patches.passes) {
+    const changed = Object.entries(patches.passes)
+      .filter(([k, v]) => (statePasses as Record<string, unknown>)[k] !== v)
+      .map(([k, v]) => `${k}=${JSON.stringify(v)}`);
+    if (changed.length) appliedParts.push(...changed.slice(0, 8));
+  }
+  if (appliedQuirks.length) appliedParts.push(`quirks=${appliedQuirks.join("+")}`);
+  return appliedParts;
+}
+
 function LoadingFallback({ label, minH }: { label: string; minH?: string }) {
   return (
     <div className="flex items-center justify-center w-full" style={minH ? { minHeight: minH } : undefined}>
@@ -265,20 +321,7 @@ export function ExecutionWorkspace({
       setState(patches);
     }
 
-    const appliedParts: string[] = [];
-    if (patches.cacheDir) appliedParts.push(`cacheDir=${patches.cacheDir}`);
-    if (patches.passRecipeOverrides) {
-      appliedParts.push(`passOverrides=${Object.keys(patches.passRecipeOverrides).join("+")}`);
-    }
-    if (patches.passes) {
-      const changed = Object.entries(patches.passes)
-        .filter(([k, v]) => (state.passes as Record<string, unknown>)[k] !== v)
-        .map(([k, v]) => `${k}=${JSON.stringify(v)}`);
-      if (changed.length) appliedParts.push(...changed.slice(0, 8));
-    }
-    if (appliedQuirks.length) {
-      appliedParts.push(`quirks=${appliedQuirks.join("+")}`);
-    }
+    const appliedParts = describeAppliedMcpPatches(patches, state.passes, appliedQuirks);
 
     setExecutionLogs((prev) => [
       ...prev,
@@ -553,54 +596,17 @@ ${owrPlatform === "web"
           : `[ERROR] Cannot queue batch job: recipe schema invalid.\n${freshSchemaErrors.map((e) => `[SCHEMA] ${e}`).join("\n")}`,
         ...(fresh.schema.valid
           ? [
-            ...fresh.validation.issues
-              .filter((issue) => issue.severity === "critical")
-              .map((issue) => `[BLOCK] ${issue.title}: ${issue.description}`),
-            ...freshBlockLines,
-          ]
+              ...fresh.validation.issues
+                .filter((issue) => issue.severity === "critical")
+                .map((issue) => `[BLOCK] ${issue.title}: ${issue.description}`),
+              ...freshBlockLines,
+            ]
           : []),
       ]);
       return;
     }
 
-    const activePassesNames: string[] = [];
-    if (state.passes.conversion)
-      activePassesNames.push(
-        `Conversion (${state.passes.conversionFormat === "onnx" ? "ONNX" : "OpenVINO"})`,
-      );
-    if (state.passes.quantization) activePassesNames.push(`Quantization (${state.passes.quantPrecision})`);
-    if (state.passes.pruning) activePassesNames.push(`Pruning (${state.passes.pruningMethod})`);
-    if (state.passes.onnxTransforms) activePassesNames.push("ORT Transforms");
-
-    if (activePassesNames.length === 0) {
-      activePassesNames.push("Default Baseline Export");
-    }
-
-    let mid = "Offline Weights Folder";
-    if (state.modelSource === "huggingface") {
-      mid = state.hfModelId || "unspecified-hf-model";
-    } else if (state.modelSource === "azure") {
-      mid = state.azureModelPath || "AzureML Asset Container";
-    }
-
-    const jobName = `Staged: ${mid.split("/").pop()} - ${state.ihvProvider.replace("ExecutionProvider", "")}`;
-
-    const recipeJsonForJob = buildRecipeJsonFromState(state);
-
-    const newJob = {
-      id: "job-" + Date.now(),
-      name: jobName,
-      modelSource: state.modelSource,
-      modelIdentifier: mid,
-      provider: state.ihvProvider,
-      passes: activePassesNames,
-      recipeJson: recipeJsonForJob,
-      status: "queued" as const,
-      progress: 0,
-      progressKnown: true,
-      logs: ["Job created from active template configuration. Awaiting queue start."],
-    };
-
+    const newJob = buildQueuedBatchJob(state);
     const currentJobs = state.batchJobs || [];
     setState({ batchJobs: [...currentJobs, newJob] });
     setJustQueued(true);

--- a/src/components/features/ExecutionWorkspace.tsx
+++ b/src/components/features/ExecutionWorkspace.tsx
@@ -211,13 +211,13 @@ export function ExecutionWorkspace({
   const lastClickedIndexRef = useRef<number | null>(null);
 
   /** Card self-submits feedback; parent hook is optional analytics / future history annotation. */
-  const handleFeedbackSubmitted = useCallback(
-    (payload: { matched_entry: string; rating: McpTroubleshootFeedbackRating }) => {
-      // No UI mutation — diagnosis display and history stay as-is after thumbs.
-      void payload.matched_entry;
-    },
-    [],
-  );
+  const handleFeedbackSubmitted = (payload: {
+    matched_entry: string;
+    rating: McpTroubleshootFeedbackRating;
+  }) => {
+    // No UI mutation — diagnosis display and history stay as-is after thumbs.
+    void payload.matched_entry;
+  };
 
   const handleApplyMcpFix = () => {
     if (!displayedDiagnostic || !canApplyMcpDiagnostic(displayedDiagnostic)) {

--- a/src/components/features/ExecutionWorkspace.tsx
+++ b/src/components/features/ExecutionWorkspace.tsx
@@ -69,6 +69,7 @@ import { JobHistoryModal } from "@/components/features/JobHistoryModal";
 import { ReportIssueModal } from "@/components/ReportIssueModal";
 import { Bug } from "lucide-react";
 import type { ReportArea } from "@/lib/issueReport";
+import type { McpTroubleshootFeedbackRating } from "@/types";
 
 const RecipeGraphView = lazy(() => import("./RecipeGraphView").then((m) => ({ default: m.RecipeGraphView })));
 
@@ -193,12 +194,33 @@ export function ExecutionWorkspace({
   const [diagnosisHistory, setDiagnosisHistory] = useState<DiagnosisEntry[]>([]);
   const [activeHistoryIndex, setActiveHistoryIndex] = useState(-1);
 
+  // Browse older history entries on the card (matched_entry + thumbs); index 0 / none = live MCP result.
+  const viewingHistoricalDiagnosis =
+    activeHistoryIndex > 0 && activeHistoryIndex < diagnosisHistory.length;
+  const displayedDiagnostic = viewingHistoricalDiagnosis
+    ? diagnosisHistory[activeHistoryIndex]!.diagnostic
+    : mcpDiagnostic;
+  const displayedFixApplied = viewingHistoricalDiagnosis
+    ? diagnosisHistory[activeHistoryIndex]!.fixApplied
+      ? "applied"
+      : ""
+    : mcpFixApplied;
+
   // Log line selection state for manual diagnosis
   const [selectedLogIndices, setSelectedLogIndices] = useState<Set<number>>(new Set());
   const lastClickedIndexRef = useRef<number | null>(null);
 
+  /** Card self-submits feedback; parent hook is optional analytics / future history annotation. */
+  const handleFeedbackSubmitted = useCallback(
+    (payload: { matched_entry: string; rating: McpTroubleshootFeedbackRating }) => {
+      // No UI mutation — diagnosis display and history stay as-is after thumbs.
+      void payload.matched_entry;
+    },
+    [],
+  );
+
   const handleApplyMcpFix = () => {
-    if (!mcpDiagnostic || !canApplyMcpDiagnostic(mcpDiagnostic)) {
+    if (!displayedDiagnostic || !canApplyMcpDiagnostic(displayedDiagnostic)) {
       setExecutionLogs((prev) => [
         ...prev,
         "[MCP FIX] Nothing auto-applyable — follow Recommended Fix / Known Quirks manually.",
@@ -206,13 +228,20 @@ export function ExecutionWorkspace({
       return;
     }
 
-    if (isStudioHfTaskSpeechFix(mcpDiagnostic)) {
+    if (isStudioHfTaskSpeechFix(displayedDiagnostic)) {
       setState({ hfTask: "automatic-speech-recognition" });
       setExecutionLogs((prev) => [
         ...prev,
         "[FIX] Hugging Face task corrected to `automatic-speech-recognition` for Whisper. Rebuild/refresh the recipe, then run Execute Live again.",
       ]);
       setMcpFixApplied("applied");
+      // Mark the history row that matches the applied diagnostic (live = index 0).
+      const historyIdx = viewingHistoricalDiagnosis ? activeHistoryIndex : 0;
+      if (historyIdx >= 0 && historyIdx < diagnosisHistory.length) {
+        setDiagnosisHistory((prev) =>
+          prev.map((entry, idx) => (idx === historyIdx ? { ...entry, fixApplied: true } : entry)),
+        );
+      }
       return;
     }
 
@@ -221,7 +250,7 @@ export function ExecutionWorkspace({
       logs,
       appliedQuirks,
       notedQuirks: _notedQuirks,
-    } = applyMcpDiagnosticToUiState(mcpDiagnostic, state.passes, state.passRecipeOverrides);
+    } = applyMcpDiagnosticToUiState(displayedDiagnostic, state.passes, state.passRecipeOverrides);
 
     const hasPatches = Object.keys(patches).length > 0;
     if (!hasPatches && logs.length === 0) {
@@ -259,7 +288,16 @@ export function ExecutionWorkspace({
         : "[MCP FIX] Logged notes only — no UI fields changed.",
     ]);
     // Gate success UI state on actual applied quirks/patches only, not noted quirks
-    setMcpFixApplied(hasPatches || appliedQuirks.length > 0 ? "applied" : "");
+    const applied = hasPatches || appliedQuirks.length > 0;
+    setMcpFixApplied(applied ? "applied" : "");
+    if (applied) {
+      const historyIdx = viewingHistoricalDiagnosis ? activeHistoryIndex : 0;
+      if (historyIdx >= 0 && historyIdx < diagnosisHistory.length) {
+        setDiagnosisHistory((prev) =>
+          prev.map((entry, idx) => (idx === historyIdx ? { ...entry, fixApplied: true } : entry)),
+        );
+      }
+    }
   };
 
   // Clear log selection when logs change (new run starts)
@@ -1657,15 +1695,16 @@ ${owrPlatform === "web"
             />
           </div>
 
-          {/* MCP Diagnostic & Auto-Fix Card */}
+          {/* MCP Diagnostic & Auto-Fix Card (matched_entry from MCP/local parsers enables thumbs) */}
           {executionStatus === "failed" && (
             <MCPDiagnosticCard
-              diagnostic={mcpDiagnostic}
+              diagnostic={displayedDiagnostic}
               isDiagnosing={isDiagnosing}
-              fixApplied={mcpFixApplied}
+              fixApplied={displayedFixApplied}
               onApplyFix={handleApplyMcpFix}
               onRunDiagnosis={handleDiagnose}
               error={diagnoseError}
+              onFeedbackSubmitted={handleFeedbackSubmitted}
             />
           )}
         </CardContent>

--- a/src/components/features/MCPDiagnosticCard.test.tsx
+++ b/src/components/features/MCPDiagnosticCard.test.tsx
@@ -1,0 +1,381 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor, act } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { McpDiagnostic, McpTroubleshootFeedbackResult } from "@/types";
+
+const mockRequestFeedback = vi.fn();
+
+vi.mock("@/lib/hooks", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/hooks")>();
+  return {
+    ...actual,
+    requestMcpTroubleshootFeedback: (...args: unknown[]) => mockRequestFeedback(...args),
+  };
+});
+
+import { MCPDiagnosticCard } from "./MCPDiagnosticCard";
+
+const MATCHED: McpDiagnostic = {
+  matched_entry: "onnxruntime-large-model-external-data",
+  title: "ONNX Export Fails for Models > 2GB",
+  root_cause: "Protobuf size limit for large models.",
+  workaround: "Enable external data format in OnnxConversion.",
+  updated_config: { use_external_data_format: true },
+  domain: "olive",
+  applyable: true,
+};
+
+const UNMATCHED: McpDiagnostic = {
+  matched_entry: null,
+  title: "Unrecognized error",
+  root_cause: "No KB match for this log pattern.",
+  workaround: "Inspect the full Olive log and retry with a simpler pass chain.",
+  domain: null,
+};
+
+const EMPTY_MATCHED: McpDiagnostic = {
+  matched_entry: "",
+  title: "Local-only pattern",
+  root_cause: "Matched by a local log heuristic without a stable KB id.",
+  workaround: "Follow the recommended fix manually.",
+};
+
+function okResult(
+  rating: "thumbs-up" | "thumbs-down",
+  entry = MATCHED.matched_entry!,
+): McpTroubleshootFeedbackResult {
+  return {
+    status: "ok",
+    matched_entry: entry,
+    rating,
+    reason_code: null,
+    thumbs_up: rating === "thumbs-up" ? 1 : 0,
+    thumbs_down: rating === "thumbs-down" ? 1 : 0,
+    total: 1,
+    score_delta: rating === "thumbs-up" ? 0.01 : -0.01,
+  };
+}
+
+describe("MCPDiagnosticCard", () => {
+  beforeEach(() => {
+    mockRequestFeedback.mockReset();
+  });
+
+  it("renders core diagnostic fields and Apply Fix when config is applyable", () => {
+    const onApplyFix = vi.fn();
+    render(
+      <MCPDiagnosticCard
+        diagnostic={MATCHED}
+        isDiagnosing={false}
+        fixApplied=""
+        onApplyFix={onApplyFix}
+      />,
+    );
+
+    expect(screen.getByText(MATCHED.title)).toBeDefined();
+    expect(screen.getByText(/Root Cause:/i)).toBeDefined();
+    expect(screen.getByText(/Recommended Fix:/i)).toBeDefined();
+    expect(screen.getByRole("button", { name: /Apply Fix/i })).toBeDefined();
+  });
+
+  it("shows accessible thumbs controls only when matched_entry is a non-empty string", () => {
+    const { rerender } = render(
+      <MCPDiagnosticCard
+        diagnostic={MATCHED}
+        isDiagnosing={false}
+        fixApplied=""
+        onApplyFix={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: /Thumbs up/i })).toBeDefined();
+    expect(screen.getByRole("button", { name: /Thumbs down/i })).toBeDefined();
+    expect(screen.getByText("Helpful?")).toBeDefined();
+
+    rerender(
+      <MCPDiagnosticCard
+        diagnostic={UNMATCHED}
+        isDiagnosing={false}
+        fixApplied=""
+        onApplyFix={vi.fn()}
+      />,
+    );
+    expect(screen.queryByRole("button", { name: /Thumbs up/i })).toBeNull();
+    expect(screen.queryByRole("button", { name: /Thumbs down/i })).toBeNull();
+    expect(screen.queryByText("Helpful?")).toBeNull();
+
+    rerender(
+      <MCPDiagnosticCard
+        diagnostic={EMPTY_MATCHED}
+        isDiagnosing={false}
+        fixApplied=""
+        onApplyFix={vi.fn()}
+      />,
+    );
+    expect(screen.queryByRole("button", { name: /Thumbs up/i })).toBeNull();
+    expect(screen.queryByRole("button", { name: /Thumbs down/i })).toBeNull();
+  });
+
+  it("submits thumbs-up once, disables both controls, and notifies the parent", async () => {
+    const user = userEvent.setup();
+    const onFeedbackSubmitted = vi.fn();
+    mockRequestFeedback.mockResolvedValueOnce(okResult("thumbs-up"));
+
+    render(
+      <MCPDiagnosticCard
+        diagnostic={MATCHED}
+        isDiagnosing={false}
+        fixApplied=""
+        onApplyFix={vi.fn()}
+        onFeedbackSubmitted={onFeedbackSubmitted}
+      />,
+    );
+
+    const up = screen.getByRole("button", { name: /Thumbs up — this diagnosis was helpful/i });
+    await user.click(up);
+
+    await waitFor(() => {
+      expect(mockRequestFeedback).toHaveBeenCalledTimes(1);
+    });
+    expect(mockRequestFeedback).toHaveBeenCalledWith(
+      { matched_entry: MATCHED.matched_entry, rating: "thumbs-up" },
+      expect.any(AbortSignal),
+    );
+
+    await waitFor(() => {
+      expect(onFeedbackSubmitted).toHaveBeenCalledWith({
+        matched_entry: MATCHED.matched_entry,
+        rating: "thumbs-up",
+      });
+    });
+
+    expect(screen.getByText(/Thanks for the feedback/i)).toBeDefined();
+    expect(
+      (screen.getByRole("button", { name: /Thumbs up submitted/i }) as HTMLButtonElement).disabled,
+    ).toBe(true);
+    expect((screen.getByRole("button", { name: /Thumbs down/i }) as HTMLButtonElement).disabled).toBe(
+      true,
+    );
+
+    // Second click must not re-submit (one submission per result/rating).
+    await user.click(screen.getByRole("button", { name: /Thumbs up submitted/i }));
+    expect(mockRequestFeedback).toHaveBeenCalledTimes(1);
+  });
+
+  it("submits thumbs-down once and does not allow switching rating after success", async () => {
+    const user = userEvent.setup();
+    mockRequestFeedback.mockResolvedValueOnce(okResult("thumbs-down"));
+
+    render(
+      <MCPDiagnosticCard
+        diagnostic={MATCHED}
+        isDiagnosing={false}
+        fixApplied=""
+        onApplyFix={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /Thumbs down — this diagnosis was not helpful/i }));
+
+    await waitFor(() => {
+      expect(mockRequestFeedback).toHaveBeenCalledTimes(1);
+    });
+    expect(mockRequestFeedback).toHaveBeenCalledWith(
+      { matched_entry: MATCHED.matched_entry, rating: "thumbs-down" },
+      expect.any(AbortSignal),
+    );
+
+    await waitFor(() => {
+      expect(
+        (screen.getByRole("button", { name: /Thumbs down submitted/i }) as HTMLButtonElement).disabled,
+      ).toBe(true);
+    });
+
+    await user.click(screen.getByRole("button", { name: /Thumbs up/i }));
+    expect(mockRequestFeedback).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps controls enabled and shows retry guidance when the MCP proxy fails", async () => {
+    const user = userEvent.setup();
+    const onFeedbackSubmitted = vi.fn();
+    mockRequestFeedback.mockResolvedValueOnce({
+      status: "error",
+      error: "http_error",
+      message: "Feedback failed (HTTP 502)",
+    });
+
+    render(
+      <MCPDiagnosticCard
+        diagnostic={MATCHED}
+        isDiagnosing={false}
+        fixApplied=""
+        onApplyFix={vi.fn()}
+        onFeedbackSubmitted={onFeedbackSubmitted}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /Thumbs up — this diagnosis was helpful/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toBeDefined();
+    });
+    expect(screen.getByText(/Feedback failed \(HTTP 502\)/i)).toBeDefined();
+    expect(screen.getByText(/You can try again/i)).toBeDefined();
+    expect(onFeedbackSubmitted).not.toHaveBeenCalled();
+
+    const up = screen.getByRole("button", { name: /Thumbs up — this diagnosis was helpful/i });
+    const down = screen.getByRole("button", { name: /Thumbs down — this diagnosis was not helpful/i });
+    expect((up as HTMLButtonElement).disabled).toBe(false);
+    expect((down as HTMLButtonElement).disabled).toBe(false);
+
+    mockRequestFeedback.mockResolvedValueOnce(okResult("thumbs-up"));
+    await user.click(up);
+
+    await waitFor(() => {
+      expect(onFeedbackSubmitted).toHaveBeenCalledTimes(1);
+    });
+    expect(mockRequestFeedback).toHaveBeenCalledTimes(2);
+  });
+
+  it("resets feedback state when matched_entry changes (new diagnosis target)", async () => {
+    const user = userEvent.setup();
+    mockRequestFeedback.mockResolvedValueOnce(okResult("thumbs-up"));
+
+    const { rerender } = render(
+      <MCPDiagnosticCard
+        diagnostic={MATCHED}
+        isDiagnosing={false}
+        fixApplied=""
+        onApplyFix={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /Thumbs up — this diagnosis was helpful/i }));
+    await waitFor(() => {
+      expect(screen.getByText(/Thanks for the feedback/i)).toBeDefined();
+    });
+
+    const next: McpDiagnostic = {
+      ...MATCHED,
+      matched_entry: "quantization-precision-mismatch",
+      title: "Quantization Precision Not Supported",
+    };
+    rerender(
+      <MCPDiagnosticCard
+        diagnostic={next}
+        isDiagnosing={false}
+        fixApplied=""
+        onApplyFix={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByText(/Thanks for the feedback/i)).toBeNull();
+    const up = screen.getByRole("button", { name: /Thumbs up — this diagnosis was helpful/i });
+    expect((up as HTMLButtonElement).disabled).toBe(false);
+
+    mockRequestFeedback.mockResolvedValueOnce(
+      okResult("thumbs-down", "quantization-precision-mismatch"),
+    );
+    await user.click(screen.getByRole("button", { name: /Thumbs down — this diagnosis was not helpful/i }));
+    await waitFor(() => {
+      expect(mockRequestFeedback).toHaveBeenLastCalledWith(
+        { matched_entry: "quantization-precision-mismatch", rating: "thumbs-down" },
+        expect.any(AbortSignal),
+      );
+    });
+  });
+
+  it("does not block Apply Fix while feedback is idle or after feedback success", async () => {
+    const user = userEvent.setup();
+    const onApplyFix = vi.fn();
+    mockRequestFeedback.mockResolvedValueOnce(okResult("thumbs-up"));
+
+    render(
+      <MCPDiagnosticCard
+        diagnostic={MATCHED}
+        isDiagnosing={false}
+        fixApplied=""
+        onApplyFix={onApplyFix}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /Apply Fix/i }));
+    expect(onApplyFix).toHaveBeenCalledTimes(1);
+
+    await user.click(screen.getByRole("button", { name: /Thumbs up — this diagnosis was helpful/i }));
+    await waitFor(() => {
+      expect(screen.getByText(/Thanks for the feedback/i)).toBeDefined();
+    });
+
+    // Apply Fix remains independently controlled by fixApplied / canApply.
+    await user.click(screen.getByRole("button", { name: /Apply Fix/i }));
+    expect(onApplyFix).toHaveBeenCalledTimes(2);
+  });
+
+  it("shows diagnosing and error states without feedback controls", () => {
+    const { rerender } = render(
+      <MCPDiagnosticCard
+        diagnostic={null}
+        isDiagnosing={true}
+        fixApplied=""
+        onApplyFix={vi.fn()}
+      />,
+    );
+    expect(screen.getByText(/Diagnosing with MCP KB/i)).toBeDefined();
+    expect(screen.queryByRole("button", { name: /Thumbs up/i })).toBeNull();
+
+    rerender(
+      <MCPDiagnosticCard
+        diagnostic={null}
+        isDiagnosing={false}
+        fixApplied=""
+        onApplyFix={vi.fn()}
+        error="MCP proxy unavailable"
+        onRunDiagnosis={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("MCP proxy unavailable")).toBeDefined();
+    expect(screen.queryByRole("button", { name: /Thumbs up/i })).toBeNull();
+  });
+
+  it("ignores concurrent clicks while a submission is in flight", async () => {
+    const user = userEvent.setup();
+    let resolveFeedback!: (value: McpTroubleshootFeedbackResult) => void;
+    mockRequestFeedback.mockImplementationOnce(
+      () =>
+        new Promise<McpTroubleshootFeedbackResult>((resolve) => {
+          resolveFeedback = resolve;
+        }),
+    );
+
+    render(
+      <MCPDiagnosticCard
+        diagnostic={MATCHED}
+        isDiagnosing={false}
+        fixApplied=""
+        onApplyFix={vi.fn()}
+      />,
+    );
+
+    const up = screen.getByRole("button", { name: /Thumbs up — this diagnosis was helpful/i });
+    await user.click(up);
+    await waitFor(() => {
+      expect(screen.getByText(/Sending/i)).toBeDefined();
+    });
+
+    // Both controls disabled while submitting.
+    expect((up as HTMLButtonElement).disabled).toBe(true);
+    expect((screen.getByRole("button", { name: /Thumbs down/i }) as HTMLButtonElement).disabled).toBe(
+      true,
+    );
+
+    await act(async () => {
+      resolveFeedback(okResult("thumbs-up"));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(/Thanks for the feedback/i)).toBeDefined();
+    });
+    expect(mockRequestFeedback).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/features/MCPDiagnosticCard.tsx
+++ b/src/components/features/MCPDiagnosticCard.tsx
@@ -1,7 +1,9 @@
-import { Check, Wrench } from "lucide-react";
-import type { McpDiagnostic } from "@/types";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Check, ThumbsDown, ThumbsUp, Wrench } from "lucide-react";
+import type { McpDiagnostic, McpTroubleshootFeedbackRating } from "@/types";
 import { canApplyMcpDiagnostic, matchActionableQuirks } from "@/lib/mcpConfigMapping";
 import type { LocalLogDiagnostic } from "@/lib/logFailurePatterns";
+import { hasMcpFeedbackTarget, requestMcpTroubleshootFeedback } from "@/lib/hooks";
 
 export interface MCPDiagnosticCardProps {
   /** The diagnostic result from the MCP knowledge base. Null = no result yet. */
@@ -16,14 +18,168 @@ export interface MCPDiagnosticCardProps {
   onRunDiagnosis?: () => void;
   /** Fetch/proxy failure message to show instead of a fake "Querying..." state. */
   error?: string | null;
+  /**
+   * Optional: fired after a successful thumbs feedback submission.
+   * Parents (ExecutionWorkspace / Batch) may wire analytics or history; diagnosis display does not wait on this.
+   */
+  onFeedbackSubmitted?: (payload: {
+    matched_entry: string;
+    rating: McpTroubleshootFeedbackRating;
+  }) => void;
+}
+
+type FeedbackStatus = "idle" | "submitting" | "success" | "error";
+
+interface DiagnosticFeedbackButtonsProps {
+  matchedEntry: string;
+  onFeedbackSubmitted?: MCPDiagnosticCardProps["onFeedbackSubmitted"];
+}
+
+/**
+ * Accessible thumbs-up / thumbs-down for a single matched KB entry.
+ * Submits via the MCP proxy; disables after success; leaves controls enabled for retry on failure.
+ */
+function DiagnosticFeedbackButtons({
+  matchedEntry,
+  onFeedbackSubmitted,
+}: DiagnosticFeedbackButtonsProps) {
+  const [status, setStatus] = useState<FeedbackStatus>("idle");
+  const [submittedRating, setSubmittedRating] = useState<McpTroubleshootFeedbackRating | null>(null);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const statusRef = useRef<FeedbackStatus>(status);
+  const abortRef = useRef<AbortController | null>(null);
+
+  statusRef.current = status;
+
+  // Reset when the diagnosis target changes (new match or history navigation).
+  useEffect(() => {
+    abortRef.current?.abort();
+    abortRef.current = null;
+    setStatus("idle");
+    setSubmittedRating(null);
+    setErrorMessage(null);
+  }, [matchedEntry]);
+
+  useEffect(() => {
+    return () => {
+      abortRef.current?.abort();
+    };
+  }, []);
+
+  const submit = useCallback(
+    async (rating: McpTroubleshootFeedbackRating) => {
+      if (statusRef.current === "submitting" || statusRef.current === "success") return;
+
+      abortRef.current?.abort();
+      const controller = new AbortController();
+      abortRef.current = controller;
+
+      setStatus("submitting");
+      setErrorMessage(null);
+      setSubmittedRating(rating);
+
+      const result = await requestMcpTroubleshootFeedback(
+        { matched_entry: matchedEntry, rating },
+        controller.signal,
+      );
+
+      if (controller.signal.aborted) return;
+
+      if (result.status === "ok") {
+        setStatus("success");
+        setSubmittedRating(result.rating);
+        onFeedbackSubmitted?.({
+          matched_entry: result.matched_entry,
+          rating: result.rating,
+        });
+        return;
+      }
+
+      if (result.error === "aborted") return;
+
+      // Failure: re-enable both controls so the user can retry.
+      setStatus("error");
+      setSubmittedRating(null);
+      setErrorMessage(result.message ?? "Could not submit feedback. Try again.");
+    },
+    [matchedEntry, onFeedbackSubmitted],
+  );
+
+  const disabled = status === "submitting" || status === "success";
+  const upActive = submittedRating === "thumbs-up";
+  const downActive = submittedRating === "thumbs-down";
+
+  return (
+    <div className="flex flex-col gap-1 pt-1">
+      <div className="flex items-center gap-1.5 flex-wrap">
+        <span className="text-[10px] text-slate-500 shrink-0">Helpful?</span>
+        <button
+          type="button"
+          aria-label={
+            status === "success" && upActive
+              ? "Thumbs up submitted"
+              : "Thumbs up — this diagnosis was helpful"
+          }
+          aria-pressed={upActive}
+          disabled={disabled}
+          onClick={() => {
+            void submit("thumbs-up");
+          }}
+          className={`inline-flex items-center justify-center rounded border p-1 transition-all cursor-pointer disabled:cursor-not-allowed focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-emerald-400/60 ${
+            upActive && status === "success"
+              ? "border-emerald-500/50 bg-emerald-500/15 text-emerald-400 disabled:opacity-100"
+              : upActive && status === "submitting"
+                ? "border-emerald-500/40 bg-emerald-500/10 text-emerald-400/80 disabled:opacity-70"
+                : "border-slate-700 bg-slate-900/40 text-slate-400 hover:border-emerald-500/40 hover:text-emerald-400 disabled:opacity-50"
+          }`}
+        >
+          <ThumbsUp className="h-3.5 w-3.5" aria-hidden />
+        </button>
+        <button
+          type="button"
+          aria-label={
+            status === "success" && downActive
+              ? "Thumbs down submitted"
+              : "Thumbs down — this diagnosis was not helpful"
+          }
+          aria-pressed={downActive}
+          disabled={disabled}
+          onClick={() => {
+            void submit("thumbs-down");
+          }}
+          className={`inline-flex items-center justify-center rounded border p-1 transition-all cursor-pointer disabled:cursor-not-allowed focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-rose-400/60 ${
+            downActive && status === "success"
+              ? "border-rose-500/50 bg-rose-500/15 text-rose-300 disabled:opacity-100"
+              : downActive && status === "submitting"
+                ? "border-rose-500/40 bg-rose-500/10 text-rose-300/80 disabled:opacity-70"
+                : "border-slate-700 bg-slate-900/40 text-slate-400 hover:border-rose-500/40 hover:text-rose-300 disabled:opacity-50"
+          }`}
+        >
+          <ThumbsDown className="h-3.5 w-3.5" aria-hidden />
+        </button>
+        {status === "submitting" && (
+          <span className="text-[10px] text-slate-500 animate-pulse">Sending…</span>
+        )}
+        {status === "success" && (
+          <span className="text-[10px] text-emerald-400/80">Thanks for the feedback</span>
+        )}
+      </div>
+      {status === "error" && errorMessage ? (
+        <p className="text-[10px] text-rose-300/90" role="alert">
+          {errorMessage}{" "}
+          <span className="text-slate-500">You can try again.</span>
+        </p>
+      ) : null}
+    </div>
+  );
 }
 
 /**
  * Displays MCP-based diagnostics and available fixes for a failed Olive run.
  *
  * Shows loading, error, idle, or diagnostic-result content, including optional
- * log evidence, recommended guidance, automatic fix controls, and diagnosis
- * retry actions.
+ * log evidence, recommended guidance, automatic fix controls, feedback thumbs
+ * (when a matched KB entry is present), and diagnosis retry actions.
  *
  * @param diagnostic - The diagnostic result to display, or `null` when no result is available
  * @param error - An error message to display when diagnosis fails
@@ -36,6 +192,7 @@ export function MCPDiagnosticCard({
   onApplyFix,
   onRunDiagnosis,
   error = null,
+  onFeedbackSubmitted,
 }: MCPDiagnosticCardProps) {
   const canApply = canApplyMcpDiagnostic(diagnostic);
   const actionableQuirkIds = diagnostic ? matchActionableQuirks(diagnostic.relevant_quirks) : [];
@@ -148,6 +305,13 @@ export function MCPDiagnosticCard({
               )}
             </div>
           )}
+
+          {hasMcpFeedbackTarget(diagnostic) ? (
+            <DiagnosticFeedbackButtons
+              matchedEntry={diagnostic.matched_entry}
+              onFeedbackSubmitted={onFeedbackSubmitted}
+            />
+          ) : null}
 
           <div className="pt-1.5 space-y-1">
             <button

--- a/src/components/features/MCPDiagnosticCard.tsx
+++ b/src/components/features/MCPDiagnosticCard.tsx
@@ -53,15 +53,7 @@ function DiagnosticFeedbackButtons({
     statusRef.current = status;
   }, [status]);
 
-  // Reset when the diagnosis target changes (new match or history navigation).
-  useEffect(() => {
-    abortRef.current?.abort();
-    abortRef.current = null;
-    setStatus("idle");
-    setSubmittedRating(null);
-    setErrorMessage(null);
-  }, [matchedEntry]);
-
+  // Feedback remounts when matched_entry changes (key), so no reset effect.
   useEffect(() => {
     return () => {
       abortRef.current?.abort();
@@ -310,6 +302,7 @@ export function MCPDiagnosticCard({
 
           {hasMcpFeedbackTarget(diagnostic) ? (
             <DiagnosticFeedbackButtons
+              key={diagnostic.matched_entry}
               matchedEntry={diagnostic.matched_entry}
               onFeedbackSubmitted={onFeedbackSubmitted}
             />

--- a/src/components/features/MCPDiagnosticCard.tsx
+++ b/src/components/features/MCPDiagnosticCard.tsx
@@ -49,7 +49,9 @@ function DiagnosticFeedbackButtons({
   const statusRef = useRef<FeedbackStatus>(status);
   const abortRef = useRef<AbortController | null>(null);
 
-  statusRef.current = status;
+  useEffect(() => {
+    statusRef.current = status;
+  }, [status]);
 
   // Reset when the diagnosis target changes (new match or history navigation).
   useEffect(() => {

--- a/src/components/features/MCPDiagnosticCard.tsx
+++ b/src/components/features/MCPDiagnosticCard.tsx
@@ -35,6 +35,60 @@ interface DiagnosticFeedbackButtonsProps {
   onFeedbackSubmitted?: MCPDiagnosticCardProps["onFeedbackSubmitted"];
 }
 
+function feedbackThumbClassName(
+  kind: "up" | "down",
+  status: FeedbackStatus,
+  active: boolean,
+): string {
+  const base =
+    "inline-flex items-center justify-center rounded border p-1 transition-all cursor-pointer disabled:cursor-not-allowed focus-visible:outline-none focus-visible:ring-1";
+  if (kind === "up") {
+    if (active && status === "success") {
+      return `${base} focus-visible:ring-emerald-400/60 border-emerald-500/50 bg-emerald-500/15 text-emerald-400 disabled:opacity-100`;
+    }
+    if (active && status === "submitting") {
+      return `${base} focus-visible:ring-emerald-400/60 border-emerald-500/40 bg-emerald-500/10 text-emerald-400/80 disabled:opacity-70`;
+    }
+    return `${base} focus-visible:ring-emerald-400/60 border-slate-700 bg-slate-900/40 text-slate-400 hover:border-emerald-500/40 hover:text-emerald-400 disabled:opacity-50`;
+  }
+  if (active && status === "success") {
+    return `${base} focus-visible:ring-rose-400/60 border-rose-500/50 bg-rose-500/15 text-rose-300 disabled:opacity-100`;
+  }
+  if (active && status === "submitting") {
+    return `${base} focus-visible:ring-rose-400/60 border-rose-500/40 bg-rose-500/10 text-rose-300/80 disabled:opacity-70`;
+  }
+  return `${base} focus-visible:ring-rose-400/60 border-slate-700 bg-slate-900/40 text-slate-400 hover:border-rose-500/40 hover:text-rose-300 disabled:opacity-50`;
+}
+
+interface FeedbackThumbButtonProps {
+  kind: "up" | "down";
+  status: FeedbackStatus;
+  active: boolean;
+  disabled: boolean;
+  onClick: () => void;
+}
+
+function FeedbackThumbButton({ kind, status, active, disabled, onClick }: FeedbackThumbButtonProps) {
+  const Icon = kind === "up" ? ThumbsUp : ThumbsDown;
+  const successLabel = kind === "up" ? "Thumbs up submitted" : "Thumbs down submitted";
+  const idleLabel =
+    kind === "up"
+      ? "Thumbs up — this diagnosis was helpful"
+      : "Thumbs down — this diagnosis was not helpful";
+  return (
+    <button
+      type="button"
+      aria-label={status === "success" && active ? successLabel : idleLabel}
+      aria-pressed={active}
+      disabled={disabled}
+      onClick={onClick}
+      className={feedbackThumbClassName(kind, status, active)}
+    >
+      <Icon className="h-3.5 w-3.5" aria-hidden />
+    </button>
+  );
+}
+
 /**
  * Accessible thumbs-up / thumbs-down for a single matched KB entry.
  * Submits via the MCP proxy; disables after success; leaves controls enabled for retry on failure.
@@ -91,7 +145,6 @@ function DiagnosticFeedbackButtons({
 
       if (result.error === "aborted") return;
 
-      // Failure: re-enable both controls so the user can retry.
       setStatus("error");
       setSubmittedRating(null);
       setErrorMessage(result.message ?? "Could not submit feedback. Try again.");
@@ -107,50 +160,24 @@ function DiagnosticFeedbackButtons({
     <div className="flex flex-col gap-1 pt-1">
       <div className="flex items-center gap-1.5 flex-wrap">
         <span className="text-[10px] text-slate-500 shrink-0">Helpful?</span>
-        <button
-          type="button"
-          aria-label={
-            status === "success" && upActive
-              ? "Thumbs up submitted"
-              : "Thumbs up — this diagnosis was helpful"
-          }
-          aria-pressed={upActive}
+        <FeedbackThumbButton
+          kind="up"
+          status={status}
+          active={upActive}
           disabled={disabled}
           onClick={() => {
             void submit("thumbs-up");
           }}
-          className={`inline-flex items-center justify-center rounded border p-1 transition-all cursor-pointer disabled:cursor-not-allowed focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-emerald-400/60 ${
-            upActive && status === "success"
-              ? "border-emerald-500/50 bg-emerald-500/15 text-emerald-400 disabled:opacity-100"
-              : upActive && status === "submitting"
-                ? "border-emerald-500/40 bg-emerald-500/10 text-emerald-400/80 disabled:opacity-70"
-                : "border-slate-700 bg-slate-900/40 text-slate-400 hover:border-emerald-500/40 hover:text-emerald-400 disabled:opacity-50"
-          }`}
-        >
-          <ThumbsUp className="h-3.5 w-3.5" aria-hidden />
-        </button>
-        <button
-          type="button"
-          aria-label={
-            status === "success" && downActive
-              ? "Thumbs down submitted"
-              : "Thumbs down — this diagnosis was not helpful"
-          }
-          aria-pressed={downActive}
+        />
+        <FeedbackThumbButton
+          kind="down"
+          status={status}
+          active={downActive}
           disabled={disabled}
           onClick={() => {
             void submit("thumbs-down");
           }}
-          className={`inline-flex items-center justify-center rounded border p-1 transition-all cursor-pointer disabled:cursor-not-allowed focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-rose-400/60 ${
-            downActive && status === "success"
-              ? "border-rose-500/50 bg-rose-500/15 text-rose-300 disabled:opacity-100"
-              : downActive && status === "submitting"
-                ? "border-rose-500/40 bg-rose-500/10 text-rose-300/80 disabled:opacity-70"
-                : "border-slate-700 bg-slate-900/40 text-slate-400 hover:border-rose-500/40 hover:text-rose-300 disabled:opacity-50"
-          }`}
-        >
-          <ThumbsDown className="h-3.5 w-3.5" aria-hidden />
-        </button>
+        />
         {status === "submitting" && (
           <span className="text-[10px] text-slate-500 animate-pulse">Sending…</span>
         )}

--- a/src/lib/__tests__/recipePipeline.test.ts
+++ b/src/lib/__tests__/recipePipeline.test.ts
@@ -4,6 +4,7 @@ import {
   parseRecipeJson,
   buildRecipeJsonFromState,
   buildOliveRecipeFromBatchJob,
+  projectUiStateToRecipeEvaluation,
   serializeRecipe,
 } from "@/lib/recipePipeline";
 import { DEFAULT_PASSES } from "@/lib/defaultPasses";
@@ -100,6 +101,185 @@ describe("buildRecipeFromState", () => {
     expect(parsed.engine).toBeDefined();
     expect(parsed.passes).toBeDefined();
     expect(parsed.systems).toBeDefined();
+  });
+});
+
+// ─── projectUiStateToRecipeEvaluation (MCP / studio-recipe bridge) ─
+
+describe("projectUiStateToRecipeEvaluation", () => {
+  /** Stable payload keys for the MCP bridge contract (camelCase, JSON-safe). */
+  const EVALUATION_KEYS = [
+    "effectiveState",
+    "recipe",
+    "schemaErrors",
+    "pipelineIssues",
+    "criticalCount",
+    "warningCount",
+    "isBlocked",
+    "advisories",
+    "localExecutionIssues",
+    "warnings",
+    "isRunnable",
+  ] as const;
+
+  // ✅ Positive: clean GPU config projects a full runnable evaluation payload
+  it("returns the stable UiStateRecipeEvaluation shape for a clean GPU config", () => {
+    // Arrange
+    const state = baseState();
+
+    // Act
+    const result = projectUiStateToRecipeEvaluation(state);
+
+    // Assert — lock payload keys for MCP Python consumers
+    for (const key of EVALUATION_KEYS) {
+      expect(result).toHaveProperty(key);
+    }
+    expect(result.isBlocked).toBe(false);
+    expect(result.isRunnable).toBe(true);
+    expect(result.schemaErrors).toEqual([]);
+    expect(result.criticalCount).toBe(0);
+    expect(Array.isArray(result.pipelineIssues)).toBe(true);
+    expect(Array.isArray(result.advisories)).toBe(true);
+    expect(Array.isArray(result.localExecutionIssues)).toBe(true);
+    expect(Array.isArray(result.warnings)).toBe(true);
+    expect(result.recipe).toHaveProperty("input_model");
+    expect(result.recipe).toHaveProperty("engine");
+    expect(result.recipe).toHaveProperty("passes");
+    expect(result.recipe).toHaveProperty("systems");
+    expect(result.effectiveState.hfModelId).toBe(state.hfModelId);
+  });
+
+  // ✅ Positive: projection matches buildRecipeFromState (single source of truth)
+  it("mirrors buildRecipeFromState recipe, counts, and runnability", () => {
+    // Arrange
+    const state = baseState({
+      ihvProvider: "CUDAExecutionProvider" as IHVProvider,
+      passes: { ...DEFAULT_PASSES, quantization: true, quantMethod: "awq", quantPrecision: "int4" },
+    });
+
+    // Act
+    const built = buildRecipeFromState(state);
+    const projected = projectUiStateToRecipeEvaluation(state);
+
+    // Assert
+    expect(projected.recipe).toEqual(built.recipe);
+    expect(projected.effectiveState).toEqual(built.state);
+    expect(projected.isRunnable).toBe(built.isRunnable);
+    expect(projected.isBlocked).toBe(built.validation.isBlocked);
+    expect(projected.criticalCount).toBe(built.validation.criticalCount);
+    expect(projected.warningCount).toBe(built.validation.warningCount);
+    expect(projected.schemaErrors).toEqual([...built.schema.errors]);
+    expect(projected.pipelineIssues).toEqual([...built.validation.issues]);
+    expect(projected.advisories).toEqual([...built.advisories]);
+    expect(projected.localExecutionIssues).toEqual([...built.localExecutionIssues]);
+    expect(projected.warnings).toEqual(
+      built.validation.issues.filter((issue) => issue.severity === "warning"),
+    );
+  });
+
+  // ✅ Positive: payload is plain JSON (no functions / circular refs)
+  it("produces a JSON-serializable payload without custom replacers", () => {
+    // Arrange
+    const result = projectUiStateToRecipeEvaluation(baseState());
+
+    // Act
+    const json = JSON.stringify(result);
+    const roundTrip = JSON.parse(json) as typeof result;
+
+    // Assert
+    expect(roundTrip.isRunnable).toBe(result.isRunnable);
+    expect(roundTrip.recipe).toEqual(result.recipe);
+    expect(roundTrip.effectiveState.ihvProvider).toBe(result.effectiveState.ihvProvider);
+    expect(roundTrip.pipelineIssues).toEqual(result.pipelineIssues);
+  });
+
+  // ✅ Positive: sanitization is reflected in effectiveState
+  it("exposes sanitized effectiveState (e.g. OpenVINO format coerced on non-OpenVINO EP)", () => {
+    // Arrange
+    const state = baseState({
+      ihvProvider: "CPUExecutionProvider" as IHVProvider,
+      passes: { ...DEFAULT_PASSES, conversion: true, conversionFormat: "openvino" },
+    });
+
+    // Act
+    const result = projectUiStateToRecipeEvaluation(state);
+
+    // Assert
+    expect(result.effectiveState.passes.conversionFormat).toBe("onnx");
+  });
+
+  // ❌ Negative: blocked pipeline still returns recipe + structured critical issues
+  it("returns recipe plus structured issues when the pipeline is blocked", () => {
+    // Arrange — Whisper model with a non-ASR task is a critical runtime issue (no autofix)
+    const state = baseState({
+      modelSource: "huggingface",
+      hfModelId: "openai/whisper-tiny",
+      hfTask: "text-generation",
+      ihvProvider: "CPUExecutionProvider" as IHVProvider,
+    });
+
+    // Act
+    const result = projectUiStateToRecipeEvaluation(state);
+
+    // Assert — evaluation succeeds as data; caller decides not to run Olive
+    expect(result.isBlocked).toBe(true);
+    expect(result.isRunnable).toBe(false);
+    expect(result.criticalCount).toBeGreaterThan(0);
+    expect(result.pipelineIssues.some((i) => i.severity === "critical")).toBe(true);
+    expect(result.pipelineIssues.some((i) => i.id === "hf-task-whisper-mismatch")).toBe(true);
+    expect(result.recipe).toBeDefined();
+    expect(result.recipe).toHaveProperty("input_model");
+    expect(result.recipe).toHaveProperty("passes");
+    // Still JSON-safe for the bridge
+    expect(() => JSON.stringify(result)).not.toThrow();
+  });
+
+  // ❌ Negative: WebGPU is not locally runnable (local-execution issues)
+  it("marks WebGPU configs non-runnable with localExecutionIssues", () => {
+    // Arrange
+    const state = baseState({
+      ihvProvider: "WebGpuExecutionProvider" as IHVProvider,
+    });
+
+    // Act
+    const result = projectUiStateToRecipeEvaluation(state);
+
+    // Assert
+    expect(result.isRunnable).toBe(false);
+    expect(result.localExecutionIssues.length).toBeGreaterThan(0);
+    expect(
+      result.localExecutionIssues.some((i) => i.id === "webgpu-local-execution-unsupported"),
+    ).toBe(true);
+    expect(result.recipe).toHaveProperty("systems");
+  });
+
+  // ❌ Negative: returned issue arrays are defensive copies
+  it("returns defensive copies of issue arrays (mutation does not leak)", () => {
+    // Arrange
+    const result = projectUiStateToRecipeEvaluation(baseState());
+    const originalIssueLen = result.pipelineIssues.length;
+    const originalAdvisoryLen = result.advisories.length;
+
+    // Act — mutate projected arrays
+    result.pipelineIssues.push({
+      id: "test-mutation",
+      severity: "critical",
+      title: "mutated",
+      description: "should not affect a fresh projection",
+    });
+    result.advisories.push({
+      id: "test-adv",
+      severity: "warning",
+      title: "mutated",
+      description: "should not affect a fresh projection",
+    });
+    result.schemaErrors.push("mutated-schema-error");
+
+    // Assert — fresh projection is unaffected
+    const fresh = projectUiStateToRecipeEvaluation(baseState());
+    expect(fresh.pipelineIssues).toHaveLength(originalIssueLen);
+    expect(fresh.advisories).toHaveLength(originalAdvisoryLen);
+    expect(fresh.schemaErrors).not.toContain("mutated-schema-error");
   });
 });
 

--- a/src/lib/hooks.ts
+++ b/src/lib/hooks.ts
@@ -1,6 +1,143 @@
 import { useEffect, useRef, useState, useCallback } from "react";
-import type { McpDiagnostic } from "@/types";
+import {
+  MCP_TROUBLESHOOT_FEEDBACK_RATINGS,
+  MCP_TROUBLESHOOT_FEEDBACK_REASON_CODES,
+  type McpDiagnostic,
+  type McpDiagnosticFrequency,
+  type McpTroubleshootFeedbackArgs,
+  type McpTroubleshootFeedbackError,
+  type McpTroubleshootFeedbackRating,
+  type McpTroubleshootFeedbackReasonCode,
+  type McpTroubleshootFeedbackResult,
+} from "@/types";
 import { matchLocalLogDiagnostic } from "@/lib/logFailurePatterns";
+
+/** Normalize optional string|null MCP fields; empty string → null. */
+function optionalNullableString(value: unknown): string | null | undefined {
+  if (value === undefined) return undefined;
+  if (value === null) return null;
+  if (typeof value === "string") return value.length > 0 ? value : null;
+  return undefined; // invalid type — caller rejects
+}
+
+/** Parse optional frequency blob; invalid shapes are dropped (not fatal). */
+function parseOptionalFrequency(value: unknown): McpDiagnosticFrequency | null | undefined {
+  if (value === undefined) return undefined;
+  if (value === null) return null;
+  if (typeof value !== "object" || Array.isArray(value)) return undefined;
+  const rec = value as Record<string, unknown>;
+  const out: McpDiagnosticFrequency = {};
+  if (rec.occurrence_count !== undefined) {
+    if (typeof rec.occurrence_count !== "number" || !Number.isFinite(rec.occurrence_count)) {
+      return undefined;
+    }
+    out.occurrence_count = rec.occurrence_count;
+  }
+  if (rec.first_seen !== undefined) {
+    if (rec.first_seen !== null && typeof rec.first_seen !== "string") return undefined;
+    out.first_seen = rec.first_seen as string | null;
+  }
+  if (rec.last_seen !== undefined) {
+    if (rec.last_seen !== null && typeof rec.last_seen !== "string") return undefined;
+    out.last_seen = rec.last_seen as string | null;
+  }
+  if (rec.label !== undefined) {
+    if (rec.label !== null && typeof rec.label !== "string") return undefined;
+    out.label = rec.label as string | null;
+  }
+  return out;
+}
+
+/** True when a diagnosis has a stable KB id suitable for feedback submission. */
+export function hasMcpFeedbackTarget(
+  diagnostic: { matched_entry?: string | null } | null | undefined,
+): diagnostic is { matched_entry: string } {
+  return typeof diagnostic?.matched_entry === "string" && diagnostic.matched_entry.length > 0;
+}
+
+/**
+ * Build a typed {@link McpDiagnostic} from an untrusted MCP tool payload.
+ * Forwards only known fields (including feedback key `matched_entry`).
+ * Returns null when required display fields are missing or optionals are malformed.
+ */
+export function parseMcpDiagnosticPayload(payload: Record<string, unknown>): McpDiagnostic | null {
+  if (
+    typeof payload.title !== "string" ||
+    !payload.title ||
+    typeof payload.root_cause !== "string" ||
+    !payload.root_cause ||
+    typeof payload.workaround !== "string" ||
+    !payload.workaround
+  ) {
+    return null;
+  }
+
+  const optionalUpdated =
+    payload.updated_config === undefined ||
+    (payload.updated_config !== null &&
+      typeof payload.updated_config === "object" &&
+      !Array.isArray(payload.updated_config));
+  const optionalQuirks =
+    payload.relevant_quirks === undefined ||
+    (Array.isArray(payload.relevant_quirks) &&
+      payload.relevant_quirks.every((q) => typeof q === "string"));
+  const optionalDomain =
+    payload.domain === undefined ||
+    payload.domain === null ||
+    payload.domain === "olive" ||
+    payload.domain === "studio";
+  const optionalApplyable = payload.applyable === undefined || typeof payload.applyable === "boolean";
+
+  // matched_entry: stable feedback id — string | null | omitted; empty → null
+  const matchedEntry = optionalNullableString(payload.matched_entry);
+  const optionalMatched = matchedEntry !== undefined || payload.matched_entry === undefined;
+
+  const relatedEntry = optionalNullableString(payload.related_olive_entry);
+  const optionalRelated = relatedEntry !== undefined || payload.related_olive_entry === undefined;
+
+  // frequency is best-effort: invalid shape is stripped, not a hard reject
+  const frequency = parseOptionalFrequency(payload.frequency);
+
+  if (
+    !optionalUpdated ||
+    !optionalQuirks ||
+    !optionalDomain ||
+    !optionalApplyable ||
+    !optionalMatched ||
+    !optionalRelated
+  ) {
+    return null;
+  }
+
+  const diagnostic: McpDiagnostic = {
+    title: payload.title,
+    root_cause: payload.root_cause,
+    workaround: payload.workaround,
+    // Always define matched_entry so feedback UI can key off a stable value.
+    matched_entry: matchedEntry === undefined ? null : matchedEntry,
+  };
+
+  if (payload.updated_config !== undefined && payload.updated_config !== null) {
+    diagnostic.updated_config = payload.updated_config as Record<string, unknown>;
+  }
+  if (Array.isArray(payload.relevant_quirks)) {
+    diagnostic.relevant_quirks = payload.relevant_quirks as string[];
+  }
+  if (payload.domain !== undefined) {
+    diagnostic.domain = payload.domain as McpDiagnostic["domain"];
+  }
+  if (typeof payload.applyable === "boolean") {
+    diagnostic.applyable = payload.applyable;
+  }
+  if (relatedEntry !== undefined) {
+    diagnostic.related_olive_entry = relatedEntry;
+  }
+  if (frequency !== undefined) {
+    diagnostic.frequency = frequency;
+  }
+
+  return diagnostic;
+}
 
 /**
  * Auto-clearing error state hook.
@@ -117,61 +254,17 @@ export async function requestMcpDiagnostic(
       return { diagnostic: null, error: payload.error };
     }
 
-    if (
-      payload &&
-      typeof payload.title === "string" &&
-      payload.title &&
-      typeof payload.root_cause === "string" &&
-      payload.root_cause &&
-      typeof payload.workaround === "string" &&
-      payload.workaround
-    ) {
-      const optionalUpdated =
-        payload.updated_config === undefined ||
-        (payload.updated_config !== null &&
-          typeof payload.updated_config === "object" &&
-          !Array.isArray(payload.updated_config));
-      const optionalQuirks =
-        payload.relevant_quirks === undefined ||
-        (Array.isArray(payload.relevant_quirks) &&
-          payload.relevant_quirks.every((q) => typeof q === "string"));
-      const optionalDomain =
-        payload.domain === undefined ||
-        payload.domain === null ||
-        payload.domain === "olive" ||
-        payload.domain === "studio";
-      const optionalApplyable = payload.applyable === undefined || typeof payload.applyable === "boolean";
-      const optionalMatched =
-        payload.matched_entry === undefined ||
-        payload.matched_entry === null ||
-        typeof payload.matched_entry === "string";
-      const optionalRelated =
-        payload.related_olive_entry === undefined ||
-        payload.related_olive_entry === null ||
-        typeof payload.related_olive_entry === "string";
-      if (
-        optionalUpdated &&
-        optionalQuirks &&
-        optionalDomain &&
-        optionalApplyable &&
-        optionalMatched &&
-        optionalRelated
-      ) {
+    if (payload) {
+      const diagnostic = parseMcpDiagnosticPayload(payload);
+      if (diagnostic) {
+        return { diagnostic, error: null };
+      }
+      if (typeof payload.title === "string" && payload.title) {
         return {
-          diagnostic: {
-            ...(payload as unknown as McpDiagnostic),
-            matched_entry: typeof payload.matched_entry === "string" ? payload.matched_entry : null,
-          },
-          error: null,
+          diagnostic: null,
+          error: "Diagnosis returned an incomplete or malformed payload.",
         };
       }
-    }
-
-    if (payload && typeof payload.title === "string" && payload.title) {
-      return {
-        diagnostic: null,
-        error: "Diagnosis returned an incomplete or malformed payload.",
-      };
     }
 
     return { diagnostic: null, error: "Diagnosis returned an unexpected response." };
@@ -182,6 +275,152 @@ export async function requestMcpDiagnostic(
     return {
       diagnostic: null,
       error: err instanceof Error ? err.message : "Diagnosis request failed",
+    };
+  }
+}
+
+const FEEDBACK_RATING_SET = new Set<string>(MCP_TROUBLESHOOT_FEEDBACK_RATINGS);
+const FEEDBACK_REASON_SET = new Set<string>(MCP_TROUBLESHOOT_FEEDBACK_REASON_CODES);
+
+/**
+ * Validate and normalize client-side feedback args before POSTing to MCP.
+ * Rejects empty matched_entry, unknown ratings, and non-allowlisted reason codes.
+ * Never accepts logs or free-form text fields.
+ */
+export function normalizeMcpTroubleshootFeedbackArgs(
+  args: McpTroubleshootFeedbackArgs,
+): { ok: true; args: McpTroubleshootFeedbackArgs } | { ok: false; error: string } {
+  const matched =
+    typeof args.matched_entry === "string" ? args.matched_entry.trim() : "";
+  if (!matched) {
+    return { ok: false, error: "matched_entry must be a non-empty string entry id." };
+  }
+  if (!FEEDBACK_RATING_SET.has(args.rating)) {
+    return { ok: false, error: "rating must be 'thumbs-up' or 'thumbs-down'." };
+  }
+  let reason_code: McpTroubleshootFeedbackReasonCode | undefined;
+  if (args.reason_code !== undefined && args.reason_code !== null) {
+    if (typeof args.reason_code !== "string" || !FEEDBACK_REASON_SET.has(args.reason_code)) {
+      return { ok: false, error: "reason_code must be an allowlisted value or omitted." };
+    }
+    reason_code = args.reason_code;
+  }
+  const normalized: McpTroubleshootFeedbackArgs = {
+    matched_entry: matched,
+    rating: args.rating as McpTroubleshootFeedbackRating,
+  };
+  if (reason_code !== undefined) normalized.reason_code = reason_code;
+  return { ok: true, args: normalized };
+}
+
+function parseFeedbackToolPayload(
+  payload: Record<string, unknown> | null,
+): McpTroubleshootFeedbackResult | McpTroubleshootFeedbackError {
+  if (!payload) {
+    return { status: "error", error: "empty_response", message: "Feedback returned an empty response." };
+  }
+  if (payload.status === "ok" && typeof payload.matched_entry === "string") {
+    const rating = payload.rating;
+    if (typeof rating === "string" && FEEDBACK_RATING_SET.has(rating)) {
+      const thumbs_up = typeof payload.thumbs_up === "number" ? payload.thumbs_up : 0;
+      const thumbs_down = typeof payload.thumbs_down === "number" ? payload.thumbs_down : 0;
+      const reasonRaw = payload.reason_code;
+      const reason_code =
+        reasonRaw === null || reasonRaw === undefined
+          ? null
+          : typeof reasonRaw === "string" && FEEDBACK_REASON_SET.has(reasonRaw)
+            ? (reasonRaw as McpTroubleshootFeedbackReasonCode)
+            : null;
+      const result: McpTroubleshootFeedbackResult = {
+        status: "ok",
+        matched_entry: payload.matched_entry,
+        rating: rating as McpTroubleshootFeedbackRating,
+        reason_code,
+        thumbs_up,
+        thumbs_down,
+        total: typeof payload.total === "number" ? payload.total : thumbs_up + thumbs_down,
+      };
+      if (typeof payload.score_delta === "number") {
+        result.score_delta = payload.score_delta;
+      }
+      return result;
+    }
+  }
+  const error =
+    (typeof payload.error === "string" && payload.error) ||
+    (typeof payload.message === "string" && "feedback_failed") ||
+    "unexpected_response";
+  const message =
+    typeof payload.message === "string"
+      ? payload.message
+      : "Feedback request failed or returned an unexpected response.";
+  return { status: "error", error, message };
+}
+
+/**
+ * Submit local aggregate troubleshoot feedback via the MCP proxy.
+ * Sends only matched_entry + rating (+ optional reason_code) — never logs.
+ */
+export async function requestMcpTroubleshootFeedback(
+  args: McpTroubleshootFeedbackArgs,
+  signal?: AbortSignal,
+): Promise<McpTroubleshootFeedbackResult | McpTroubleshootFeedbackError> {
+  const normalized = normalizeMcpTroubleshootFeedbackArgs(args);
+  if (!normalized.ok) {
+    return { status: "error", error: "invalid_args", message: normalized.error };
+  }
+
+  try {
+    const toolArgs: Record<string, string> = {
+      matched_entry: normalized.args.matched_entry,
+      rating: normalized.args.rating,
+    };
+    if (normalized.args.reason_code) {
+      toolArgs.reason_code = normalized.args.reason_code;
+    }
+
+    const resp = await fetch("/api/mcp/tool", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        toolName: "record_troubleshoot_feedback",
+        args: toolArgs,
+      }),
+      signal,
+    });
+    const data: unknown = await resp.json().catch(() => null);
+    if (signal?.aborted) {
+      return { status: "error", error: "aborted", message: "Feedback request was cancelled." };
+    }
+
+    const record = data && typeof data === "object" ? (data as Record<string, unknown>) : null;
+    const payload =
+      record && record.result && typeof record.result === "object" && !Array.isArray(record.result)
+        ? (record.result as Record<string, unknown>)
+        : record;
+
+    if (!resp.ok) {
+      const msg =
+        (payload && typeof payload.error === "string" && payload.error) ||
+        (payload && typeof payload.message === "string" && payload.message) ||
+        (record && typeof record.error === "string" && record.error) ||
+        `Feedback failed (HTTP ${resp.status})`;
+      return {
+        status: "error",
+        error: typeof payload?.error === "string" ? payload.error : "http_error",
+        message: msg,
+      };
+    }
+
+    return parseFeedbackToolPayload(payload);
+  } catch (err: unknown) {
+    if (signal?.aborted || (err instanceof DOMException && err.name === "AbortError")) {
+      return { status: "error", error: "aborted", message: "Feedback request was cancelled." };
+    }
+    return {
+      status: "error",
+      error: "request_failed",
+      message: err instanceof Error ? err.message : "Feedback request failed",
     };
   }
 }

--- a/src/lib/hooks.ts
+++ b/src/lib/hooks.ts
@@ -27,25 +27,34 @@ function parseOptionalFrequency(value: unknown): McpDiagnosticFrequency | null |
   if (typeof value !== "object" || Array.isArray(value)) return undefined;
   const rec = value as Record<string, unknown>;
   const out: McpDiagnosticFrequency = {};
-  if (rec.occurrence_count !== undefined) {
-    if (typeof rec.occurrence_count !== "number" || !Number.isFinite(rec.occurrence_count)) {
-      return undefined;
-    }
-    out.occurrence_count = rec.occurrence_count;
-  }
-  if (rec.first_seen !== undefined) {
-    if (rec.first_seen !== null && typeof rec.first_seen !== "string") return undefined;
-    out.first_seen = rec.first_seen as string | null;
-  }
-  if (rec.last_seen !== undefined) {
-    if (rec.last_seen !== null && typeof rec.last_seen !== "string") return undefined;
-    out.last_seen = rec.last_seen as string | null;
-  }
-  if (rec.label !== undefined) {
-    if (rec.label !== null && typeof rec.label !== "string") return undefined;
-    out.label = rec.label as string | null;
-  }
+  if (!assignOptionalFrequencyCount(rec, out)) return undefined;
+  if (!assignOptionalFrequencyString(rec, out, "first_seen")) return undefined;
+  if (!assignOptionalFrequencyString(rec, out, "last_seen")) return undefined;
+  if (!assignOptionalFrequencyString(rec, out, "label")) return undefined;
   return out;
+}
+
+function assignOptionalFrequencyCount(
+  rec: Record<string, unknown>,
+  out: McpDiagnosticFrequency,
+): boolean {
+  if (rec.occurrence_count === undefined) return true;
+  if (typeof rec.occurrence_count !== "number" || !Number.isFinite(rec.occurrence_count)) {
+    return false;
+  }
+  out.occurrence_count = rec.occurrence_count;
+  return true;
+}
+
+function assignOptionalFrequencyString(
+  rec: Record<string, unknown>,
+  out: McpDiagnosticFrequency,
+  key: "first_seen" | "last_seen" | "label",
+): boolean {
+  if (rec[key] === undefined) return true;
+  if (rec[key] !== null && typeof rec[key] !== "string") return false;
+  out[key] = rec[key] as string | null;
+  return true;
 }
 
 /** True when a diagnosis has a stable KB id suitable for feedback submission. */
@@ -320,31 +329,8 @@ function parseFeedbackToolPayload(
     return { status: "error", error: "empty_response", message: "Feedback returned an empty response." };
   }
   if (payload.status === "ok" && typeof payload.matched_entry === "string") {
-    const rating = payload.rating;
-    if (typeof rating === "string" && FEEDBACK_RATING_SET.has(rating)) {
-      const thumbs_up = typeof payload.thumbs_up === "number" ? payload.thumbs_up : 0;
-      const thumbs_down = typeof payload.thumbs_down === "number" ? payload.thumbs_down : 0;
-      const reasonRaw = payload.reason_code;
-      const reason_code =
-        reasonRaw === null || reasonRaw === undefined
-          ? null
-          : typeof reasonRaw === "string" && FEEDBACK_REASON_SET.has(reasonRaw)
-            ? (reasonRaw as McpTroubleshootFeedbackReasonCode)
-            : null;
-      const result: McpTroubleshootFeedbackResult = {
-        status: "ok",
-        matched_entry: payload.matched_entry,
-        rating: rating as McpTroubleshootFeedbackRating,
-        reason_code,
-        thumbs_up,
-        thumbs_down,
-        total: typeof payload.total === "number" ? payload.total : thumbs_up + thumbs_down,
-      };
-      if (typeof payload.score_delta === "number") {
-        result.score_delta = payload.score_delta;
-      }
-      return result;
-    }
+    const ok = parseFeedbackOkPayload(payload);
+    if (ok) return ok;
   }
   const error =
     (typeof payload.error === "string" && payload.error) ||
@@ -355,6 +341,35 @@ function parseFeedbackToolPayload(
       ? payload.message
       : "Feedback request failed or returned an unexpected response.";
   return { status: "error", error, message };
+}
+
+function parseFeedbackOkPayload(
+  payload: Record<string, unknown>,
+): McpTroubleshootFeedbackResult | null {
+  const rating = payload.rating;
+  if (typeof rating !== "string" || !FEEDBACK_RATING_SET.has(rating)) return null;
+  const thumbs_up = typeof payload.thumbs_up === "number" ? payload.thumbs_up : 0;
+  const thumbs_down = typeof payload.thumbs_down === "number" ? payload.thumbs_down : 0;
+  const reasonRaw = payload.reason_code;
+  const reason_code =
+    reasonRaw === null || reasonRaw === undefined
+      ? null
+      : typeof reasonRaw === "string" && FEEDBACK_REASON_SET.has(reasonRaw)
+        ? (reasonRaw as McpTroubleshootFeedbackReasonCode)
+        : null;
+  const result: McpTroubleshootFeedbackResult = {
+    status: "ok",
+    matched_entry: payload.matched_entry as string,
+    rating: rating as McpTroubleshootFeedbackRating,
+    reason_code,
+    thumbs_up,
+    thumbs_down,
+    total: typeof payload.total === "number" ? payload.total : thumbs_up + thumbs_down,
+  };
+  if (typeof payload.score_delta === "number") {
+    result.score_delta = payload.score_delta;
+  }
+  return result;
 }
 
 /**

--- a/src/lib/hooks.ts
+++ b/src/lib/hooks.ts
@@ -64,23 +64,18 @@ export function hasMcpFeedbackTarget(
   return typeof diagnostic?.matched_entry === "string" && diagnostic.matched_entry.length > 0;
 }
 
-/**
- * Build a typed {@link McpDiagnostic} from an untrusted MCP tool payload.
- * Forwards only known fields (including feedback key `matched_entry`).
- * Returns null when required display fields are missing or optionals are malformed.
- */
-export function parseMcpDiagnosticPayload(payload: Record<string, unknown>): McpDiagnostic | null {
-  if (
-    typeof payload.title !== "string" ||
-    !payload.title ||
-    typeof payload.root_cause !== "string" ||
-    !payload.root_cause ||
-    typeof payload.workaround !== "string" ||
-    !payload.workaround
-  ) {
-    return null;
-  }
+function mcpDiagnosticRequiredFieldsPresent(payload: Record<string, unknown>): boolean {
+  return (
+    typeof payload.title === "string" &&
+    Boolean(payload.title) &&
+    typeof payload.root_cause === "string" &&
+    Boolean(payload.root_cause) &&
+    typeof payload.workaround === "string" &&
+    Boolean(payload.workaround)
+  );
+}
 
+function mcpDiagnosticOptionalsValid(payload: Record<string, unknown>): boolean {
   const optionalUpdated =
     payload.updated_config === undefined ||
     (payload.updated_config !== null &&
@@ -96,36 +91,30 @@ export function parseMcpDiagnosticPayload(payload: Record<string, unknown>): Mcp
     payload.domain === "olive" ||
     payload.domain === "studio";
   const optionalApplyable = payload.applyable === undefined || typeof payload.applyable === "boolean";
-
-  // matched_entry: stable feedback id — string | null | omitted; empty → null
   const matchedEntry = optionalNullableString(payload.matched_entry);
   const optionalMatched = matchedEntry !== undefined || payload.matched_entry === undefined;
-
   const relatedEntry = optionalNullableString(payload.related_olive_entry);
   const optionalRelated = relatedEntry !== undefined || payload.related_olive_entry === undefined;
+  return (
+    optionalUpdated &&
+    optionalQuirks &&
+    optionalDomain &&
+    optionalApplyable &&
+    optionalMatched &&
+    optionalRelated
+  );
+}
 
-  // frequency is best-effort: invalid shape is stripped, not a hard reject
+function buildMcpDiagnosticFromPayload(payload: Record<string, unknown>): McpDiagnostic {
+  const matchedEntry = optionalNullableString(payload.matched_entry);
+  const relatedEntry = optionalNullableString(payload.related_olive_entry);
   const frequency = parseOptionalFrequency(payload.frequency);
-
-  if (
-    !optionalUpdated ||
-    !optionalQuirks ||
-    !optionalDomain ||
-    !optionalApplyable ||
-    !optionalMatched ||
-    !optionalRelated
-  ) {
-    return null;
-  }
-
   const diagnostic: McpDiagnostic = {
-    title: payload.title,
-    root_cause: payload.root_cause,
-    workaround: payload.workaround,
-    // Always define matched_entry so feedback UI can key off a stable value.
+    title: payload.title as string,
+    root_cause: payload.root_cause as string,
+    workaround: payload.workaround as string,
     matched_entry: matchedEntry === undefined ? null : matchedEntry,
   };
-
   if (payload.updated_config !== undefined && payload.updated_config !== null) {
     diagnostic.updated_config = payload.updated_config as Record<string, unknown>;
   }
@@ -144,8 +133,19 @@ export function parseMcpDiagnosticPayload(payload: Record<string, unknown>): Mcp
   if (frequency !== undefined) {
     diagnostic.frequency = frequency;
   }
-
   return diagnostic;
+}
+
+/**
+ * Build a typed {@link McpDiagnostic} from an untrusted MCP tool payload.
+ * Forwards only known fields (including feedback key `matched_entry`).
+ * Returns null when required display fields are missing or optionals are malformed.
+ */
+export function parseMcpDiagnosticPayload(payload: Record<string, unknown>): McpDiagnostic | null {
+  if (!mcpDiagnosticRequiredFieldsPresent(payload) || !mcpDiagnosticOptionalsValid(payload)) {
+    return null;
+  }
+  return buildMcpDiagnosticFromPayload(payload);
 }
 
 /**
@@ -407,27 +407,7 @@ export async function requestMcpTroubleshootFeedback(
     if (signal?.aborted) {
       return { status: "error", error: "aborted", message: "Feedback request was cancelled." };
     }
-
-    const record = data && typeof data === "object" ? (data as Record<string, unknown>) : null;
-    const payload =
-      record && record.result && typeof record.result === "object" && !Array.isArray(record.result)
-        ? (record.result as Record<string, unknown>)
-        : record;
-
-    if (!resp.ok) {
-      const msg =
-        (payload && typeof payload.error === "string" && payload.error) ||
-        (payload && typeof payload.message === "string" && payload.message) ||
-        (record && typeof record.error === "string" && record.error) ||
-        `Feedback failed (HTTP ${resp.status})`;
-      return {
-        status: "error",
-        error: typeof payload?.error === "string" ? payload.error : "http_error",
-        message: msg,
-      };
-    }
-
-    return parseFeedbackToolPayload(payload);
+    return interpretFeedbackHttpResponse(resp, data);
   } catch (err: unknown) {
     if (signal?.aborted || (err instanceof DOMException && err.name === "AbortError")) {
       return { status: "error", error: "aborted", message: "Feedback request was cancelled." };
@@ -438,6 +418,38 @@ export async function requestMcpTroubleshootFeedback(
       message: err instanceof Error ? err.message : "Feedback request failed",
     };
   }
+}
+
+function feedbackPayloadRecord(data: unknown): {
+  record: Record<string, unknown> | null;
+  payload: Record<string, unknown> | null;
+} {
+  const record = data && typeof data === "object" ? (data as Record<string, unknown>) : null;
+  const payload =
+    record && record.result && typeof record.result === "object" && !Array.isArray(record.result)
+      ? (record.result as Record<string, unknown>)
+      : record;
+  return { record, payload };
+}
+
+function interpretFeedbackHttpResponse(
+  resp: Response,
+  data: unknown,
+): McpTroubleshootFeedbackResult | McpTroubleshootFeedbackError {
+  const { record, payload } = feedbackPayloadRecord(data);
+  if (!resp.ok) {
+    const msg =
+      (payload && typeof payload.error === "string" && payload.error) ||
+      (payload && typeof payload.message === "string" && payload.message) ||
+      (record && typeof record.error === "string" && record.error) ||
+      `Feedback failed (HTTP ${resp.status})`;
+    return {
+      status: "error",
+      error: typeof payload?.error === "string" ? payload.error : "http_error",
+      message: msg,
+    };
+  }
+  return parseFeedbackToolPayload(payload);
 }
 
 /**

--- a/src/lib/pipelineValidation.ts
+++ b/src/lib/pipelineValidation.ts
@@ -796,7 +796,10 @@ export function applyIssueAutofix(state: UIState, issue: PipelineIssue): Partial
   return next;
 }
 
-export function mergeUiState(state: UIState, patch: Partial<UIState>): UIState {
+/** Partial UIState merge patch; nested `passes` keys are shallow-merged at runtime. */
+export type UiStatePatch = Partial<Omit<UIState, "passes">> & { passes?: Partial<UIState["passes"]> };
+
+export function mergeUiState(state: UIState, patch: UiStatePatch): UIState {
   // Replace (do not deep-merge) when the key is present so recipe loads can
   // clear stale MCP overrides with `passRecipeOverrides: {}`. Callers that need
   // incremental accumulation (MCP Apply Fix) must merge onto current overrides

--- a/src/lib/recipePipeline.ts
+++ b/src/lib/recipePipeline.ts
@@ -3,6 +3,7 @@ import {
   getPipelineValidation,
   getLocalExecutionIssues,
   getRemainingAdvisories,
+  PipelineIssue,
   PipelineValidationResult,
   PipelineValidationOptions,
   sanitizePipelineState,
@@ -18,6 +19,35 @@ export interface RecipePipelineResult {
   advisories: ReturnType<typeof getRemainingAdvisories>;
   /** Local-only blockers (e.g. WebGPU Execute Live) not covered by graph validation alone. */
   localExecutionIssues: ReturnType<typeof getLocalExecutionIssues>;
+  isRunnable: boolean;
+}
+
+/**
+ * JSON-safe UIState recipe evaluation for the MCP / studio-recipe bridge.
+ * Plain data only — safe to `JSON.stringify` without custom replacers.
+ */
+export interface UiStateRecipeEvaluation {
+  /** Sanitized state after coerce/autofix (same as `buildRecipeFromState().state`). */
+  effectiveState: UIState;
+  /** Built Olive recipe object. */
+  recipe: Record<string, unknown>;
+  /** Structural schema validation errors (empty when valid). */
+  schemaErrors: string[];
+  /** Full pipeline issue list from validation. */
+  pipelineIssues: PipelineIssue[];
+  /** Count of critical pipeline issues. */
+  criticalCount: number;
+  /** Count of warning-severity pipeline issues. */
+  warningCount: number;
+  /** Whether the pipeline has critical blockers. */
+  isBlocked: boolean;
+  /** Remaining advisories (warning severity, no autofix). */
+  advisories: PipelineIssue[];
+  /** Local-only execution blockers (e.g. WebGPU Execute Live). */
+  localExecutionIssues: PipelineIssue[];
+  /** All warning-severity pipeline issues (includes autofixable warnings). */
+  warnings: PipelineIssue[];
+  /** True when schema is valid, pipeline is not blocked, and no local-execution issues. */
   isRunnable: boolean;
 }
 
@@ -50,6 +80,43 @@ export function buildRecipeFromState(
     advisories: validation.issues.filter((issue) => issue.severity === "warning" && !issue.autofix),
     localExecutionIssues,
     isRunnable: !validation.isBlocked && localExecutionIssues.length === 0 && schema.valid,
+  };
+}
+
+/**
+ * Project UIState into a stable, JSON-safe recipe evaluation payload for the
+ * MCP / studio-recipe bridge. Wraps {@link buildRecipeFromState}; pure — no I/O,
+ * temp files, or Olive execution.
+ *
+ * @param state - The UI state to evaluate
+ * @param options - Optional pipeline validation settings (e.g. hardware probe)
+ */
+export function projectUiStateToRecipeEvaluation(
+  state: UIState,
+  options?: PipelineValidationOptions,
+): UiStateRecipeEvaluation {
+  const {
+    state: effectiveState,
+    recipe,
+    validation,
+    schema,
+    advisories,
+    localExecutionIssues,
+    isRunnable,
+  } = buildRecipeFromState(state, options);
+
+  return {
+    effectiveState,
+    recipe,
+    schemaErrors: [...schema.errors],
+    pipelineIssues: [...validation.issues],
+    criticalCount: validation.criticalCount,
+    warningCount: validation.warningCount,
+    isBlocked: validation.isBlocked,
+    advisories: [...advisories],
+    localExecutionIssues: [...localExecutionIssues],
+    warnings: validation.issues.filter((issue) => issue.severity === "warning"),
+    isRunnable,
   };
 }
 

--- a/src/lib/stores/pipelineStore.ts
+++ b/src/lib/stores/pipelineStore.ts
@@ -3,23 +3,29 @@ import { UIState } from "@/types";
 import { DEFAULT_PASSES } from "@/lib/defaultPasses";
 import { commitUiStateUpdate } from "@/lib/pipelineValidation";
 
-const defaultState: UIState = {
-  modelSource: "huggingface",
-  localFiles: [],
-  azureModelPath: "",
-  hfModelId: "meta-llama/Meta-Llama-3-8B",
-  hfTask: "",
-  hfDataset: "",
-  ihvProvider: "CPUExecutionProvider",
-  openvinoTargetDevice: "CPU",
-  memoryOffload: "gpu_only",
-  cudaVersion: "auto",
-  cacheDir: "",
-  azureStr: "",
-  distributedCaching: false,
-  activeJobId: null,
-  passes: { ...DEFAULT_PASSES },
-};
+/**
+ * Pure factory for default pipeline UI state.
+ * Returns a fresh object each call (no shared mutable singleton).
+ */
+export function createDefaultPipelineState(): UIState {
+  return {
+    modelSource: "huggingface",
+    localFiles: [],
+    azureModelPath: "",
+    hfModelId: "meta-llama/Meta-Llama-3-8B",
+    hfTask: "",
+    hfDataset: "",
+    ihvProvider: "CPUExecutionProvider",
+    openvinoTargetDevice: "CPU",
+    memoryOffload: "gpu_only",
+    cudaVersion: "auto",
+    cacheDir: "",
+    azureStr: "",
+    distributedCaching: false,
+    activeJobId: null,
+    passes: { ...DEFAULT_PASSES },
+  };
+}
 
 interface PipelineStore {
   state: UIState;
@@ -31,7 +37,7 @@ interface PipelineStore {
 }
 
 export const usePipelineStore = create<PipelineStore>((set) => ({
-  state: defaultState,
+  state: createDefaultPipelineState(),
 
   setState: (partial) =>
     set((store) => ({
@@ -45,7 +51,7 @@ export const usePipelineStore = create<PipelineStore>((set) => ({
 
   resetState: () =>
     set({
-      state: commitUiStateUpdate(defaultState, {}),
+      state: commitUiStateUpdate(createDefaultPipelineState(), {}),
     }),
 }));
 

--- a/src/server/__tests__/routes.integration.test.ts
+++ b/src/server/__tests__/routes.integration.test.ts
@@ -12,6 +12,7 @@ import type { Server } from "http";
 
 import { stubGlobalFetch, restoreGlobalFetch } from "./setup.integration.ts";
 import { app, markServerReady } from "../../../server.ts";
+import { jobRegistry } from "../services/olive/state.ts";
 
 let server: Server;
 let baseUrl: string;
@@ -229,6 +230,266 @@ describe("Route integration tests", () => {
 
       expect(typeof body.hint).toBe("string");
       expect(body.hint.length).toBeGreaterThan(0);
+    });
+  });
+
+  // ─── POST /api/mcp/studio-recipe (loopback bridge, no Olive) ─────────────
+
+  describe("POST /api/mcp/studio-recipe", () => {
+    /** Minimal valid partial UIState for a clean CPU conversion recipe. */
+    const validUiState = {
+      modelSource: "huggingface",
+      hfModelId: "meta-llama/Meta-Llama-3-8B",
+      ihvProvider: "CPUExecutionProvider",
+      passes: {
+        conversion: true,
+        conversionFormat: "onnx",
+        quantization: false,
+      },
+    };
+
+    // ✅ Positive: valid UIState returns recipe + validation payload
+    it("returns 200 with recipe and validation fields for a valid uiState", async () => {
+      // Arrange
+      const jobsBefore = jobRegistry.size;
+
+      // Act
+      const res = await fetch(`${baseUrl}/api/mcp/studio-recipe`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ uiState: validUiState }),
+      });
+
+      // Assert
+      expect(res.status).toBe(200);
+      expect(res.headers.get("content-type")).toContain("application/json");
+      const body = await res.json();
+      expect(body.ok).toBe(true);
+      expect(body).toHaveProperty("recipe");
+      expect(body.recipe).toHaveProperty("input_model");
+      expect(body.recipe).toHaveProperty("engine");
+      expect(body.recipe).toHaveProperty("passes");
+      expect(body.recipe).toHaveProperty("systems");
+      expect(body).toHaveProperty("effectiveState");
+      expect(body).toHaveProperty("schemaErrors");
+      expect(body).toHaveProperty("pipelineIssues");
+      expect(body).toHaveProperty("criticalCount");
+      expect(body).toHaveProperty("warningCount");
+      expect(body).toHaveProperty("isBlocked");
+      expect(body).toHaveProperty("advisories");
+      expect(body).toHaveProperty("localExecutionIssues");
+      expect(body).toHaveProperty("warnings");
+      expect(body).toHaveProperty("isRunnable");
+      expect(typeof body.isRunnable).toBe("boolean");
+      expect(Array.isArray(body.pipelineIssues)).toBe(true);
+      expect(Array.isArray(body.schemaErrors)).toBe(true);
+      // Loopback tests must not hit 403
+      expect(res.status).not.toBe(403);
+      // No Olive job side effects
+      expect(jobRegistry.size).toBe(jobsBefore);
+    });
+
+    // ✅ Positive: bare partial UIState (without uiState wrapper) is accepted
+    it("accepts a direct partial UIState object (Python-optional shape)", async () => {
+      // Arrange / Act
+      const res = await fetch(`${baseUrl}/api/mcp/studio-recipe`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(validUiState),
+      });
+
+      // Assert
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.ok).toBe(true);
+      expect(body.recipe).toBeDefined();
+      expect(body.effectiveState.ihvProvider).toBe("CPUExecutionProvider");
+    });
+
+    // ✅ Positive: empty object merges defaults and still evaluates
+    it("evaluates empty body against default pipeline state", async () => {
+      // Arrange / Act
+      const res = await fetch(`${baseUrl}/api/mcp/studio-recipe`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({}),
+      });
+
+      // Assert
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.ok).toBe(true);
+      expect(body.effectiveState).toBeDefined();
+      expect(body.recipe).toBeDefined();
+    });
+
+    // ✅ Positive / blocked: incompatible config returns recipe + structured issues (not 400)
+    it("returns recipe and structured issues for a blocked pipeline (HTTP 200)", async () => {
+      // Arrange — Whisper + wrong HF task → critical pipeline issue after projection
+      const blockedUiState = {
+        modelSource: "huggingface",
+        hfModelId: "openai/whisper-tiny",
+        hfTask: "text-generation",
+        ihvProvider: "CPUExecutionProvider",
+      };
+      const jobsBefore = jobRegistry.size;
+
+      // Act
+      const res = await fetch(`${baseUrl}/api/mcp/studio-recipe`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ uiState: blockedUiState }),
+      });
+
+      // Assert — validation payload, not a client error
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.ok).toBe(true);
+      expect(body.isBlocked).toBe(true);
+      expect(body.isRunnable).toBe(false);
+      expect(body.criticalCount).toBeGreaterThan(0);
+      expect(Array.isArray(body.pipelineIssues)).toBe(true);
+      expect(body.pipelineIssues.some((i: { severity?: string }) => i.severity === "critical")).toBe(
+        true,
+      );
+      expect(body.pipelineIssues.some((i: { id?: string }) => i.id === "hf-task-whisper-mismatch")).toBe(
+        true,
+      );
+      expect(body.recipe).toHaveProperty("input_model");
+      expect(body.recipe).toHaveProperty("passes");
+      // Still no Olive execution
+      expect(jobRegistry.size).toBe(jobsBefore);
+      expect(body).not.toHaveProperty("jobId");
+      expect(body).not.toHaveProperty("oliveJobId");
+    });
+
+    // ❌ Negative: non-object JSON body → 400 invalid_body
+    it("returns 400 invalid_body when body is a JSON array", async () => {
+      // Arrange / Act
+      const res = await fetch(`${baseUrl}/api/mcp/studio-recipe`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify([{ hfModelId: "x" }]),
+      });
+
+      // Assert
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.ok).toBe(false);
+      expect(body.code).toBe("invalid_body");
+      expect(body.error).toMatch(/JSON object/i);
+    });
+
+    // ❌ Negative: uiState must be an object
+    it("returns 400 invalid_ui_state when uiState is not an object", async () => {
+      // Arrange / Act
+      const res = await fetch(`${baseUrl}/api/mcp/studio-recipe`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ uiState: "not-an-object" }),
+      });
+
+      // Assert
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.ok).toBe(false);
+      expect(body.code).toBe("invalid_ui_state");
+      expect(body.error).toMatch(/uiState/i);
+    });
+
+    // ❌ Negative: passes must be a plain object when present
+    it("returns 400 invalid_passes when passes is an array", async () => {
+      // Arrange / Act
+      const res = await fetch(`${baseUrl}/api/mcp/studio-recipe`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          uiState: {
+            hfModelId: "meta-llama/Meta-Llama-3-8B",
+            passes: ["conversion"],
+          },
+        }),
+      });
+
+      // Assert
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.ok).toBe(false);
+      expect(body.code).toBe("invalid_passes");
+      expect(body.error).toMatch(/passes/i);
+    });
+
+    // ❌ Negative: bridge never reaches /olive/run and creates no jobs
+    it("never creates Olive jobs or requires /olive/run (no-execution guarantee)", async () => {
+      // Arrange
+      jobRegistry.clear();
+      const payloads = [
+        { uiState: validUiState },
+        {
+          uiState: {
+            modelSource: "huggingface",
+            hfModelId: "openai/whisper-tiny",
+            hfTask: "text-generation",
+            ihvProvider: "CPUExecutionProvider",
+          },
+        },
+        {
+          uiState: {
+            ihvProvider: "WebGpuExecutionProvider",
+            hfModelId: "microsoft/resnet-50",
+          },
+        },
+      ];
+
+      // Act — multiple bridge evaluations
+      for (const payload of payloads) {
+        const res = await fetch(`${baseUrl}/api/mcp/studio-recipe`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(payload),
+        });
+        expect(res.status).toBe(200);
+        const body = await res.json();
+        expect(body.ok).toBe(true);
+        // Evaluation-only contract: no job identifiers
+        expect(body.jobId).toBeUndefined();
+        expect(body.oliveJobId).toBeUndefined();
+        expect(body.activeJobId).toBeUndefined();
+      }
+
+      // Assert — job registry untouched; unknown job still 404
+      expect(jobRegistry.size).toBe(0);
+      const statusRes = await fetch(`${baseUrl}/api/olive/status/studio-recipe-should-not-exist`);
+      expect(statusRes.status).toBe(404);
+    });
+
+    // ❌ Negative: dangerous keys are ignored (not applied as server config)
+    it("ignores dangerous keys such as batchJobs and activeJobId", async () => {
+      // Arrange / Act
+      const res = await fetch(`${baseUrl}/api/mcp/studio-recipe`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          uiState: {
+            ...validUiState,
+            batchJobs: [{ id: "evil", status: "running" }],
+            activeJobId: "should-not-stick",
+            userScript: "import os; os.system('echo pwned')",
+            passRecipeOverrides: { OnnxConversion: { config: { evil: true } } },
+          },
+        }),
+      });
+
+      // Assert
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.ok).toBe(true);
+      // Defaults win for rejected keys — no attacker-controlled job linkage
+      expect(body.effectiveState.activeJobId == null || body.effectiveState.activeJobId === null).toBe(
+        true,
+      );
+      expect(body.effectiveState.batchJobs).toBeUndefined();
+      expect(jobRegistry.size).toBe(0);
     });
   });
 

--- a/src/server/middleware/rateLimit.ts
+++ b/src/server/middleware/rateLimit.ts
@@ -79,6 +79,15 @@ export const staticServeRateLimit = rateLimit({
   message: "Too many requests",
 });
 
+/** Loopback MCP tool proxy, including write-capable feedback tools. */
+export const mcpToolRateLimit = rateLimit({
+  windowMs: 60_000,
+  max: 30,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: { error: "Too many MCP tool requests. Please wait a minute and try again." },
+});
+
 /** No-side-effect studio-recipe bridge (loopback MCP → UIState recipe validation/build). */
 export const studioRecipeRateLimit = rateLimit({
   windowMs: 60_000,

--- a/src/server/middleware/rateLimit.ts
+++ b/src/server/middleware/rateLimit.ts
@@ -78,3 +78,12 @@ export const staticServeRateLimit = rateLimit({
   legacyHeaders: false,
   message: "Too many requests",
 });
+
+/** No-side-effect studio-recipe bridge (loopback MCP → UIState recipe validation/build). */
+export const studioRecipeRateLimit = rateLimit({
+  windowMs: 60_000,
+  max: 30,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: { ok: false, error: "Too many studio-recipe bridge requests. Please wait a minute and try again." },
+});

--- a/src/server/routes/mcp.ts
+++ b/src/server/routes/mcp.ts
@@ -23,6 +23,7 @@ import {
   kbStatusRateLimit,
   kbSyncRateLimit,
   studioRecipeRateLimit,
+  mcpToolRateLimit,
 } from "../middleware/rateLimit.ts";
 import { readStudioConfig, writeStudioConfig } from "../config.ts";
 import type { KbStatusCache } from "../types.ts";
@@ -32,6 +33,14 @@ import type { KbStatusCache } from "../types.ts";
  * Rejects reverse-proxy hops and non-loopback clients. Never honors
  * OLIVE_ARENA_ALLOW_REMOTE — this bridge is local MCP ↔ Studio only.
  */
+function mcpToolLocalOnly(req: Request, res: Response, next: NextFunction): void {
+  if (hasProxyForwardingHeaders(req) || !isLoopbackRemoteAddress(req.socket.remoteAddress)) {
+    res.status(403).json({ error: "MCP tool proxy is only available from loopback" });
+    return;
+  }
+  next();
+}
+
 function studioRecipeLocalOnly(req: Request, res: Response, next: NextFunction): void {
   if (hasProxyForwardingHeaders(req)) {
     res.status(403).json({
@@ -228,7 +237,7 @@ export function performKbSync():
  */
 export function mountMcpRoutes(router: Router): void {
   // ─── MCP Tool Proxy ───────────────────────────────────────────────────
-  router.post("/mcp/tool", async (req, res) => {
+  router.post("/mcp/tool", mcpToolLocalOnly, mcpToolRateLimit, async (req, res) => {
     const { toolName, args } = req.body as { toolName?: string; args?: Record<string, unknown> };
     if (!toolName) {
       return res.status(400).json({ error: "Missing toolName" });

--- a/src/server/routes/mcp.ts
+++ b/src/server/routes/mcp.ts
@@ -31,9 +31,10 @@ import { readStudioConfig, writeStudioConfig } from "../config.ts";
 import type { KbStatusCache } from "../types.ts";
 
 /**
- * Strict loopback gate for the private studio-recipe bridge.
- * Rejects reverse-proxy hops and non-loopback clients. Never honors
- * OLIVE_ARENA_ALLOW_REMOTE — this bridge is local MCP ↔ Studio only.
+ * Strict loopback gate for the MCP tool proxy (including write-capable tools
+ * such as record_troubleshoot_feedback). Rejects reverse-proxy hops and
+ * non-loopback clients. Never honors OLIVE_ARENA_ALLOW_REMOTE — this proxy is
+ * local MCP ↔ Studio only.
  */
 function mcpToolLocalOnly(req: Request, res: Response, next: NextFunction): void {
   if (hasProxyForwardingHeaders(req) || !isLoopbackRemoteAddress(req.socket.remoteAddress)) {

--- a/src/server/routes/mcp.ts
+++ b/src/server/routes/mcp.ts
@@ -1,8 +1,8 @@
 /**
  * MCP (Model Compatibility Protocol) route handlers.
- * Tool proxy, KB status, KB sync.
+ * Tool proxy, KB status, KB sync, and loopback-only studio-recipe bridge.
  */
-import type { Router } from "express";
+import type { NextFunction, Request, Response, Router } from "express";
 import path from "path";
 import fs from "fs";
 
@@ -14,9 +14,41 @@ import {
   setKbSyncInProgress,
 } from "../services/mcp/state.ts";
 import { callOliveMcpTool } from "../services/mcp/client.ts";
-import { kbStatusRateLimit, kbSyncRateLimit } from "../middleware/rateLimit.ts";
+import { evaluateStudioRecipeBridge } from "../services/mcp/studioRecipeBridge.ts";
+import {
+  hasProxyForwardingHeaders,
+  isLoopbackRemoteAddress,
+} from "../middleware/localOnly.ts";
+import {
+  kbStatusRateLimit,
+  kbSyncRateLimit,
+  studioRecipeRateLimit,
+} from "../middleware/rateLimit.ts";
 import { readStudioConfig, writeStudioConfig } from "../config.ts";
 import type { KbStatusCache } from "../types.ts";
+
+/**
+ * Strict loopback gate for the private studio-recipe bridge.
+ * Rejects reverse-proxy hops and non-loopback clients. Never honors
+ * OLIVE_ARENA_ALLOW_REMOTE — this bridge is local MCP ↔ Studio only.
+ */
+function studioRecipeLocalOnly(req: Request, res: Response, next: NextFunction): void {
+  if (hasProxyForwardingHeaders(req)) {
+    res.status(403).json({
+      ok: false,
+      error: "Studio recipe bridge is only available from loopback (not via reverse proxy)",
+    });
+    return;
+  }
+  if (isLoopbackRemoteAddress(req.socket.remoteAddress)) {
+    next();
+    return;
+  }
+  res.status(403).json({
+    ok: false,
+    error: "Studio recipe bridge is only available from loopback",
+  });
+}
 
 /**
  * Determines whether a value is a non-null object with string keys.
@@ -187,7 +219,10 @@ export function performKbSync():
 }
 
 /**
- * Registers MCP tool proxy, knowledge-base status, and knowledge-base synchronization routes on a router.
+ * Registers MCP tool proxy, studio-recipe bridge, knowledge-base status,
+ * and knowledge-base synchronization routes on a router.
+ *
+ * Paths are relative to the `/api` mount (e.g. `/mcp/tool` → `/api/mcp/tool`).
  *
  * @param router - The router on which to register the MCP routes
  */
@@ -210,6 +245,28 @@ export function mountMcpRoutes(router: Router): void {
       return res.status(500).json({ error: msg });
     }
   });
+
+  // ─── Studio recipe bridge (loopback-only, no Olive execution) ─────────
+  // Separate from the Python-MCP tool proxy. Pure UIState → recipe/validation.
+  router.post(
+    "/mcp/studio-recipe",
+    studioRecipeLocalOnly,
+    studioRecipeRateLimit,
+    (req, res) => {
+      try {
+        const result = evaluateStudioRecipeBridge(req.body);
+        if (!result.ok) {
+          // Bad input from bridge (invalid_body | invalid_ui_state | invalid_passes).
+          return res.status(400).json(result);
+        }
+        return res.json(result);
+      } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : String(err);
+        console.warn(`[mcp] studio-recipe bridge failed: ${msg}`);
+        return res.status(500).json({ ok: false, error: "Studio recipe evaluation failed" });
+      }
+    },
+  );
 
   // ─── KB Status ────────────────────────────────────────────────────────
   router.get("/mcp/kb-status", kbStatusRateLimit, (_req, res) => {

--- a/src/server/services/mcp/allowedTools.ts
+++ b/src/server/services/mcp/allowedTools.ts
@@ -16,6 +16,10 @@ export const ALLOWED_MCP_TOOL_NAMES = new Set([
   "get_pass_parameters",
   "evaluate_optimization_tradeoff",
   "get_context_for_pipeline",
+  // Write-capable / studio bridge tools: HTTP proxy is loopback-only (mcpToolLocalOnly).
+  "validate_ui_state_recipe",
+  "get_recipe_for_ui_state",
+  "record_troubleshoot_feedback",
 ]);
 
 export function isAllowedMcpToolName(toolName: string): boolean {

--- a/src/server/services/mcp/client.ts
+++ b/src/server/services/mcp/client.ts
@@ -129,7 +129,14 @@ export async function callOliveMcpTools(requests: McpToolRequest[]): Promise<Mcp
         if (!isObjectRecord(row)) return { error: `MCP tool ${req.toolName} missing from batch` };
         if (typeof row.error === "string" && row.error) return { error: row.error };
         const inner = row.result;
-        if (isObjectRecord(inner) && typeof inner.error === "string" && inner.error) {
+        // Tool payloads may intentionally use { status: "error", error, message }
+        // for user-facing validation failures; only unwrap proxy error envelopes.
+        if (
+          isObjectRecord(inner) &&
+          typeof inner.error === "string" &&
+          inner.error &&
+          inner.status !== "error"
+        ) {
           return { error: String(inner.error) };
         }
         return { result: inner };

--- a/src/server/services/mcp/studioRecipeBridge.ts
+++ b/src/server/services/mcp/studioRecipeBridge.ts
@@ -1,0 +1,192 @@
+/**
+ * Studio → MCP recipe bridge core (no HTTP, no Olive execution).
+ *
+ * Accepts an untrusted bridge body, allowlist-merges a partial UIState onto
+ * {@link createDefaultPipelineState}, then projects once via
+ * {@link projectUiStateToRecipeEvaluation}.
+ *
+ * **Response contract (camelCase, JSON-safe):** matches
+ * {@link UiStateRecipeEvaluation} plus `ok: true`. Python MCP tools accept
+ * these keys (with snake_case aliases). Never runs Olive or touches job state.
+ */
+import type { IHVProvider, ModelSource, OpenVinoTargetDevice, UIState } from "../../../types.ts";
+import { coercePassValue } from "../../../lib/auditAutofix.ts";
+import { mergeUiState } from "../../../lib/pipelineValidation.ts";
+import {
+  projectUiStateToRecipeEvaluation,
+  type UiStateRecipeEvaluation,
+} from "../../../lib/recipePipeline.ts";
+import { createDefaultPipelineState } from "../../../lib/stores/pipelineStore.ts";
+
+const IHV_PROVIDERS = new Set<string>([
+  "CPUExecutionProvider",
+  "CUDAExecutionProvider",
+  "TensorrtExecutionProvider",
+  "NvTensorRTRTXExecutionProvider",
+  "DmlExecutionProvider",
+  "OpenVINOExecutionProvider",
+  "QNNExecutionProvider",
+  "ROCMExecutionProvider",
+  "WebGpuExecutionProvider",
+]);
+
+const MODEL_SOURCES = new Set<string>(["huggingface", "local", "azure"]);
+const MEMORY_OFFLOAD = new Set<string>(["gpu_only", "auto"]);
+const OPENVINO_TARGETS = new Set<string>(["CPU", "GPU", "NPU"]);
+const CUDA_VERSIONS = new Set<string>([
+  "auto",
+  "cpu",
+  "cu118",
+  "cu121",
+  "cu124",
+  "cu126",
+  "cu128",
+  "cu130",
+  "cu132",
+]);
+
+/** Fields that must never be accepted from the bridge (execution / server config). */
+const REJECTED_KEYS = new Set([
+  "batchJobs",
+  "activeJobId",
+  "passRecipeOverrides",
+  "userScript",
+]);
+
+export type StudioRecipeBridgeDeps = {
+  createDefaultState?: () => UIState;
+  evaluate?: typeof projectUiStateToRecipeEvaluation;
+};
+
+/** Success payload: camelCase, stable for MCP Python tools. */
+export type StudioRecipeBridgeSuccess = UiStateRecipeEvaluation & { ok: true };
+
+export type StudioRecipeBridgeError = {
+  ok: false;
+  error: string;
+  code: "invalid_body" | "invalid_ui_state" | "invalid_passes";
+};
+
+export type StudioRecipeBridgeResult = StudioRecipeBridgeSuccess | StudioRecipeBridgeError;
+
+function isObjectRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function clipString(value: unknown, max: number): string | undefined {
+  if (typeof value !== "string") return undefined;
+  return value.trim().slice(0, max);
+}
+
+function parseLocalFiles(raw: unknown): UIState["localFiles"] | undefined {
+  if (!Array.isArray(raw)) return undefined;
+  const out: UIState["localFiles"] = [];
+  for (const item of raw) {
+    if (!isObjectRecord(item)) continue;
+    if (typeof item.name !== "string" || typeof item.size !== "number" || !Number.isFinite(item.size)) {
+      continue;
+    }
+    out.push({ name: item.name.trim().slice(0, 512), size: Math.max(0, item.size) });
+  }
+  return out;
+}
+
+/**
+ * Allowlist-merge untrusted partial UI fields. Unknown / dangerous keys ignored.
+ * Returns an error when `passes` is present but not a plain object.
+ */
+export function mergeBridgeUiState(
+  defaults: UIState,
+  raw: Record<string, unknown>,
+): { ok: true; state: UIState } | StudioRecipeBridgeError {
+  const partial: Partial<UIState> = {};
+
+  if (typeof raw.modelSource === "string" && MODEL_SOURCES.has(raw.modelSource)) {
+    partial.modelSource = raw.modelSource as ModelSource;
+  }
+  if (typeof raw.ihvProvider === "string" && IHV_PROVIDERS.has(raw.ihvProvider)) {
+    partial.ihvProvider = raw.ihvProvider as IHVProvider;
+  }
+  if (typeof raw.openvinoTargetDevice === "string" && OPENVINO_TARGETS.has(raw.openvinoTargetDevice)) {
+    partial.openvinoTargetDevice = raw.openvinoTargetDevice as OpenVinoTargetDevice;
+  }
+  if (typeof raw.memoryOffload === "string" && MEMORY_OFFLOAD.has(raw.memoryOffload)) {
+    partial.memoryOffload = raw.memoryOffload as UIState["memoryOffload"];
+  }
+  if (typeof raw.cudaVersion === "string" && CUDA_VERSIONS.has(raw.cudaVersion)) {
+    partial.cudaVersion = raw.cudaVersion as UIState["cudaVersion"];
+  }
+  if (typeof raw.distributedCaching === "boolean") {
+    partial.distributedCaching = raw.distributedCaching;
+  }
+
+  const hfModelId = clipString(raw.hfModelId, 256);
+  if (hfModelId !== undefined) partial.hfModelId = hfModelId;
+  const hfDataset = clipString(raw.hfDataset, 256);
+  if (hfDataset !== undefined) partial.hfDataset = hfDataset;
+  const hfTask = clipString(raw.hfTask, 128);
+  if (hfTask !== undefined) partial.hfTask = hfTask;
+  const azureModelPath = clipString(raw.azureModelPath, 1024);
+  if (azureModelPath !== undefined) partial.azureModelPath = azureModelPath;
+  const azureStr = clipString(raw.azureStr, 1024);
+  if (azureStr !== undefined) partial.azureStr = azureStr;
+  const cacheDir = clipString(raw.cacheDir, 512);
+  if (cacheDir !== undefined) partial.cacheDir = cacheDir;
+
+  const localFiles = parseLocalFiles(raw.localFiles);
+  if (localFiles) partial.localFiles = localFiles;
+
+  if ("passes" in raw) {
+    if (!isObjectRecord(raw.passes)) {
+      return { ok: false, code: "invalid_passes", error: "passes must be a plain object" };
+    }
+    const passes: Partial<UIState["passes"]> = {};
+    for (const [key, value] of Object.entries(raw.passes)) {
+      const coerced = coercePassValue(key, value);
+      if (coerced === null) continue;
+      (passes as Record<string, unknown>)[key] = coerced;
+    }
+    if (Object.keys(passes).length > 0) partial.passes = passes;
+  }
+
+  // Explicitly drop dangerous keys even if somehow copied later.
+  for (const key of REJECTED_KEYS) {
+    delete (partial as Record<string, unknown>)[key];
+  }
+
+  return { ok: true, state: mergeUiState(defaults, partial) };
+}
+
+/**
+ * Evaluate an untrusted bridge body into a JSON-safe recipe validation payload.
+ *
+ * Body shapes accepted:
+ * - `{ uiState: { ...partial UIState } }` (Python MCP contract)
+ * - `{ ...partial UIState }` (direct state object)
+ *
+ * @param body - Untrusted request body
+ * @param deps - Optional DI for defaults factory and projection helper
+ */
+export function evaluateStudioRecipeBridge(
+  body: unknown,
+  deps: StudioRecipeBridgeDeps = {},
+): StudioRecipeBridgeResult {
+  if (!isObjectRecord(body)) {
+    return { ok: false, code: "invalid_body", error: "Request body must be a JSON object" };
+  }
+
+  const rawState = "uiState" in body ? body.uiState : body;
+  if (!isObjectRecord(rawState)) {
+    return { ok: false, code: "invalid_ui_state", error: "uiState must be a JSON object" };
+  }
+
+  const createDefaultState = deps.createDefaultState ?? createDefaultPipelineState;
+  const evaluate = deps.evaluate ?? projectUiStateToRecipeEvaluation;
+
+  const merged = mergeBridgeUiState(createDefaultState(), rawState);
+  if (!merged.ok) return merged;
+
+  // Exactly one projection call — pure, no Olive / I/O.
+  const evaluation = evaluate(merged.state);
+  return { ok: true, ...evaluation };
+}

--- a/src/server/services/mcp/studioRecipeBridge.ts
+++ b/src/server/services/mcp/studioRecipeBridge.ts
@@ -91,6 +91,24 @@ function parseLocalFiles(raw: unknown): UIState["localFiles"] | undefined {
   return out;
 }
 
+function assignClippedBridgeStrings(
+  partial: UiStatePatch,
+  raw: Record<string, unknown>,
+): void {
+  const hfModelId = clipString(raw.hfModelId, 256);
+  if (hfModelId !== undefined) partial.hfModelId = hfModelId;
+  const hfDataset = clipString(raw.hfDataset, 256);
+  if (hfDataset !== undefined) partial.hfDataset = hfDataset;
+  const hfTask = clipString(raw.hfTask, 128);
+  if (hfTask !== undefined) partial.hfTask = hfTask;
+  const azureModelPath = clipString(raw.azureModelPath, 1024);
+  if (azureModelPath !== undefined) partial.azureModelPath = azureModelPath;
+  const azureStr = clipString(raw.azureStr, 1024);
+  if (azureStr !== undefined) partial.azureStr = azureStr;
+  const cacheDir = clipString(raw.cacheDir, 512);
+  if (cacheDir !== undefined) partial.cacheDir = cacheDir;
+}
+
 /**
  * Allowlist-merge untrusted partial UI fields. Unknown / dangerous keys ignored.
  * Returns an error when `passes` is present but not a plain object.
@@ -120,18 +138,7 @@ export function mergeBridgeUiState(
     partial.distributedCaching = raw.distributedCaching;
   }
 
-  const hfModelId = clipString(raw.hfModelId, 256);
-  if (hfModelId !== undefined) partial.hfModelId = hfModelId;
-  const hfDataset = clipString(raw.hfDataset, 256);
-  if (hfDataset !== undefined) partial.hfDataset = hfDataset;
-  const hfTask = clipString(raw.hfTask, 128);
-  if (hfTask !== undefined) partial.hfTask = hfTask;
-  const azureModelPath = clipString(raw.azureModelPath, 1024);
-  if (azureModelPath !== undefined) partial.azureModelPath = azureModelPath;
-  const azureStr = clipString(raw.azureStr, 1024);
-  if (azureStr !== undefined) partial.azureStr = azureStr;
-  const cacheDir = clipString(raw.cacheDir, 512);
-  if (cacheDir !== undefined) partial.cacheDir = cacheDir;
+  assignClippedBridgeStrings(partial, raw);
 
   const localFiles = parseLocalFiles(raw.localFiles);
   if (localFiles) partial.localFiles = localFiles;

--- a/src/server/services/mcp/studioRecipeBridge.ts
+++ b/src/server/services/mcp/studioRecipeBridge.ts
@@ -11,7 +11,7 @@
  */
 import type { IHVProvider, ModelSource, OpenVinoTargetDevice, UIState } from "../../../types.ts";
 import { coercePassValue } from "../../../lib/auditAutofix.ts";
-import { mergeUiState } from "../../../lib/pipelineValidation.ts";
+import { mergeUiState, type UiStatePatch } from "../../../lib/pipelineValidation.ts";
 import {
   projectUiStateToRecipeEvaluation,
   type UiStateRecipeEvaluation,
@@ -99,7 +99,7 @@ export function mergeBridgeUiState(
   defaults: UIState,
   raw: Record<string, unknown>,
 ): { ok: true; state: UIState } | StudioRecipeBridgeError {
-  const partial: Partial<UIState> = {};
+  const partial: UiStatePatch = {};
 
   if (typeof raw.modelSource === "string" && MODEL_SOURCES.has(raw.modelSource)) {
     partial.modelSource = raw.modelSource as ModelSource;

--- a/src/server/services/mcp/studioRecipeBridge.ts
+++ b/src/server/services/mcp/studioRecipeBridge.ts
@@ -109,16 +109,7 @@ function assignClippedBridgeStrings(
   if (cacheDir !== undefined) partial.cacheDir = cacheDir;
 }
 
-/**
- * Allowlist-merge untrusted partial UI fields. Unknown / dangerous keys ignored.
- * Returns an error when `passes` is present but not a plain object.
- */
-export function mergeBridgeUiState(
-  defaults: UIState,
-  raw: Record<string, unknown>,
-): { ok: true; state: UIState } | StudioRecipeBridgeError {
-  const partial: UiStatePatch = {};
-
+function assignEnumBridgeFields(partial: UiStatePatch, raw: Record<string, unknown>): void {
   if (typeof raw.modelSource === "string" && MODEL_SOURCES.has(raw.modelSource)) {
     partial.modelSource = raw.modelSource as ModelSource;
   }
@@ -137,24 +128,44 @@ export function mergeBridgeUiState(
   if (typeof raw.distributedCaching === "boolean") {
     partial.distributedCaching = raw.distributedCaching;
   }
+}
 
+function assignBridgePasses(
+  partial: UiStatePatch,
+  raw: Record<string, unknown>,
+): StudioRecipeBridgeError | null {
+  if (!("passes" in raw)) return null;
+  if (!isObjectRecord(raw.passes)) {
+    return { ok: false, code: "invalid_passes", error: "passes must be a plain object" };
+  }
+  const passes: Partial<UIState["passes"]> = {};
+  for (const [key, value] of Object.entries(raw.passes)) {
+    const coerced = coercePassValue(key, value);
+    if (coerced === null) continue;
+    (passes as Record<string, unknown>)[key] = coerced;
+  }
+  if (Object.keys(passes).length > 0) partial.passes = passes;
+  return null;
+}
+
+/**
+ * Allowlist-merge untrusted partial UI fields. Unknown / dangerous keys ignored.
+ * Returns an error when `passes` is present but not a plain object.
+ */
+export function mergeBridgeUiState(
+  defaults: UIState,
+  raw: Record<string, unknown>,
+): { ok: true; state: UIState } | StudioRecipeBridgeError {
+  const partial: UiStatePatch = {};
+
+  assignEnumBridgeFields(partial, raw);
   assignClippedBridgeStrings(partial, raw);
 
   const localFiles = parseLocalFiles(raw.localFiles);
   if (localFiles) partial.localFiles = localFiles;
 
-  if ("passes" in raw) {
-    if (!isObjectRecord(raw.passes)) {
-      return { ok: false, code: "invalid_passes", error: "passes must be a plain object" };
-    }
-    const passes: Partial<UIState["passes"]> = {};
-    for (const [key, value] of Object.entries(raw.passes)) {
-      const coerced = coercePassValue(key, value);
-      if (coerced === null) continue;
-      (passes as Record<string, unknown>)[key] = coerced;
-    }
-    if (Object.keys(passes).length > 0) partial.passes = passes;
-  }
+  const passesError = assignBridgePasses(partial, raw);
+  if (passesError) return passesError;
 
   // Explicitly drop dangerous keys even if somehow copied later.
   for (const key of REJECTED_KEYS) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -160,8 +160,20 @@ export interface UIState {
   };
 }
 
-/** MCP diagnostic response from troubleshoot_olive_error tool. */
+/**
+ * MCP diagnostic response from `troubleshoot_olive_error`.
+ *
+ * Display fields (`title`, `root_cause`, `workaround`, …) are unchanged for
+ * existing cards/history. Feedback (thumbs up/down) is keyed only by
+ * {@link McpDiagnostic.matched_entry} — never by log text.
+ */
 export interface McpDiagnostic {
+  /**
+   * Stable knowledge-base entry id when a match is found; `null` when unmatched.
+   * Required on the type so callers always read a defined value; local Studio
+   * matchers and MCP both set it. Use a non-empty string as the feedback key
+   * for `record_troubleshoot_feedback`; omit feedback UI when null/empty.
+   */
   matched_entry: string | null;
   title: string;
   root_cause: string;
@@ -173,4 +185,85 @@ export interface McpDiagnostic {
   /** When false, Apply Fix stays disabled even if updated_config is present. */
   applyable?: boolean;
   related_olive_entry?: string | null;
+  /**
+   * Optional occurrence metadata from the MCP server (forwarded when present).
+   * Not required for feedback; safe to omit on local/unmatched diagnoses.
+   */
+  frequency?: McpDiagnosticFrequency | null;
+}
+
+/** Occurrence stats attached to some MCP diagnosis payloads. */
+export interface McpDiagnosticFrequency {
+  occurrence_count?: number;
+  first_seen?: string | null;
+  last_seen?: string | null;
+  label?: string | null;
+}
+
+/**
+ * Thumbs rating for local aggregate troubleshoot feedback.
+ * Must match olive-mcp-server `ALLOWED_RATINGS` (`thumbs-up` | `thumbs-down`).
+ */
+export type McpTroubleshootFeedbackRating = "thumbs-up" | "thumbs-down";
+
+/**
+ * Allowlisted reason codes for `record_troubleshoot_feedback`.
+ * Must match olive-mcp-server `ALLOWED_REASON_CODES` — never free-form text.
+ */
+export type McpTroubleshootFeedbackReasonCode =
+  | "accurate"
+  | "clear_fix"
+  | "fixed_issue"
+  | "wrong_match"
+  | "outdated"
+  | "incomplete"
+  | "incorrect_fix";
+
+/** Runtime allowlist for feedback ratings (mirrors MCP server). */
+export const MCP_TROUBLESHOOT_FEEDBACK_RATINGS: readonly McpTroubleshootFeedbackRating[] = [
+  "thumbs-up",
+  "thumbs-down",
+] as const;
+
+/** Runtime allowlist for feedback reason codes (mirrors MCP server). */
+export const MCP_TROUBLESHOOT_FEEDBACK_REASON_CODES: readonly McpTroubleshootFeedbackReasonCode[] = [
+  "accurate",
+  "clear_fix",
+  "fixed_issue",
+  "wrong_match",
+  "outdated",
+  "incomplete",
+  "incorrect_fix",
+] as const;
+
+/**
+ * Args for MCP tool `record_troubleshoot_feedback`.
+ * Aggregate-only: entry id + rating (+ optional bounded reason code).
+ * Never includes logs, tracebacks, or free-form diagnostic text.
+ */
+export interface McpTroubleshootFeedbackArgs {
+  /** Must be a non-empty {@link McpDiagnostic.matched_entry} known to the KB. */
+  matched_entry: string;
+  rating: McpTroubleshootFeedbackRating;
+  /** Optional allowlisted reason code — not free-form user prose. */
+  reason_code?: McpTroubleshootFeedbackReasonCode;
+}
+
+/** Successful aggregate acknowledgement from `record_troubleshoot_feedback`. */
+export interface McpTroubleshootFeedbackResult {
+  status: "ok";
+  matched_entry: string;
+  rating: McpTroubleshootFeedbackRating;
+  reason_code: McpTroubleshootFeedbackReasonCode | null;
+  thumbs_up: number;
+  thumbs_down: number;
+  total: number;
+  score_delta?: number;
+}
+
+/** Structured error from `record_troubleshoot_feedback` or the proxy. */
+export interface McpTroubleshootFeedbackError {
+  status: "error";
+  error: string;
+  message?: string;
 }


### PR DESCRIPTION
## Summary
Implements [docs/mcp-validation-kb-feedback.plan.md](docs/mcp-validation-kb-feedback.plan.md):

1. **UIState ↔ Recipe bridge** — `createDefaultPipelineState`, `projectUiStateToRecipeEvaluation`, `studioRecipeBridge`, loopback-only `POST /api/mcp/studio-recipe` + rate limit
2. **Python MCP tools** — `validate_ui_state_recipe`, `get_recipe_for_ui_state` (fixed `OLIVE_STUDIO_API_URL` loopback only)
3. **Evidence-backed compatibility matrix** — schema requires `olive_pass` + provenance; expanded matrix; `test_compatibility_matrix.py`; CI `olive-pass-availability` job (enumerate only, no optimization)
4. **Reviewable KB refresh** — deterministic generator metadata; `kb-update.yml` runs generators+tests and opens labeled `kb-refresh` PR (no auto-merge)
5. **Local troubleshooting feedback** — `record_troubleshoot_feedback`, bounded ranking in hybrid scorer, thumbs UI on `MCPDiagnosticCard` wired through ExecutionWorkspace + BatchProcessingPanel

## Test plan
- [ ] `pnpm exec vitest run --config vitest.config.ts src/lib/__tests__/recipePipeline.test.ts`
- [ ] `pnpm exec vitest run --config vitest.integration.config.ts src/server/__tests__/routes.integration.test.ts`
- [ ] `pnpm exec vitest run --config vitest.component.config.ts` (MCPDiagnosticCard / EW / Batch)
- [ ] `cd olive-mcp-server && python -m pytest tests/test_studio_recipe.py tests/test_compatibility_matrix.py tests/test_feedback.py tests/test_troubleshooting_hybrid.py tests/test_integration.py -q`
- [ ] CI green (lint, unit, server, integration, component, python-tests, olive-pass-availability)

## Notes
- Isolated worktree branch `feature/mcp-validation-kb-feedback` (original dirty branch preserved)
- No real Olive optimization in tests/CI
- Feedback is local aggregate-only (no log/traceback storage)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tonythethompson/Olive-Studio/pull/130?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

