### PR TITLE
fix(bodyGuard): guard remaining request bodies

### DIFF
--- a/docs/Tech Debt & Issues.md
+++ b/docs/Tech Debt & Issues.md
@@ -17,15 +17,15 @@
 | 9 | Module-level mutable state in ai.ts | ✅ Resolved (Pass 6) |
 | 10 | Fragile substring matching | ✅ Resolved (Pass 4) |
 | 11 | Flat passes bag | ⏳ Open |
-| 12 | Builder if/else chain | ⏳ Open |
-| 13 | No request body validation | ⏳ Open |
+| 12 | Builder if/else chain | ✅ Resolved |
+| 13 | No request body validation | ✅ Resolved |
 | 14 | getPipelineValidation rebuilds recipe | ✅ Resolved (Pass 2) |
 | 15 | Unbounded SSE logs | ✅ Resolved (Pass 5) |
-| 16 | Uncancellable polling loops | ⏳ Open |
+| 16 | Uncancellable polling loops | ✅ Resolved |
 | 17 | No persistent job history | ✅ Closed as mitigated (Pass 5) |
 | 18 | Duplicated coercion/validation rules | ✅ Resolved (Pass 4) |
 | 19 | vite in both dep sections | ✅ Resolved (Pass 1) |
-| 20 | MCP no health check | ⏳ Open |
+| 20 | MCP no health check | ✅ Resolved |
 
 ## 🟢 Quick Wins
 
@@ -75,15 +75,15 @@ Both are now explicit ordered lookup tables (`HF_TASK_RULES`, `MODEL_TYPE_RULES`
 
 ### 11. ⏳ UIState.passes flat bag — open
 
-Still a flat object of ~30 fields. A discriminated union per pass type remains the target; do after #12.
+Still a flat object of ~30 fields. A discriminated union per pass type remains an independent follow-up.
 
-### 12. ⏳ oliveRecipeBuilder if/else chain — open
+### 12. ✅ oliveRecipeBuilder if/else chain — resolved
 
-The quantization block has grown to 11 branches. Per-pass builder functions registered in a map (keyed by pass type) is still the plan.
+`PASS_BUILDERS` dispatches the conversion, transformer optimization, quantization, splitting, PEFT, and pruning builders in fixed pipeline order. Quantization uses first-match `QUANT_METHOD_BUILDERS` with provider gates, then `FORMAT_QUANT_BUILDERS` as the fallback, so native HQQ/RTN selection and OpenVINO/QNN/TensorRT fallback behavior are explicit and testable.
 
-### 13. ⏳ No request body validation — open
+### 13. ✅ No request body validation — resolved
 
-Routes still destructure `req.body` directly (some manual guards exist in `/olive/run` and `mcp.ts`). A schema library (zod) or manual guards at the route boundary is still recommended.
+`parseBody` in `src/server/middleware/bodyGuard.ts` provides stable 400 boundaries through its discriminated result API. Guarded routes parse object bodies and field types before handlers use them, while preserving their established response envelopes and messages; no schema dependency is required.
 
 ### 14. ✅ getPipelineValidation rebuilds — resolved (Pass 2)
 
@@ -93,9 +93,9 @@ Covered by the Pass 2 memoization/reuse work; the recipe built inside `getPipeli
 
 `job.logs` is capped at 1,000 lines (batched trim at a 1,250 watermark), `OliveJob.logsTruncated` records the trim, the SSE reconnect replay emits an `[info]` marker when truncated, and `/olive/status` exposes `logsTruncated`. Live subscribers still receive every line — the cap bounds server memory and replay, not the live stream. Tests: `gpu.test.ts`, truncated-replay case in `olive.stream.test.ts`.
 
-### 16. ⏳ ensureOllama/ensureLms polling loops — open
+### 16. ✅ ensureOllama/ensureLms polling loops — resolved
 
-Still fixed-interval `sleepMs(1000)` loops (40 / 30 iterations) with no AbortSignal. Planned together with replacing `execSync` CLI probing (see Performance section). Note: the sleeps are awaited promises (they don't block the event loop); the real gaps are cancellability and backoff.
+LM Studio and Ollama readiness-loop polling/backoff waits accept `AbortSignal`, so a disconnect releases that client's setup waiter; shared readiness polling is aborted only when the last waiter leaves. Initial health checks and CLI discovery probes remain bounded independently. LM Studio CLI discovery is asynchronous, cached, and single-flight, so concurrent requests share one bounded probe instead of blocking the event loop.
 
 ### 17. ✅ No persistent job history — closed as mitigated (Pass 5)
 
@@ -109,9 +109,9 @@ Terminal runs are persisted client-side in IndexedDB (`src/lib/jobHistoryStore.t
 
 `server.ts` imports vite dynamically inside the dev branch only; vite lives in `devDependencies` exclusively. Production static serving never loads vite.
 
-### 20. ⏳ MCP health check / restart — open, reframed
+### 20. ✅ MCP health check / restart — resolved
 
-The MCP client spawns a fresh Python subprocess per call (`services/mcp/client.ts`), so there is no long-lived process to die or restart — the original framing is outdated. Remaining work: a circuit breaker/failure counter and status surfacing so repeated MCP failures show up as "MCP unavailable" instead of per-call 500s.
+The MCP client still uses a fresh Python subprocess per call, with a circuit breaker for infrastructure failures: three failures open it, callers receive a stable 503-unavailable result, and a single half-open probe recovers after cooldown. Tool-level errors do not trip the breaker.
 
 ## Performance & Efficiency Improvements
 
@@ -121,7 +121,7 @@ The MCP client spawns a fresh Python subprocess per call (`services/mcp/client.t
 - ✅ **onnxruntime-web** — no action needed: all runtime imports are dynamic (`InBrowserValidation`, `WebGpuBenchmarkPanel`, `ArenaPanel`); the earlier "critical path" flag was a grep false positive — the match in `owrExportConfigs.ts` sits inside a generated-code template string, not a real import. Build emits ORT as its own 386kb chunk.
 - ✅ **@mendable/firecrawl-js** — removed (Pass 3): zero imports anywhere; the dependency and its `allowBuilds` entry are gone.
 - ❌ **React Query probe cache** — not applicable: the hardware probe (`/api/system/hardware-probe`) is fetched with plain `fetch` (`fetchHardwareProbe`), not React Query, and the server already caches probe results with a TTL (`system.ts`).
-- ⏳ **execSync in findLmsCli** — open: `execSync("where/which lms|ollama")` still used with an in-memory cache; convert to async probing together with #16.
+- ✅ **Async CLI probing** — `findLmsCli` uses a bounded asynchronous `execFile` probe, positive/miss caching, and a cached single-flight request for concurrent callers; it never blocks the event loop.
 
 ## Verification
 

--- a/src/lib/__tests__/oliveRecipeBuilder.test.ts
+++ b/src/lib/__tests__/oliveRecipeBuilder.test.ts
@@ -521,6 +521,53 @@ describe("buildOliveRecipe", () => {
     expect((q.config as Record<string, unknown>).quant_mode).toBe("static");
   });
 
+  it("uses HQQ for CPU targets", () => {
+    const recipe = buildOliveRecipe(
+      baseState({
+        ihvProvider: "CPUExecutionProvider",
+        passes: { ...DEFAULT_PASSES, quantization: true, quantMethod: "hqq", quantPrecision: "int4" },
+      }),
+    );
+    const quantization = (recipe.passes as Record<string, Record<string, unknown>>).quantization;
+    expect(quantization).toEqual({ type: "OnnxHqqQuantization", config: { precision: "int4" } });
+  });
+
+  it("falls back to QNN quantization when HQQ is unavailable", () => {
+    const recipe = buildOliveRecipe(
+      baseState({
+        ihvProvider: "QNNExecutionProvider",
+        passes: { ...DEFAULT_PASSES, quantization: true, quantMethod: "hqq" },
+      }),
+    );
+    const quantization = (recipe.passes as Record<string, Record<string, unknown>>).quantization;
+    expect(quantization).toEqual({ type: "QNNQuantization", config: {} });
+  });
+
+  it("uses RTN for CUDA targets", () => {
+    const recipe = buildOliveRecipe(
+      baseState({
+        ihvProvider: "CUDAExecutionProvider",
+        passes: { ...DEFAULT_PASSES, quantization: true, quantMethod: "rtn", quantPrecision: "int4" },
+      }),
+    );
+    const quantization = (recipe.passes as Record<string, Record<string, unknown>>).quantization;
+    expect(quantization).toEqual({
+      type: "OnnxBlockWiseRtnQuantization",
+      config: { bits: 4, block_size: 128, is_symmetric: true },
+    });
+  });
+
+  it("uses OpenVINO quantization for PTQ", () => {
+    const recipe = buildOliveRecipe(
+      baseState({
+        ihvProvider: "OpenVINOExecutionProvider",
+        passes: { ...DEFAULT_PASSES, quantization: true, quantMethod: "ptq", quantPrecision: "int8" },
+      }),
+    );
+    const quantization = (recipe.passes as Record<string, Record<string, unknown>>).quantization;
+    expect(quantization).toEqual({ type: "OpenVINOQuantization", config: {} });
+  });
+
   it("adds user_script to quantization config when provided", () => {
     const state = baseState({
       userScript: "/path/to/script.py",

--- a/src/server/__tests__/routes.integration.test.ts
+++ b/src/server/__tests__/routes.integration.test.ts
@@ -7,7 +7,7 @@
  * All external dependencies (Python, AI providers, LM Studio, Ollama) are
  * mocked via `setup.integration.ts` so these tests run reliably in CI.
  */
-import { describe, it, expect, beforeAll, afterAll, beforeEach } from "vitest";
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from "vitest";
 import type { Server } from "http";
 
 import { stubGlobalFetch, restoreGlobalFetch } from "./setup.integration.ts";
@@ -110,6 +110,52 @@ describe("Route integration tests", () => {
       expect(Array.isArray(body.models)).toBe(true);
       expect(body.models).toEqual([]);
       expect(body.source).toBe("fallback");
+    });
+  });
+
+  describe("POST /api/ai/provider and /api/ai/models body guards", () => {
+    it("rejects non-string provider fields", async () => {
+      const providerResponse = await fetch(`${baseUrl}/api/ai/provider`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ provider: 42 }),
+      });
+      expect(providerResponse.status).toBe(400);
+      await expect(providerResponse.json()).resolves.toEqual({ error: "provider must be a string" });
+
+      const modelsResponse = await fetch(`${baseUrl}/api/ai/models`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ provider: "openai", baseUrl: 42 }),
+      });
+      expect(modelsResponse.status).toBe(400);
+      await expect(modelsResponse.json()).resolves.toEqual({ error: "baseUrl must be a string" });
+    });
+  });
+
+  describe("POST /api/cloudflare body guards", () => {
+    it("keeps generic object errors and manual credential errors stable", async () => {
+      const syncResponse = await fetch(`${baseUrl}/api/cloudflare/sync`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify([]),
+      });
+      expect(syncResponse.status).toBe(400);
+      await expect(syncResponse.json()).resolves.toEqual({
+        ok: false,
+        error: "Request body must be a JSON object",
+      });
+
+      const manualResponse = await fetch(`${baseUrl}/api/cloudflare/login/manual`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ apiToken: 42, accountId: "a".repeat(32) }),
+      });
+      expect(manualResponse.status).toBe(400);
+      await expect(manualResponse.json()).resolves.toEqual({
+        ok: false,
+        error: "apiToken and accountId are required.",
+      });
     });
   });
 
@@ -504,6 +550,100 @@ describe("Route integration tests", () => {
       const body = JSON.parse(text) as { error?: string; type?: string };
       expect(body.error || body.type).toBeTruthy();
     });
+
+    it("rejects a non-string modelTag before opening a stream", async () => {
+      const res = await fetch(`${baseUrl}/api/ai/local-pull`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ modelTag: 42 }),
+      });
+
+      expect(res.status).toBe(400);
+      expect(res.headers.get("content-type")).toContain("application/json");
+      await expect(res.json()).resolves.toEqual({ error: "modelTag must be a string" });
+    });
+  });
+
+  describe("POST local model control body guards", () => {
+    it("rejects malformed local and Ollama model tags", async () => {
+      const localUnload = await fetch(`${baseUrl}/api/ai/local-unload`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ modelTag: false }),
+      });
+      expect(localUnload.status).toBe(400);
+      await expect(localUnload.json()).resolves.toEqual({ error: "modelTag must be a string" });
+
+      const ollamaPull = await fetch(`${baseUrl}/api/ai/ollama-pull`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({}),
+      });
+      expect(ollamaPull.status).toBe(400);
+      expect(ollamaPull.headers.get("content-type")).toContain("application/json");
+      await expect(ollamaPull.json()).resolves.toEqual({ error: "Missing modelTag" });
+
+      const ollamaLoad = await fetch(`${baseUrl}/api/ai/ollama-load`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ modelTag: 42 }),
+      });
+      expect(ollamaLoad.status).toBe(400);
+      await expect(ollamaLoad.json()).resolves.toEqual({ error: "modelTag must be a string" });
+
+      const ollamaUnload = await fetch(`${baseUrl}/api/ai/ollama-unload`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ modelTag: [] }),
+      });
+      expect(ollamaUnload.status).toBe(400);
+      await expect(ollamaUnload.json()).resolves.toEqual({ error: "modelTag must be a string" });
+    });
+  });
+
+  describe("POST /api/ai/ollama-pull", () => {
+    it("streams an error event when Ollama fails after streaming begins", async () => {
+      const mockedFetch = globalThis.fetch;
+      vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+        if (url.includes("127.0.0.1:11434/api/pull")) {
+          const encoder = new TextEncoder();
+          return new Response(
+            new ReadableStream({
+              start(controller) {
+                controller.enqueue(
+                  encoder.encode(
+                    `${JSON.stringify({ status: "pulling manifest", completed: 1, total: 2 })}\n${JSON.stringify({ error: "Ollama test pull failed" })}\n`,
+                  ),
+                );
+                controller.close();
+              },
+            }),
+            { status: 200, headers: { "Content-Type": "application/x-ndjson" } },
+          );
+        }
+        return mockedFetch(input, init);
+      });
+
+      try {
+        const res = await fetch(`${baseUrl}/api/ai/ollama-pull`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ modelTag: "llama3:8b" }),
+        });
+
+        expect(res.status).toBe(200);
+        expect(res.headers.get("content-type")).toContain("application/x-ndjson");
+        const events = (await res.text())
+          .trim()
+          .split("\n")
+          .map((line) => JSON.parse(line) as { type?: string; error?: string });
+        expect(events.some((event) => event.type === "progress")).toBe(true);
+        expect(events).toContainEqual({ type: "error", error: "Ollama test pull failed" });
+      } finally {
+        vi.stubGlobal("fetch", mockedFetch);
+      }
+    });
   });
 
   // ─── POST /api/env/venv-install ─────────────────────────────────────────
@@ -593,6 +733,41 @@ describe("Route integration tests", () => {
       expect(res.status).toBe(400);
       const body = await res.json();
       expect(body).toHaveProperty("error");
+    });
+
+    it("preserves the run error envelope for a wrong-type recipeJson", async () => {
+      const res = await fetch(`${baseUrl}/api/olive/run`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ recipeJson: {} }),
+      });
+
+      expect(res.status).toBe(400);
+      await expect(res.json()).resolves.toEqual({ ok: false, error: "recipeJson must be a string" });
+    });
+  });
+
+  describe("POST /api/olive/cancel", () => {
+    it("preserves the missing jobId 404 contract", async () => {
+      const res = await fetch(`${baseUrl}/api/olive/cancel`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({}),
+      });
+
+      expect(res.status).toBe(404);
+      await expect(res.json()).resolves.toEqual({ error: "Job not found" });
+    });
+
+    it("rejects a wrong-type jobId", async () => {
+      const res = await fetch(`${baseUrl}/api/olive/cancel`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ jobId: 42 }),
+      });
+
+      expect(res.status).toBe(400);
+      await expect(res.json()).resolves.toEqual({ error: "jobId must be a string" });
     });
   });
 

--- a/src/server/middleware/bodyGuard.test.ts
+++ b/src/server/middleware/bodyGuard.test.ts
@@ -24,7 +24,7 @@ describe("parseBody", () => {
       recipe: { type: "json" },
     });
 
-    expect(result).toEqual({ parsed: { recipe: '{"passes":{}}' } });
+    expect(result).toEqual({ parsed: { recipe: { passes: {} } } });
   });
 
   it("omits optional json fields when the value is an empty string", () => {

--- a/src/server/middleware/bodyGuard.ts
+++ b/src/server/middleware/bodyGuard.ts
@@ -74,7 +74,7 @@ const TYPE_DESCRIPTIONS: Record<BodyFieldType, string> = {
   boolean: "a boolean",
   object: "an object",
   "string[]": "an array of strings",
-  json: "a string or JSON object",
+  json: "valid JSON",
   unknown: "a value",
 };
 
@@ -109,7 +109,7 @@ export function parseBody<T extends Record<string, unknown>>(
     if (!TYPE_CHECKERS[fieldSpec.type](value)) {
       return { error: `${field} must be ${TYPE_DESCRIPTIONS[fieldSpec.type]}` };
     }
-    parsed[field] = value;
+    parsed[field] = fieldSpec.type === "json" && typeof value === "string" ? JSON.parse(value) : value;
   }
 
   return { parsed: parsed as T };

--- a/src/server/middleware/bodyGuard.ts
+++ b/src/server/middleware/bodyGuard.ts
@@ -53,7 +53,17 @@ const TYPE_CHECKERS: Record<BodyFieldType, (value: unknown) => boolean> = {
   "string[]": (value) =>
     Array.isArray(value) && value.every((item) => typeof item === "string"),
   // Recipes arrive either pre-parsed or as a JSON string.
-  json: (value) => typeof value === "string" || isPlainObject(value),
+function isJsonString(value: string): boolean {
+  try {
+    JSON.parse(value);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const TYPE_CHECKERS: Record<BodyFieldType, (value: unknown) => boolean> = {
+  json: (value) => isPlainObject(value) || (typeof value === "string" && isJsonString(value)),
   // Pass-through fields with their own lenient handling downstream (e.g. clamps).
   // Does not narrow the parsed generic — callers must treat these as `unknown`.
   unknown: () => true,

--- a/src/server/middleware/bodyGuard.ts
+++ b/src/server/middleware/bodyGuard.ts
@@ -45,14 +45,6 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-const TYPE_CHECKERS: Record<BodyFieldType, (value: unknown) => boolean> = {
-  string: (value) => typeof value === "string",
-  number: (value) => typeof value === "number" && Number.isFinite(value),
-  boolean: (value) => typeof value === "boolean",
-  object: (value) => isPlainObject(value),
-  "string[]": (value) =>
-    Array.isArray(value) && value.every((item) => typeof item === "string"),
-  // Recipes arrive either pre-parsed or as a JSON string.
 function isJsonString(value: string): boolean {
   try {
     JSON.parse(value);
@@ -63,6 +55,13 @@ function isJsonString(value: string): boolean {
 }
 
 const TYPE_CHECKERS: Record<BodyFieldType, (value: unknown) => boolean> = {
+  string: (value) => typeof value === "string",
+  number: (value) => typeof value === "number" && Number.isFinite(value),
+  boolean: (value) => typeof value === "boolean",
+  object: (value) => isPlainObject(value),
+  "string[]": (value) =>
+    Array.isArray(value) && value.every((item) => typeof item === "string"),
+  // Recipes arrive either pre-parsed or as a JSON string.
   json: (value) => isPlainObject(value) || (typeof value === "string" && isJsonString(value)),
   // Pass-through fields with their own lenient handling downstream (e.g. clamps).
   // Does not narrow the parsed generic — callers must treat these as `unknown`.

--- a/src/server/routes/ai/chatRoutes.ts
+++ b/src/server/routes/ai/chatRoutes.ts
@@ -104,9 +104,7 @@ export function mountChatRoutes(router: Router): void {
     if (isParseBodyError(body)) return res.status(400).json({ error: body.error });
     const { recipe } = body.parsed;
     try {
-      const validation = validateOliveRecipeStructure(
-        typeof recipe === "string" ? JSON.parse(recipe) : recipe,
-      );
+      const validation = validateOliveRecipeStructure(recipe);
       if (!validation.valid) return res.json({ valid: false, errors: validation.errors });
       const system =
         "You are an Olive model optimization validator. Review the recipe and return JSON: { valid: boolean, warnings: string[], suggestions: string[] }";

--- a/src/server/routes/ai/cloudflareRoutes.ts
+++ b/src/server/routes/ai/cloudflareRoutes.ts
@@ -13,6 +13,7 @@ import {
   syncCloudflareFromWrangler,
 } from "../../../lib/cloudflare/client.ts";
 import { isValidCloudflareAccountId } from "../../../lib/cloudflare/credentials.ts";
+import { isParseBodyError, parseBody } from "../../middleware/bodyGuard.ts";
 import { authActionRateLimit } from "../../middleware/rateLimit.ts";
 
 export function mountCloudflareRoutes(router: Router): void {
@@ -27,9 +28,12 @@ export function mountCloudflareRoutes(router: Router): void {
   });
 
   router.post("/cloudflare/sync", authActionRateLimit, async (req, res) => {
+    const body = parseBody<{ accountId?: string }>(req.body, {
+      accountId: { type: "string", required: false },
+    });
+    if (isParseBodyError(body)) return res.status(400).json({ ok: false, error: body.error });
     try {
-      const preferredAccountId =
-        typeof req.body?.accountId === "string" ? req.body.accountId.trim() : undefined;
+      const preferredAccountId = body.parsed.accountId?.trim() || undefined;
       const creds = await syncCloudflareFromWrangler(preferredAccountId);
       return res.json({
         ok: true,
@@ -44,9 +48,15 @@ export function mountCloudflareRoutes(router: Router): void {
   });
 
   router.post("/cloudflare/login/manual", authActionRateLimit, (req, res) => {
+    const body = parseBody<{ apiToken: unknown; accountId: unknown }>(req.body, {
+      apiToken: { type: "unknown", message: "apiToken and accountId are required." },
+      accountId: { type: "unknown", message: "apiToken and accountId are required." },
+    });
+    if (isParseBodyError(body)) return res.status(400).json({ ok: false, error: body.error });
     try {
-      const apiToken = typeof req.body?.apiToken === "string" ? req.body.apiToken.trim() : "";
-      const accountId = typeof req.body?.accountId === "string" ? req.body.accountId.trim() : "";
+      const { apiToken: rawApiToken, accountId: rawAccountId } = body.parsed;
+      const apiToken = typeof rawApiToken === "string" ? rawApiToken.trim() : "";
+      const accountId = typeof rawAccountId === "string" ? rawAccountId.trim() : "";
       if (!apiToken || !accountId) {
         return res.status(400).json({ ok: false, error: "apiToken and accountId are required." });
       }

--- a/src/server/routes/ai/lmStudioRoutes.ts
+++ b/src/server/routes/ai/lmStudioRoutes.ts
@@ -104,8 +104,11 @@ export function mountLmStudioRoutes(router: Router): void {
   });
 
   router.post("/ai/local-unload", async (req, res) => {
-    const { modelTag } = req.body ?? {};
-    if (!modelTag) return res.status(400).json({ error: "Missing modelTag" });
+    const body = parseBody<{ modelTag: string }>(req.body, {
+      modelTag: { type: "string", message: "Missing modelTag" },
+    });
+    if (isParseBodyError(body)) return res.status(400).json({ error: body.error });
+    const { modelTag } = body.parsed;
     try {
       const r = await fetch(`http://127.0.0.1:${LM_STUDIO_PORT}/v1/models/unload`, {
         method: "POST",
@@ -123,8 +126,11 @@ export function mountLmStudioRoutes(router: Router): void {
   });
 
   router.post("/ai/local-pull", heavyCommandRateLimit, async (req, res) => {
-    const { modelTag } = req.body ?? {};
-    if (!modelTag) return res.status(400).json({ error: "Missing modelTag" });
+    const body = parseBody<{ modelTag: string }>(req.body, {
+      modelTag: { type: "string", message: "Missing modelTag" },
+    });
+    if (isParseBodyError(body)) return res.status(400).json({ error: body.error });
+    const { modelTag } = body.parsed;
     const guard = trackStreamClient(req, res);
     const rawSend = beginPullSse(res);
     const send = (evt: Record<string, unknown>) => {

--- a/src/server/routes/ai/ollamaRoutes.ts
+++ b/src/server/routes/ai/ollamaRoutes.ts
@@ -102,7 +102,7 @@ export function mountOllamaRoutes(router: Router): void {
 
       localEngineRuntime.ollamaPullBusyTag = tag;
       ownsBusy = true;
-      const ready = await ensureOllamaReady((evt) => send(evt));
+      const ready = await ensureOllamaReady((evt) => send(evt), guard.signal);
       if (guard.disconnected()) {
         releaseBusy();
         guard.endOnce();

--- a/src/server/routes/ai/ollamaRoutes.ts
+++ b/src/server/routes/ai/ollamaRoutes.ts
@@ -17,6 +17,7 @@ import {
   OLLAMA_PULL_MAX_MS,
 } from "./localEngines.ts";
 import { trackStreamClient, beginPullSse } from "./streamHelpers.ts";
+import { isParseBodyError, parseBody } from "../../middleware/bodyGuard.ts";
 
 export function mountOllamaRoutes(router: Router): void {
   router.get("/ai/ollama-models", async (_req, res) => {
@@ -60,8 +61,11 @@ export function mountOllamaRoutes(router: Router): void {
   });
 
   router.post("/ai/ollama-pull", heavyCommandRateLimit, async (req, res) => {
-    const { modelTag } = req.body ?? {};
-    if (!modelTag) return res.status(400).json({ error: "Missing modelTag" });
+    const body = parseBody<{ modelTag: string }>(req.body, {
+      modelTag: { type: "string", message: "Missing modelTag" },
+    });
+    if (isParseBodyError(body)) return res.status(400).json({ error: body.error });
+    const { modelTag } = body.parsed;
     const guard = trackStreamClient(req, res);
     const rawSend = beginPullSse(res);
     const send = (evt: Record<string, unknown>) => {
@@ -259,8 +263,11 @@ export function mountOllamaRoutes(router: Router): void {
   });
 
   router.post("/ai/ollama-load", async (req, res) => {
-    const { modelTag } = req.body ?? {};
-    if (!modelTag) return res.status(400).json({ error: "Missing modelTag" });
+    const body = parseBody<{ modelTag: string }>(req.body, {
+      modelTag: { type: "string", message: "Missing modelTag" },
+    });
+    if (isParseBodyError(body)) return res.status(400).json({ error: body.error });
+    const { modelTag } = body.parsed;
     try {
       const r = await fetch(`http://127.0.0.1:${OLLAMA_PORT}/api/generate`, {
         method: "POST",
@@ -278,8 +285,11 @@ export function mountOllamaRoutes(router: Router): void {
   });
 
   router.post("/ai/ollama-unload", async (req, res) => {
-    const { modelTag } = req.body ?? {};
-    if (!modelTag) return res.status(400).json({ error: "Missing modelTag" });
+    const body = parseBody<{ modelTag: string }>(req.body, {
+      modelTag: { type: "string", message: "Missing modelTag" },
+    });
+    if (isParseBodyError(body)) return res.status(400).json({ error: body.error });
+    const { modelTag } = body.parsed;
     try {
       const r = await fetch(`http://127.0.0.1:${OLLAMA_PORT}/api/generate`, {
         method: "POST",

--- a/src/server/routes/ai/providerRoutes.ts
+++ b/src/server/routes/ai/providerRoutes.ts
@@ -20,6 +20,7 @@ import { getCodexAppServer } from "../../../lib/codex/CodexAppServerClient.ts";
 import { listDevinModels } from "../../../lib/devin/client.ts";
 import type { ProviderConfig } from "../../types.ts";
 import { authActionRateLimit } from "../../middleware/rateLimit.ts";
+import { isParseBodyError, parseBody } from "../../middleware/bodyGuard.ts";
 import { fetchLiveModelCatalog } from "./modelCatalog.ts";
 
 /** Local openai-compat endpoints may omit API keys for model listing. */
@@ -117,7 +118,19 @@ export function mountProviderRoutes(router: Router): void {
   });
 
   router.post("/ai/provider", authActionRateLimit, (req, res) => {
-    const { provider, apiKey, model, baseUrl } = req.body ?? {};
+    const body = parseBody<{
+      provider: ProviderConfig["provider"];
+      apiKey?: string;
+      model?: string;
+      baseUrl?: string;
+    }>(req.body, {
+      provider: { type: "string", message: "Missing provider" },
+      apiKey: { type: "string", required: false },
+      model: { type: "string", required: false },
+      baseUrl: { type: "string", required: false },
+    });
+    if (isParseBodyError(body)) return res.status(400).json({ error: body.error });
+    const { provider, apiKey, model, baseUrl } = body.parsed;
     if (!provider) return res.status(400).json({ error: "Missing provider" });
     if (!ALLOWED_AI_PROVIDERS.has(provider))
       return res.status(400).json({ error: `Unsupported provider: ${provider}` });
@@ -173,7 +186,17 @@ export function mountProviderRoutes(router: Router): void {
   });
 
   router.post("/ai/models", async (req, res) => {
-    const { provider, apiKey, baseUrl } = req.body ?? {};
+    const body = parseBody<{
+      provider: ProviderConfig["provider"];
+      apiKey?: string;
+      baseUrl?: string;
+    }>(req.body, {
+      provider: { type: "string", message: "Missing provider" },
+      apiKey: { type: "string", required: false },
+      baseUrl: { type: "string", required: false },
+    });
+    if (isParseBodyError(body)) return res.status(400).json({ error: body.error });
+    const { provider, apiKey, baseUrl } = body.parsed;
     if (!provider) return res.status(400).json({ error: "Missing provider" });
     if (!ALLOWED_AI_PROVIDERS.has(provider))
       return res.status(400).json({ error: `Unsupported provider: ${provider}` });

--- a/src/server/routes/olive.ts
+++ b/src/server/routes/olive.ts
@@ -35,6 +35,7 @@ import {
 } from "../services/venv/index.ts";
 import type { OliveRecipe, OliveJob } from "../types.ts";
 import { oliveRunRateLimit } from "../middleware/rateLimit.ts";
+import { isParseBodyError, parseBody } from "../middleware/bodyGuard.ts";
 import type { HardwareProbeResult } from "../../lib/hardwareProbe.ts";
 
 /** Grace period after SIGTERM before escalating cancel to SIGKILL. */
@@ -56,10 +57,12 @@ export function mountOliveRoutes(router: Router): void {
 
   // ─── POST /api/olive/run ──────────────────────────────────────────────
   router.post("/olive/run", oliveRunRateLimit, async (req, res) => {
-    const { recipeJson, cudaVersion = "auto" } = req.body as { recipeJson?: string; cudaVersion?: string };
-    if (!recipeJson) {
-      return res.status(400).json({ ok: false, error: "Missing recipeJson" });
-    }
+    const body = parseBody<{ recipeJson: string; cudaVersion?: string }>(req.body, {
+      recipeJson: { type: "string", message: "Missing recipeJson" },
+      cudaVersion: { type: "string", required: false },
+    });
+    if (isParseBodyError(body)) return res.status(400).json({ ok: false, error: body.error });
+    const { recipeJson, cudaVersion = "auto" } = body.parsed;
 
     let recipe: OliveRecipe;
     try {
@@ -389,8 +392,12 @@ export function mountOliveRoutes(router: Router): void {
 
   // ─── Cancel ───────────────────────────────────────────────────────────
   router.post("/olive/cancel", (req, res) => {
-    const { jobId } = req.body ?? {};
-    const job = jobRegistry.get(jobId);
+    const body = parseBody<{ jobId?: string }>(req.body, {
+      jobId: { type: "string", required: false },
+    });
+    if (isParseBodyError(body)) return res.status(400).json({ error: body.error });
+    const { jobId } = body.parsed;
+    const job = jobId ? jobRegistry.get(jobId) : undefined;
     if (!job) return res.status(404).json({ error: "Job not found" });
 
     // Already terminal — nothing to cancel.


### PR DESCRIPTION
## Summary`n- Guard remaining request-body boundaries.`n- Preserve Ollama pre-stream JSON versus operational NDJSON behavior.`n- Preserve legacy Olive and Cloudflare contracts.`n- Add four quantization dispatch regression tests.`n- Resolve documentation tech debt #12, #13, #16, and #20.`n`n## Validation`n- Passed: tsc, routes integration (49), validate:recipe, and diff check.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tonythethompson/Olive-Studio/pull/133?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

