### PR TITLE
feat(hardware): EP catalog gaps (export/platform targets)

### DIFF
--- a/olive-mcp-server/olive_mcp_server/knowledge_base/hardware_profiles.json
+++ b/olive-mcp-server/olive_mcp_server/knowledge_base/hardware_profiles.json
@@ -324,10 +324,11 @@
       "memory_gb": 2,
       "ops_supported": ["Conv", "Gemm", "MaxPool", "Softmax"],
       "known_issues": [
-        "TFLite conversion/export path; not a local Olive Execute Live EP.",
+        "Olive has no first-class .tflite emitter in this catalog; this profile prepares ONNX for external TFLite tooling.",
+        "Not a local Olive Execute Live EP — export/recipe only.",
         "Operator coverage differs from ONNX ORT EPs."
       ],
-      "notes": "Export-target profile for TFLite conversion. Prefer INT8 TFLite tooling outside Studio Execute Live."
+      "notes": "ONNX preparation profile for external TensorFlow Lite conversion (e.g. onnx2tf / TFLite converter). Studio marks TensorflowLiteExecutionProvider as an export target; do not treat the recommended Olive passes as a complete .tflite export chain."
     }
   ]
 }

--- a/olive-mcp-server/olive_mcp_server/knowledge_base/hardware_profiles.json
+++ b/olive-mcp-server/olive_mcp_server/knowledge_base/hardware_profiles.json
@@ -1,6 +1,6 @@
 {
-  "version": "0.3.0",
-  "last_updated": "2026-08-06",
+  "version": "0.4.0",
+  "last_updated": "2026-08-07",
   "profiles": [
     {
       "target": "NVIDIA RTX 4090",
@@ -264,6 +264,70 @@
         "INT8 support varies by browser/GPU."
       ],
       "notes": "Export/optimize ONNX for in-browser ORT Web WebGPU. Prefer FP16. Use Studio for recipe build/export, not Execute Live."
+    },
+    {
+      "target": "XNNPACK (Mobile)",
+      "accelerator": "cpu",
+      "execution_providers": ["XnnpackExecutionProvider"],
+      "recommended_passes": ["OnnxConversion", "OnnxModelOptimizer", "OnnxFloatToFloat16"],
+      "typical_speedup": "1-3x",
+      "calibration_size": 64,
+      "optimal_batch_size": 1,
+      "memory_gb": 4,
+      "ops_supported": ["Conv", "Gemm", "Softmax", "Relu"],
+      "known_issues": [
+        "OWR / ORT Mobile CPU backend only; not a local Olive Studio Execute Live EP.",
+        "Prefer as mobile CPU fallback beside NNAPI."
+      ],
+      "notes": "Export-target profile. Recommend FP16/INT8 export chains similar to WebGPU, not CUDA AWQ."
+    },
+    {
+      "target": "WASM (Browser)",
+      "accelerator": "cpu",
+      "execution_providers": ["WasmExecutionProvider"],
+      "recommended_passes": ["OnnxConversion", "OnnxModelOptimizer", "OnnxFloatToFloat16"],
+      "typical_speedup": "0.5-2x",
+      "calibration_size": 64,
+      "optimal_batch_size": 1,
+      "memory_gb": 2,
+      "ops_supported": ["Conv", "Gemm", "Softmax"],
+      "known_issues": [
+        "ORT Web WASM CPU path; not a local Olive Python EP.",
+        "Often paired as WebGPU fallback in OWR web configs."
+      ],
+      "notes": "Export-target profile for browser CPU. Prefer FP16; keep graphs small."
+    },
+    {
+      "target": "Qualcomm SNPE (Legacy)",
+      "accelerator": "npu",
+      "execution_providers": ["SNPEExecutionProvider"],
+      "recommended_passes": ["OnnxConversion", "SNPEConversion"],
+      "typical_speedup": "2-6x",
+      "calibration_size": 64,
+      "optimal_batch_size": 1,
+      "memory_gb": 4,
+      "ops_supported": ["Conv", "Gemm", "Relu", "Softmax"],
+      "known_issues": [
+        "Legacy Qualcomm SNPE / DLC path; prefer QNNExecutionProvider for new Snapdragon work.",
+        "Not available for Studio Execute Live."
+      ],
+      "notes": "Legacy export profile. MCP should prefer QNN hardware guidance; keep SNPE only for DLC conversion recipes."
+    },
+    {
+      "target": "TensorFlow Lite Export",
+      "accelerator": "cpu",
+      "execution_providers": ["TensorflowLiteExecutionProvider"],
+      "recommended_passes": ["OnnxConversion", "OnnxModelOptimizer"],
+      "typical_speedup": "1-3x",
+      "calibration_size": 64,
+      "optimal_batch_size": 1,
+      "memory_gb": 2,
+      "ops_supported": ["Conv", "Gemm", "MaxPool", "Softmax"],
+      "known_issues": [
+        "TFLite conversion/export path; not a local Olive Execute Live EP.",
+        "Operator coverage differs from ONNX ORT EPs."
+      ],
+      "notes": "Export-target profile for TFLite conversion. Prefer INT8 TFLite tooling outside Studio Execute Live."
     }
   ]
 }

--- a/olive-mcp-server/olive_mcp_server/knowledge_base/passes.json
+++ b/olive-mcp-server/olive_mcp_server/knowledge_base/passes.json
@@ -1657,7 +1657,7 @@
           "default": "fp16"
         }
       },
-      "hardware_requirements": ["CPUExecutionProvider", "CUDAExecutionProvider", "DirectMLExecutionProvider"],
+      "hardware_requirements": ["CPUExecutionProvider", "CUDAExecutionProvider", "DmlExecutionProvider"],
       "typical_compression": "varies",
       "gotchas": ["Optimized for ONNX Runtime GenAI execution engine."]
     },

--- a/olive-mcp-server/olive_mcp_server/tools/normalization.py
+++ b/olive-mcp-server/olive_mcp_server/tools/normalization.py
@@ -92,8 +92,15 @@ _EXECUTION_PROVIDER_TO_TARGET = {
     "QNNExecutionProvider": "Qualcomm Snapdragon NPU",
     "ROCMExecutionProvider": "AMD MI300X / ROCm",
     "DmlExecutionProvider": "Windows DirectML GPU",
-    "DirectMLExecutionProvider": "Windows DirectML GPU",  # passes.json spelling
+    "DirectMLExecutionProvider": "Windows DirectML GPU",  # legacy alias only (canonical EP id is DmlExecutionProvider)
     "WebGpuExecutionProvider": "WebGPU (Browser)",
+    "CoreMLExecutionProvider": "Apple M2/M3 (CoreML)",
+    "NNAPIExecutionProvider": "Android NNAPI",
+    "VitisAIExecutionProvider": "Xilinx Vitis AI DPU",
+    "SNPEExecutionProvider": "Qualcomm SNPE (Legacy)",
+    "TensorflowLiteExecutionProvider": "TensorFlow Lite Export",
+    "XnnpackExecutionProvider": "XNNPACK (Mobile)",
+    "WasmExecutionProvider": "WASM (Browser)",
 }
 
 _EXECUTION_PROVIDER_TO_TARGET_LOWER = {
@@ -115,6 +122,14 @@ _HARDWARE_ALIASES = {
     "webgpu": "WebGPU (Browser)",
     "web gpu": "WebGPU (Browser)",
     "ort web": "WebGPU (Browser)",
+    "coreml": "Apple M2/M3 (CoreML)",
+    "nnapi": "Android NNAPI",
+    "vitisai": "Xilinx Vitis AI DPU",
+    "vitis-ai": "Xilinx Vitis AI DPU",
+    "snpe": "Qualcomm SNPE (Legacy)",
+    "tflite": "TensorFlow Lite Export",
+    "xnnpack": "XNNPACK (Mobile)",
+    "wasm": "WASM (Browser)",
 }
 
 OpenVinoDevice = Literal["CPU", "GPU", "NPU"]

--- a/olive-mcp-server/tests/test_hardware_ep_profiles.py
+++ b/olive-mcp-server/tests/test_hardware_ep_profiles.py
@@ -207,3 +207,17 @@ def test_compatibility_invalid_ov_device_errors() -> None:
     assert "tpu" in result["error"].lower()
     assert "openvino_device" not in result
     assert "selected_hardware" not in result
+
+
+def test_tflite_profile_is_onnx_prep_not_tflite_emitter() -> None:
+    """TFLite catalog entry prepares ONNX for external converters (no .tflite pass)."""
+    result = get_hardware_optimization_guide(target_hardware="tflite")
+    assert "error" not in result, result
+    assert result["target_hardware"] == "TensorFlow Lite Export"
+    assert "TensorflowLiteExecutionProvider" in result["execution_providers"]
+    assert result["recommended_passes"] == ["OnnxConversion", "OnnxModelOptimizer"]
+    notes = str(result.get("notes", "")).lower()
+    issues = " ".join(str(x).lower() for x in result.get("known_issues", []))
+    assert "onnx" in notes or "onnx" in issues
+    assert "external" in notes or "external" in issues
+    assert ".tflite" in notes or "tflite" in issues

--- a/scripts/validate-recipe-builder.ts
+++ b/scripts/validate-recipe-builder.ts
@@ -10,6 +10,7 @@ import { sanitizePipelineState } from "../src/lib/pipelineValidation";
 import { validateOliveRecipeStructure } from "../src/lib/oliveRecipeSchema";
 import { getPipelineValidation, prepareProviderChange } from "../src/lib/pipelineValidation";
 import { getSelectableProviders } from "../src/lib/hardwareProbe";
+import { alwaysSelectableProviders } from "../src/lib/providerRuntimeKind";
 import { deriveUiStateFromOliveRecipe } from "../src/lib/oliveRecipeHub";
 import { UIState } from "../src/types";
 
@@ -215,8 +216,13 @@ assert.equal(
 
 assert.deepEqual(
   getSelectableProviders(mockDesktopProbe),
-  ["CPUExecutionProvider", "CUDAExecutionProvider"],
-  "selectable providers must match probe detection"
+  Array.from(
+    new Set([
+      ...mockDesktopProbe.detectedProviders,
+      ...alwaysSelectableProviders(),
+    ]),
+  ),
+  "selectable providers must be detected ∪ always-selectable (export/platform)"
 );
 
 for (const [target, device] of [

--- a/src/components/features/BatchProcessingPanel.test.tsx
+++ b/src/components/features/BatchProcessingPanel.test.tsx
@@ -58,17 +58,21 @@ vi.mock("@/lib/hooks", async (importOriginal) => {
 });
 
 // Mock hardware probe
-vi.mock("@/lib/hardwareProbe", () => ({
-  fetchHardwareProbe: () =>
-    Promise.resolve({
-      probedAt: "now",
-      platform: { cpuModel: "Test CPU", cpuCores: 8, os: "win", arch: "x64" },
-      detectedProviders: ["CPUExecutionProvider"],
-      recommendedProvider: "CPUExecutionProvider",
-      notes: [],
-    }),
-  getSelectableProviders: () => ["CPUExecutionProvider"],
-}));
+vi.mock("@/lib/hardwareProbe", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/hardwareProbe")>();
+  return {
+    ...actual,
+    fetchHardwareProbe: () =>
+      Promise.resolve({
+        probedAt: "now",
+        platform: { cpuModel: "Test CPU", cpuCores: 8, os: "win", arch: "x64" },
+        detectedProviders: ["CPUExecutionProvider"],
+        recommendedProvider: "CPUExecutionProvider",
+        notes: [],
+      }),
+    getSelectableProviders: () => ["CPUExecutionProvider"],
+  };
+});
 
 function failedJob(id = "job-failed"): BatchJob {
   return {

--- a/src/components/features/BatchProcessingPanel.tsx
+++ b/src/components/features/BatchProcessingPanel.tsx
@@ -187,7 +187,7 @@ export function BatchProcessingPanel({
       };
       const jobValidation = getPipelineValidation(jobState, {
         forLocalExecution: true,
-        probe: hardwareProbe,
+        hardwareProbe,
       });
       if (jobValidation.isBlocked) {
         const errorLogs = [

--- a/src/components/features/BatchProcessingPanel.tsx
+++ b/src/components/features/BatchProcessingPanel.tsx
@@ -185,7 +185,10 @@ export function BatchProcessingPanel({
         azureModelPath: job.modelSource === "azure" ? job.modelIdentifier : state.azureModelPath,
         ihvProvider: job.provider,
       };
-      const jobValidation = getPipelineValidation(jobState, { forLocalExecution: true });
+      const jobValidation = getPipelineValidation(jobState, {
+        forLocalExecution: true,
+        probe: hardwareProbe,
+      });
       if (jobValidation.isBlocked) {
         const errorLogs = [
           ...((jobsRef.current ?? []).find((j) => j.id === job.id)?.logs || []),

--- a/src/components/features/HardwareProviderCard.tsx
+++ b/src/components/features/HardwareProviderCard.tsx
@@ -31,6 +31,11 @@ import {
 } from "@/lib/hardwareProbe";
 import type { ProviderCatalogEntry } from "@/lib/providerCatalog";
 import {
+  isExportTargetProvider,
+  isLegacyExportProvider,
+  isPlatformLocalProvider,
+} from "@/lib/providerRuntimeKind";
+import {
   OPEN_VINO_GPU_DRIVER_URL,
   OPEN_VINO_NPU_DRIVER_URL,
   pickOpenVinoTargetFromDevices,
@@ -102,7 +107,11 @@ function resolveCardChrome(input: {
   cardHardwareBlocked: boolean;
   cardHasCritical: boolean;
   cardHasWarning: boolean;
+  /** WebGPU keeps the historical “Browser deploy target” badge copy. */
   isWebGpuTarget: boolean;
+  isExportTarget: boolean;
+  isLegacyTarget: boolean;
+  isPlatformTarget: boolean;
   detectedLocally: boolean;
   probeLoading: boolean;
   needsPluginInstall: boolean;
@@ -121,10 +130,15 @@ function resolveCardChrome(input: {
     cardHasCritical,
     cardHasWarning,
     isWebGpuTarget,
+    isExportTarget,
+    isLegacyTarget,
+    isPlatformTarget,
     detectedLocally,
     probeLoading,
     needsPluginInstall,
   } = input;
+
+  const softTarget = isExportTarget || isPlatformTarget;
 
   if (isSelected) {
     if (cardBlocked) {
@@ -146,11 +160,17 @@ function resolveCardChrome(input: {
     return {
       cardClasses: base + "border-electric-blue bg-electric-blue/5",
       badgeText:
-        !detectedLocally && !probeLoading && !isWebGpuTarget
+        !detectedLocally && !probeLoading && !softTarget
           ? "Active (not local)"
           : isWebGpuTarget
             ? "Active (browser target)"
-            : "Active Target",
+            : isLegacyTarget
+              ? "Active (legacy export)"
+              : isExportTarget
+                ? "Active (export target)"
+                : isPlatformTarget
+                  ? "Active (platform)"
+                  : "Active Target",
       BadgeIcon: CheckCircle,
       badgeColor: "bg-electric-blue/10 text-electric-blue border-electric-blue/20",
     };
@@ -162,6 +182,32 @@ function resolveCardChrome(input: {
       badgeText: "Browser deploy target",
       BadgeIcon: Globe,
       badgeColor: "bg-slate-800/80 text-slate-300 border-slate-700/60",
+    };
+  }
+  if (isLegacyTarget) {
+    return {
+      cardClasses: base + "border-slate-800/80 bg-slate-900/40 hover:bg-slate-900 hover:border-slate-700",
+      badgeText: "Legacy export",
+      BadgeIcon: Globe,
+      badgeColor: "bg-amber-500/10 text-amber-400/90 border-amber-500/20",
+    };
+  }
+  if (isExportTarget) {
+    return {
+      cardClasses: base + "border-slate-800/80 bg-slate-900/40 hover:bg-slate-900 hover:border-slate-700",
+      badgeText: "Export target",
+      BadgeIcon: Globe,
+      badgeColor: "bg-slate-800/80 text-slate-300 border-slate-700/60",
+    };
+  }
+  if (isPlatformTarget) {
+    return {
+      cardClasses: base + "border-slate-800/80 bg-slate-900/40 hover:bg-slate-900 hover:border-slate-700",
+      badgeText: detectedLocally ? "Platform (local)" : "Platform",
+      BadgeIcon: detectedLocally ? CheckCircle : Globe,
+      badgeColor: detectedLocally
+        ? "bg-emerald-500/10 text-emerald-400 border-emerald-500/20"
+        : "bg-slate-800/80 text-slate-300 border-slate-700/60",
     };
   }
   if (cardHardwareBlocked) {
@@ -744,7 +790,7 @@ export function HardwareProviderCard({
   const pConflicts = getProviderConflicts(p.id, state.passes);
   const cardHasCritical = pConflicts.some((c) => c.severity === "critical");
   const cardHardwareBlocked =
-    p.id !== "WebGpuExecutionProvider" &&
+    !isExportTargetProvider(p.id) &&
     (Boolean(getProviderHardwareBlock(p.id, hardwareProbe)) ||
       (p.id === "CPUExecutionProvider" && !hardwareProbe));
   const cardBlocked = cardHasCritical || cardHardwareBlocked;
@@ -752,6 +798,9 @@ export function HardwareProviderCard({
   const showSwitchAssist = pConflicts.length > 0 && (isSelected || !cardBlocked);
   const detectedLocally = isProviderDetectedLocally(p.id, hardwareProbe);
   const isWebGpuTarget = p.id === "WebGpuExecutionProvider";
+  const isExportTarget = isExportTargetProvider(p.id);
+  const isLegacyTarget = isLegacyExportProvider(p.id);
+  const isPlatformTarget = isPlatformLocalProvider(p.id);
   const qnnNeedsInstall =
     Boolean(hardwareProbe) &&
     isProviderDetectedLocally("QNNExecutionProvider", hardwareProbe) &&
@@ -775,6 +824,9 @@ export function HardwareProviderCard({
     cardHasCritical,
     cardHasWarning,
     isWebGpuTarget,
+    isExportTarget,
+    isLegacyTarget,
+    isPlatformTarget,
     detectedLocally,
     probeLoading,
     needsPluginInstall,
@@ -882,7 +934,23 @@ export function HardwareProviderCard({
               Chrome or Edge 113+.
             </p>
           ) : null}
-          {!detectedLocally && !probeLoading && !isWebGpuTarget && !needsPluginInstall ? (
+          {isExportTarget && !isWebGpuTarget ? (
+            <p className="text-[11px] text-slate-500 mt-0.5 leading-relaxed">
+              {isLegacyTarget
+                ? "Legacy export path (prefer QNN for Snapdragon). Not available for Studio Execute Live."
+                : "Export / deploy target only. Not a local Python EP — Execute Live stays blocked."}
+            </p>
+          ) : null}
+          {isPlatformTarget && !detectedLocally && !probeLoading ? (
+            <p className="text-[11px] text-slate-500 mt-0.5 leading-relaxed">
+              Platform EP: selectable for recipes; Execute Live requires a matching ORT probe hit on this host.
+            </p>
+          ) : null}
+          {!detectedLocally &&
+          !probeLoading &&
+          !isExportTarget &&
+          !isPlatformTarget &&
+          !needsPluginInstall ? (
             <p className="text-[11px] text-slate-600">
               {p.id === "CPUExecutionProvider"
                 ? "Hardware detection unavailable — CPU status is unknown."

--- a/src/components/features/HardwareProviderCard.tsx
+++ b/src/components/features/HardwareProviderCard.tsx
@@ -791,6 +791,7 @@ export function HardwareProviderCard({
   const cardHasCritical = pConflicts.some((c) => c.severity === "critical");
   const cardHardwareBlocked =
     !isExportTargetProvider(p.id) &&
+    !isPlatformLocalProvider(p.id) &&
     (Boolean(getProviderHardwareBlock(p.id, hardwareProbe)) ||
       (p.id === "CPUExecutionProvider" && !hardwareProbe));
   const cardBlocked = cardHasCritical || cardHardwareBlocked;

--- a/src/components/features/IHVIntegrationPanel.tsx
+++ b/src/components/features/IHVIntegrationPanel.tsx
@@ -493,10 +493,7 @@ export function IHVIntegrationPanel({
     () => selectableProviders.filter((p) => getProviderRuntimeKind(p.id) !== "local"),
     [selectableProviders],
   );
-  const detectedProviders = useMemo(
-    () => hardwareProbe?.detectedProviders ?? (["CPUExecutionProvider"] as IHVProvider[]),
-    [hardwareProbe],
-  );
+  const detectedProviders = useMemo(() => getSelectableProviders(hardwareProbe), [hardwareProbe]);
   const locallyDetectedCount = useMemo(
     () => selectableProviders.filter((p) => isProviderDetectedLocally(p.id, hardwareProbe)).length,
     [selectableProviders, hardwareProbe],

--- a/src/components/features/IHVIntegrationPanel.tsx
+++ b/src/components/features/IHVIntegrationPanel.tsx
@@ -28,6 +28,7 @@ import { isMemoryOffloadAvailable, hasHuggingFaceModel } from "@/lib/memoryOfflo
 import { isGpuProvider, formatMemoryGb } from "@/lib/vramEstimate";
 import {
   fetchHardwareProbe,
+  getSelectableProviders,
   isProviderDetectedLocally,
   type HardwareProbeResult,
 } from "@/lib/hardwareProbe";

--- a/src/components/features/IHVIntegrationPanel.tsx
+++ b/src/components/features/IHVIntegrationPanel.tsx
@@ -28,10 +28,10 @@ import { isMemoryOffloadAvailable, hasHuggingFaceModel } from "@/lib/memoryOfflo
 import { isGpuProvider, formatMemoryGb } from "@/lib/vramEstimate";
 import {
   fetchHardwareProbe,
-  getSelectableProviders,
   isProviderDetectedLocally,
   type HardwareProbeResult,
 } from "@/lib/hardwareProbe";
+import { getProviderRuntimeKind } from "@/lib/providerRuntimeKind";
 import {
   isPreMaxwellNvidiaBox,
 } from "@/lib/cudaDeps";
@@ -485,7 +485,18 @@ export function IHVIntegrationPanel({
   // Real-time conflicts of the selected hardware provider
   const selectedConflicts = getProviderConflicts(state.ihvProvider, state.passes);
   const selectableProviders = useMemo(() => providers, []);
-  const detectedProviders = useMemo(() => getSelectableProviders(hardwareProbe), [hardwareProbe]);
+  const localAccelerators = useMemo(
+    () => selectableProviders.filter((p) => getProviderRuntimeKind(p.id) === "local"),
+    [selectableProviders],
+  );
+  const exportAndPlatformTargets = useMemo(
+    () => selectableProviders.filter((p) => getProviderRuntimeKind(p.id) !== "local"),
+    [selectableProviders],
+  );
+  const detectedProviders = useMemo(
+    () => hardwareProbe?.detectedProviders ?? (["CPUExecutionProvider"] as IHVProvider[]),
+    [hardwareProbe],
+  );
   const locallyDetectedCount = useMemo(
     () => selectableProviders.filter((p) => isProviderDetectedLocally(p.id, hardwareProbe)).length,
     [selectableProviders, hardwareProbe],
@@ -697,42 +708,94 @@ export function IHVIntegrationPanel({
               </div>
             ) : (
               <TooltipProvider delayDuration={200}>
-                {selectableProviders.map((p) => (
-                  <HardwareProviderCard
-                    key={p.id}
-                    provider={p}
-                    state={state}
-                    setState={setState}
-                    hardwareProbe={hardwareProbe}
-                    probeLoading={probeLoading}
-                    detectedProviders={detectedProviders}
-                    trtRtxNeedsInstall={trtRtxNeedsInstall}
-                    trtNeedsInstall={trtNeedsInstall}
-                    openvinoNeedsInstall={openvinoNeedsInstall}
-                    hardwareInstallBusy={hardwareInstallBusy}
-                    installingTrtRtx={installingTrtRtx}
-                    installTrtRtxError={installTrtRtxError}
-                    installTrtRtxLog={installTrtRtxLog}
-                    onInstallTensorRtRtx={() => void handleInstallTensorRtRtx()}
-                    installingTrt={installingTrt}
-                    installTrtError={installTrtError}
-                    installTrtLog={installTrtLog}
-                    onInstallTensorRt={() => void handleInstallTensorRt()}
-                    openvinoInstall={openvinoInstall}
-                    qnnInstall={qnnInstall}
-                    directMlInstall={directMlInstall}
-                    isPreMaxwellBox={isPreMaxwellBox}
-                    cudaNeedsOrtGpuInstall={cudaNeedsOrtGpuInstall}
-                    cudaToolkitMissingAndEpWorks={cudaToolkitMissingAndEpWorks}
-                    cudaToolkitMissing={cudaToolkitMissing}
-                    cudaEpInVenv={cudaEpInVenv}
-                    nvidiaGpus={nvidiaGpus}
-                    installingOrtGpu={installingOrtGpu}
-                    installOrtGpuError={installOrtGpuError}
-                    installOrtGpuLog={installOrtGpuLog}
-                    onInstallOrtGpu={() => void handleInstallOrtGpu()}
-                  />
-                ))}
+                <div className="space-y-5">
+                  <div className="space-y-3">
+                    <p className="text-[10px] font-mono uppercase tracking-wider text-slate-500">
+                      Local accelerators
+                    </p>
+                    <div className="grid gap-4 min-w-0 w-full">
+                      {localAccelerators.map((p) => (
+                        <HardwareProviderCard
+                          key={p.id}
+                          provider={p}
+                          state={state}
+                          setState={setState}
+                          hardwareProbe={hardwareProbe}
+                          probeLoading={probeLoading}
+                          detectedProviders={detectedProviders}
+                          trtRtxNeedsInstall={trtRtxNeedsInstall}
+                          trtNeedsInstall={trtNeedsInstall}
+                          openvinoNeedsInstall={openvinoNeedsInstall}
+                          hardwareInstallBusy={hardwareInstallBusy}
+                          installingTrtRtx={installingTrtRtx}
+                          installTrtRtxError={installTrtRtxError}
+                          installTrtRtxLog={installTrtRtxLog}
+                          onInstallTensorRtRtx={() => void handleInstallTensorRtRtx()}
+                          installingTrt={installingTrt}
+                          installTrtError={installTrtError}
+                          installTrtLog={installTrtLog}
+                          onInstallTensorRt={() => void handleInstallTensorRt()}
+                          openvinoInstall={openvinoInstall}
+                          qnnInstall={qnnInstall}
+                          directMlInstall={directMlInstall}
+                          isPreMaxwellBox={isPreMaxwellBox}
+                          cudaNeedsOrtGpuInstall={cudaNeedsOrtGpuInstall}
+                          cudaToolkitMissingAndEpWorks={cudaToolkitMissingAndEpWorks}
+                          cudaToolkitMissing={cudaToolkitMissing}
+                          cudaEpInVenv={cudaEpInVenv}
+                          nvidiaGpus={nvidiaGpus}
+                          installingOrtGpu={installingOrtGpu}
+                          installOrtGpuError={installOrtGpuError}
+                          installOrtGpuLog={installOrtGpuLog}
+                          onInstallOrtGpu={() => void handleInstallOrtGpu()}
+                        />
+                      ))}
+                    </div>
+                  </div>
+                  <div className="space-y-3">
+                    <p className="text-[10px] font-mono uppercase tracking-wider text-slate-500">
+                      Export &amp; platform targets
+                    </p>
+                    <div className="grid gap-4 min-w-0 w-full">
+                      {exportAndPlatformTargets.map((p) => (
+                        <HardwareProviderCard
+                          key={p.id}
+                          provider={p}
+                          state={state}
+                          setState={setState}
+                          hardwareProbe={hardwareProbe}
+                          probeLoading={probeLoading}
+                          detectedProviders={detectedProviders}
+                          trtRtxNeedsInstall={trtRtxNeedsInstall}
+                          trtNeedsInstall={trtNeedsInstall}
+                          openvinoNeedsInstall={openvinoNeedsInstall}
+                          hardwareInstallBusy={hardwareInstallBusy}
+                          installingTrtRtx={installingTrtRtx}
+                          installTrtRtxError={installTrtRtxError}
+                          installTrtRtxLog={installTrtRtxLog}
+                          onInstallTensorRtRtx={() => void handleInstallTensorRtRtx()}
+                          installingTrt={installingTrt}
+                          installTrtError={installTrtError}
+                          installTrtLog={installTrtLog}
+                          onInstallTensorRt={() => void handleInstallTensorRt()}
+                          openvinoInstall={openvinoInstall}
+                          qnnInstall={qnnInstall}
+                          directMlInstall={directMlInstall}
+                          isPreMaxwellBox={isPreMaxwellBox}
+                          cudaNeedsOrtGpuInstall={cudaNeedsOrtGpuInstall}
+                          cudaToolkitMissingAndEpWorks={cudaToolkitMissingAndEpWorks}
+                          cudaToolkitMissing={cudaToolkitMissing}
+                          cudaEpInVenv={cudaEpInVenv}
+                          nvidiaGpus={nvidiaGpus}
+                          installingOrtGpu={installingOrtGpu}
+                          installOrtGpuError={installOrtGpuError}
+                          installOrtGpuLog={installOrtGpuLog}
+                          onInstallOrtGpu={() => void handleInstallOrtGpu()}
+                        />
+                      ))}
+                    </div>
+                  </div>
+                </div>
               </TooltipProvider>
             )}
           </div>

--- a/src/components/features/recipe-graph/RecipeValidationPanel.tsx
+++ b/src/components/features/recipe-graph/RecipeValidationPanel.tsx
@@ -52,7 +52,21 @@ function getHardwareTargetFromProvider(provider: IHVProvider): string {
     case "ROCMExecutionProvider":
       return "AMD MI300X / ROCm";
     case "WebGpuExecutionProvider":
-      return "";
+      return "WebGPU (Browser)";
+    case "CoreMLExecutionProvider":
+      return "Apple M2/M3 (CoreML)";
+    case "NNAPIExecutionProvider":
+      return "Android NNAPI";
+    case "VitisAIExecutionProvider":
+      return "Xilinx Vitis AI DPU";
+    case "SNPEExecutionProvider":
+      return "Qualcomm SNPE (Legacy)";
+    case "TensorflowLiteExecutionProvider":
+      return "TensorFlow Lite Export";
+    case "XnnpackExecutionProvider":
+      return "XNNPACK (Mobile)";
+    case "WasmExecutionProvider":
+      return "WASM (Browser)";
     default: {
       const _exhaustive: never = provider;
       return _exhaustive;

--- a/src/lib/__tests__/oliveRecipeBuilder.test.ts
+++ b/src/lib/__tests__/oliveRecipeBuilder.test.ts
@@ -183,6 +183,16 @@ describe("providerToAccelerator", () => {
     });
   });
 
+  it("maps CoreML / NNAPI / VitisAI / SNPE to npu and Wasm / Xnnpack / TFLite to cpu", () => {
+    expect(providerToAccelerator("CoreMLExecutionProvider").device).toBe("npu");
+    expect(providerToAccelerator("NNAPIExecutionProvider").device).toBe("npu");
+    expect(providerToAccelerator("VitisAIExecutionProvider").device).toBe("npu");
+    expect(providerToAccelerator("SNPEExecutionProvider").device).toBe("npu");
+    expect(providerToAccelerator("XnnpackExecutionProvider").device).toBe("cpu");
+    expect(providerToAccelerator("WasmExecutionProvider").device).toBe("cpu");
+    expect(providerToAccelerator("TensorflowLiteExecutionProvider").device).toBe("cpu");
+  });
+
   it("returns execution_providers array containing the provider string", () => {
     const providers: IHVProvider[] = [
       "CPUExecutionProvider",
@@ -192,6 +202,13 @@ describe("providerToAccelerator", () => {
       "OpenVINOExecutionProvider",
       "QNNExecutionProvider",
       "ROCMExecutionProvider",
+      "CoreMLExecutionProvider",
+      "NNAPIExecutionProvider",
+      "VitisAIExecutionProvider",
+      "SNPEExecutionProvider",
+      "TensorflowLiteExecutionProvider",
+      "XnnpackExecutionProvider",
+      "WasmExecutionProvider",
     ];
     for (const p of providers) {
       expect(providerToAccelerator(p).execution_providers).toEqual([p]);

--- a/src/lib/__tests__/oliveRecipeHub.directml.test.ts
+++ b/src/lib/__tests__/oliveRecipeHub.directml.test.ts
@@ -30,4 +30,33 @@ describe("oliveRecipeHub DirectML mapping", () => {
   it("maps DmlExecutionProvider to DirectML catalog device", () => {
     expect(mapProviderToCatalogDevice("DmlExecutionProvider")).toBe("DirectML");
   });
+
+  it("maps newly catalogued export/platform EP tokens on import", () => {
+    const cases: Array<[string, ReturnType<typeof getExecutionProviderFromRecipe>]> = [
+      ["CoreMLExecutionProvider", "CoreMLExecutionProvider"],
+      ["coreml", "CoreMLExecutionProvider"],
+      ["NNAPIExecutionProvider", "NNAPIExecutionProvider"],
+      ["VitisAIExecutionProvider", "VitisAIExecutionProvider"],
+      ["vitis-ai", "VitisAIExecutionProvider"],
+      ["SNPEExecutionProvider", "SNPEExecutionProvider"],
+      ["TensorflowLiteExecutionProvider", "TensorflowLiteExecutionProvider"],
+      ["tflite", "TensorflowLiteExecutionProvider"],
+      ["XnnpackExecutionProvider", "XnnpackExecutionProvider"],
+      ["WasmExecutionProvider", "WasmExecutionProvider"],
+      ["CPUExecutionProvider", "CPUExecutionProvider"],
+    ];
+    for (const [token, expected] of cases) {
+      expect(
+        getExecutionProviderFromRecipe({
+          systems: {
+            local_system: {
+              config: {
+                accelerators: [{ execution_providers: [token] }],
+              },
+            },
+          },
+        }),
+      ).toBe(expected);
+    }
+  });
 });

--- a/src/lib/__tests__/owrExportConfigs.test.ts
+++ b/src/lib/__tests__/owrExportConfigs.test.ts
@@ -49,10 +49,16 @@ describe("owrExportConfigs", () => {
   it("keeps intentional Studio vs OWR EP spelling dualism", () => {
     expect(STUDIO_WEB_GPU_EP).toBe("WebGpuExecutionProvider");
     expect(studioWebGpuToOwrEp()).toBe(OWR_WEB_GPU_EP);
+    expect(studioWebGpuToOwrEp(STUDIO_WEB_GPU_EP)).toBe(OWR_WEB_GPU_EP);
+    expect(studioWebGpuToOwrEp(OWR_WEB_GPU_EP)).toBe(OWR_WEB_GPU_EP);
     expect(OWR_WEB_GPU_EP).toBe("WebGPUExecutionProvider");
     expect(STUDIO_NNAPI_EP).toBe("NNAPIExecutionProvider");
     expect(studioNnapiToOwrEp()).toBe(OWR_NNAPI_EP);
+    expect(studioNnapiToOwrEp(STUDIO_NNAPI_EP)).toBe(OWR_NNAPI_EP);
+    expect(studioNnapiToOwrEp(OWR_NNAPI_EP)).toBe(OWR_NNAPI_EP);
     expect(OWR_NNAPI_EP).toBe("NnapiExecutionProvider");
+    expect(() => studioWebGpuToOwrEp("CUDAExecutionProvider")).toThrow(/WebGPU/);
+    expect(() => studioNnapiToOwrEp("garbage")).toThrow(/NNAPI/);
   });
 
   it("builds web and mobile configs without throwing", () => {

--- a/src/lib/__tests__/owrExportConfigs.test.ts
+++ b/src/lib/__tests__/owrExportConfigs.test.ts
@@ -1,5 +1,17 @@
 import { describe, expect, it } from "vitest";
-import { buildOwrConfigs, deduceOwrArchitecture, resolveOwrModelName } from "@/lib/owrExportConfigs";
+import {
+  buildOwrConfigs,
+  deduceOwrArchitecture,
+  OWR_NNAPI_EP,
+  OWR_WEB_GPU_EP,
+  OWR_WASM_EP,
+  OWR_XNNPACK_EP,
+  resolveOwrModelName,
+  studioNnapiToOwrEp,
+  studioWebGpuToOwrEp,
+  STUDIO_NNAPI_EP,
+  STUDIO_WEB_GPU_EP,
+} from "@/lib/owrExportConfigs";
 import type { UIState } from "@/types";
 
 function minimalState(overrides: Partial<UIState> = {}): UIState {
@@ -34,6 +46,15 @@ describe("owrExportConfigs", () => {
     ).toBe("weights.bin");
   });
 
+  it("keeps intentional Studio vs OWR EP spelling dualism", () => {
+    expect(STUDIO_WEB_GPU_EP).toBe("WebGpuExecutionProvider");
+    expect(studioWebGpuToOwrEp()).toBe(OWR_WEB_GPU_EP);
+    expect(OWR_WEB_GPU_EP).toBe("WebGPUExecutionProvider");
+    expect(STUDIO_NNAPI_EP).toBe("NNAPIExecutionProvider");
+    expect(studioNnapiToOwrEp()).toBe(OWR_NNAPI_EP);
+    expect(OWR_NNAPI_EP).toBe("NnapiExecutionProvider");
+  });
+
   it("builds web and mobile configs without throwing", () => {
     const configs = buildOwrConfigs({
       state: minimalState(),
@@ -41,9 +62,23 @@ describe("owrExportConfigs", () => {
       threads: "4",
       vramMode: "performance",
     });
-    expect(configs.ortConfig.session_options.execution_providers).toContain("WebGPUExecutionProvider");
+    expect(configs.ortConfig.session_options.execution_providers).toEqual([
+      OWR_WEB_GPU_EP,
+      OWR_WASM_EP,
+    ]);
     expect(configs.manifestConfig.model_metadata.architecture).toBe("Llama");
     expect(configs.webInitCode).toContain("webgpu");
     expect(configs.mobileInitCode).toContain("OnnxModelExecutor");
+
+    const mobile = buildOwrConfigs({
+      state: minimalState(),
+      platform: "mobile",
+      threads: "2",
+      vramMode: "memory",
+    });
+    expect(mobile.ortConfig.session_options.execution_providers).toEqual([
+      OWR_XNNPACK_EP,
+      OWR_NNAPI_EP,
+    ]);
   });
 });

--- a/src/lib/__tests__/pipelineValidation.test.ts
+++ b/src/lib/__tests__/pipelineValidation.test.ts
@@ -533,6 +533,23 @@ describe("getPipelineValidation", () => {
     expect(r.issues.some((i) => i.id === "qnn-readiness-qnn_out_of_scope")).toBe(true);
   });
 
+  it("emits a single critical for undetected platform-local Execute Live", () => {
+    const probe = {
+      probedAt: new Date().toISOString(),
+      platform: { os: "linux", arch: "x64", cpuModel: "Intel", cpuCores: 8 },
+      detectedProviders: ["CPUExecutionProvider"] as IHVProvider[],
+      recommendedProvider: "CPUExecutionProvider" as IHVProvider,
+      notes: [],
+    };
+    const r = getPipelineValidation(baseState({ ihvProvider: "CoreMLExecutionProvider" }), {
+      forLocalExecution: true,
+      hardwareProbe: probe,
+    });
+    const critical = r.issues.filter((i) => i.severity === "critical");
+    expect(critical.map((i) => i.id)).toEqual(["platform-local-execution-unavailable"]);
+    expect(r.isBlocked).toBe(true);
+  });
+
   it("blocks QNN when runtime is not loadable on Windows ARM64", () => {
     const probe = {
       probedAt: new Date().toISOString(),

--- a/src/lib/__tests__/providerCatalog.test.ts
+++ b/src/lib/__tests__/providerCatalog.test.ts
@@ -48,6 +48,14 @@ describe("PROVIDER_CATALOG", () => {
     expect(ids).toContain("ROCMExecutionProvider");
     expect(ids).toContain("QNNExecutionProvider");
     expect(ids).toContain("WebGpuExecutionProvider");
+    expect(ids).toContain("CoreMLExecutionProvider");
+    expect(ids).toContain("NNAPIExecutionProvider");
+    expect(ids).toContain("VitisAIExecutionProvider");
+    expect(ids).toContain("SNPEExecutionProvider");
+    expect(ids).toContain("TensorflowLiteExecutionProvider");
+    expect(ids).toContain("XnnpackExecutionProvider");
+    expect(ids).toContain("WasmExecutionProvider");
+    expect(ids).toHaveLength(16);
   });
 
   it("returns the matching entry from getProviderCatalogEntry", () => {

--- a/src/lib/__tests__/providerRuntimeKind.test.ts
+++ b/src/lib/__tests__/providerRuntimeKind.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import {
+  alwaysSelectableProviders,
+  getProviderRuntimeKind,
+  isExportTargetProvider,
+  isLegacyExportProvider,
+  isPlatformLocalProvider,
+} from "@/lib/providerRuntimeKind";
+import {
+  getProviderAvailabilityBlock,
+  getSelectableProviders,
+  mapOrtProvidersToIhv,
+  type HardwareProbeResult,
+} from "@/lib/hardwareProbe";
+
+function cpuOnlyProbe(): HardwareProbeResult {
+  return {
+    probedAt: new Date().toISOString(),
+    platform: { os: "linux", arch: "x64", cpuModel: "Test CPU", cpuCores: 8 },
+    detectedProviders: ["CPUExecutionProvider"],
+    recommendedProvider: "CPUExecutionProvider",
+    notes: [],
+  };
+}
+
+describe("providerRuntimeKind", () => {
+  it("classifies local / export / platform roles", () => {
+    expect(getProviderRuntimeKind("CUDAExecutionProvider")).toBe("local");
+    expect(getProviderRuntimeKind("WebGpuExecutionProvider")).toBe("exportTarget");
+    expect(getProviderRuntimeKind("NNAPIExecutionProvider")).toBe("exportTarget");
+    expect(getProviderRuntimeKind("CoreMLExecutionProvider")).toBe("platformLocal");
+    expect(getProviderRuntimeKind("VitisAIExecutionProvider")).toBe("platformLocal");
+    expect(isLegacyExportProvider("SNPEExecutionProvider")).toBe(true);
+    expect(isExportTargetProvider("WasmExecutionProvider")).toBe(true);
+    expect(isPlatformLocalProvider("CoreMLExecutionProvider")).toBe(true);
+  });
+});
+
+describe("export-target probe carve-outs", () => {
+  it("never treats export targets as availability failures", () => {
+    const probe = cpuOnlyProbe();
+    for (const provider of alwaysSelectableProviders()) {
+      expect(getProviderAvailabilityBlock(provider, probe)).toBeNull();
+    }
+  });
+
+  it("keeps export targets selectable even when absent from detectedProviders", () => {
+    const selectable = getSelectableProviders(cpuOnlyProbe());
+    expect(selectable).toContain("CPUExecutionProvider");
+    expect(selectable).toContain("WebGpuExecutionProvider");
+    expect(selectable).toContain("NNAPIExecutionProvider");
+    expect(selectable).toContain("XnnpackExecutionProvider");
+    expect(selectable).toContain("WasmExecutionProvider");
+    expect(selectable).not.toContain("CUDAExecutionProvider");
+  });
+
+  it("maps CoreML / VitisAI ORT names when present", () => {
+    expect(mapOrtProvidersToIhv(["CoreMLExecutionProvider", "VitisAIExecutionProvider"])).toEqual(
+      expect.arrayContaining(["CoreMLExecutionProvider", "VitisAIExecutionProvider"]),
+    );
+    expect(mapOrtProvidersToIhv(["WebGPUExecutionProvider", "NnapiExecutionProvider"])).toEqual(
+      expect.arrayContaining(["WebGpuExecutionProvider", "NNAPIExecutionProvider"]),
+    );
+  });
+});

--- a/src/lib/__tests__/providerRuntimeKind.test.ts
+++ b/src/lib/__tests__/providerRuntimeKind.test.ts
@@ -51,7 +51,16 @@ describe("export-target probe carve-outs", () => {
     expect(selectable).toContain("NNAPIExecutionProvider");
     expect(selectable).toContain("XnnpackExecutionProvider");
     expect(selectable).toContain("WasmExecutionProvider");
+    expect(selectable).toContain("CoreMLExecutionProvider");
+    expect(selectable).toContain("VitisAIExecutionProvider");
     expect(selectable).not.toContain("CUDAExecutionProvider");
+  });
+
+  it("includes platform-local providers in alwaysSelectableProviders", () => {
+    const always = alwaysSelectableProviders();
+    expect(always).toEqual(
+      expect.arrayContaining(["CoreMLExecutionProvider", "VitisAIExecutionProvider"]),
+    );
   });
 
   it("maps CoreML / VitisAI ORT names when present", () => {

--- a/src/lib/__tests__/recipePipeline.test.ts
+++ b/src/lib/__tests__/recipePipeline.test.ts
@@ -253,6 +253,44 @@ describe("projectUiStateToRecipeEvaluation", () => {
     expect(result.recipe).toHaveProperty("systems");
   });
 
+  it("marks export-target EPs non-runnable for local Execute Live", () => {
+    for (const ihvProvider of [
+      "NNAPIExecutionProvider",
+      "XnnpackExecutionProvider",
+      "WasmExecutionProvider",
+      "SNPEExecutionProvider",
+      "TensorflowLiteExecutionProvider",
+    ] as const) {
+      const result = projectUiStateToRecipeEvaluation(baseState({ ihvProvider }));
+      expect(result.isRunnable).toBe(false);
+      expect(
+        result.localExecutionIssues.some((i) => i.id === "export-target-local-execution-unsupported"),
+      ).toBe(true);
+    }
+  });
+
+  it("blocks platform-local EPs until the probe lists them", () => {
+    const blocked = projectUiStateToRecipeEvaluation(
+      baseState({ ihvProvider: "CoreMLExecutionProvider" }),
+    );
+    expect(blocked.isRunnable).toBe(false);
+    expect(
+      blocked.localExecutionIssues.some((i) => i.id === "platform-local-execution-unavailable"),
+    ).toBe(true);
+
+    const probe: HardwareProbeResult = {
+      probedAt: new Date().toISOString(),
+      platform: { os: "darwin", arch: "arm64", cpuModel: "Apple M2", cpuCores: 8 },
+      detectedProviders: ["CPUExecutionProvider", "CoreMLExecutionProvider"],
+      recommendedProvider: "CoreMLExecutionProvider",
+      notes: [],
+    };
+    const allowed = buildRecipeFromState(baseState({ ihvProvider: "CoreMLExecutionProvider" }), {
+      hardwareProbe: probe,
+    });
+    expect(allowed.localExecutionIssues).toEqual([]);
+  });
+
   // ❌ Negative: returned issue arrays are defensive copies
   it("returns defensive copies of issue arrays (mutation does not leak)", () => {
     // Arrange

--- a/src/lib/__tests__/venvFamily.test.ts
+++ b/src/lib/__tests__/venvFamily.test.ts
@@ -35,6 +35,24 @@ describe("venvFamily policy", () => {
     expect(mandatoryFamilyForProvider("OpenVINOExecutionProvider")).toBe("openvino");
     expect(mandatoryFamilyForProvider("QNNExecutionProvider")).toBe("qnn");
     expect(mandatoryFamilyForProvider("CPUExecutionProvider")).toBeNull();
+    expect(mandatoryFamilyForProvider("WebGpuExecutionProvider")).toBeNull();
+    expect(mandatoryFamilyForProvider("CoreMLExecutionProvider")).toBeNull();
+    expect(mandatoryFamilyForProvider("NNAPIExecutionProvider")).toBeNull();
+    expect(mandatoryFamilyForProvider("VitisAIExecutionProvider")).toBeNull();
+    expect(mandatoryFamilyForProvider("SNPEExecutionProvider")).toBeNull();
+    expect(mandatoryFamilyForProvider("TensorflowLiteExecutionProvider")).toBeNull();
+    expect(mandatoryFamilyForProvider("XnnpackExecutionProvider")).toBeNull();
+    expect(mandatoryFamilyForProvider("WasmExecutionProvider")).toBeNull();
+  });
+
+  it("normalizes new export/platform aliases", () => {
+    expect(normalizeIhvProvider("coreml")).toBe("CoreMLExecutionProvider");
+    expect(normalizeIhvProvider("nnapi")).toBe("NNAPIExecutionProvider");
+    expect(normalizeIhvProvider("vitisai")).toBe("VitisAIExecutionProvider");
+    expect(normalizeIhvProvider("snpe")).toBe("SNPEExecutionProvider");
+    expect(normalizeIhvProvider("tflite")).toBe("TensorflowLiteExecutionProvider");
+    expect(normalizeIhvProvider("xnnpack")).toBe("XnnpackExecutionProvider");
+    expect(normalizeIhvProvider("wasm")).toBe("WasmExecutionProvider");
   });
 
   it("labels openvino and qnn families", () => {

--- a/src/lib/hardwareProbe.ts
+++ b/src/lib/hardwareProbe.ts
@@ -6,6 +6,10 @@ import {
   pinnedOrtGpuInstallCommand,
 } from "@/lib/cudaDeps";
 import { resolveQnnHostMode } from "@/lib/qnnDeps";
+import {
+  alwaysSelectableProviders,
+  isExportTargetProvider,
+} from "@/lib/providerRuntimeKind";
 
 /**
  * Compute capability is reported as `"<major>.<minor>"` (e.g. `"8.9"` for
@@ -172,6 +176,16 @@ const ORT_PROVIDER_MAP: Record<string, IHVProvider> = {
   QNNExecutionProvider: "QNNExecutionProvider",
   ROCMExecutionProvider: "ROCMExecutionProvider",
   WebGpuExecutionProvider: "WebGpuExecutionProvider",
+  // Browser / OWR spellings are not local Python EPs; map if a probe ever reports them.
+  WebGPUExecutionProvider: "WebGpuExecutionProvider",
+  CoreMLExecutionProvider: "CoreMLExecutionProvider",
+  NNAPIExecutionProvider: "NNAPIExecutionProvider",
+  NnapiExecutionProvider: "NNAPIExecutionProvider",
+  VitisAIExecutionProvider: "VitisAIExecutionProvider",
+  SNPEExecutionProvider: "SNPEExecutionProvider",
+  TensorflowLiteExecutionProvider: "TensorflowLiteExecutionProvider",
+  XnnpackExecutionProvider: "XnnpackExecutionProvider",
+  WasmExecutionProvider: "WasmExecutionProvider",
 };
 
 /**
@@ -457,6 +471,20 @@ function undetectedProviderReason(
     }
     case "WebGpuExecutionProvider":
       return "WebGPU is a browser deploy target (ONNX Runtime Web), not a local Python EP. Select it to build web-oriented recipes, then run Browser Test / WebGPU benchmark in Recipe & run (Chrome 113+ / Edge 113+).";
+    case "CoreMLExecutionProvider":
+      return "Apple CoreML was not detected (requires macOS/iOS onnxruntime with CoreMLExecutionProvider). You can still select it for recipe export; Execute Live needs a probe hit.";
+    case "VitisAIExecutionProvider":
+      return "AMD/Xilinx Vitis AI was not detected (requires a Vitis AI ORT build). You can still select it for recipe export; Execute Live needs a probe hit.";
+    case "NNAPIExecutionProvider":
+      return "Android NNAPI is an OWR / mobile export target, not a local Python EP.";
+    case "SNPEExecutionProvider":
+      return "Qualcomm SNPE is a legacy export path (prefer QNN). Not available for Studio Execute Live.";
+    case "TensorflowLiteExecutionProvider":
+      return "TensorFlow Lite is a conversion/export path, not a local Olive Execute Live EP.";
+    case "XnnpackExecutionProvider":
+      return "XNNPACK is an OWR / ORT Mobile CPU export target, not a local Python EP.";
+    case "WasmExecutionProvider":
+      return "WASM is an ONNX Runtime Web CPU export target, not a local Python EP.";
     case "DmlExecutionProvider":
       return "Windows DirectML was not detected (requires Windows + onnxruntime-directml in the default .venv). Use Install in Hardware.";
     case "CPUExecutionProvider":
@@ -468,21 +496,30 @@ function undetectedProviderReason(
   }
 }
 
-/** Providers the user may select after local hardware detection. */
+/**
+ * Providers the user may select after local hardware detection.
+ * Export targets (WebGPU, OWR mobile/web, TFLite, SNPE) are always choosable
+ * even when absent from `detectedProviders` — they are not local Python EPs,
+ * so missing them from the probe must never look like a failed detection.
+ */
 export function getSelectableProviders(probe: HardwareProbeResult | null | undefined): IHVProvider[] {
+  const extras = alwaysSelectableProviders();
   if (!probe) {
-    return ["CPUExecutionProvider"];
+    return Array.from(new Set<IHVProvider>(["CPUExecutionProvider", ...extras]));
   }
-  return probe.detectedProviders;
+  return Array.from(new Set<IHVProvider>([...probe.detectedProviders, ...extras]));
 }
 
-/** Block selection when a provider is absent from the local probe. */
+/**
+ * Block selection when a provider is absent from the local probe.
+ * Export targets never return a block (selectable without “not detected”).
+ */
 export function getProviderAvailabilityBlock(
   provider: IHVProvider,
   probe: HardwareProbeResult | null | undefined,
 ): { reason: string } | null {
-  // WebGPU is a browser deploy target (ORT Web), not a local Python EP to probe.
-  if (provider === "WebGpuExecutionProvider") {
+  // Export targets (incl. WebGPU) are not local Python EPs to probe.
+  if (isExportTargetProvider(provider)) {
     return null;
   }
   if (provider === "CPUExecutionProvider") {

--- a/src/lib/hardwareProbe.ts
+++ b/src/lib/hardwareProbe.ts
@@ -499,9 +499,9 @@ function undetectedProviderReason(
 
 /**
  * Providers the user may select after local hardware detection.
- * Export targets (WebGPU, OWR mobile/web, TFLite, SNPE) are always choosable
- * even when absent from `detectedProviders` — they are not local Python EPs,
- * so missing them from the probe must never look like a failed detection.
+ * Export targets and platform-local EPs (CoreML/VitisAI) are always choosable
+ * even when absent from `detectedProviders` — recipe selection must not look
+ * like a failed detection. Execute Live is gated separately.
  */
 export function getSelectableProviders(probe: HardwareProbeResult | null | undefined): IHVProvider[] {
   const extras = alwaysSelectableProviders();

--- a/src/lib/hardwareProbe.ts
+++ b/src/lib/hardwareProbe.ts
@@ -513,14 +513,15 @@ export function getSelectableProviders(probe: HardwareProbeResult | null | undef
 
 /**
  * Block selection when a provider is absent from the local probe.
- * Export targets never return a block (selectable without “not detected”).
+ * Export targets and platform-local EPs never return a block (selectable without
+ * “not detected”); Execute Live is gated separately via pipeline validation.
  */
 export function getProviderAvailabilityBlock(
   provider: IHVProvider,
   probe: HardwareProbeResult | null | undefined,
 ): { reason: string } | null {
-  // Export targets (incl. WebGPU) are not local Python EPs to probe.
-  if (isExportTargetProvider(provider)) {
+  // Export / platform-local targets are recipe-selectable without a probe hit.
+  if (isExportTargetProvider(provider) || isPlatformLocalProvider(provider)) {
     return null;
   }
   if (provider === "CPUExecutionProvider") {

--- a/src/lib/hardwareProbe.ts
+++ b/src/lib/hardwareProbe.ts
@@ -9,6 +9,7 @@ import { resolveQnnHostMode } from "@/lib/qnnDeps";
 import {
   alwaysSelectableProviders,
   isExportTargetProvider,
+  isPlatformLocalProvider,
 } from "@/lib/providerRuntimeKind";
 
 /**

--- a/src/lib/oliveRecipeBuilder.ts
+++ b/src/lib/oliveRecipeBuilder.ts
@@ -10,7 +10,13 @@ const GPU_PROVIDERS: IHVProvider[] = [
   "WebGpuExecutionProvider",
   "DmlExecutionProvider",
 ];
-const NPU_PROVIDERS: IHVProvider[] = ["QNNExecutionProvider"];
+const NPU_PROVIDERS: IHVProvider[] = [
+  "QNNExecutionProvider",
+  "CoreMLExecutionProvider",
+  "NNAPIExecutionProvider",
+  "VitisAIExecutionProvider",
+  "SNPEExecutionProvider",
+];
 
 /**
  * Ordered task-inference rules — first match wins. Order is significant

--- a/src/lib/oliveRecipeHub.ts
+++ b/src/lib/oliveRecipeHub.ts
@@ -174,6 +174,18 @@ function mapExecutionProviderFromRecipe(parsed: any): IHVProvider | undefined {
         if (token.includes("openvino")) return "OpenVINOExecutionProvider";
         if (token.includes("webgpu")) return "WebGpuExecutionProvider";
         if (token.includes("rocm")) return "ROCMExecutionProvider";
+        if (token.includes("coreml")) return "CoreMLExecutionProvider";
+        if (token.includes("nnapi")) return "NNAPIExecutionProvider";
+        if (token.includes("vitisai") || token.includes("vitis-ai") || token.includes("vitis_ai")) {
+          return "VitisAIExecutionProvider";
+        }
+        if (token.includes("snpe")) return "SNPEExecutionProvider";
+        if (token.includes("tflite") || token.includes("tensorflowlite")) {
+          return "TensorflowLiteExecutionProvider";
+        }
+        if (token.includes("xnnpack")) return "XnnpackExecutionProvider";
+        if (token.includes("wasm")) return "WasmExecutionProvider";
+        if (token.includes("cpu")) return "CPUExecutionProvider";
       }
     }
   }
@@ -219,6 +231,16 @@ export function getCatalogDeviceFromRecipe(parsed: unknown): string | undefined 
         if (token.includes("openvino")) return "OpenVINO";
         if (token.includes("webgpu")) return "WebGPU";
         if (token.includes("rocm")) return "CUDA";
+        if (token.includes("coreml")) return "CoreML";
+        if (token.includes("nnapi")) return "NNAPI";
+        if (token.includes("vitisai") || token.includes("vitis-ai") || token.includes("vitis_ai")) {
+          return "VitisAI";
+        }
+        if (token.includes("snpe")) return "SNPE";
+        if (token.includes("tflite") || token.includes("tensorflowlite")) return "TFLite";
+        if (token.includes("xnnpack")) return "XNNPACK";
+        if (token.includes("wasm")) return "WASM";
+        if (token.includes("cpu")) return "CPU";
       }
     }
   }

--- a/src/lib/oliveRecipeHub.ts
+++ b/src/lib/oliveRecipeHub.ts
@@ -248,6 +248,20 @@ export function mapProviderToCatalogDevice(provider: IHVProvider): string {
       return "DirectML";
     case "WebGpuExecutionProvider":
       return "WebGPU";
+    case "CoreMLExecutionProvider":
+      return "CoreML";
+    case "NNAPIExecutionProvider":
+      return "NNAPI";
+    case "VitisAIExecutionProvider":
+      return "VitisAI";
+    case "SNPEExecutionProvider":
+      return "SNPE";
+    case "TensorflowLiteExecutionProvider":
+      return "TFLite";
+    case "XnnpackExecutionProvider":
+      return "XNNPACK";
+    case "WasmExecutionProvider":
+      return "WASM";
     case "CPUExecutionProvider":
       return "CPU";
     default: {

--- a/src/lib/owrExportConfigs.ts
+++ b/src/lib/owrExportConfigs.ts
@@ -3,6 +3,40 @@ import type { UIState } from "@/types";
 export type OwrPlatform = "web" | "mobile";
 export type OwrVramMode = "performance" | "memory";
 
+/**
+ * Intentional dual spellings between Studio catalog and ORT Web / OWR:
+ * - Studio / Olive recipe: `WebGpuExecutionProvider`
+ * - ORT Web session config: `WebGPUExecutionProvider`
+ * - Studio / Olive recipe: `NNAPIExecutionProvider`
+ * - OWR mobile ORT config: `NnapiExecutionProvider`
+ */
+export const STUDIO_WEB_GPU_EP = "WebGpuExecutionProvider" as const;
+export const OWR_WEB_GPU_EP = "WebGPUExecutionProvider" as const;
+export const STUDIO_NNAPI_EP = "NNAPIExecutionProvider" as const;
+export const OWR_NNAPI_EP = "NnapiExecutionProvider" as const;
+export const OWR_WASM_EP = "WasmExecutionProvider" as const;
+export const OWR_XNNPACK_EP = "XnnpackExecutionProvider" as const;
+
+/** Map Studio WebGPU id → ORT Web / OWR web session EP string. */
+export function studioWebGpuToOwrEp(
+  provider: typeof STUDIO_WEB_GPU_EP | string = STUDIO_WEB_GPU_EP,
+): typeof OWR_WEB_GPU_EP {
+  if (provider === STUDIO_WEB_GPU_EP || provider === OWR_WEB_GPU_EP) {
+    return OWR_WEB_GPU_EP;
+  }
+  return OWR_WEB_GPU_EP;
+}
+
+/** Map Studio NNAPI id → OWR mobile session EP string. */
+export function studioNnapiToOwrEp(
+  provider: typeof STUDIO_NNAPI_EP | string = STUDIO_NNAPI_EP,
+): typeof OWR_NNAPI_EP {
+  if (provider === STUDIO_NNAPI_EP || provider === OWR_NNAPI_EP) {
+    return OWR_NNAPI_EP;
+  }
+  return OWR_NNAPI_EP;
+}
+
 const ARCHITECTURE_MATCHERS: Array<{ needle: string; architecture: string }> = [
   { needle: "llama", architecture: "Llama" },
   { needle: "phi", architecture: "Phi" },
@@ -31,17 +65,20 @@ export function resolveOwrModelName(state: Pick<UIState, "hfModelId" | "localFil
 
 export function buildOrtConfig(opts: { platform: OwrPlatform; vramMode: OwrVramMode; threads: string }) {
   const { platform, vramMode, threads } = opts;
+  // OWR web uses ORT-Web spelling (WebGPUExecutionProvider), not Studio WebGpuExecutionProvider.
   const webProviders =
     vramMode === "performance"
-      ? ["WebGPUExecutionProvider", "WasmExecutionProvider"]
-      : ["WasmExecutionProvider"];
+      ? [studioWebGpuToOwrEp(), OWR_WASM_EP]
+      : [OWR_WASM_EP];
 
   return {
     model_path: platform === "web" ? "models/optimized/model.onnx" : "models/optimized/model.ort",
     session_options: {
       execution_mode: "ORT_SEQUENTIAL",
       execution_providers:
-        platform === "web" ? webProviders : ["XnnpackExecutionProvider", "NnapiExecutionProvider"],
+        platform === "web"
+          ? webProviders
+          : [OWR_XNNPACK_EP, studioNnapiToOwrEp()],
       graph_optimization_level: "ORT_ENABLE_ALL",
       intra_op_num_threads: parseInt(threads) || 4,
       inter_op_num_threads: 1,

--- a/src/lib/owrExportConfigs.ts
+++ b/src/lib/owrExportConfigs.ts
@@ -19,22 +19,22 @@ export const OWR_XNNPACK_EP = "XnnpackExecutionProvider" as const;
 
 /** Map Studio WebGPU id → ORT Web / OWR web session EP string. */
 export function studioWebGpuToOwrEp(
-  provider: typeof STUDIO_WEB_GPU_EP | string = STUDIO_WEB_GPU_EP,
+  provider: string = STUDIO_WEB_GPU_EP,
 ): typeof OWR_WEB_GPU_EP {
   if (provider === STUDIO_WEB_GPU_EP || provider === OWR_WEB_GPU_EP) {
     return OWR_WEB_GPU_EP;
   }
-  return OWR_WEB_GPU_EP;
+  throw new Error(`Expected Studio/ORT-Web WebGPU provider id, got: ${provider}`);
 }
 
 /** Map Studio NNAPI id → OWR mobile session EP string. */
 export function studioNnapiToOwrEp(
-  provider: typeof STUDIO_NNAPI_EP | string = STUDIO_NNAPI_EP,
+  provider: string = STUDIO_NNAPI_EP,
 ): typeof OWR_NNAPI_EP {
   if (provider === STUDIO_NNAPI_EP || provider === OWR_NNAPI_EP) {
     return OWR_NNAPI_EP;
   }
-  return OWR_NNAPI_EP;
+  throw new Error(`Expected Studio/OWR NNAPI provider id, got: ${provider}`);
 }
 
 const ARCHITECTURE_MATCHERS: Array<{ needle: string; architecture: string }> = [

--- a/src/lib/passParameterValidation.ts
+++ b/src/lib/passParameterValidation.ts
@@ -51,6 +51,20 @@ function hardwareLabel(provider: IHVProvider): string {
       return "Windows DirectML";
     case "WebGpuExecutionProvider":
       return "WebGPU";
+    case "CoreMLExecutionProvider":
+      return "Apple CoreML";
+    case "NNAPIExecutionProvider":
+      return "Android NNAPI";
+    case "VitisAIExecutionProvider":
+      return "Vitis AI";
+    case "SNPEExecutionProvider":
+      return "Qualcomm SNPE";
+    case "TensorflowLiteExecutionProvider":
+      return "TensorFlow Lite";
+    case "XnnpackExecutionProvider":
+      return "XNNPACK";
+    case "WasmExecutionProvider":
+      return "WASM";
     case "CPUExecutionProvider":
       return "CPU";
     default: {

--- a/src/lib/pipelineValidation.ts
+++ b/src/lib/pipelineValidation.ts
@@ -5,6 +5,11 @@ import { buildOliveRecipe, isPyTorchNativeQuantMethod } from "@/lib/oliveRecipeB
 import { assessQnnRecipeReadiness, type QnnReadinessIssue } from "@/lib/qnnReadiness";
 import { isKnownPass, getPassSchema } from "@/lib/schemaEngine";
 import { pickOpenVinoTargetFromDevices } from "@/lib/openvinoDeps";
+import {
+  isExportTargetProvider,
+  isLegacyExportProvider,
+  isPlatformLocalProvider,
+} from "@/lib/providerRuntimeKind";
 
 export type PipelineValidationOptions = {
   hardwareProbe?: HardwareProbeResult | null;
@@ -700,22 +705,62 @@ function getPassCatalogIssues(state: UIState, recipe: OliveRecipe): PipelineIssu
  *
  * @param state - The current pipeline configuration.
  * @param forLocalExecution - Whether the pipeline is being prepared for local execution.
+ * @param probe - Optional hardware probe (needed to clear platform-local gates).
  * @returns Critical issues affecting local execution.
  */
-export function getLocalExecutionIssues(state: UIState, forLocalExecution?: boolean): PipelineIssue[] {
-  if (!forLocalExecution || state.ihvProvider !== "WebGpuExecutionProvider") {
+export function getLocalExecutionIssues(
+  state: UIState,
+  forLocalExecution?: boolean,
+  probe?: HardwareProbeResult | null,
+): PipelineIssue[] {
+  if (!forLocalExecution) {
     return [];
   }
-  return [
-    {
-      id: "webgpu-local-execution-unsupported",
-      severity: "critical",
-      title: "WebGPU cannot run via local Olive Python",
-      description:
-        "WebGpuExecutionProvider is a browser deploy target (ONNX Runtime Web), not a local Python EP. Export the recipe and use Browser Test / WebGPU benchmark instead of Execute Live.",
-      affectedPasses: ["provider"],
-    },
-  ];
+
+  const provider = state.ihvProvider;
+  if (isExportTargetProvider(provider)) {
+    const legacyNote = isLegacyExportProvider(provider)
+      ? " Prefer QNNExecutionProvider for Snapdragon NPU work."
+      : "";
+    if (provider === "WebGpuExecutionProvider") {
+      return [
+        {
+          id: "webgpu-local-execution-unsupported",
+          severity: "critical",
+          title: "WebGPU cannot run via local Olive Python",
+          description:
+            "WebGpuExecutionProvider is a browser deploy target (ONNX Runtime Web), not a local Python EP. Export the recipe and use Browser Test / WebGPU benchmark instead of Execute Live.",
+          affectedPasses: ["provider"],
+        },
+      ];
+    }
+    return [
+      {
+        id: "export-target-local-execution-unsupported",
+        severity: "critical",
+        title: `${provider} cannot run via local Olive Python`,
+        description: `${provider} is an export / deploy target, not a local Python execution provider. Build or export the recipe for the target runtime instead of Execute Live.${legacyNote}`,
+        affectedPasses: ["provider"],
+      },
+    ];
+  }
+
+  if (isPlatformLocalProvider(provider)) {
+    const detected = Boolean(probe?.detectedProviders.includes(provider));
+    if (!detected) {
+      return [
+        {
+          id: "platform-local-execution-unavailable",
+          severity: "critical",
+          title: `${provider} is not available for local Execute Live`,
+          description: `${provider} requires a matching ORT build on this host (and must appear in the hardware probe). You can still select it for recipe export; Execute Live stays blocked until it is detected.`,
+          affectedPasses: ["provider"],
+        },
+      ];
+    }
+  }
+
+  return [];
 }
 
 /**
@@ -754,7 +799,7 @@ export function getPipelineValidation(
     ...getProviderIssues(state),
     ...getProviderHardwareIssues(state, options?.hardwareProbe),
     ...getQnnRecipeReadinessIssues(state, recipe, options?.hardwareProbe),
-    ...getLocalExecutionIssues(state, options?.forLocalExecution),
+    ...getLocalExecutionIssues(state, options?.forLocalExecution, options?.hardwareProbe),
     ...getAdvisoryIssues(state),
     ...getRecipeRuntimeIssues(state, recipe),
     ...getPassCatalogIssues(state, recipe),

--- a/src/lib/providerCatalog.ts
+++ b/src/lib/providerCatalog.ts
@@ -160,6 +160,93 @@ export const PROVIDER_CATALOG: ProviderCatalogEntry[] = [
         "Use FP16 for broadest WebGPU compatibility. INT8 support varies by browser and GPU vendor. Export to ONNX format for web deployment.",
     },
   },
+  {
+    id: "CoreMLExecutionProvider",
+    name: "Apple CoreML",
+    shortName: "CoreML",
+    desc: "Apple Neural Engine / GPU via CoreML on macOS and iOS (platform-local when ORT lists it).",
+    icon: CpuIcon,
+    tooltip: {
+      requirements: "macOS or iOS with onnxruntime CoreML EP. Prefer fixed input shapes.",
+      quantMethods: "PTQ INT8 (per-channel recommended), FP16.",
+      recommendation:
+        "Build recipes for Apple edge deploy. Execute Live only when the probe reports CoreMLExecutionProvider (Darwin + ORT CoreML).",
+    },
+  },
+  {
+    id: "NNAPIExecutionProvider",
+    name: "Android NNAPI",
+    shortName: "NNAPI",
+    desc: "Android Neural Networks API export target for OWR / mobile ORT (not a local Python EP).",
+    icon: CpuIcon,
+    tooltip: {
+      requirements: "Android device or OWR mobile export. Studio does not run NNAPI via Execute Live.",
+      quantMethods: "PTQ INT8 / uint8 (NNAPI limits vary by driver).",
+      recommendation:
+        "Prefer INT8 with small graphs. Use OWR mobile export; many ops fall back to CPU on device.",
+    },
+  },
+  {
+    id: "VitisAIExecutionProvider",
+    name: "AMD/Xilinx Vitis AI",
+    shortName: "Vitis AI",
+    desc: "Xilinx DPU / Vitis AI edge target (platform-local when ORT lists it).",
+    icon: CpuIcon,
+    tooltip: {
+      requirements: "Xilinx board with Vitis AI ORT EP. Power-of-2 scale constraints apply.",
+      quantMethods: "VitisAIQuantization / INT8 calibration.",
+      recommendation:
+        "Best for edge CNNs. Execute Live only when the probe reports VitisAIExecutionProvider.",
+    },
+  },
+  {
+    id: "SNPEExecutionProvider",
+    name: "Qualcomm SNPE (Legacy)",
+    shortName: "SNPE",
+    desc: "Legacy Qualcomm SNPE / DLC path. Prefer QNN for Snapdragon NPU work.",
+    icon: CpuIcon,
+    tooltip: {
+      requirements: "Legacy SNPE SDK / DLC conversion. Not supported for Studio Execute Live.",
+      quantMethods: "SNPEConversion + vendor quantization tooling.",
+      recommendation: "Prefer QNNExecutionProvider for new Qualcomm targets. Keep SNPE only for legacy DLC pipelines.",
+    },
+  },
+  {
+    id: "TensorflowLiteExecutionProvider",
+    name: "TensorFlow Lite",
+    shortName: "TFLite",
+    desc: "TFLite conversion / export path (not a local Olive Execute Live EP).",
+    icon: Cpu,
+    tooltip: {
+      requirements: "TFLite runtime or conversion toolchain. Studio blocks Execute Live for this target.",
+      quantMethods: "INT8 TFLite conversion paths.",
+      recommendation: "Use for TFLite export recipes only. Prefer ONNX + QNN/NNAPI/WebGPU for Studio-first flows.",
+    },
+  },
+  {
+    id: "XnnpackExecutionProvider",
+    name: "XNNPACK (Mobile)",
+    shortName: "XNNPACK",
+    desc: "OWR / ONNX Runtime Mobile CPU backend via XNNPACK (export target).",
+    icon: Cpu,
+    tooltip: {
+      requirements: "ORT Mobile / OWR mobile package. Not a local Python EP in Studio.",
+      quantMethods: "FP16 / INT8 suitable for mobile CPU.",
+      recommendation: "Pair with OWR mobile export. Prefer as CPU fallback beside NNAPI on Android.",
+    },
+  },
+  {
+    id: "WasmExecutionProvider",
+    name: "WASM (Browser)",
+    shortName: "WASM",
+    desc: "ONNX Runtime Web WASM CPU backend for browsers (export target).",
+    icon: Cpu,
+    tooltip: {
+      requirements: "onnxruntime-web WASM build. Not a local Python EP.",
+      quantMethods: "FP32 / FP16; INT8 support depends on ORT Web build.",
+      recommendation: "Use as WebGPU fallback in OWR web configs, or alone for CPU-only browser deploy.",
+    },
+  },
 ];
 
 export function getProviderCatalogEntry(id: IHVProvider): ProviderCatalogEntry | undefined {

--- a/src/lib/providerRuntimeKind.ts
+++ b/src/lib/providerRuntimeKind.ts
@@ -51,7 +51,6 @@ export function isLegacyExportProvider(provider: IHVProvider): boolean {
   return provider === "SNPEExecutionProvider";
 }
 
-/** Providers always choosable in Batch / ProviderInspector without local detection. */
 export function alwaysSelectableProviders(): IHVProvider[] {
   return (
     [
@@ -61,6 +60,8 @@ export function alwaysSelectableProviders(): IHVProvider[] {
       "TensorflowLiteExecutionProvider",
       "XnnpackExecutionProvider",
       "WasmExecutionProvider",
+      "CoreMLExecutionProvider",
+      "VitisAIExecutionProvider",
     ] as const
   ).slice();
 }

--- a/src/lib/providerRuntimeKind.ts
+++ b/src/lib/providerRuntimeKind.ts
@@ -1,0 +1,66 @@
+/**
+ * Runtime role for each IHV execution provider in Olive Studio.
+ *
+ * - `local`: Python ORT EP that can run via Execute Live when probe/venv allow.
+ * - `exportTarget`: Recipe/export wiring only (browser, OWR, conversion paths).
+ * - `platformLocal`: Real ORT EP on some hosts (Darwin CoreML, Vitis AI boards);
+ *   selectable for recipes always; Execute Live only when the probe lists it.
+ */
+import type { IHVProvider } from "@/types";
+
+export type ProviderRuntimeKind = "local" | "exportTarget" | "platformLocal";
+
+export function getProviderRuntimeKind(provider: IHVProvider): ProviderRuntimeKind {
+  switch (provider) {
+    case "WebGpuExecutionProvider":
+    case "NNAPIExecutionProvider":
+    case "SNPEExecutionProvider":
+    case "TensorflowLiteExecutionProvider":
+    case "XnnpackExecutionProvider":
+    case "WasmExecutionProvider":
+      return "exportTarget";
+    case "CoreMLExecutionProvider":
+    case "VitisAIExecutionProvider":
+      return "platformLocal";
+    case "CPUExecutionProvider":
+    case "CUDAExecutionProvider":
+    case "TensorrtExecutionProvider":
+    case "NvTensorRTRTXExecutionProvider":
+    case "DmlExecutionProvider":
+    case "OpenVINOExecutionProvider":
+    case "QNNExecutionProvider":
+    case "ROCMExecutionProvider":
+      return "local";
+    default: {
+      const _exhaustive: never = provider;
+      return _exhaustive;
+    }
+  }
+}
+
+export function isExportTargetProvider(provider: IHVProvider): boolean {
+  return getProviderRuntimeKind(provider) === "exportTarget";
+}
+
+export function isPlatformLocalProvider(provider: IHVProvider): boolean {
+  return getProviderRuntimeKind(provider) === "platformLocal";
+}
+
+/** Qualcomm SNPE is legacy; prefer QNN for new Snapdragon work. */
+export function isLegacyExportProvider(provider: IHVProvider): boolean {
+  return provider === "SNPEExecutionProvider";
+}
+
+/** Providers always choosable in Batch / ProviderInspector without local detection. */
+export function alwaysSelectableProviders(): IHVProvider[] {
+  return (
+    [
+      "WebGpuExecutionProvider",
+      "NNAPIExecutionProvider",
+      "SNPEExecutionProvider",
+      "TensorflowLiteExecutionProvider",
+      "XnnpackExecutionProvider",
+      "WasmExecutionProvider",
+    ] as const
+  ).slice();
+}

--- a/src/lib/providerRuntimeKind.ts
+++ b/src/lib/providerRuntimeKind.ts
@@ -51,6 +51,11 @@ export function isLegacyExportProvider(provider: IHVProvider): boolean {
   return provider === "SNPEExecutionProvider";
 }
 
+/**
+ * Providers always choosable for recipe selection without a local probe hit:
+ * export targets (WebGPU, OWR mobile/web, TFLite, SNPE) and platform-local EPs
+ * (CoreML, VitisAI). Execute Live stays gated separately via pipeline validation.
+ */
 export function alwaysSelectableProviders(): IHVProvider[] {
   return (
     [

--- a/src/lib/recipePipeline.ts
+++ b/src/lib/recipePipeline.ts
@@ -67,7 +67,7 @@ export function buildRecipeFromState(
   // Reuse the recipe getPipelineValidation already built instead of rebuilding.
   const recipe = validation.recipe as unknown as Record<string, unknown>;
   const recipeJson = serializeRecipe(recipe);
-  const localExecutionIssues = getLocalExecutionIssues(sanitized, true);
+  const localExecutionIssues = getLocalExecutionIssues(sanitized, true, options?.hardwareProbe);
   const schema = validateOliveRecipeStructure(recipe);
 
   return {

--- a/src/lib/venvFamily.ts
+++ b/src/lib/venvFamily.ts
@@ -25,6 +25,13 @@ export const KNOWN_IHV_PROVIDERS: readonly IHVProvider[] = [
   "QNNExecutionProvider",
   "ROCMExecutionProvider",
   "WebGpuExecutionProvider",
+  "CoreMLExecutionProvider",
+  "NNAPIExecutionProvider",
+  "VitisAIExecutionProvider",
+  "SNPEExecutionProvider",
+  "TensorflowLiteExecutionProvider",
+  "XnnpackExecutionProvider",
+  "WasmExecutionProvider",
 ] as const;
 
 const KNOWN_SET = new Set<string>(KNOWN_IHV_PROVIDERS);
@@ -43,6 +50,13 @@ const PROVIDER_ALIASES: ReadonlyMap<string, IHVProvider> = new Map([
   ["qnnexecutionprovider", "QNNExecutionProvider"],
   ["rocmexecutionprovider", "ROCMExecutionProvider"],
   ["webgpuexecutionprovider", "WebGpuExecutionProvider"],
+  ["coremlexecutionprovider", "CoreMLExecutionProvider"],
+  ["nnapiexecutionprovider", "NNAPIExecutionProvider"],
+  ["vitisaiexecutionprovider", "VitisAIExecutionProvider"],
+  ["snpeexecutionprovider", "SNPEExecutionProvider"],
+  ["tensorflowliteexecutionprovider", "TensorflowLiteExecutionProvider"],
+  ["xnnpackexecutionprovider", "XnnpackExecutionProvider"],
+  ["wasmexecutionprovider", "WasmExecutionProvider"],
   ["cpu", "CPUExecutionProvider"],
   ["cuda", "CUDAExecutionProvider"],
   ["tensorrt", "TensorrtExecutionProvider"],
@@ -55,6 +69,15 @@ const PROVIDER_ALIASES: ReadonlyMap<string, IHVProvider> = new Map([
   ["qnn", "QNNExecutionProvider"],
   ["rocm", "ROCMExecutionProvider"],
   ["webgpu", "WebGpuExecutionProvider"],
+  ["coreml", "CoreMLExecutionProvider"],
+  ["nnapi", "NNAPIExecutionProvider"],
+  ["vitisai", "VitisAIExecutionProvider"],
+  ["vitis-ai", "VitisAIExecutionProvider"],
+  ["snpe", "SNPEExecutionProvider"],
+  ["tflite", "TensorflowLiteExecutionProvider"],
+  ["tensorflowlite", "TensorflowLiteExecutionProvider"],
+  ["xnnpack", "XnnpackExecutionProvider"],
+  ["wasm", "WasmExecutionProvider"],
 ]);
 
 export function isKnownIhvProvider(id: string): id is IHVProvider {
@@ -106,6 +129,13 @@ export function mandatoryFamilyForProvider(provider: IHVProvider): VenvFamily | 
       return "default";
     case "CPUExecutionProvider":
     case "WebGpuExecutionProvider":
+    case "CoreMLExecutionProvider":
+    case "NNAPIExecutionProvider":
+    case "VitisAIExecutionProvider":
+    case "SNPEExecutionProvider":
+    case "TensorflowLiteExecutionProvider":
+    case "XnnpackExecutionProvider":
+    case "WasmExecutionProvider":
       return null;
     default: {
       const _exhaustive: never = provider;
@@ -125,10 +155,10 @@ export function resolveVenvFamily(
   const mandatory = mandatoryFamilyForProvider(provider);
   if (mandatory) return mandatory;
 
-  if (provider === "WebGpuExecutionProvider") return "default";
+  // CPU / export / platform targets: prefer default if CPU-usable; else cuda; else default.
+  // Do not place these jobs on the openvino or qnn families.
+  if (provider !== "CPUExecutionProvider") return "default";
 
-  // CPU: prefer default if CPU-usable; else cuda if CPU-usable; else default (will create).
-  // Do not place CPU jobs on the openvino or qnn families.
   if (flags.default.cpuUsable) return "default";
   if (flags.cuda.cpuUsable) return "cuda";
   return "default";
@@ -152,7 +182,7 @@ export function resolveRequiredFamilies(
       hasCpu = true;
       continue;
     }
-    if (provider === "WebGpuExecutionProvider") continue;
+    // Export / platform targets with no venv family do not provision runtimes.
     const mandatory = mandatoryFamilyForProvider(provider);
     if (mandatory) families.add(mandatory);
   }

--- a/src/lib/vramEstimate.ts
+++ b/src/lib/vramEstimate.ts
@@ -206,6 +206,13 @@ export function isGpuProvider(provider: IHVProvider): boolean {
     case "CPUExecutionProvider":
     case "OpenVINOExecutionProvider":
     case "QNNExecutionProvider":
+    case "CoreMLExecutionProvider":
+    case "NNAPIExecutionProvider":
+    case "VitisAIExecutionProvider":
+    case "SNPEExecutionProvider":
+    case "TensorflowLiteExecutionProvider":
+    case "XnnpackExecutionProvider":
+    case "WasmExecutionProvider":
       return false;
     default: {
       const _exhaustive: never = provider;

--- a/src/server/routes/olive.ts
+++ b/src/server/routes/olive.ts
@@ -16,6 +16,7 @@ import { normalizeIhvProvider } from "../../lib/venvFamily.ts";
 import { resolveQnnHostMode } from "../../lib/qnnDeps.ts";
 import { assessQnnRecipeReadiness } from "../../lib/qnnReadiness.ts";
 import { DEFAULT_PASSES } from "../../lib/defaultPasses.ts";
+import { isExportTargetProvider } from "../../lib/providerRuntimeKind.ts";
 
 import {
   jobRegistry,
@@ -84,6 +85,13 @@ export function mountOliveRoutes(router: Router): void {
       return res.status(400).json({
         ok: false,
         error: `Unknown execution provider: ${String(providerRaw)}`,
+      });
+    }
+
+    if (isExportTargetProvider(provider)) {
+      return res.status(400).json({
+        ok: false,
+        error: `${provider} cannot run via local Olive Python; export the recipe for the target runtime instead`,
       });
     }
 

--- a/src/server/routes/system.ts
+++ b/src/server/routes/system.ts
@@ -545,8 +545,10 @@ async function probeSystemHardware(opts: SystemProbeOptions): Promise<HardwarePr
     ),
   });
 
+  // Execute Live uses the default Olive runtime for platform-local EPs. Do not
+  // let providers from system/CUDA/OpenVINO/QNN runtimes authorize that path.
   const detectedProviders = mergeDetectedProviders({
-    onnxRuntimeProviders,
+    onnxRuntimeProviders: defaultOrtProviders,
     hasNvidiaGpu: Boolean(nvidia?.gpus.length),
     hasRocmGpu: Boolean(rocm?.gpus.length),
     hasOpenVino: Boolean(openvino?.available),

--- a/src/server/services/mcp/studioRecipeBridge.ts
+++ b/src/server/services/mcp/studioRecipeBridge.ts
@@ -28,6 +28,13 @@ const IHV_PROVIDERS = new Set<string>([
   "QNNExecutionProvider",
   "ROCMExecutionProvider",
   "WebGpuExecutionProvider",
+  "CoreMLExecutionProvider",
+  "NNAPIExecutionProvider",
+  "VitisAIExecutionProvider",
+  "SNPEExecutionProvider",
+  "TensorflowLiteExecutionProvider",
+  "XnnpackExecutionProvider",
+  "WasmExecutionProvider",
 ]);
 
 const MODEL_SOURCES = new Set<string>(["huggingface", "local", "azure"]);

--- a/src/server/services/venv/capabilityEnsure.ts
+++ b/src/server/services/venv/capabilityEnsure.ts
@@ -13,7 +13,7 @@ import { ensureTensorRt } from "../olive/tensorrt.ts";
 import { ensureTensorRtRtx } from "../olive/tensorrt-rtx.ts";
 import { ensureQnn } from "../olive/qnn.ts";
 import { ensureVenvFamily } from "./familyEnsure.ts";
-import { isExportTargetProvider } from "../../../lib/providerRuntimeKind.ts";
+import { isExportTargetProvider, isPlatformLocalProvider } from "../../../lib/providerRuntimeKind.ts";
 import { getVenvPython } from "./paths.ts";
 import {
   capabilityForProvider,
@@ -98,19 +98,24 @@ export async function ensureProviderCapability(
       ? qnnCapabilityForUsage(status, usage)
       : capabilityForProvider(status, provider);
 
-  // Providers without a capability slot (ROCm/WebGPU/export/platform) only need the family base.
+  // Providers without a capability slot:
+  // - export targets are rejected above
+  // - platform-local (CoreML/VitisAI) must appear in this family's ORT providers
+  // - ROCm is best-effort on the default family base
   if (cap === undefined) {
-    if (
-      provider === "ROCMExecutionProvider" ||
-      provider === "WebGpuExecutionProvider" ||
-      provider === "CoreMLExecutionProvider" ||
-      provider === "NNAPIExecutionProvider" ||
-      provider === "VitisAIExecutionProvider" ||
-      provider === "SNPEExecutionProvider" ||
-      provider === "TensorflowLiteExecutionProvider" ||
-      provider === "XnnpackExecutionProvider" ||
-      provider === "WasmExecutionProvider"
-    ) {
+    if (isPlatformLocalProvider(provider)) {
+      const python = getVenvPython(family);
+      if (!status.ortProviders.includes(provider)) {
+        return {
+          ok: false,
+          error: `${provider} is not registered in ${humanFamilyLabel(family)} ORT; export the recipe or run on a host where the hardware probe detects it`,
+          family,
+          python,
+        };
+      }
+      return { ok: true, family, python };
+    }
+    if (provider === "ROCMExecutionProvider") {
       return { ok: true, family, python: getVenvPython(family) };
     }
     return {

--- a/src/server/services/venv/capabilityEnsure.ts
+++ b/src/server/services/venv/capabilityEnsure.ts
@@ -13,6 +13,7 @@ import { ensureTensorRt } from "../olive/tensorrt.ts";
 import { ensureTensorRtRtx } from "../olive/tensorrt-rtx.ts";
 import { ensureQnn } from "../olive/qnn.ts";
 import { ensureVenvFamily } from "./familyEnsure.ts";
+import { isExportTargetProvider } from "../../../lib/providerRuntimeKind.ts";
 import { getVenvPython } from "./paths.ts";
 import {
   capabilityForProvider,
@@ -60,6 +61,15 @@ export async function ensureProviderCapability(
   onLine: SetupListener,
   opts?: EnsureProviderCapabilityOptions,
 ): Promise<EnsureProviderCapabilityResult> {
+  if (isExportTargetProvider(provider)) {
+    return {
+      ok: false,
+      error: `${provider} cannot run via local Olive Python; export the recipe for the target runtime instead`,
+      family: "default",
+      python: null,
+    };
+  }
+
   const dual = await getDualRuntimeStatus({ force: true });
   const flags = familyFlagsFromStatus(dual.families);
   const family = resolveVenvFamily(provider, flags);

--- a/src/server/services/venv/capabilityEnsure.ts
+++ b/src/server/services/venv/capabilityEnsure.ts
@@ -88,9 +88,19 @@ export async function ensureProviderCapability(
       ? qnnCapabilityForUsage(status, usage)
       : capabilityForProvider(status, provider);
 
-  // Providers without a capability slot (ROCm/WebGPU) only need the family base.
+  // Providers without a capability slot (ROCm/WebGPU/export/platform) only need the family base.
   if (cap === undefined) {
-    if (provider === "ROCMExecutionProvider" || provider === "WebGpuExecutionProvider") {
+    if (
+      provider === "ROCMExecutionProvider" ||
+      provider === "WebGpuExecutionProvider" ||
+      provider === "CoreMLExecutionProvider" ||
+      provider === "NNAPIExecutionProvider" ||
+      provider === "VitisAIExecutionProvider" ||
+      provider === "SNPEExecutionProvider" ||
+      provider === "TensorflowLiteExecutionProvider" ||
+      provider === "XnnpackExecutionProvider" ||
+      provider === "WasmExecutionProvider"
+    ) {
       return { ok: true, family, python: getVenvPython(family) };
     }
     return {
@@ -124,6 +134,13 @@ async function installCapabilityPackages(
       case "DmlExecutionProvider":
       case "ROCMExecutionProvider":
       case "WebGpuExecutionProvider":
+      case "CoreMLExecutionProvider":
+      case "NNAPIExecutionProvider":
+      case "VitisAIExecutionProvider":
+      case "SNPEExecutionProvider":
+      case "TensorflowLiteExecutionProvider":
+      case "XnnpackExecutionProvider":
+      case "WasmExecutionProvider":
         return { ok: true };
 
       case "QNNExecutionProvider": {

--- a/src/server/services/venv/status.ts
+++ b/src/server/services/venv/status.ts
@@ -495,6 +495,13 @@ export function capabilityForProvider(
       return status.capabilities.qnnPreparation;
     case "ROCMExecutionProvider":
     case "WebGpuExecutionProvider":
+    case "CoreMLExecutionProvider":
+    case "NNAPIExecutionProvider":
+    case "VitisAIExecutionProvider":
+    case "SNPEExecutionProvider":
+    case "TensorflowLiteExecutionProvider":
+    case "XnnpackExecutionProvider":
+    case "WasmExecutionProvider":
       return undefined;
     default: {
       const _exhaustive: never = provider;

--- a/src/server/services/venv/status.ts
+++ b/src/server/services/venv/status.ts
@@ -39,6 +39,8 @@ export type RuntimeFamilyStatus = {
   integrityHealthy: boolean;
   needsRepair: boolean;
   python: string | null;
+  /** ORT `get_available_providers()` from this family venv (empty when unprobed). */
+  ortProviders: string[];
   capabilities: {
     cpu: CapabilityStatus;
     directml?: CapabilityStatus;
@@ -337,6 +339,7 @@ export async function probeFamilyStatus(family: VenvFamily): Promise<RuntimeFami
       integrityHealthy: false,
       needsRepair: false,
       python: null,
+      ortProviders: [],
       capabilities: {
         cpu: missing("venv missing"),
         ...(family === "default"
@@ -392,6 +395,7 @@ export async function probeFamilyStatus(family: VenvFamily): Promise<RuntimeFami
     integrityHealthy,
     needsRepair,
     python,
+    ortProviders: Array.isArray(probe?.providers) ? probe.providers.slice() : [],
     capabilities: buildCapabilities(family, probe),
   };
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -39,7 +39,14 @@ export type IHVProvider =
   | "OpenVINOExecutionProvider"
   | "QNNExecutionProvider"
   | "ROCMExecutionProvider"
-  | "WebGpuExecutionProvider";
+  | "WebGpuExecutionProvider"
+  | "CoreMLExecutionProvider"
+  | "NNAPIExecutionProvider"
+  | "VitisAIExecutionProvider"
+  | "SNPEExecutionProvider"
+  | "TensorflowLiteExecutionProvider"
+  | "XnnpackExecutionProvider"
+  | "WasmExecutionProvider";
 
 /** OpenVINOExecutionProvider silicon target (maps to Olive accelerator.device). */
 export type OpenVinoTargetDevice = "CPU" | "GPU" | "NPU";


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Stacked on #131. Closes the mismatch between Studio’s fixed IHV catalog and EPs already present in MCP KB / OWR export.

- Widen `IHVProvider` / `PROVIDER_CATALOG` with CoreML, NNAPI, VitisAI, SNPE, TFLite, XNNPACK, WASM
- Centralize `providerRuntimeKind` (`local` | `exportTarget` | `platformLocal`)
- Export targets always selectable; Execute Live blocked (WebGPU messaging preserved)
- Platform locals (CoreML / VitisAI) selectable for recipes; Execute Live probe-gated
- Hardware UI badges: Local / Export target / Legacy / Platform; light section grouping
- OWR helpers document intentional `WebGpu` vs `WebGPU` and `NNAPI` vs `Nnapi` spellings
- MCP: canonicalize `DmlExecutionProvider` in `passes.json`; keep `DirectMLExecutionProvider` as normalization alias only; thin profiles for new export targets

## Validation

- `pnpm vitest run` on touched unit tests (201 passed)
- `pnpm vitest run --config vitest.component.config.ts` IHV panel
- `pnpm lint:quick` + `tsc --noEmit`
- `pytest tests/test_normalization.py` (87 passed)

## Out of scope

Real Execute Live for CoreML/VitisAI/SNPE in CI; new venv installers; OWR UX redesign.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8465bc39-24d1-486a-9f54-9270e1b9c663?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8465bc39-24d1-486a-9f54-9270e1b9c663&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tonythethompson/Olive-Studio/pull/141?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

