### PR TITLE
fix: PR 161 coderabbit follow-ups (index.html.gz caching, silent failures, codex errors)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,6 +16,7 @@ overrides:
   adm-zip@<0.6.0: '>=0.6.0 <1.0.0'
   sharp@<0.35.0: '>=0.35.0 <1.0.0'
   onnxruntime-web: 1.27.0
+  nanoid@<3.3.17: '>=3.3.17 <4.0.0'
 
 importers:
 
@@ -3748,8 +3749,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+  nanoid@3.3.17:
+    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -8273,7 +8274,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  nanoid@3.3.16: {}
+  nanoid@3.3.17: {}
 
   natural-compare@1.4.0: {}
 
@@ -8489,7 +8490,7 @@ snapshots:
 
   postcss@8.5.25:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.17
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -24,6 +24,9 @@ overrides:
   'sharp@<0.35.0': '>=0.35.0 <1.0.0'
   # Keep a single onnxruntime-web for the app + transformers.js tokenizer path.
   onnxruntime-web: '1.27.0'
+  # GHSA-2v37-7h3g-55p8: nanoid custom generators infinite loop when size is zero
+  # (via postcss → vite/tailwind/storybook). Stay on 3.x for postcss compatibility.
+  'nanoid@<3.3.17': '>=3.3.17 <4.0.0'
 peerDependencyRules:
   # Storybook 8 still declares vite<=6; Olive Studio runs Vite 8 (Rolldown).
   allowedVersions:

--- a/server.ts
+++ b/server.ts
@@ -212,7 +212,11 @@ async function startServer() {
         orderPreference: ["gz"],
         serveStatic: {
           setHeaders: (res, filePath) => {
-            if (filePath.endsWith("index.html")) {
+            if (/index\.html(\.gz)?$/.test(filePath)) {
+              // express-static-gzip rewrites the served path to the .gz
+              // variant when the client accepts it, so a plain endsWith
+              // check on "index.html" misses it — the SPA shell would fall
+              // through to the hashed-asset branch below and get cached.
               res.setHeader("Cache-Control", "no-cache, no-store, must-revalidate");
               return;
             }

--- a/src/components/features/execute/ExecutionWorkspace.tsx
+++ b/src/components/features/execute/ExecutionWorkspace.tsx
@@ -347,6 +347,7 @@ export function ExecutionWorkspace({
   const [owrSelectedFile, setOwrSelectedFile] = useState<
     "ort_config.json" | "web_init.js" | "mobile_init.kt" | "onnx_model_manifest.json"
   >("ort_config.json");
+  const [owrDownloadError, setOwrDownloadError] = useState<string | null>(null);
 
   const { data: hardwareProbe = null } = useHardwareProbe();
 
@@ -382,6 +383,7 @@ export function ExecutionWorkspace({
   );
 
   const handleDownloadOwrBundle = async () => {
+    setOwrDownloadError(null);
     const { ortConfig, manifestConfig, webInitCode, mobileInitCode } = owrConfigs;
     let zip: InstanceType<typeof import("jszip")>;
     try {
@@ -389,6 +391,7 @@ export function ExecutionWorkspace({
       zip = new JSZip();
     } catch (e) {
       console.error("Failed to load ZIP module", e);
+      setOwrDownloadError("Couldn't load the ZIP module. Check your connection and try again.");
       return;
     }
 
@@ -436,6 +439,7 @@ ${owrPlatform === "web"
       URL.revokeObjectURL(url);
     } catch (e) {
       console.error("ZIP Generation failed", e);
+      setOwrDownloadError("ZIP generation failed. Try again, or check the browser console for details.");
     }
   };
 
@@ -725,6 +729,7 @@ ${owrPlatform === "web"
         vramMode={owrVramMode}
         onVramModeChange={setOwrVramMode}
         onDownloadBundle={handleDownloadOwrBundle}
+        downloadError={owrDownloadError}
       />
 
       {/* Recipe Preview */}

--- a/src/components/features/execute/ExecutionWorkspace.tsx
+++ b/src/components/features/execute/ExecutionWorkspace.tsx
@@ -348,6 +348,7 @@ export function ExecutionWorkspace({
     "ort_config.json" | "web_init.js" | "mobile_init.kt" | "onnx_model_manifest.json"
   >("ort_config.json");
   const [owrDownloadError, setOwrDownloadError] = useState<string | null>(null);
+  const [isOwrDownloading, setIsOwrDownloading] = useState(false);
 
   const { data: hardwareProbe = null } = useHardwareProbe();
 
@@ -383,63 +384,69 @@ export function ExecutionWorkspace({
   );
 
   const handleDownloadOwrBundle = async () => {
-    setOwrDownloadError(null);
-    const { ortConfig, manifestConfig, webInitCode, mobileInitCode } = owrConfigs;
-    let zip: InstanceType<typeof import("jszip")>;
+    if (isOwrDownloading) return;
+    setIsOwrDownloading(true);
     try {
-      const { default: JSZip } = await import("jszip");
-      zip = new JSZip();
-    } catch (e) {
-      console.error("Failed to load ZIP module", e);
-      setOwrDownloadError("Couldn't load the ZIP module. Check your connection and try again.");
-      return;
-    }
-
-    zip.file("ort_config.json", JSON.stringify(ortConfig, null, 2));
-    zip.file("onnx_model_manifest.json", JSON.stringify(manifestConfig, null, 2));
-
-    if (owrPlatform === "web") {
-      zip.file("web_init.js", webInitCode);
-    } else {
-      zip.file("mobile_init.kt", mobileInitCode);
-    }
-
-    const rawModelId = state.hfModelId || (state.localFiles && state.localFiles[0]?.name) || "model";
-    const modelName = rawModelId.split("/").pop() || "model";
-
-    const readme = `ONNX Runtime Web/Mobile (OWR) Deployment Bundle
-==================================================
-Created: ${new Date().toLocaleString()}
-Target Environment: ONNX Runtime ${owrPlatform === "web" ? "Web (WebGPU/WASM)" : "Mobile (Android/iOS)"}
-Optimized Model: ${modelName}
-
-Contents of this bundle:
-1. onnx_model_manifest.json - Full optimization and pipeline conversion audit trail from MS Olive.
-2. ort_config.json - Direct configuration rules for loading the model session dynamically.
-3. ${owrPlatform === "web" ? "web_init.js" : "mobile_init.kt"} - Boilerplate initialization and execution patterns.
-
-Deployment Steps:
-${owrPlatform === "web"
-        ? "- Place the optimized model file (model.onnx) in your public asset folder.\\n- Install 'onnxruntime-web' dependency using pnpm.\\n- Import and invoke your customized initializeOrtSession() function. "
-        : "- Place the compiled ORT flatbuffer file (model.ort) under your Android App's 'src/main/assets' directory.\\n- Implement 'ai.onnxruntime:onnxruntime-android' via gradle.\\n- Wire up your OnnxModelExecutor wrapper inside Activities/Handlers."
+      setOwrDownloadError(null);
+      const { ortConfig, manifestConfig, webInitCode, mobileInitCode } = owrConfigs;
+      let zip: InstanceType<typeof import("jszip")>;
+      try {
+        const { default: JSZip } = await import("jszip");
+        zip = new JSZip();
+      } catch (e) {
+        console.error("Failed to load ZIP module", e);
+        setOwrDownloadError("Couldn't load the ZIP module. Check your connection and try again.");
+        return;
       }
-`;
-    zip.file("README.txt", readme);
 
-    try {
-      const content = await zip.generateAsync({ type: "blob" });
-      const url = URL.createObjectURL(content);
-      const link = document.createElement("a");
-      link.href = url;
-      const modelCleanName = modelName.replace(/[^a-z0-9_-]/gi, "_").toLowerCase();
-      link.download = `owr_bundle_${owrPlatform}_${modelCleanName}.zip`;
-      document.body.appendChild(link);
-      link.click();
-      document.body.removeChild(link);
-      URL.revokeObjectURL(url);
-    } catch (e) {
-      console.error("ZIP Generation failed", e);
-      setOwrDownloadError("ZIP generation failed. Try again, or check the browser console for details.");
+      zip.file("ort_config.json", JSON.stringify(ortConfig, null, 2));
+      zip.file("onnx_model_manifest.json", JSON.stringify(manifestConfig, null, 2));
+
+      if (owrPlatform === "web") {
+        zip.file("web_init.js", webInitCode);
+      } else {
+        zip.file("mobile_init.kt", mobileInitCode);
+      }
+
+      const rawModelId = state.hfModelId || (state.localFiles && state.localFiles[0]?.name) || "model";
+      const modelName = rawModelId.split("/").pop() || "model";
+
+      const readme = `ONNX Runtime Web/Mobile (OWR) Deployment Bundle
+  ==================================================
+  Created: ${new Date().toLocaleString()}
+  Target Environment: ONNX Runtime ${owrPlatform === "web" ? "Web (WebGPU/WASM)" : "Mobile (Android/iOS)"}
+  Optimized Model: ${modelName}
+
+  Contents of this bundle:
+  1. onnx_model_manifest.json - Full optimization and pipeline conversion audit trail from MS Olive.
+  2. ort_config.json - Direct configuration rules for loading the model session dynamically.
+  3. ${owrPlatform === "web" ? "web_init.js" : "mobile_init.kt"} - Boilerplate initialization and execution patterns.
+
+  Deployment Steps:
+  ${owrPlatform === "web"
+          ? "- Place the optimized model file (model.onnx) in your public asset folder.\\n- Install 'onnxruntime-web' dependency using pnpm.\\n- Import and invoke your customized initializeOrtSession() function. "
+          : "- Place the compiled ORT flatbuffer file (model.ort) under your Android App's 'src/main/assets' directory.\\n- Implement 'ai.onnxruntime:onnxruntime-android' via gradle.\\n- Wire up your OnnxModelExecutor wrapper inside Activities/Handlers."
+        }
+  `;
+      zip.file("README.txt", readme);
+
+      try {
+        const content = await zip.generateAsync({ type: "blob" });
+        const url = URL.createObjectURL(content);
+        const link = document.createElement("a");
+        link.href = url;
+        const modelCleanName = modelName.replace(/[^a-z0-9_-]/gi, "_").toLowerCase();
+        link.download = `owr_bundle_${owrPlatform}_${modelCleanName}.zip`;
+        document.body.appendChild(link);
+        link.click();
+        document.body.removeChild(link);
+        URL.revokeObjectURL(url);
+      } catch (e) {
+        console.error("ZIP Generation failed", e);
+        setOwrDownloadError("ZIP generation failed. Try again, or check the browser console for details.");
+      }
+    } finally {
+      setIsOwrDownloading(false);
     }
   };
 
@@ -729,6 +736,7 @@ ${owrPlatform === "web"
         vramMode={owrVramMode}
         onVramModeChange={setOwrVramMode}
         onDownloadBundle={handleDownloadOwrBundle}
+        isDownloading={isOwrDownloading}
         downloadError={owrDownloadError}
       />
 

--- a/src/components/features/execute/OwrExportOverlay.tsx
+++ b/src/components/features/execute/OwrExportOverlay.tsx
@@ -35,6 +35,7 @@ export interface OwrExportOverlayProps {
   vramMode: "performance" | "memory";
   onVramModeChange: (mode: "performance" | "memory") => void;
   onDownloadBundle: () => void;
+  downloadError?: string | null;
 }
 
 /**
@@ -56,6 +57,7 @@ export function OwrExportOverlay({
   vramMode,
   onVramModeChange,
   onDownloadBundle,
+  downloadError,
 }: OwrExportOverlayProps) {
   const [isOwrCopied, setIsOwrCopied] = useState(false);
   const titleId = useId();
@@ -384,6 +386,11 @@ export function OwrExportOverlay({
                   <Download className="h-4 w-4 mr-1.5" /> Download Bundle (.zip)
                 </Button>
               </div>
+              {downloadError && (
+                <p role="alert" className="text-xs text-rose-400 text-right">
+                  {downloadError}
+                </p>
+              )}
             </div>
           </div>
         </CardContent>

--- a/src/components/features/execute/OwrExportOverlay.tsx
+++ b/src/components/features/execute/OwrExportOverlay.tsx
@@ -36,6 +36,7 @@ export interface OwrExportOverlayProps {
   onVramModeChange: (mode: "performance" | "memory") => void;
   onDownloadBundle: () => void;
   downloadError?: string | null;
+  isDownloading?: boolean;
 }
 
 /**
@@ -58,6 +59,7 @@ export function OwrExportOverlay({
   onVramModeChange,
   onDownloadBundle,
   downloadError,
+  isDownloading = false,
 }: OwrExportOverlayProps) {
   const [isOwrCopied, setIsOwrCopied] = useState(false);
   const titleId = useId();
@@ -382,6 +384,7 @@ export function OwrExportOverlay({
                   variant="default"
                   className="text-xs h-9 bg-electric-blue hover:bg-electric-blue-dark text-slate-950 font-bold"
                   onClick={onDownloadBundle}
+                  disabled={isDownloading}
                 >
                   <Download className="h-4 w-4 mr-1.5" /> Download Bundle (.zip)
                 </Button>

--- a/src/components/features/input/InputEnvironmentPanel.test.tsx
+++ b/src/components/features/input/InputEnvironmentPanel.test.tsx
@@ -156,8 +156,13 @@ describe("InputEnvironmentPanel", () => {
       expect(await screen.findByText(/couldn't check token status/i)).toBeTruthy();
     });
 
-    it("does not clear the cached token status on a failed DELETE", async () => {
+    it("does not clear the cached token status on a failed DELETE and recovers on successful save", async () => {
       let deleteCalled = false;
+      let resolveDelete!: (res: Response) => void;
+      const deletePromise = new Promise<Response>((resolve) => {
+        resolveDelete = resolve;
+      });
+
       vi.spyOn(globalThis, "fetch").mockImplementation((url: unknown, init?: RequestInit) => {
         const urlStr = String(url);
         if (urlStr.includes("hf-token-status")) {
@@ -165,7 +170,7 @@ describe("InputEnvironmentPanel", () => {
         }
         if (urlStr.includes("/api/env/hf-token") && init?.method === "DELETE") {
           deleteCalled = true;
-          return Promise.resolve(new Response("Internal Error", { status: 500 }));
+          return deletePromise;
         }
         return Promise.resolve(new Response("{}", { status: 200 }));
       });
@@ -181,14 +186,43 @@ describe("InputEnvironmentPanel", () => {
 
       expect(await screen.findByText(/set for this session/i)).toBeTruthy();
       const clearButton = screen.getByRole("button", { name: /clear/i });
-      await act(async () => {
+
+      act(() => {
         fireEvent.click(clearButton);
+      });
+
+      // Assert button becomes disabled and shows spinner/loading accessible name while pending
+      const pendingButton = await screen.findByRole("button", { name: /clearing token/i });
+      expect(pendingButton.hasAttribute("disabled")).toBe(true);
+      expect(deleteCalled).toBe(true);
+
+      // Resolve DELETE with failure
+      await act(async () => {
+        resolveDelete(new Response("Internal Error", { status: 500 }));
         await Promise.resolve();
       });
 
-      expect(deleteCalled).toBe(true);
       // Status stays "runtime" — a failed DELETE must not optimistically clear the cache.
       expect(screen.getByText(/set for this session/i)).toBeTruthy();
+
+      // Assert error alert is displayed
+      const alert = await screen.findByRole("alert");
+      expect(alert).toBeTruthy();
+      expect(alert.textContent).toMatch(/couldn't clear the token/i);
+
+      // Perform a successful Save after the failure and verify recovery
+      const input = screen.getByPlaceholderText("hf_...") as HTMLInputElement;
+      fireEvent.change(input, { target: { value: "hf_new_token_123" } });
+      const saveButton = screen.getByRole("button", { name: /save/i });
+
+      await act(async () => {
+        fireEvent.click(saveButton);
+        await Promise.resolve();
+      });
+
+      // Verify the alert recovers (is removed) and token input is cleared
+      expect(screen.queryByRole("alert")).toBeNull();
+      expect(input.value).toBe("");
     });
   });
 });

--- a/src/components/features/input/InputEnvironmentPanel.tsx
+++ b/src/components/features/input/InputEnvironmentPanel.tsx
@@ -162,6 +162,7 @@ export function InputEnvironmentPanel({
     onSuccess: () => {
       queryClient.setQueryData(["hf-token-status"], "runtime");
       setHfTokenInput("");
+      clearTokenMutation.reset();
     },
   });
 
@@ -175,8 +176,10 @@ export function InputEnvironmentPanel({
     },
   });
 
+  const isTokenMutating = submitTokenMutation.isPending || clearTokenMutation.isPending;
+
   const handleSubmitToken = async () => {
-    if (!hfTokenInput.trim()) return;
+    if (isTokenMutating || !hfTokenInput.trim()) return;
     try {
       await submitTokenMutation.mutateAsync(hfTokenInput.trim());
     } catch {
@@ -185,6 +188,7 @@ export function InputEnvironmentPanel({
   };
 
   const handleClearToken = async () => {
+    if (isTokenMutating) return;
     try {
       await clearTokenMutation.mutateAsync();
     } catch {
@@ -1599,7 +1603,7 @@ export function InputEnvironmentPanel({
                           )}
                           {hfTokenStatus === "error" && (
                             <span className="text-[10px] bg-rose-500/10 border border-rose-500/20 text-rose-400 px-2 py-0.5 rounded font-mono">
-                              Couldn't check token status
+                              Couldn&apos;t check token status
                             </span>
                           )}
                         </div>
@@ -1616,12 +1620,13 @@ export function InputEnvironmentPanel({
                                 value={hfTokenInput}
                                 onChange={(e) => setHfTokenInput(e.target.value)}
                                 onKeyDown={(e) => e.key === "Enter" && handleSubmitToken()}
+                                disabled={isTokenMutating}
                               />
                             </div>
                             <Button
                               type="button"
                               onClick={handleSubmitToken}
-                              disabled={!hfTokenInput.trim() || submitTokenMutation.isPending}
+                              disabled={!hfTokenInput.trim() || isTokenMutating}
                               className="h-9 px-4 text-xs bg-electric-blue hover:bg-electric-blue/90 text-slate-950 font-bold"
                             >
                               {submitTokenMutation.isPending ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : "Save"}
@@ -1631,11 +1636,15 @@ export function InputEnvironmentPanel({
                                 type="button"
                                 variant="outline"
                                 onClick={handleClearToken}
-                                disabled={clearTokenMutation.isPending}
+                                disabled={isTokenMutating}
+                                aria-label={clearTokenMutation.isPending ? "Clearing token" : undefined}
                                 className="h-9 px-3 text-xs border-red-500/30 text-red-400 hover:bg-red-500/10"
                               >
                                 {clearTokenMutation.isPending ? (
-                                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                                  <>
+                                    <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                                    <span className="sr-only">Clearing token</span>
+                                  </>
                                 ) : (
                                   "Clear"
                                 )}
@@ -1645,7 +1654,7 @@ export function InputEnvironmentPanel({
                         )}
                         {clearTokenMutation.isError && (
                           <p role="alert" className="text-[10px] text-rose-400">
-                            Couldn't clear the token — try again.
+                            Couldn&apos;t clear the token — try again.
                           </p>
                         )}
 

--- a/src/components/features/input/InputEnvironmentPanel.tsx
+++ b/src/components/features/input/InputEnvironmentPanel.tsx
@@ -1,5 +1,4 @@
 import { useState, useRef, useEffect, ChangeEvent, useMemo, useTransition } from "react";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   Card,
   CardContent,
@@ -45,6 +44,7 @@ import { useHardwareProbe } from "@/lib/hooks/useHardwareProbe";
 import { navigatePipeline } from "@/lib/pipelineNavigation";
 import { estimateVramForCatalogPreset } from "@/lib/presetVramEstimate";
 import { CompatCountSummary, CompatStatusPill } from "@/components/features/input/CompatStatus";
+import { useHfToken } from "@/components/features/input/useHfToken";
 import {
   DownloadCloud,
   KeyRound,
@@ -119,7 +119,6 @@ export function InputEnvironmentPanel({
   const storeState = usePipelineState();
   const state = propState ?? storeState.state;
   const setState = propSetState ?? storeState.setState;
-  const queryClient = useQueryClient();
   const fileInputRef = useRef<HTMLInputElement>(null);
   const chunkFilesRef = useRef<Map<string, File>>(new Map());
   const [isReconstructing, setIsReconstructing] = useState(false);
@@ -130,71 +129,16 @@ export function InputEnvironmentPanel({
   const [downloadUrl, setDownloadUrl] = useState<string | null>(null);
   const [downloadName, setDownloadName] = useState<string | null>(null);
 
-  // HuggingFace token
-  const [hfTokenInput, setHfTokenInput] = useState("");
-
-  const hfTokenStatusQuery = useQuery({
-    queryKey: ["hf-token-status"],
-    queryFn: async (): Promise<"environment" | "runtime" | "none"> => {
-      const r = await fetch("/api/env/hf-token-status");
-      if (!r.ok) throw new Error(`HTTP ${r.status}`);
-      const d = await r.json();
-      const source = d?.source;
-      return source === "environment" || source === "runtime" ? source : "none";
-    },
-    retry: false,
-  });
-  const hfTokenStatus = hfTokenStatusQuery.isLoading
-    ? "loading"
-    : hfTokenStatusQuery.isError
-      ? "error"
-      : (hfTokenStatusQuery.data ?? "none");
-
-  const submitTokenMutation = useMutation({
-    mutationFn: async (token: string) => {
-      const r = await fetch("/api/env/hf-token", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ token }),
-      });
-      if (!r.ok) throw new Error(`HTTP ${r.status}`);
-    },
-    onSuccess: () => {
-      queryClient.setQueryData(["hf-token-status"], "runtime");
-      setHfTokenInput("");
-      clearTokenMutation.reset();
-    },
-  });
-
-  const clearTokenMutation = useMutation({
-    mutationFn: async () => {
-      const r = await fetch("/api/env/hf-token", { method: "DELETE" });
-      if (!r.ok) throw new Error(`HTTP ${r.status}`);
-    },
-    onSuccess: () => {
-      queryClient.setQueryData(["hf-token-status"], "none");
-    },
-  });
-
-  const isTokenMutating = submitTokenMutation.isPending || clearTokenMutation.isPending;
-
-  const handleSubmitToken = async () => {
-    if (isTokenMutating || !hfTokenInput.trim()) return;
-    try {
-      await submitTokenMutation.mutateAsync(hfTokenInput.trim());
-    } catch {
-      /* ignore */
-    }
-  };
-
-  const handleClearToken = async () => {
-    if (isTokenMutating) return;
-    try {
-      await clearTokenMutation.mutateAsync();
-    } catch {
-      /* ignore — clearTokenMutation.error is rendered next to the Clear button */
-    }
-  };
+  const {
+    hfTokenInput,
+    setHfTokenInput,
+    hfTokenStatus,
+    submitTokenMutation,
+    clearTokenMutation,
+    isTokenMutating,
+    handleSubmitToken,
+    handleClearToken,
+  } = useHfToken();
 
   // States for the Olive Recipe Hub
   const [recipeSearch, setRecipeSearch] = useState("");

--- a/src/components/features/input/InputEnvironmentPanel.tsx
+++ b/src/components/features/input/InputEnvironmentPanel.tsx
@@ -188,7 +188,7 @@ export function InputEnvironmentPanel({
     try {
       await clearTokenMutation.mutateAsync();
     } catch {
-      /* ignore — clearTokenMutation.error surfaces via mutation state */
+      /* ignore — clearTokenMutation.error is rendered next to the Clear button */
     }
   };
 
@@ -1631,12 +1631,22 @@ export function InputEnvironmentPanel({
                                 type="button"
                                 variant="outline"
                                 onClick={handleClearToken}
+                                disabled={clearTokenMutation.isPending}
                                 className="h-9 px-3 text-xs border-red-500/30 text-red-400 hover:bg-red-500/10"
                               >
-                                Clear
+                                {clearTokenMutation.isPending ? (
+                                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                                ) : (
+                                  "Clear"
+                                )}
                               </Button>
                             )}
                           </div>
+                        )}
+                        {clearTokenMutation.isError && (
+                          <p role="alert" className="text-[10px] text-rose-400">
+                            Couldn't clear the token — try again.
+                          </p>
                         )}
 
                         <p className="text-[10px] text-slate-500 leading-relaxed">

--- a/src/components/features/input/useHfToken.test.ts
+++ b/src/components/features/input/useHfToken.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { createElement } from "react";
+import { useHfToken } from "./useHfToken";
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return createElement(QueryClientProvider, { client: queryClient }, children);
+  };
+}
+
+describe("useHfToken", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("maps a failed status request to error", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation((url: unknown) => {
+      if (String(url).includes("hf-token-status")) {
+        return Promise.resolve(new Response("Internal Error", { status: 500 }));
+      }
+      return Promise.resolve(new Response("{}", { status: 200 }));
+    });
+
+    const { result } = renderHook(() => useHfToken(), { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(result.current.hfTokenStatus).toBe("error");
+    });
+  });
+
+  it("maps a successful status request to the returned source", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation((url: unknown) => {
+      if (String(url).includes("hf-token-status")) {
+        return Promise.resolve(new Response(JSON.stringify({ source: "runtime" }), { status: 200 }));
+      }
+      return Promise.resolve(new Response("{}", { status: 200 }));
+    });
+
+    const { result } = renderHook(() => useHfToken(), { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(result.current.hfTokenStatus).toBe("runtime");
+    });
+  });
+
+  it("keeps runtime status on failed clear and recovers after a successful save", async () => {
+    let resolveDelete!: (res: Response) => void;
+    const deletePromise = new Promise<Response>((resolve) => {
+      resolveDelete = resolve;
+    });
+
+    vi.spyOn(globalThis, "fetch").mockImplementation((url: unknown, init?: RequestInit) => {
+      const urlStr = String(url);
+      if (urlStr.includes("hf-token-status")) {
+        return Promise.resolve(new Response(JSON.stringify({ source: "runtime" }), { status: 200 }));
+      }
+      if (urlStr.includes("/api/env/hf-token") && init?.method === "DELETE") {
+        return deletePromise;
+      }
+      if (urlStr.includes("/api/env/hf-token") && init?.method === "POST") {
+        return Promise.resolve(new Response("{}", { status: 200 }));
+      }
+      return Promise.resolve(new Response("{}", { status: 200 }));
+    });
+
+    const { result } = renderHook(() => useHfToken(), { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(result.current.hfTokenStatus).toBe("runtime");
+    });
+
+    let clearPromise: Promise<void>;
+    act(() => {
+      clearPromise = result.current.handleClearToken();
+    });
+
+    await waitFor(() => {
+      expect(result.current.clearTokenMutation.isPending).toBe(true);
+    });
+
+    await act(async () => {
+      resolveDelete(new Response("Internal Error", { status: 500 }));
+      await clearPromise;
+    });
+
+    expect(result.current.hfTokenStatus).toBe("runtime");
+    await waitFor(() => {
+      expect(result.current.clearTokenMutation.isError).toBe(true);
+    });
+
+    act(() => {
+      result.current.setHfTokenInput("hf_new_token_123");
+    });
+
+    await act(async () => {
+      await result.current.handleSubmitToken();
+    });
+
+    expect(result.current.hfTokenStatus).toBe("runtime");
+    expect(result.current.hfTokenInput).toBe("");
+    expect(result.current.clearTokenMutation.isError).toBe(false);
+  });
+});

--- a/src/components/features/input/useHfToken.test.ts
+++ b/src/components/features/input/useHfToken.test.ts
@@ -1,8 +1,7 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { renderHook, act, waitFor } from "@testing-library/react";
-import type { ReactNode } from "react";
+import { createElement, type ReactNode } from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { createElement } from "react";
 import { useHfToken } from "./useHfToken";
 
 function createWrapper() {

--- a/src/components/features/input/useHfToken.ts
+++ b/src/components/features/input/useHfToken.ts
@@ -1,0 +1,89 @@
+import { useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+export const HF_TOKEN_STATUS_QUERY_KEY = ["hf-token-status"] as const;
+
+export type HfTokenStatusSource = "environment" | "runtime" | "none";
+export type HfTokenStatus = HfTokenStatusSource | "loading" | "error";
+
+/**
+ * Hugging Face token status + save/clear mutations for the model source panel.
+ */
+export function useHfToken() {
+  const queryClient = useQueryClient();
+  const [hfTokenInput, setHfTokenInput] = useState("");
+
+  const hfTokenStatusQuery = useQuery({
+    queryKey: HF_TOKEN_STATUS_QUERY_KEY,
+    queryFn: async (): Promise<HfTokenStatusSource> => {
+      const r = await fetch("/api/env/hf-token-status");
+      if (!r.ok) throw new Error(`HTTP ${r.status}`);
+      const d = await r.json();
+      const source = d?.source;
+      return source === "environment" || source === "runtime" ? source : "none";
+    },
+    retry: false,
+  });
+  const hfTokenStatus: HfTokenStatus = hfTokenStatusQuery.isLoading
+    ? "loading"
+    : hfTokenStatusQuery.isError
+      ? "error"
+      : (hfTokenStatusQuery.data ?? "none");
+
+  const clearTokenMutation = useMutation({
+    mutationFn: async () => {
+      const r = await fetch("/api/env/hf-token", { method: "DELETE" });
+      if (!r.ok) throw new Error(`HTTP ${r.status}`);
+    },
+    onSuccess: () => {
+      queryClient.setQueryData(HF_TOKEN_STATUS_QUERY_KEY, "none");
+    },
+  });
+
+  const submitTokenMutation = useMutation({
+    mutationFn: async (token: string) => {
+      const r = await fetch("/api/env/hf-token", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ token }),
+      });
+      if (!r.ok) throw new Error(`HTTP ${r.status}`);
+    },
+    onSuccess: () => {
+      queryClient.setQueryData(HF_TOKEN_STATUS_QUERY_KEY, "runtime");
+      setHfTokenInput("");
+      clearTokenMutation.reset();
+    },
+  });
+
+  const isTokenMutating = submitTokenMutation.isPending || clearTokenMutation.isPending;
+
+  const handleSubmitToken = async () => {
+    if (isTokenMutating || !hfTokenInput.trim()) return;
+    try {
+      await submitTokenMutation.mutateAsync(hfTokenInput.trim());
+    } catch {
+      /* ignore */
+    }
+  };
+
+  const handleClearToken = async () => {
+    if (isTokenMutating) return;
+    try {
+      await clearTokenMutation.mutateAsync();
+    } catch {
+      /* ignore — clearTokenMutation.error is rendered next to the Clear button */
+    }
+  };
+
+  return {
+    hfTokenInput,
+    setHfTokenInput,
+    hfTokenStatus,
+    submitTokenMutation,
+    clearTokenMutation,
+    isTokenMutating,
+    handleSubmitToken,
+    handleClearToken,
+  };
+}

--- a/src/lib/codex/codexAgent.test.ts
+++ b/src/lib/codex/codexAgent.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import {
   isModuleNotFoundError,
   _resetCodexStateForTests,
@@ -10,6 +10,10 @@ import {
 describe("codexAgent", () => {
   beforeEach(() => {
     _resetCodexStateForTests();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
   });
 
   describe("isModuleNotFoundError", () => {
@@ -30,6 +34,14 @@ describe("codexAgent", () => {
       const err = new Error("Cannot find package 'some-transitive-dep' imported from /node_modules/@openai/codex-sdk/index.js");
       (err as unknown as Record<string, unknown>).code = "ERR_MODULE_NOT_FOUND";
       (err as unknown as Record<string, unknown>).specifier = "some-transitive-dep";
+      expect(isModuleNotFoundError(err)).toBe(false);
+    });
+
+    it("returns false for missing transitive dependencies without err.specifier", () => {
+      const err = new Error(
+        "Cannot find package 'some-transitive-dep' imported from /node_modules/@openai/codex-sdk/index.js",
+      );
+      (err as unknown as Record<string, unknown>).code = "ERR_MODULE_NOT_FOUND";
       expect(isModuleNotFoundError(err)).toBe(false);
     });
 

--- a/src/lib/codex/codexAgent.test.ts
+++ b/src/lib/codex/codexAgent.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import {
+  isModuleNotFoundError,
+  _resetCodexStateForTests,
+  getCodex,
+  codexAsk,
+  buildCodexPrompt,
+} from "./codexAgent";
+
+describe("codexAgent", () => {
+  beforeEach(() => {
+    _resetCodexStateForTests();
+  });
+
+  describe("isModuleNotFoundError", () => {
+    it("returns true for direct @openai/codex-sdk missing package errors", () => {
+      const err = new Error("Cannot find package '@openai/codex-sdk' imported from /app");
+      (err as unknown as Record<string, unknown>).code = "ERR_MODULE_NOT_FOUND";
+      expect(isModuleNotFoundError(err)).toBe(true);
+    });
+
+    it("returns true when err.specifier or err.url contains @openai/codex-sdk", () => {
+      const err = new Error("Module not found");
+      (err as unknown as Record<string, unknown>).code = "ERR_MODULE_NOT_FOUND";
+      (err as unknown as Record<string, unknown>).specifier = "@openai/codex-sdk";
+      expect(isModuleNotFoundError(err)).toBe(true);
+    });
+
+    it("returns false for missing transitive dependencies inside installed packages", () => {
+      const err = new Error("Cannot find package 'some-transitive-dep' imported from /node_modules/@openai/codex-sdk/index.js");
+      (err as unknown as Record<string, unknown>).code = "ERR_MODULE_NOT_FOUND";
+      (err as unknown as Record<string, unknown>).specifier = "some-transitive-dep";
+      expect(isModuleNotFoundError(err)).toBe(false);
+    });
+
+    it("returns false for non-module-not-found errors", () => {
+      expect(isModuleNotFoundError(new Error("SyntaxError"))).toBe(false);
+      expect(isModuleNotFoundError(new TypeError("Not a function"))).toBe(false);
+      expect(isModuleNotFoundError("string error")).toBe(false);
+    });
+  });
+
+  describe("buildCodexPrompt", () => {
+    it("formats prompt with instructions and conversation history", () => {
+      const prompt = buildCodexPrompt("System instructions here", [
+        { role: "user", content: "Hello" },
+        { role: "assistant", content: "Hi there" },
+      ]);
+      expect(prompt).toContain("System instructions here");
+      expect(prompt).toContain("User: Hello");
+      expect(prompt).toContain("Assistant: Hi there");
+    });
+  });
+
+  describe("getCodex & export validation", () => {
+    it("routes missing direct package through unavailable error message", async () => {
+      const err = new Error("Cannot find package '@openai/codex-sdk'");
+      (err as unknown as Record<string, unknown>).code = "ERR_MODULE_NOT_FOUND";
+
+      // Mock dynamic import
+      vi.stubGlobal("Function", function () {
+        return () => Promise.reject(err);
+      });
+
+      await expect(getCodex()).rejects.toThrow(
+        /Codex provider unavailable: @openai\/codex-sdk \(optionalDependencies\) is not installed/i,
+      );
+    });
+
+    it("routes missing transitive dependency through 'failed to load' error message", async () => {
+      const err = new Error("Cannot find package 'some-transitive-dep'");
+      (err as unknown as Record<string, unknown>).code = "ERR_MODULE_NOT_FOUND";
+      (err as unknown as Record<string, unknown>).specifier = "some-transitive-dep";
+
+      vi.stubGlobal("Function", function () {
+        return () => Promise.reject(err);
+      });
+
+      await expect(getCodex()).rejects.toThrow(/Codex provider failed to load\./i);
+    });
+
+    it("routes resolved SDK module without a valid Codex export through 'failed to load' error message", async () => {
+      vi.stubGlobal("Function", function () {
+        return () => Promise.resolve({});
+      });
+
+      await expect(getCodex()).rejects.toThrow(/Codex provider failed to load\./i);
+    });
+
+    it("successfully instantiates client when Codex constructor export is valid", async () => {
+      class MockCodex {
+        startThread() {
+          return {
+            run: () => Promise.resolve({ finalResponse: "Agent response", items: [] }),
+          };
+        }
+      }
+
+      vi.stubGlobal("Function", function () {
+        return () => Promise.resolve({ Codex: MockCodex });
+      });
+
+      const codex = await getCodex();
+      expect(codex).toBeTruthy();
+
+      const response = await codexAsk("Test prompt");
+      expect(response).toBe("Agent response");
+    });
+  });
+});

--- a/src/lib/codex/codexAgent.test.ts
+++ b/src/lib/codex/codexAgent.test.ts
@@ -118,5 +118,43 @@ describe("codexAgent", () => {
       const response = await codexAsk("Test prompt");
       expect(response).toBe("Agent response");
     });
+
+    it("clears cached state when Codex constructor throws so a later call can retry", async () => {
+      let loadCount = 0;
+
+      class ThrowingCodex {
+        constructor() {
+          throw new Error("constructor boom");
+        }
+      }
+
+      class GoodCodex {
+        startThread() {
+          return {
+            run: () => Promise.resolve({ finalResponse: "recovered", items: [] }),
+          };
+        }
+      }
+
+      vi.stubGlobal("Function", function () {
+        return () => {
+          loadCount += 1;
+          if (loadCount === 1) {
+            return Promise.resolve({ Codex: ThrowingCodex });
+          }
+          return Promise.resolve({ Codex: GoodCodex });
+        };
+      });
+
+      await expect(getCodex()).rejects.toThrow(/Codex provider failed to load\./i);
+      expect(loadCount).toBe(1);
+
+      const codex = await getCodex();
+      expect(codex).toBeTruthy();
+      expect(loadCount).toBe(2);
+
+      const response = await codexAsk("retry");
+      expect(response).toBe("recovered");
+    });
   });
 });

--- a/src/lib/codex/codexAgent.ts
+++ b/src/lib/codex/codexAgent.ts
@@ -48,21 +48,40 @@ function loadCodexSdk(): Promise<CodexSdkModule> {
   return dynamicImport("@openai/codex-sdk");
 }
 
-/** True only for Node's "can't resolve this specifier" errors, not evaluation/export failures. */
-function isModuleNotFoundError(err: unknown): boolean {
-  return (
-    err instanceof Error &&
-    "code" in err &&
-    (err.code === "ERR_MODULE_NOT_FOUND" || err.code === "MODULE_NOT_FOUND")
-  );
+/** True only for Node's "can't resolve @openai/codex-sdk" errors, not transitive module or evaluation/export failures. */
+export function isModuleNotFoundError(err: unknown): boolean {
+  if (
+    !(
+      err instanceof Error &&
+      "code" in err &&
+      (err.code === "ERR_MODULE_NOT_FOUND" || err.code === "MODULE_NOT_FOUND")
+    )
+  ) {
+    return false;
+  }
+  const specifier =
+    ("specifier" in err && typeof err.specifier === "string" ? err.specifier : "") ||
+    ("url" in err && typeof err.url === "string" ? err.url : "") ||
+    err.message;
+
+  return specifier.includes("@openai/codex-sdk");
 }
 
-async function getCodex(): Promise<CodexClient> {
+export function _resetCodexStateForTests(): void {
+  codexSingleton = null;
+  codexModulePromise = null;
+}
+
+export async function getCodex(): Promise<CodexClient> {
   if (!codexSingleton) {
     codexModulePromise ??= loadCodexSdk();
     let Codex: CodexSdkModule["Codex"];
     try {
-      ({ Codex } = await codexModulePromise);
+      const mod = await codexModulePromise;
+      Codex = mod?.Codex;
+      if (typeof Codex !== "function") {
+        throw new Error("Module '@openai/codex-sdk' does not export a valid Codex constructor.");
+      }
     } catch (err) {
       // Reset so a later install (or a transient failure) doesn't require a server restart.
       codexModulePromise = null;

--- a/src/lib/codex/codexAgent.ts
+++ b/src/lib/codex/codexAgent.ts
@@ -60,11 +60,14 @@ export function isModuleNotFoundError(err: unknown): boolean {
     return false;
   }
   const specifier =
-    ("specifier" in err && typeof err.specifier === "string" ? err.specifier : "") ||
-    ("url" in err && typeof err.url === "string" ? err.url : "") ||
-    err.message;
+    ("specifier" in err && typeof err.specifier === "string" && err.specifier
+      ? err.specifier
+      : "url" in err && typeof err.url === "string" && err.url
+        ? err.url
+        : err.message.match(/Cannot find (?:package|module) ['"]([^'\"]+)['\"]/)?.[1]) ??
+    "";
 
-  return specifier.includes("@openai/codex-sdk");
+  return specifier === "@openai/codex-sdk";
 }
 
 export function _resetCodexStateForTests(): void {

--- a/src/lib/codex/codexAgent.ts
+++ b/src/lib/codex/codexAgent.ts
@@ -48,6 +48,15 @@ function loadCodexSdk(): Promise<CodexSdkModule> {
   return dynamicImport("@openai/codex-sdk");
 }
 
+/** True only for Node's "can't resolve this specifier" errors, not evaluation/export failures. */
+function isModuleNotFoundError(err: unknown): boolean {
+  return (
+    err instanceof Error &&
+    "code" in err &&
+    (err.code === "ERR_MODULE_NOT_FOUND" || err.code === "MODULE_NOT_FOUND")
+  );
+}
+
 async function getCodex(): Promise<CodexClient> {
   if (!codexSingleton) {
     codexModulePromise ??= loadCodexSdk();
@@ -55,12 +64,17 @@ async function getCodex(): Promise<CodexClient> {
     try {
       ({ Codex } = await codexModulePromise);
     } catch (err) {
-      // Reset so a later install doesn't require a server restart.
+      // Reset so a later install (or a transient failure) doesn't require a server restart.
       codexModulePromise = null;
-      throw new Error(
-        "Codex provider unavailable: @openai/codex-sdk (optionalDependencies) is not installed. Run `pnpm add @openai/codex-sdk` to enable it.",
-        { cause: err },
-      );
+      if (isModuleNotFoundError(err)) {
+        throw new Error(
+          "Codex provider unavailable: @openai/codex-sdk (optionalDependencies) is not installed. Run `pnpm add --save-optional @openai/codex-sdk` to enable it.",
+          { cause: err },
+        );
+      }
+      // Module resolved but failed to evaluate/export correctly — a missing-package
+      // message here would be misleading.
+      throw new Error("Codex provider failed to load.", { cause: err });
     }
     codexSingleton = new Codex({
       codexPathOverride: process.env.CODEX_PATH || undefined,

--- a/src/lib/codex/codexAgent.ts
+++ b/src/lib/codex/codexAgent.ts
@@ -78,15 +78,19 @@ export function _resetCodexStateForTests(): void {
 export async function getCodex(): Promise<CodexClient> {
   if (!codexSingleton) {
     codexModulePromise ??= loadCodexSdk();
-    let Codex: CodexSdkModule["Codex"];
     try {
       const mod = await codexModulePromise;
-      Codex = mod?.Codex;
+      const Codex = mod?.Codex;
       if (typeof Codex !== "function") {
         throw new Error("Module '@openai/codex-sdk' does not export a valid Codex constructor.");
       }
+      // Construct inside the guarded path so ctor failures also clear caches for retry.
+      codexSingleton = new Codex({
+        codexPathOverride: process.env.CODEX_PATH || undefined,
+      });
     } catch (err) {
       // Reset so a later install (or a transient failure) doesn't require a server restart.
+      codexSingleton = null;
       codexModulePromise = null;
       if (isModuleNotFoundError(err)) {
         throw new Error(
@@ -94,13 +98,10 @@ export async function getCodex(): Promise<CodexClient> {
           { cause: err },
         );
       }
-      // Module resolved but failed to evaluate/export correctly — a missing-package
+      // Module resolved but failed to evaluate/export/construct correctly — a missing-package
       // message here would be misleading.
       throw new Error("Codex provider failed to load.", { cause: err });
     }
-    codexSingleton = new Codex({
-      codexPathOverride: process.env.CODEX_PATH || undefined,
-    });
   }
   return codexSingleton;
 }


### PR DESCRIPTION
## Summary
Follow-up on #161's coderabbit review — 5 findings that weren't addressed before merge.

- **server.ts**: `index.html.gz` (the path express-static-gzip actually serves when a client accepts gzip) wasn't matched by the `endsWith("index.html")` check, so the SPA shell could get 1-hour cached instead of `no-cache`.
- **ExecutionWorkspace/OwrExportOverlay**: jszip load and zip generation failures only logged to console with no user feedback. Added a `downloadError` shown with `role="alert"` next to the download button.
- **InputEnvironmentPanel**: a failed token DELETE was silently swallowed; the Clear button stayed clickable mid-request with no error shown. Now disables while pending and surfaces `clearTokenMutation.error`.
- **codexAgent**: distinguishes "module not found" from other load failures (a resolved-but-broken module no longer gets the misleading "not installed" message), and corrected the install command to `pnpm add --save-optional`.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `eslint` 0 errors (1 pre-existing warning, unrelated)
- [x] `pnpm build` succeeds
- [x] Verified `index.html` / `index.html.gz` / hashed JS / unhashed assets all get correct `Cache-Control` headers against the built server
- [x] 905/905 unit, 130/130 component, 63/63 integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tonythethompson/Olive-Studio/pull/165?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

