### PR TITLE
Update autopilot.yml to include composio logout

### DIFF
--- a/.github/workflows/autopilot.yml
+++ b/.github/workflows/autopilot.yml
@@ -207,7 +207,8 @@ jobs:
         env:
           COMPOSIO_API_KEY: ${{ secrets.COMPOSIO_API_KEY }}
         run: |
-          composio login --api-key "$COMPOSIO_API_KEY"
+          composio logout || true
+          composio add --api-key "$COMPOSIO_API_KEY"
           echo "COMPOSIO_HEADERS={\"x-consumer-api-key\":\"$COMPOSIO_API_KEY\"}" >> $GITHUB_ENV
 
       # Agent has no GitHub token. It edits files and writes a report; the

--- a/.github/workflows/autopilot.yml
+++ b/.github/workflows/autopilot.yml
@@ -147,6 +147,7 @@ jobs:
         if: steps.threads.outputs.count != '0'
         with:
           node-version: '22'
+          cache: pnpm
 
       - uses: actions/setup-python@v5
         if: steps.threads.outputs.count != '0'
@@ -207,7 +208,7 @@ jobs:
         env:
           COMPOSIO_API_KEY: ${{ secrets.COMPOSIO_API_KEY }}
         run: |
-          composio logout || true
+          composio logout || echo "::notice::composio logout failed (continuing)"
           composio add --api-key "$COMPOSIO_API_KEY"
           echo "COMPOSIO_HEADERS={\"x-consumer-api-key\":\"$COMPOSIO_API_KEY\"}" >> $GITHUB_ENV
 


### PR DESCRIPTION
<h3>PR Summary by Qodo</h3>

Ensure Composio session is reset in autopilot workflow

<code>⚙️ Configuration changes</code> <code>🕐 Less than 5 minutes</code>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<details>
<summary>AI Description</summary>

<dl>
<dd>
<br/>

><pre>
>• Reset any existing Composio CLI session before configuring API access
>• Replace <b><i>composio login</i></b> with <b><i>composio add</i></b> using the workflow secret key
></pre>

</dd>
</dl>

</details>

<details>
<summary>Diagram</summary>

<dl>
<dd>

<br/>

```mermaid
graph TD
  A["autopilot.yml"] --> B["GitHub runner"] --> C(("COMPOSIO_API_KEY")) --> D["composio CLI"] --> E{{"Composio API"}}
  D -- "logout || true" --> D
  D -- "add --api-key" --> E
  subgraph Legend
    direction LR
    _file["Workflow file"] ~~~ _secret(("Secret/env var")) ~~~ _ext{{"External service"}}
  end
```

</dd>
</dl>

</details>




<details>
<summary>High-Level Assessment</summary>

<dl>
<dd>

<br/>

>The following are alternative approaches to this PR:

<details>
<summary><b>1. Use an isolated config directory (ephemeral HOME)</b></summary>

<dl>
<dd>

- ➕ Avoids needing logout; guarantees clean auth state per run
- ➕ Prevents cross-step contamination if the runner workspace is reused
- ➖ May require knowledge of Composio’s config location/env vars
- ➖ Adds extra workflow setup steps (mkdir/export HOME)

</dd>
</dl>

</details>

<details>
<summary><b>2. Prefer a built-in &#x27;force&#x27; / non-interactive login mode (if available)</b></summary>

<dl>
<dd>

- ➕ Keeps intent explicit (authenticate with provided key) without stateful cleanup
- ➕ Potentially clearer than logout-then-add
- ➖ Depends on CLI support/flags; may not exist or may change across versions
- ➖ Still might not clear all persisted state if CLI caches tokens elsewhere

</dd>
</dl>

</details>

>**Recommendation:** The current approach (best-effort `composio logout` followed by `composio add`) is a pragmatic, low-risk way to eliminate flaky failures from lingering CLI auth state. If auth-state issues persist or the runner environment is reused across jobs, consider switching to an isolated config directory (ephemeral HOME/Composio config path) to guarantee a clean session without relying on logout behavior.

</dd>
</dl>

</details>

<details>
<summary> Files changed (1) <code> +2 / -1 </code> </summary>

<dl>
<dd>

<br/>

<details>
<summary>Other (1) <code> +2 / -1 </code></summary>

<dl>
<dd>

<details>
<summary>autopilot.yml<code>Reset Composio CLI session before adding API key</code> <code>+2/-1</code></summary>

<br/>

>Reset Composio CLI session before adding API key
>
><pre>
>• Updates the autopilot workflow to run &#x27;composio logout || true&#x27; before configuring Composio with the secret API key. Replaces the prior &#x27;composio login&#x27; call with &#x27;composio add&#x27; to set up access for subsequent steps.
></pre>
>
><a href='https://github.com/tonythethompson/Olive-Studio/pull/168/files#diff-fb611f41345dfcc2d53e843bd4ef97abf58ae3b2cd662e4c20f7ce4c084d6cb0'>.github/workflows/autopilot.yml</a>

</details>

</dd>
</dl>

</details>

</dd>
</dl>

</details>