### PR TITLE
Fix formatting of max-steps to max_steps in workflow

### DIFF
--- a/.github/workflows/autopilot.yml
+++ b/.github/workflows/autopilot.yml
@@ -251,7 +251,7 @@ jobs:
           TASK
           )" \
             --model "gemini/gemini-3.6-flash" \
-            --max-steps "${{ vars.AUTOPILOT_MAX_STEPS || 100 }}" \
+            --max_steps "${{ vars.AUTOPILOT_MAX_STEPS || 100 }}" \
             --config yolo
 
       - name: Sanity checks


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes the autopilot workflow to use the correct CLI flag for step limiting. Replaces --max-steps with --max_steps so the `AUTOPILOT_MAX_STEPS` value is applied.

<sup>Written for commit 35d0a4b53ae3417be4337ee702b8cfafee5ba556. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tonythethompson/Olive-Studio/pull/170?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

