### PR TITLE
test(mcp): centralize semantic inflight drain in conftest

### DIFF
--- a/olive-mcp-server/tests/conftest.py
+++ b/olive-mcp-server/tests/conftest.py
@@ -1,0 +1,53 @@
+"""Shared pytest fixtures for olive-mcp-server tests."""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Callable, Iterator
+
+import pytest
+
+from olive_mcp_server.tools import retrieval
+
+# Generous ceiling for abandoned budget workers (tests use ≤0.55s sleeps today).
+_INFLIGHT_DRAIN_TIMEOUT_S = 5.0
+
+
+def wait_for_inflight_semantic_clear(
+    *,
+    timeout_s: float = _INFLIGHT_DRAIN_TIMEOUT_S,
+) -> None:
+    """
+    Poll retrieval single-flight state until the tracked future is idle.
+
+    Clears a done future so the next ``run_with_budget`` call is not stuck on
+    a stale handle. Fails if work is still active after ``timeout_s``.
+    """
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        with retrieval._INFLIGHT_LOCK:
+            fut = retrieval._INFLIGHT_FUTURE
+            if fut is None or fut.done():
+                retrieval._INFLIGHT_FUTURE = None
+                return
+        time.sleep(0.05)
+    with retrieval._INFLIGHT_LOCK:
+        fut = retrieval._INFLIGHT_FUTURE
+    raise AssertionError(
+        f"semantic budget worker still in flight after {timeout_s}s "
+        f"(future={fut!r})"
+    )
+
+
+@pytest.fixture
+def wait_inflight_semantic_clear() -> Callable[..., None]:
+    """Expose the drain helper to tests that must wait mid-body."""
+    return wait_for_inflight_semantic_clear
+
+
+@pytest.fixture(autouse=True)
+def _drain_semantic_inflight_between_tests() -> Iterator[None]:
+    """Ensure no abandoned ``run_with_budget`` worker leaks across tests."""
+    wait_for_inflight_semantic_clear()
+    yield
+    wait_for_inflight_semantic_clear()

--- a/olive-mcp-server/tests/test_capabilities.py
+++ b/olive-mcp-server/tests/test_capabilities.py
@@ -112,8 +112,6 @@ def test_run_with_budget_timeout():
     result, outcome = run_with_budget(slow, budget_ms=50)
     assert outcome == "timeout"
     assert result is None
-    # Drain abandoned worker so later tests are not blocked by single-flight.
-    time.sleep(0.55)
 
 
 def test_run_with_budget_ok():
@@ -122,7 +120,7 @@ def test_run_with_budget_ok():
     assert result == 42
 
 
-def test_run_with_budget_single_flight_during_timeout():
+def test_run_with_budget_single_flight_during_timeout(wait_inflight_semantic_clear):
     """Consecutive calls during a timeout must not start a second callable."""
     import time
 
@@ -141,8 +139,8 @@ def test_run_with_budget_single_flight_during_timeout():
     assert o2 == "busy" and r2 is None
     assert started == [1]
 
-    time.sleep(0.5)
     # After the in-flight work finishes, a new callable may start.
+    wait_inflight_semantic_clear()
     r3, o3 = run_with_budget(lambda: "fresh", budget_ms=5000)
     assert o3 == "ok" and r3 == "fresh"
     assert started == [1]
@@ -201,5 +199,3 @@ def test_troubleshoot_auto_budget_degraded(monkeypatch: pytest.MonkeyPatch):
     assert result["retrieval"]["effective"] == "keyword"
     # Keyword path should still diagnose OOM (may match oom-quantization)
     assert isinstance(result.get("title"), str)
-    # Drain abandoned budget worker for subsequent tests.
-    time.sleep(0.5)

--- a/olive-mcp-server/tests/test_docs_search_semantic.py
+++ b/olive-mcp-server/tests/test_docs_search_semantic.py
@@ -411,18 +411,7 @@ def test_live_auto_budgets_even_when_model_is_warm(monkeypatch: pytest.MonkeyPat
     """Warm model must not skip the auto budget: live fetch/index can still be cold."""
     import time
 
-    from olive_mcp_server.tools import retrieval
     from olive_mcp_server.tools.retrieval import retrieval_meta
-
-    # Ensure no abandoned budget worker from a prior test blocks single-flight.
-    deadline = time.monotonic() + 2.0
-    while time.monotonic() < deadline:
-        with retrieval._INFLIGHT_LOCK:
-            fut = retrieval._INFLIGHT_FUTURE
-            if fut is None or fut.done():
-                retrieval._INFLIGHT_FUTURE = None
-                break
-        time.sleep(0.05)
 
     monkeypatch.setenv("OLIVE_MCP_SEMANTIC_BUDGET_MS", "50")
 
@@ -480,9 +469,6 @@ def test_live_auto_budgets_even_when_model_is_warm(monkeypatch: pytest.MonkeyPat
     assert again
     assert all(r["source"].startswith("live:") for r in again)
     assert again_meta.get("effective") == "keyword"
-
-    # Drain abandoned budget worker for subsequent tests.
-    time.sleep(0.55)
 
 
 def test_shared_semantic_budget_zero_remaining_forces_live_keyword(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Centralizes semantic budget worker cleanup so tests no longer rely on fixed `time.sleep` drains that race with single-flight `run_with_budget`.

## Changes

- Add `olive-mcp-server/tests/conftest.py` autouse fixture that polls `retrieval._INFLIGHT_FUTURE` under `_INFLIGHT_LOCK` until idle (or fails after 5s).
- Expose `wait_inflight_semantic_clear` for mid-test waits.
- `test_capabilities.py`: drop trailing drain sleeps; wait on the tracked future before the post-busy submit so `started` stays deterministic.
- `test_docs_search_semantic.py`: remove inline pre/post polling sleeps (covered by the shared fixture).

## Validation

```bash
cd olive-mcp-server && python -m pytest tests -q
# 438 passed
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-878cb105-92f7-4b47-bd41-3b4563205193?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-878cb105-92f7-4b47-bd41-3b4563205193&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tonythethompson/Olive-Studio/pull/176?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

