### PR TITLE
test(server): reset jobRegistry between integration tests

### DIFF
--- a/src/server/__tests__/routes.integration.test.ts
+++ b/src/server/__tests__/routes.integration.test.ts
@@ -14,7 +14,7 @@ import { stubGlobalFetch, restoreGlobalFetch } from "./setup.integration.ts";
 import { resetMcpBreaker } from "../services/mcp/breaker.ts";
 import { resetLocalEngineRuntime } from "../services/ai/localEngineState.ts";
 import { app, markServerReady } from "../../../server.ts";
-import { jobRegistry } from "../services/olive/state.ts";
+import { jobRegistry, resetJobRegistry } from "../services/olive/state.ts";
 
 let server: Server;
 let baseUrl: string;
@@ -54,6 +54,7 @@ afterAll(async () => {
 beforeEach(() => {
   resetMcpBreaker();
   resetLocalEngineRuntime();
+  resetJobRegistry();
 });
 
 describe("Route integration tests", () => {

--- a/src/server/services/olive/state.test.ts
+++ b/src/server/services/olive/state.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { jobRegistry, cleanupJobArtifacts, sweepJobRegistry, finalizeJob } from "./state.ts";
+import { jobRegistry, cleanupJobArtifacts, sweepJobRegistry, finalizeJob, resetJobRegistry } from "./state.ts";
 import {
   clearIdempotencyIndex,
   findJobByIdempotency,
@@ -139,6 +139,39 @@ describe("olive job registry cleanup", () => {
       vi.spyOn(fs, "rmSync").mockImplementation(() => undefined);
       expect(sweepJobRegistry(now)).toBe(1);
       expect(jobRegistry.has("stuck")).toBe(false);
+    });
+  });
+
+  describe("resetJobRegistry", () => {
+    it("kills active children, clears artifacts, registry, and MCP idempotency keys", () => {
+      const kill = vi.fn();
+      const tmp = path.join(os.tmpdir(), `olive-reset-test-${Date.now()}.json`);
+      fs.writeFileSync(tmp, "{}", "utf-8");
+      const job = makeJob("live", {
+        status: "running",
+        finishedAt: null,
+        exitCode: null,
+        source: "mcp",
+        fingerprint: "fp-reset",
+        idempotencyKey: "k-reset",
+        tempRecipePath: tmp,
+        process: {
+          kill,
+          exitCode: null,
+          signalCode: null,
+        } as unknown as OliveJob["process"],
+      });
+      jobRegistry.set(job.id, job);
+      rememberIdempotencyKeys(job);
+      expect(idempotencyIndexSize()).toBeGreaterThan(0);
+
+      resetJobRegistry();
+
+      expect(kill).toHaveBeenCalledWith("SIGKILL");
+      expect(jobRegistry.size).toBe(0);
+      expect(idempotencyIndexSize()).toBe(0);
+      expect(fs.existsSync(tmp)).toBe(false);
+      expect(findJobByIdempotency({ idempotencyKey: "k-reset" }).kind).toBe("miss");
     });
   });
 

--- a/src/server/services/olive/state.ts
+++ b/src/server/services/olive/state.ts
@@ -1,7 +1,11 @@
 import fs from "fs";
 import type { OliveJob } from "../../types.ts";
 import { appConfig } from "../../config.ts";
-import { forgetIdempotencyKeysForJobId, pruneIdempotencyIndex } from "./jobIdempotency.ts";
+import {
+  clearIdempotencyIndex,
+  forgetIdempotencyKeysForJobId,
+  pruneIdempotencyIndex,
+} from "./jobIdempotency.ts";
 
 /** Central job registry — all active Olive jobs. */
 export const jobRegistry = new Map<string, OliveJob>();
@@ -54,6 +58,33 @@ export function cleanupJobArtifacts(job: OliveJob): boolean {
   } catch {
     return false;
   }
+}
+
+/**
+ * Test helper: terminate active Olive children, reclaim artifacts, and clear
+ * the registry plus MCP idempotency index so cases cannot leak across tests.
+ */
+export function resetJobRegistry(): void {
+  for (const job of [...jobRegistry.values()]) {
+    if (job.venvListener) {
+      job.venvListener = undefined;
+    }
+    const proc = job.process;
+    if (proc) {
+      try {
+        if (proc.exitCode === null && proc.signalCode === null) {
+          proc.kill("SIGKILL");
+        }
+      } catch {
+        /* already exited / not killable in mocks */
+      }
+      job.process = null;
+    }
+    cleanupJobArtifacts(job);
+    finalizeJob(job);
+  }
+  jobRegistry.clear();
+  clearIdempotencyIndex();
 }
 
 /**


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Integration `beforeEach` already reset MCP breaker and local-engine runtime, but `jobRegistry` (and MCP idempotency keys) could still leak across cases.

## Changes

- Add `resetJobRegistry()` in `state.ts`: SIGKILL active children when needed, `cleanupJobArtifacts` + `finalizeJob`, then clear the registry and `clearIdempotencyIndex()`.
- Call it from `routes.integration.test.ts` `beforeEach` alongside `resetMcpBreaker` / `resetLocalEngineRuntime`.
- Unit coverage for the new helper.

## Validation

```bash
pnpm vitest run --config vitest.server.config.ts src/server/services/olive/state.test.ts
# 15 passed
pnpm vitest run --config vitest.integration.config.ts src/server/__tests__/routes.integration.test.ts
# 63 passed
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-878cb105-92f7-4b47-bd41-3b4563205193?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-878cb105-92f7-4b47-bd41-3b4563205193&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tonythethompson/Olive-Studio/pull/177?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

