### PR TITLE
test(server): harden MCP tool injection integration coverage

### DIFF
--- a/src/server/__tests__/routes.integration.test.ts
+++ b/src/server/__tests__/routes.integration.test.ts
@@ -10,11 +10,12 @@
 import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from "vitest";
 import type { Server } from "http";
 
-import { stubGlobalFetch, restoreGlobalFetch } from "./setup.integration.ts";
+import { stubGlobalFetch, restoreGlobalFetch, clearChildProcessLaunchLog, childProcessLaunchLog } from "./setup.integration.ts";
 import { resetMcpBreaker } from "../services/mcp/breaker.ts";
 import { resetLocalEngineRuntime } from "../services/ai/localEngineState.ts";
 import { app, markServerReady } from "../../../server.ts";
 import { jobRegistry } from "../services/olive/state.ts";
+import { isAllowedMcpToolName } from "../services/mcp/allowedTools.ts";
 
 let server: Server;
 let baseUrl: string;
@@ -54,6 +55,7 @@ afterAll(async () => {
 beforeEach(() => {
   resetMcpBreaker();
   resetLocalEngineRuntime();
+  clearChildProcessLaunchLog();
 });
 
 describe("Route integration tests", () => {
@@ -620,18 +622,32 @@ describe("Route integration tests", () => {
     });
 
     it("rejects toolName with command injection characters", async () => {
+      const unsafeToolName = "pass_catalog; rm -rf /";
+      // Allowlist is exact-match; sanitizer strips metacharacters to a non-allowlisted token.
+      const sanitizedToolName = unsafeToolName.replace(/[^a-zA-Z0-9_-]/g, "");
+      expect(sanitizedToolName).toBe("pass_catalogrm-rf");
+      expect(sanitizedToolName).not.toMatch(/[;|&`$]/);
+      expect(isAllowedMcpToolName(unsafeToolName)).toBe(false);
+      expect(isAllowedMcpToolName(sanitizedToolName)).toBe(false);
+
+      const launchesBefore = childProcessLaunchLog.length;
       const res = await fetch(`${baseUrl}/api/mcp/tool`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ toolName: "pass_catalog; rm -rf /", args: {} }),
+        body: JSON.stringify({ toolName: unsafeToolName, args: {} }),
       });
 
-      // The sanitizer strips special chars, so the resulting tool name "pass_catalogrmrf"
-      // won't be found, but it should still be a valid call (will fail at Python level).
-      // The server should not return 400 for the toolName itself after sanitization.
-      // It may return an error from Python execution (500) or succeed.
-      expect(res.status).toBeGreaterThanOrEqual(200);
-      expect(res.status).toBeLessThan(600);
+      // Rejected at the allowlist gate — no Python/MCP launch.
+      expect(res.status).toBe(400);
+      expect(await res.json()).toEqual({ error: "Unknown toolName" });
+      expect(childProcessLaunchLog.slice(launchesBefore)).toEqual([]);
+
+      for (const launch of childProcessLaunchLog) {
+        const encoded = JSON.stringify(launch.args);
+        expect(encoded).not.toContain(unsafeToolName);
+        expect(encoded).not.toContain("rm -rf");
+        expect(encoded).not.toMatch(/;|\|\s*|`|\$\(/);
+      }
     });
 
     it("attempts to call a valid tool and returns JSON", async () => {

--- a/src/server/__tests__/setup.integration.ts
+++ b/src/server/__tests__/setup.integration.ts
@@ -16,12 +16,20 @@
 import { EventEmitter } from "events";
 import { vi } from "vitest";
 
+/** Recorded child_process launches for assertions (MCP injection tests, etc.). */
+export const childProcessLaunchLog: { fn: "execFile" | "spawn"; args: unknown[] }[] = [];
+
+export function clearChildProcessLaunchLog(): void {
+  childProcessLaunchLog.length = 0;
+}
+
 // ─── child_process: mock execFile + spawn ─────────────────────────────────
 
 vi.mock("child_process", async (importOriginal) => {
   const actual = await importOriginal<typeof import("child_process")>();
 
   function mockExecFile(...execArgs: unknown[]): ReturnType<typeof actual.execFile> {
+    childProcessLaunchLog.push({ fn: "execFile", args: execArgs });
     const lastArg = execArgs[execArgs.length - 1];
     if (typeof lastArg === "function") {
       lastArg(null, "", "");
@@ -31,7 +39,8 @@ vi.mock("child_process", async (importOriginal) => {
     return (actual.execFile as any)(...execArgs);
   }
 
-  function mockSpawn(): ReturnType<typeof actual.spawn> {
+  function mockSpawn(...spawnArgs: unknown[]): ReturnType<typeof actual.spawn> {
+    childProcessLaunchLog.push({ fn: "spawn", args: spawnArgs });
     const proc = new EventEmitter() as unknown as ReturnType<typeof actual.spawn>;
     proc.stdout = new EventEmitter() as unknown as ReturnType<typeof actual.spawn>["stdout"];
     proc.stderr = new EventEmitter() as unknown as ReturnType<typeof actual.spawn>["stderr"];


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The MCP tool command-injection integration case only asserted `200 ≤ status < 600`, which does not prove non-execution.

## Changes

- Record mocked `child_process` `execFile` / `spawn` args in `setup.integration.ts`.
- Strengthen the injection test to:
  - show the unsafe name (and its sanitized form) is not allowlisted
  - expect `400` + `Unknown toolName`
  - assert no new child_process launches for that request
  - assert launch args never embed the unsafe payload / shell metacharacters

Request setup (`toolName: "pass_catalog; rm -rf /"`) is unchanged.

## Validation

```bash
pnpm vitest run --config vitest.integration.config.ts src/server/__tests__/routes.integration.test.ts
# 63 passed
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-878cb105-92f7-4b47-bd41-3b4563205193?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-878cb105-92f7-4b47-bd41-3b4563205193&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tonythethompson/Olive-Studio/pull/178?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

