### PR TITLE
test(server): restore OLIVE_MCP_ACCESS after mcpAccess suite

### DIFF
--- a/src/server/routes/mcp.test.ts
+++ b/src/server/routes/mcp.test.ts
@@ -230,8 +230,14 @@ describe("POST /api/mcp/tool", () => {
 });
 
 describe("POST /api/mcp/studio-recipe mcpAccess", () => {
+  const previousOliveMcpAccess = process.env.OLIVE_MCP_ACCESS;
+
   afterEach(() => {
-    delete process.env.OLIVE_MCP_ACCESS;
+    if (previousOliveMcpAccess === undefined) {
+      delete process.env.OLIVE_MCP_ACCESS;
+    } else {
+      process.env.OLIVE_MCP_ACCESS = previousOliveMcpAccess;
+    }
   });
 
   it("returns 403 when master mcpAccess is disabled", async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The `POST /api/mcp/studio-recipe mcpAccess` suite always `delete`d `process.env.OLIVE_MCP_ACCESS` in `afterEach`, which could wipe a pre-existing value from the test process.

## Change

Capture the prior `OLIVE_MCP_ACCESS` value when the suite loads and restore it after each test (delete only when it was initially unset).

## Validation

```bash
pnpm vitest run --config vitest.server.config.ts src/server/routes/mcp.test.ts
# 11 passed
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-878cb105-92f7-4b47-bd41-3b4563205193?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-878cb105-92f7-4b47-bd41-3b4563205193&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tonythethompson/Olive-Studio/pull/179?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

