### PR TITLE
test(server): hoist writeStudioConfig import in olive.stream tests

### DIFF
--- a/src/server/routes/olive.stream.test.ts
+++ b/src/server/routes/olive.stream.test.ts
@@ -8,10 +8,12 @@ import express from "express";
 import type { Server } from "http";
 import type { OliveJob } from "../types.ts";
 import type { GpuMetrics } from "../../lib/gpuMetrics.ts";
+import { writeStudioConfig } from "../config.ts";
 import { pushGpuMetrics, pushLog } from "../services/olive/gpu.ts";
 import { finalizeJob, jobRegistry } from "../services/olive/state.ts";
 
 // Keep agent-access policy mutations out of the real `.olive-studio/config.json`.
+// vi.mock is hoisted, so the static import above resolves to this fake.
 vi.mock("../config.ts", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../config.ts")>();
   let cfg: Record<string, unknown> = {};
@@ -24,8 +26,6 @@ vi.mock("../config.ts", async (importOriginal) => {
     },
   };
 });
-
-import { writeStudioConfig } from "../config.ts";
 
 const { mountOliveRoutes } = await import("./olive.ts");
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`writeStudioConfig` was imported mid-file after `vi.mock`. Move it into the module’s top import block.

## Notes

Vitest hoists `vi.mock`, so the in-memory `../config.ts` fake remains active under `vitest.server.config.ts`. Usage in `beforeEach` / `afterEach` / cases is unchanged.

## Validation

```bash
pnpm vitest run --config vitest.server.config.ts src/server/routes/olive.stream.test.ts
# 15 passed
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-878cb105-92f7-4b47-bd41-3b4563205193?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-878cb105-92f7-4b47-bd41-3b4563205193&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tonythethompson/Olive-Studio/pull/180?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

