### PR TITLE
test(server): make QNN preflight host-mode asserts deterministic

### DIFF
--- a/src/server/services/olive/jobPreflight.test.ts
+++ b/src/server/services/olive/jobPreflight.test.ts
@@ -1,7 +1,15 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { resolveQnnHostMode } from "../../../lib/qnnDeps.ts";
 import { fingerprintRecipe, preflightOliveRecipe } from "./jobPreflight.ts";
 import type { OliveRecipe } from "../../types.ts";
+
+vi.mock("../../../lib/qnnDeps.ts", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../../lib/qnnDeps.ts")>();
+  return {
+    ...actual,
+    resolveQnnHostMode: vi.fn(actual.resolveQnnHostMode),
+  };
+});
 
 function minimalRecipe(ep = "CPUExecutionProvider"): OliveRecipe {
   // Cast via unknown: server OliveRecipe accelerators omit optional `device`.
@@ -113,16 +121,22 @@ describe("preflightOliveRecipe", () => {
     expect(fingerprintRecipe(withUndef, "auto")).toBe(fingerprintRecipe(without, "auto"));
   });
 
-  it("QNN validate stays structural: no probe means no NPU/runtime hard-fail here", () => {
+  it("QNN validate stays structural: deferred readiness warning on local-inference", () => {
+    vi.mocked(resolveQnnHostMode).mockReturnValue("local-inference");
     const pre = preflightOliveRecipe(minimalRecipe("QNNExecutionProvider"));
     // Missing NPU/runtime must not fail sync validate (probe is deferred to startOliveJob).
     expect(pre.errors.some((e) => /npu|runtime not ready/i.test(e))).toBe(false);
-    // On local-inference hosts, surface an explicit deferred-probe warning.
-    const mode = resolveQnnHostMode({ platform: process.platform, arch: process.arch });
-    if (mode === "local-inference") {
-      expect(pre.warnings.some((w) => /npu\/runtime readiness is not checked at validate/i.test(w))).toBe(
-        true,
-      );
-    }
+    expect(pre.warnings.some((w) => /npu\/runtime readiness is not checked at validate/i.test(w))).toBe(
+      true,
+    );
+  });
+
+  it("QNN out-of-scope host skips deferred-readiness warning without NPU hard-fail", () => {
+    vi.mocked(resolveQnnHostMode).mockReturnValue("out-of-scope");
+    const pre = preflightOliveRecipe(minimalRecipe("QNNExecutionProvider"));
+    expect(pre.errors.some((e) => /npu|runtime not ready/i.test(e))).toBe(false);
+    expect(pre.warnings.some((w) => /npu\/runtime readiness is not checked at validate/i.test(w))).toBe(
+      false,
+    );
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The QNN preflight case only asserted the deferred-readiness warning when the real host reported `local-inference`, so Linux CI skipped that path.

## Changes

- Mock `resolveQnnHostMode` and force `local-inference` so the deferred warning is asserted unconditionally.
- Add a separate `out-of-scope` case that still expects no NPU/runtime hard-fail and no deferred warning.

## Validation

```bash
pnpm vitest run --config vitest.server.config.ts src/server/services/olive/jobPreflight.test.ts
# 11 passed
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-878cb105-92f7-4b47-bd41-3b4563205193?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-878cb105-92f7-4b47-bd41-3b4563205193&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tonythethompson/Olive-Studio/pull/181?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

