### PR TITLE
test(server): align idempotency mocks with jobRunner spawn shape

### DIFF
--- a/src/server/services/olive/jobRunner.idempotency.test.ts
+++ b/src/server/services/olive/jobRunner.idempotency.test.ts
@@ -16,9 +16,13 @@ vi.mock("./jobPreflight.ts", () => ({
 }));
 
 vi.mock("../venv/index.ts", () => ({
-  ensureProviderCapability: vi.fn(async () => ({ ok: true })),
+  ensureProviderCapability: vi.fn(async () => ({
+    ok: true,
+    python: "python",
+    family: "default",
+  })),
   buildOliveRunEnvironment: vi.fn(() => ({})),
-  resolveOliveCommand: vi.fn(() => ({ cmd: "echo", args: ["ok"] })),
+  resolveOliveCommand: vi.fn(() => ({ executable: "echo", args: ["ok"] })),
 }));
 
 import { startOliveJob } from "./jobRunner.ts";


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`jobRunner.idempotency.test.ts` mocked `resolveOliveCommand` with `{ cmd, args }`, but `jobRunner.ts` destructures `{ executable, args }`. Capability setup also omitted `python`, so `getVenvPython` could resolve a real interpreter during async setup.

## Changes

- Return `{ executable: "echo", args: ["ok"] }` from the `resolveOliveCommand` mock.
- Include `python: "python"` (and `family`) on the `ensureProviderCapability` mock result.

## Validation

```bash
pnpm vitest run --config vitest.server.config.ts src/server/services/olive/jobRunner.idempotency.test.ts
# 1 passed
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-878cb105-92f7-4b47-bd41-3b4563205193?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-878cb105-92f7-4b47-bd41-3b4563205193&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tonythethompson/Olive-Studio/pull/182?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

