### PR TITLE
fix(server): lock MCP submits on fingerprint and idempotency key

### DIFF
--- a/src/server/services/olive/jobRunner.idempotency.test.ts
+++ b/src/server/services/olive/jobRunner.idempotency.test.ts
@@ -16,9 +16,13 @@ vi.mock("./jobPreflight.ts", () => ({
 }));
 
 vi.mock("../venv/index.ts", () => ({
-  ensureProviderCapability: vi.fn(async () => ({ ok: true })),
+  ensureProviderCapability: vi.fn(async () => ({
+    ok: true,
+    python: "python",
+    family: "default",
+  })),
   buildOliveRunEnvironment: vi.fn(() => ({})),
-  resolveOliveCommand: vi.fn(() => ({ cmd: "echo", args: ["ok"] })),
+  resolveOliveCommand: vi.fn(() => ({ executable: "echo", args: ["ok"] })),
 }));
 
 import { startOliveJob } from "./jobRunner.ts";
@@ -41,9 +45,34 @@ describe("startOliveJob MCP idempotency lock", () => {
     expect(a.ok).toBe(true);
     expect(b.ok).toBe(true);
     if (!a.ok || !b.ok) return;
-    // Lock shares one promise: identical payload, single registry entry.
     expect(a.jobId).toBe(b.jobId);
-    expect(a.reused).toBe(b.reused);
     expect([...jobRegistry.keys()]).toHaveLength(1);
+    // Sequential critical section: one fresh submit, one reuse.
+    expect([a.reused, b.reused].filter(Boolean)).toHaveLength(1);
+  });
+
+  it("serializes key-bearing and fingerprint-only submits for the same recipe", async () => {
+    const recipe = { input_model: {}, passes: {}, engine: {}, systems: {} } as never;
+    const [withKey, fpOnly] = await Promise.all([
+      startOliveJob({ recipe, source: "mcp", idempotencyKey: "agent-key-1" }),
+      startOliveJob({ recipe, source: "mcp" }),
+    ]);
+    expect(withKey.ok).toBe(true);
+    expect(fpOnly.ok).toBe(true);
+    if (!withKey.ok || !fpOnly.ok) return;
+    // Fingerprint-only must reuse the in-flight/keyed job (not spawn a second GPU run).
+    expect(withKey.jobId).toBe(fpOnly.jobId);
+    expect([...jobRegistry.keys()]).toHaveLength(1);
+  });
+
+  it("still allows a distinct idempotency key to start a new job after the first settles", async () => {
+    const recipe = { input_model: {}, passes: {}, engine: {}, systems: {} } as never;
+    const first = await startOliveJob({ recipe, source: "mcp", idempotencyKey: "key-a" });
+    const second = await startOliveJob({ recipe, source: "mcp", idempotencyKey: "key-b" });
+    expect(first.ok).toBe(true);
+    expect(second.ok).toBe(true);
+    if (!first.ok || !second.ok) return;
+    expect(first.jobId).not.toBe(second.jobId);
+    expect([...jobRegistry.keys()]).toHaveLength(2);
   });
 });

--- a/src/server/services/olive/jobRunner.ts
+++ b/src/server/services/olive/jobRunner.ts
@@ -62,8 +62,41 @@ export type StartOliveJobResult =
       jobId?: string;
     };
 
-/** In-flight MCP submits keyed by idempotency key or fingerprint (serialize check-then-act). */
-const mcpSubmitLocks = new Map<string, Promise<StartOliveJobResult>>();
+/** Per-key promise tails that serialize MCP submit critical sections. */
+const mcpSubmitLockTails = new Map<string, Promise<void>>();
+
+/**
+ * Acquire exclusive tails for the given lock keys (sorted to avoid deadlocks).
+ * Callers with overlapping fingerprint/key sets cannot both pass lookup-and-register.
+ */
+async function withMcpSubmitLocks<T>(keys: string[], fn: () => Promise<T>): Promise<T> {
+  const sorted = [...new Set(keys)].sort();
+  const releases: Array<() => void> = [];
+  try {
+    for (const key of sorted) {
+      let release!: () => void;
+      const held = new Promise<void>((resolve) => {
+        release = resolve;
+      });
+      const prev = mcpSubmitLockTails.get(key) ?? Promise.resolve();
+      // Chain: next waiter awaits prev, then our held promise until we release.
+      mcpSubmitLockTails.set(
+        key,
+        prev.then(
+          () => held,
+          () => held,
+        ),
+      );
+      await prev;
+      releases.push(release);
+    }
+    return await fn();
+  } finally {
+    while (releases.length > 0) {
+      releases.pop()!();
+    }
+  }
+}
 
 /**
  * Validates a recipe, prepares its execution environment, and starts an Olive job or reuses an idempotent MCP submission.
@@ -101,26 +134,20 @@ export async function startOliveJob(opts: StartOliveJobOpts): Promise<StartOlive
 
   // Idempotency is for MCP/agent submit only — UI re-runs should always spawn.
   if (opts.source === "mcp") {
-    const lockKey = opts.idempotencyKey
-      ? `key:${opts.idempotencyKey}`
-      : `fp:${fingerprint}`;
-    const inflight = mcpSubmitLocks.get(lockKey);
-    if (inflight) return inflight;
-
-    const work = startMcpOliveJobLocked({
-      recipe,
-      provider,
-      cudaVersion,
-      fingerprint,
-      idempotencyKey: opts.idempotencyKey,
-    });
-    mcpSubmitLocks.set(lockKey, work);
-    try {
-      return await work;
-    } finally {
-      // Only clear if we still own the slot (avoid deleting a newer waiter's promise).
-      if (mcpSubmitLocks.get(lockKey) === work) mcpSubmitLocks.delete(lockKey);
-    }
+    // Always lock the recipe fingerprint so key-bearing and fingerprint-only
+    // callers cannot both observe a miss and spawn duplicate jobs. Also lock
+    // the idempotency key when present so same-key conflict checks serialize.
+    const lockKeys = [`fp:${fingerprint}`];
+    if (opts.idempotencyKey) lockKeys.push(`key:${opts.idempotencyKey}`);
+    return withMcpSubmitLocks(lockKeys, () =>
+      startMcpOliveJobLocked({
+        recipe,
+        provider,
+        cudaVersion,
+        fingerprint,
+        idempotencyKey: opts.idempotencyKey,
+      }),
+    );
   }
 
   return registerAndStartOliveJob({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Valid review finding: MCP submit locking used either `key:…` or `fp:…`, so a key-bearing submit and a fingerprint-only submit for the same recipe could both observe an idempotency miss and start two jobs.

## Fix

- Acquire sorted mutex tails for `fp:${fingerprint}` and (when present) `key:${idempotencyKey}` around lookup-and-register.
- Overlapping callers wait rather than sharing one result promise, so lookup semantics stay intact (distinct keys can still start a new job after the first settles).
- Tests cover same-key concurrency, key + fingerprint-only concurrency, and distinct-key new runs.
- Also align the test’s `resolveOliveCommand` / `ensureProviderCapability` mocks with the real spawn shape.

## Validation

```bash
pnpm vitest run --config vitest.server.config.ts src/server/services/olive/jobRunner.idempotency.test.ts
# 3 passed
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-878cb105-92f7-4b47-bd41-3b4563205193?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-878cb105-92f7-4b47-bd41-3b4563205193&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tonythethompson/Olive-Studio/pull/183?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

