### PR TITLE
fix(mcp): MCP_harden review follow-ups (Codex + CodeRabbit)

### DIFF
--- a/olive-mcp-server/tests/conftest.py
+++ b/olive-mcp-server/tests/conftest.py
@@ -1,0 +1,53 @@
+"""Shared pytest fixtures for olive-mcp-server tests."""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Callable, Iterator
+
+import pytest
+
+from olive_mcp_server.tools import retrieval
+
+# Generous ceiling for abandoned budget workers (tests use ≤0.55s sleeps today).
+_INFLIGHT_DRAIN_TIMEOUT_S = 5.0
+
+
+def wait_for_inflight_semantic_clear(
+    *,
+    timeout_s: float = _INFLIGHT_DRAIN_TIMEOUT_S,
+) -> None:
+    """
+    Poll retrieval single-flight state until the tracked future is idle.
+
+    Clears a done future so the next ``run_with_budget`` call is not stuck on
+    a stale handle. Fails if work is still active after ``timeout_s``.
+    """
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        with retrieval._INFLIGHT_LOCK:
+            fut = retrieval._INFLIGHT_FUTURE
+            if fut is None or fut.done():
+                retrieval._INFLIGHT_FUTURE = None
+                return
+        time.sleep(0.05)
+    with retrieval._INFLIGHT_LOCK:
+        fut = retrieval._INFLIGHT_FUTURE
+    raise AssertionError(
+        f"semantic budget worker still in flight after {timeout_s}s "
+        f"(future={fut!r})"
+    )
+
+
+@pytest.fixture
+def wait_inflight_semantic_clear() -> Callable[..., None]:
+    """Expose the drain helper to tests that must wait mid-body."""
+    return wait_for_inflight_semantic_clear
+
+
+@pytest.fixture(autouse=True)
+def _drain_semantic_inflight_between_tests() -> Iterator[None]:
+    """Ensure no abandoned ``run_with_budget`` worker leaks across tests."""
+    wait_for_inflight_semantic_clear()
+    yield
+    wait_for_inflight_semantic_clear()

--- a/olive-mcp-server/tests/test_capabilities.py
+++ b/olive-mcp-server/tests/test_capabilities.py
@@ -112,8 +112,6 @@ def test_run_with_budget_timeout():
     result, outcome = run_with_budget(slow, budget_ms=50)
     assert outcome == "timeout"
     assert result is None
-    # Drain abandoned worker so later tests are not blocked by single-flight.
-    time.sleep(0.55)
 
 
 def test_run_with_budget_ok():
@@ -122,7 +120,7 @@ def test_run_with_budget_ok():
     assert result == 42
 
 
-def test_run_with_budget_single_flight_during_timeout():
+def test_run_with_budget_single_flight_during_timeout(wait_inflight_semantic_clear):
     """Consecutive calls during a timeout must not start a second callable."""
     import time
 
@@ -141,8 +139,8 @@ def test_run_with_budget_single_flight_during_timeout():
     assert o2 == "busy" and r2 is None
     assert started == [1]
 
-    time.sleep(0.5)
     # After the in-flight work finishes, a new callable may start.
+    wait_inflight_semantic_clear()
     r3, o3 = run_with_budget(lambda: "fresh", budget_ms=5000)
     assert o3 == "ok" and r3 == "fresh"
     assert started == [1]
@@ -201,5 +199,3 @@ def test_troubleshoot_auto_budget_degraded(monkeypatch: pytest.MonkeyPatch):
     assert result["retrieval"]["effective"] == "keyword"
     # Keyword path should still diagnose OOM (may match oom-quantization)
     assert isinstance(result.get("title"), str)
-    # Drain abandoned budget worker for subsequent tests.
-    time.sleep(0.5)

--- a/olive-mcp-server/tests/test_docs_search_semantic.py
+++ b/olive-mcp-server/tests/test_docs_search_semantic.py
@@ -411,18 +411,7 @@ def test_live_auto_budgets_even_when_model_is_warm(monkeypatch: pytest.MonkeyPat
     """Warm model must not skip the auto budget: live fetch/index can still be cold."""
     import time
 
-    from olive_mcp_server.tools import retrieval
     from olive_mcp_server.tools.retrieval import retrieval_meta
-
-    # Ensure no abandoned budget worker from a prior test blocks single-flight.
-    deadline = time.monotonic() + 2.0
-    while time.monotonic() < deadline:
-        with retrieval._INFLIGHT_LOCK:
-            fut = retrieval._INFLIGHT_FUTURE
-            if fut is None or fut.done():
-                retrieval._INFLIGHT_FUTURE = None
-                break
-        time.sleep(0.05)
 
     monkeypatch.setenv("OLIVE_MCP_SEMANTIC_BUDGET_MS", "50")
 
@@ -480,9 +469,6 @@ def test_live_auto_budgets_even_when_model_is_warm(monkeypatch: pytest.MonkeyPat
     assert again
     assert all(r["source"].startswith("live:") for r in again)
     assert again_meta.get("effective") == "keyword"
-
-    # Drain abandoned budget worker for subsequent tests.
-    time.sleep(0.55)
 
 
 def test_shared_semantic_budget_zero_remaining_forces_live_keyword(

--- a/scripts/mcp-agent-smoke.mjs
+++ b/scripts/mcp-agent-smoke.mjs
@@ -36,6 +36,7 @@ import {
   acquireStudioConfigSmokeLock,
   tryRemoveEmptyStudioConfigDir,
 } from "./studioConfigSmokeLock.mjs";
+import { stopStudioThenAlways } from "./stopStudioThenAlways.mjs";
 import { resolvePython } from "./resolvePython.mjs";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -200,7 +201,11 @@ function callToolAsync(selector, toolArgs, opts = {}) {
       }
       killEscalation = setTimeout(() => {
         try {
-          if (!child.killed) child.kill("SIGKILL");
+          // `killed` can be true after SIGTERM even while the process is still running;
+          // exit/signal codes are the authoritative "already exited" check.
+          if (child.exitCode === null && child.signalCode === null) {
+            child.kill("SIGKILL");
+          }
         } catch {
           /* ignore */
         }
@@ -538,42 +543,55 @@ let cleanupPromise = null;
 async function cleanup() {
   if (cleanupPromise) return cleanupPromise;
   cleanupPromise = (async () => {
-    await stopStudio(studioChild);
-    studioChild = null;
-    try {
-      if (lastSmokeConfigBytes !== undefined) {
-        restoreStudioConfigFile(STUDIO_CONFIG_PATH, configSnapshot, {
-          expectedContents: lastSmokeConfigBytes,
-        });
-      } else {
-        restoreStudioConfigFile(STUDIO_CONFIG_PATH, configSnapshot);
-      }
-      configRestoreError = null;
-    } catch (e) {
-      configRestoreError = e;
-      console.warn(
-        "restore Studio config failed:",
-        e instanceof Error ? e.message : e,
-      );
-    }
-    // Drop the lock only after restore so another smoke cannot snapshot mid-restore.
-    if (releaseSmokeConfigLock) {
-      try {
-        releaseSmokeConfigLock();
-      } catch {
-        /* ignore */
-      }
-      releaseSmokeConfigLock = null;
-    }
-    // Restore may have left `.olive-studio/` because the lock file still existed.
-    if (configSnapshot && !configSnapshot.existed) {
-      tryRemoveEmptyStudioConfigDir(path.dirname(STUDIO_CONFIG_PATH));
-    }
-    try {
-      rmSync(smokeConfigDir, { recursive: true, force: true });
-    } catch {
-      /* ignore */
-    }
+    await stopStudioThenAlways(
+      async () => {
+        try {
+          await stopStudio(studioChild);
+        } catch (e) {
+          console.warn(
+            "stop Studio failed:",
+            e instanceof Error ? e.message : e,
+          );
+        }
+      },
+      async () => {
+        studioChild = null;
+        try {
+          if (lastSmokeConfigBytes !== undefined) {
+            restoreStudioConfigFile(STUDIO_CONFIG_PATH, configSnapshot, {
+              expectedContents: lastSmokeConfigBytes,
+            });
+          } else {
+            restoreStudioConfigFile(STUDIO_CONFIG_PATH, configSnapshot);
+          }
+          configRestoreError = null;
+        } catch (e) {
+          configRestoreError = e;
+          console.warn(
+            "restore Studio config failed:",
+            e instanceof Error ? e.message : e,
+          );
+        }
+        // Drop the lock only after restore so another smoke cannot snapshot mid-restore.
+        if (releaseSmokeConfigLock) {
+          try {
+            releaseSmokeConfigLock();
+          } catch {
+            /* ignore */
+          }
+          releaseSmokeConfigLock = null;
+        }
+        // Restore may have left `.olive-studio/` because the lock file still existed.
+        if (configSnapshot && !configSnapshot.existed) {
+          tryRemoveEmptyStudioConfigDir(path.dirname(STUDIO_CONFIG_PATH));
+        }
+        try {
+          rmSync(smokeConfigDir, { recursive: true, force: true });
+        } catch {
+          /* ignore */
+        }
+      },
+    );
   })();
   return cleanupPromise;
 }

--- a/scripts/mcp-agent-smoke.mjs
+++ b/scripts/mcp-agent-smoke.mjs
@@ -32,12 +32,21 @@ import {
   restoreStudioConfigFile,
   snapshotStudioConfigFile,
 } from "./studioConfigSnapshot.mjs";
+import {
+  acquireStudioConfigSmokeLock,
+  tryRemoveEmptyStudioConfigDir,
+} from "./studioConfigSmokeLock.mjs";
 import { resolvePython } from "./resolvePython.mjs";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const root = path.resolve(__dirname, "..");
 const MCPORTER = "mcporter@0.13.0";
 const STUDIO_CONFIG_PATH = path.join(root, ".olive-studio", "config.json");
+const STUDIO_CONFIG_SMOKE_LOCK = path.join(
+  root,
+  ".olive-studio",
+  "mcp-agent-smoke.lock",
+);
 const STRICT = process.env.MCP_SMOKE_STRICT === "1";
 
 /** Minimal CPU recipe accepted by Studio preflight (no real Olive execute required). */
@@ -365,9 +374,16 @@ let configSnapshot = null;
 let lastSmokeConfigBytes = undefined;
 /** Set when snapshot restore throws so callers cannot exit 0 with a dirty policy file. */
 let configRestoreError = /** @type {unknown | null} */ (null);
+/** @type {null | (() => void)} */
+let releaseSmokeConfigLock = null;
 
 async function runJobControlSmoke() {
-  // Snapshot before any disk mutation (exact bytes + existence).
+  // Serialize overlapping smokes so we never snapshot another run's temporary
+  // allowJobSubmission:true (or leave it restored afterward).
+  const lock = await acquireStudioConfigSmokeLock(STUDIO_CONFIG_SMOKE_LOCK);
+  releaseSmokeConfigLock = lock.release;
+
+  // Snapshot only after the lock is held (exact bytes + existence).
   configSnapshot = snapshotStudioConfigFile(STUDIO_CONFIG_PATH);
 
   // Denied path: submission off before Studio boots (no PUT / rate-limit burn).
@@ -539,6 +555,19 @@ async function cleanup() {
         "restore Studio config failed:",
         e instanceof Error ? e.message : e,
       );
+    }
+    // Drop the lock only after restore so another smoke cannot snapshot mid-restore.
+    if (releaseSmokeConfigLock) {
+      try {
+        releaseSmokeConfigLock();
+      } catch {
+        /* ignore */
+      }
+      releaseSmokeConfigLock = null;
+    }
+    // Restore may have left `.olive-studio/` because the lock file still existed.
+    if (configSnapshot && !configSnapshot.existed) {
+      tryRemoveEmptyStudioConfigDir(path.dirname(STUDIO_CONFIG_PATH));
     }
     try {
       rmSync(smokeConfigDir, { recursive: true, force: true });

--- a/scripts/mcp-agent-smoke.mjs
+++ b/scripts/mcp-agent-smoke.mjs
@@ -1,71 +1,579 @@
 /**
- * Pinned mcporter canary smoke for Olive MCP (Phase 0).
- * Non-blocking CI by default — third-party CLI must not hard-break product PRs.
+ * Pinned mcporter canary smoke for Olive MCP (Phase 0 + job-control path).
+ * Non-blocking by default (exit 0 on failure). Set MCP_SMOKE_STRICT=1 to fail the job.
+ *
+ * Covers:
+ *   - list --status, get_olive_passes, get_mcp_capabilities (against live Studio env)
+ *   - policy-gated submit / status / cancel / idempotent reuse via MCP → Studio
+ *   - one allowed job (reuse + terminal cancel) and one denied submit
+ *
+ * Studio is started with OLIVE_JOB_SETUP_STUB=1 so submits never download models
+ * or run Olive (AGENTS.md: no real Olive execute in CI/VM).
  *
  * Usage (repo root):
  *   node scripts/mcp-agent-smoke.mjs
  *   pnpm mcp:agent-smoke
  */
-import { spawnSync } from "node:child_process";
-import { existsSync } from "node:fs";
+import { spawn, spawnSync } from "node:child_process";
+import { createServer } from "node:net";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import {
+  restoreStudioConfigFile,
+  snapshotStudioConfigFile,
+} from "./studioConfigSnapshot.mjs";
+import { resolvePython } from "./resolvePython.mjs";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const root = path.resolve(__dirname, "..");
 const MCPORTER = "mcporter@0.13.0";
-const configCandidates = [
-  path.join(root, "config", "mcporter.json"),
-  path.join(root, "config", "mcporter.example.json"),
-];
-const configPath = configCandidates.find((p) => existsSync(p));
-if (!configPath) {
-  console.error("No mcporter config found (config/mcporter.json or config/mcporter.example.json)");
-  process.exit(1);
+const STUDIO_CONFIG_PATH = path.join(root, ".olive-studio", "config.json");
+const STRICT = process.env.MCP_SMOKE_STRICT === "1";
+
+/** Minimal CPU recipe accepted by Studio preflight (no real Olive execute required). */
+const SMOKE_RECIPE = {
+  input_model: { type: "PyTorchModel", config: {} },
+  systems: {
+    local_system: {
+      type: "LocalSystem",
+      config: {
+        accelerators: [
+          { device: "cpu", execution_providers: ["CPUExecutionProvider"] },
+        ],
+      },
+    },
+  },
+  passes: {
+    conversion: { type: "OnnxConversion", config: { target_opset: 20 } },
+  },
+  engine: {
+    search_strategy: false,
+    host: "local_system",
+    target: "local_system",
+    cache_dir: "./cache",
+    output_dir: "./out",
+  },
+};
+
+function writeSmokeMcporterConfig() {
+  const dir = mkdtempSync(path.join(tmpdir(), "olive-mcp-agent-smoke-"));
+  const configPath = path.join(dir, "mcporter.json");
+  writeFileSync(
+    configPath,
+    JSON.stringify(
+      {
+        mcpServers: {
+          olive: {
+            command: resolvePython(root),
+            args: [path.join(root, "olive-mcp-server", "run.py")],
+            cwd: root,
+          },
+        },
+      },
+      null,
+      2,
+    ),
+    "utf8",
+  );
+  return { dir, configPath };
+}
+
+function readStudioDiskConfig() {
+  if (!existsSync(STUDIO_CONFIG_PATH)) return {};
+  let parsed;
+  try {
+    parsed = JSON.parse(readFileSync(STUDIO_CONFIG_PATH, "utf8"));
+  } catch (e) {
+    throw new Error(
+      `refusing to patch unreadable Studio config at ${STUDIO_CONFIG_PATH}: ${
+        e instanceof Error ? e.message : e
+      }`,
+    );
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error(`unexpected Studio config shape at ${STUDIO_CONFIG_PATH}`);
+  }
+  return parsed;
+}
+
+/** Patch agentAccess on disk — resolveAgentAccess re-reads each request (avoids PUT rate limit). */
+function patchAgentAccessDisk(patch) {
+  const cfg = readStudioDiskConfig();
+  cfg.agentAccess = { ...(cfg.agentAccess || {}), ...patch };
+  mkdirSync(path.dirname(STUDIO_CONFIG_PATH), { recursive: true });
+  writeFileSync(STUDIO_CONFIG_PATH, JSON.stringify(cfg, null, 2), "utf8");
+  return cfg.agentAccess;
 }
 
 /**
  * Runs a pinned mcporter command with the selected configuration.
- * @param {string[]} args - Arguments to pass to mcporter.
- * @param {number} [timeoutMs=90000] - Maximum execution time in milliseconds.
+ * @param {string[]} args
+ * @param {{ timeoutMs?: number, env?: NodeJS.ProcessEnv, expectOk?: boolean }} [opts]
  */
-function run(args, timeoutMs = 90_000) {
-  const full = ["--yes", MCPORTER, ...args, "--config", configPath];
+function run(args, opts = {}) {
+  const { timeoutMs = 90_000, env = process.env, expectOk = true } = opts;
+  const full = ["--yes", MCPORTER, ...args, "--config", smokeConfigPath];
   console.log(`$ npx ${full.join(" ")}`);
   const r = spawnSync("npx", full, {
     cwd: root,
     encoding: "utf8",
     timeout: timeoutMs,
     shell: process.platform === "win32",
-    env: { ...process.env },
+    env: { ...env },
   });
   if (r.stdout) process.stdout.write(r.stdout);
   if (r.stderr) process.stderr.write(r.stderr);
-  if (r.status !== 0) {
-    console.error(`mcporter failed status=${r.status} signal=${r.signal}`);
-    process.exit(r.status ?? 1);
+  if (expectOk && r.status !== 0) {
+    throw new Error(`mcporter failed status=${r.status} signal=${r.signal}`);
+  }
+  return r;
+}
+
+/** @param {string} stdout */
+function parseJsonPayload(stdout) {
+  const text = (stdout || "").trim();
+  if (!text) throw new Error("empty mcporter stdout");
+  for (let i = 0; i < text.length; i += 1) {
+    const ch = text[i];
+    if (ch !== "{" && ch !== "[") continue;
+    try {
+      return JSON.parse(text.slice(i));
+    } catch {
+      /* not a complete document at this offset */
+    }
+  }
+  throw new Error(`no JSON in mcporter stdout: ${text.slice(0, 200)}`);
+}
+
+/**
+ * @param {string} selector
+ * @param {Record<string, unknown>} [toolArgs]
+ * @param {{ timeoutMs?: number, env?: NodeJS.ProcessEnv }} [opts]
+ */
+function callToolAsync(selector, toolArgs, opts = {}) {
+  const timeoutMs = opts.timeoutMs ?? 90_000;
+  const args = ["call", selector];
+  if (toolArgs && Object.keys(toolArgs).length > 0) {
+    args.push("--args", JSON.stringify(toolArgs));
+  }
+  args.push("--timeout", String(timeoutMs), "--output", "json");
+  const full = ["--yes", MCPORTER, ...args, "--config", smokeConfigPath];
+  console.log(`$ npx ${full.join(" ")}`);
+
+  return new Promise((resolve, reject) => {
+    const child = spawn("npx", full, {
+      cwd: root,
+      env: { ...(opts.env ?? process.env) },
+      shell: process.platform === "win32",
+    });
+    let stdout = "";
+    let stderr = "";
+    /** @type {ReturnType<typeof setTimeout> | undefined} */
+    let killEscalation;
+    const graceMs = 15_000;
+    const timer = setTimeout(() => {
+      try {
+        child.kill("SIGTERM");
+      } catch {
+        /* ignore */
+      }
+      killEscalation = setTimeout(() => {
+        try {
+          if (!child.killed) child.kill("SIGKILL");
+        } catch {
+          /* ignore */
+        }
+      }, 2000);
+      reject(
+        new Error(
+          `mcporter ${selector} timed out after ${timeoutMs + graceMs}ms`,
+        ),
+      );
+    }, timeoutMs + graceMs);
+    const clearTimers = () => {
+      clearTimeout(timer);
+      if (killEscalation) clearTimeout(killEscalation);
+    };
+    child.stdout?.on("data", (buf) => {
+      const s = String(buf);
+      stdout += s;
+      process.stdout.write(s);
+    });
+    child.stderr?.on("data", (buf) => {
+      const s = String(buf);
+      stderr += s;
+      process.stderr.write(s);
+    });
+    child.on("error", (err) => {
+      clearTimers();
+      reject(err);
+    });
+    child.on("close", (code) => {
+      clearTimers();
+      if (code !== 0) {
+        reject(
+          new Error(
+            `mcporter ${selector} exited ${code}: ${(stderr || stdout).slice(0, 400)}`,
+          ),
+        );
+        return;
+      }
+      try {
+        resolve(parseJsonPayload(stdout));
+      } catch (e) {
+        reject(e);
+      }
+    });
+  });
+}
+
+function freePort() {
+  return new Promise((resolve, reject) => {
+    const s = createServer();
+    s.listen(0, "127.0.0.1", () => {
+      const addr = s.address();
+      const port = typeof addr === "object" && addr ? addr.port : 0;
+      s.close((err) => (err ? reject(err) : resolve(port)));
+    });
+    s.on("error", reject);
+  });
+}
+
+/**
+ * @param {string} baseUrl
+ * @param {import("node:child_process").ChildProcess} child
+ * @param {number} [timeoutMs]
+ */
+async function waitForStudio(baseUrl, child, timeoutMs = 60_000) {
+  const deadline = Date.now() + timeoutMs;
+  let lastErr = "";
+  let exited = /** @type {string | null} */ (null);
+  child?.once("exit", (code, signal) => {
+    exited = `studio exited code=${code} signal=${signal}`;
+  });
+  while (Date.now() < deadline) {
+    if (exited) throw new Error(exited);
+    try {
+      const res = await fetch(`${baseUrl}/api/olive/agent-access`, {
+        signal: AbortSignal.timeout(5_000),
+      });
+      if (res.ok) return;
+      lastErr = `HTTP ${res.status}`;
+    } catch (e) {
+      lastErr = e instanceof Error ? e.message : String(e);
+    }
+    await new Promise((r) => setTimeout(r, 250));
+  }
+  throw new Error(`Studio did not become ready at ${baseUrl}: ${lastErr}`);
+}
+
+/** @param {number} port */
+function startStudio(port) {
+  const env = { ...process.env, PORT: String(port), OLIVE_JOB_SETUP_STUB: "1" };
+  // Disk policy must win for the deny path; strip inherited job-policy overrides.
+  delete env.OLIVE_MCP_ALLOW_JOBS;
+  const child = spawn("pnpm", ["exec", "tsx", "server.ts"], {
+    cwd: root,
+    env,
+    stdio: ["ignore", "pipe", "pipe"],
+    shell: process.platform === "win32",
+  });
+  child.stdout?.on("data", (buf) => process.stdout.write(`[studio] ${buf}`));
+  child.stderr?.on("data", (buf) => process.stderr.write(`[studio] ${buf}`));
+  return child;
+}
+
+/** @param {import("node:child_process").ChildProcess | null} child */
+async function stopStudio(child) {
+  if (!child) return;
+  let closed = child.exitCode !== null || child.signalCode !== null;
+  if (closed) return;
+
+  let resolveClosed;
+  const closedPromise = new Promise((resolve) => {
+    resolveClosed = resolve;
+  });
+  child.once("close", () => {
+    closed = true;
+    resolveClosed();
+  });
+
+  try {
+    child.kill("SIGTERM");
+  } catch {
+    /* ignore */
+  }
+
+  await Promise.race([
+    closedPromise,
+    new Promise((resolve) => setTimeout(resolve, 2000)),
+  ]);
+  if (!closed) {
+    try {
+      child.kill("SIGKILL");
+    } catch {
+      /* ignore */
+    }
+    await Promise.race([
+      closedPromise,
+      new Promise((resolve) => setTimeout(resolve, 2000)),
+    ]);
   }
 }
 
-run(["list", "olive", "--status", "--timeout", "60000"]);
-run([
-  "call",
-  "olive.get_olive_passes",
-  "filter=quantization",
-  "--timeout",
-  "60000",
-  "--output",
-  "json",
-]);
-run(
-  [
-    "call",
-    "olive.get_mcp_capabilities",
-    "--timeout",
-    "90000",
-    "--output",
-    "json",
-  ],
-  120_000,
-);
-console.log("PASS: pinned mcporter agent smoke");
+/**
+ * @param {string} jobId
+ * @param {NodeJS.ProcessEnv} env
+ * @param {number} [timeoutMs]
+ */
+async function waitForTerminal(jobId, env, timeoutMs = 60_000) {
+  const deadline = Date.now() + timeoutMs;
+  let last = null;
+  while (Date.now() < deadline) {
+    last = await callToolAsync(
+      "olive.get_optimization_job",
+      { job_id: jobId },
+      { timeoutMs: 60_000, env },
+    );
+    if (last.terminal === true) return last;
+    await new Promise((r) => setTimeout(r, 500));
+  }
+  throw new Error(`job ${jobId} not terminal: ${JSON.stringify(last)}`);
+}
+
+const { dir: smokeConfigDir, configPath: smokeConfigPath } = writeSmokeMcporterConfig();
+let studioChild = null;
+/** @type {import("./studioConfigSnapshot.mjs").StudioConfigSnapshot | null} */
+let configSnapshot = null;
+/** Set when snapshot restore throws so callers cannot exit 0 with a dirty policy file. */
+let configRestoreError = /** @type {unknown | null} */ (null);
+
+async function runJobControlSmoke() {
+  // Snapshot before any disk mutation (exact bytes + existence).
+  configSnapshot = snapshotStudioConfigFile(STUDIO_CONFIG_PATH);
+
+  // Denied path: submission off before Studio boots (no PUT / rate-limit burn).
+  patchAgentAccessDisk({
+    allowJobSubmission: false,
+    allowJobCancellation: true,
+  });
+
+  const port = await freePort();
+  const studioBase = `http://127.0.0.1:${port}`;
+  studioChild = startStudio(port);
+  await waitForStudio(studioBase, studioChild);
+
+  const studioEnv = { ...process.env, OLIVE_STUDIO_API_URL: studioBase };
+  delete studioEnv.OLIVE_MCP_ALLOW_JOBS;
+
+  run(["list", "olive", "--status", "--timeout", "60000"], { env: studioEnv });
+  run(
+    [
+      "call",
+      "olive.get_olive_passes",
+      "filter=quantization",
+      "--timeout",
+      "60000",
+      "--output",
+      "json",
+    ],
+    { env: studioEnv },
+  );
+  run(
+    [
+      "call",
+      "olive.get_mcp_capabilities",
+      "--timeout",
+      "90000",
+      "--output",
+      "json",
+    ],
+    { timeoutMs: 120_000, env: studioEnv },
+  );
+
+  const idempotencyKey = `mcp-agent-smoke-${Date.now()}-${process.pid}`;
+
+  const denied = await callToolAsync(
+    "olive.submit_optimization_job",
+    {
+      recipe: SMOKE_RECIPE,
+      cuda_version: "auto",
+      idempotency_key: `${idempotencyKey}-denied`,
+    },
+    { timeoutMs: 120_000, env: studioEnv },
+  );
+  if (denied.ok !== false || denied.error !== "forbidden") {
+    throw new Error(`expected forbidden denial, got ${JSON.stringify(denied)}`);
+  }
+  if (
+    typeof denied.reason === "string" &&
+    !/submission is disabled/i.test(denied.reason)
+  ) {
+    throw new Error(`unexpected deny reason: ${JSON.stringify(denied)}`);
+  }
+  console.log("denied submit ok (forbidden)");
+
+  patchAgentAccessDisk({
+    allowJobSubmission: true,
+    allowJobCancellation: true,
+  });
+
+  const submitArgs = {
+    recipe: SMOKE_RECIPE,
+    cuda_version: "auto",
+    idempotency_key: idempotencyKey,
+  };
+  // Same-key reuse + distinct-key new job (Studio contract; setup is stubbed).
+  const [first, second, third] = await Promise.all([
+    callToolAsync("olive.submit_optimization_job", submitArgs, {
+      timeoutMs: 120_000,
+      env: studioEnv,
+    }),
+    callToolAsync("olive.submit_optimization_job", submitArgs, {
+      timeoutMs: 120_000,
+      env: studioEnv,
+    }),
+    callToolAsync(
+      "olive.submit_optimization_job",
+      {
+        recipe: SMOKE_RECIPE,
+        cuda_version: "auto",
+        idempotency_key: `${idempotencyKey}-other`,
+      },
+      { timeoutMs: 120_000, env: studioEnv },
+    ),
+  ]);
+  if (!first.ok || !second.ok || !third.ok) {
+    throw new Error(`submit failed: ${JSON.stringify({ first, second, third })}`);
+  }
+  if (first.job_id !== second.job_id) {
+    throw new Error(
+      `idempotency split jobs: ${JSON.stringify({ first, second })}`,
+    );
+  }
+  if (!first.reused && !second.reused) {
+    throw new Error(
+      `expected one reused submit, got ${JSON.stringify({ first, second })}`,
+    );
+  }
+  if (third.job_id === first.job_id) {
+    throw new Error(
+      `distinct key unexpectedly reused job: ${JSON.stringify({ first, third })}`,
+    );
+  }
+  const jobId = first.job_id;
+  console.log(
+    `submit+reuse ok job_id=${jobId} reused=${first.reused}|${second.reused} other=${third.job_id}`,
+  );
+
+  const midStatus = await callToolAsync(
+    "olive.get_optimization_job",
+    { job_id: jobId },
+    { timeoutMs: 60_000, env: studioEnv },
+  );
+  if (midStatus.id !== jobId) {
+    throw new Error(`status id mismatch: ${JSON.stringify(midStatus)}`);
+  }
+  console.log(`status ok status=${midStatus.status} terminal=${midStatus.terminal}`);
+
+  const cancelled = await callToolAsync(
+    "olive.cancel_optimization_job",
+    { job_id: jobId },
+    { timeoutMs: 60_000, env: studioEnv },
+  );
+  const terminal = await waitForTerminal(jobId, studioEnv, 60_000);
+  if (terminal.status !== "cancelled" || terminal.terminal !== true) {
+    throw new Error(
+      `expected terminal cancelled, got ${JSON.stringify({ cancelled, terminal })}`,
+    );
+  }
+  console.log("allowed job terminal+reuse ok");
+
+  try {
+    await callToolAsync(
+      "olive.cancel_optimization_job",
+      { job_id: third.job_id },
+      { timeoutMs: 30_000, env: studioEnv },
+    );
+  } catch {
+    /* ignore */
+  }
+}
+
+let cleanupPromise = null;
+async function cleanup() {
+  if (cleanupPromise) return cleanupPromise;
+  cleanupPromise = (async () => {
+    await stopStudio(studioChild);
+    studioChild = null;
+    try {
+      restoreStudioConfigFile(STUDIO_CONFIG_PATH, configSnapshot);
+      configRestoreError = null;
+    } catch (e) {
+      configRestoreError = e;
+      console.warn(
+        "restore Studio config failed:",
+        e instanceof Error ? e.message : e,
+      );
+    }
+    try {
+      rmSync(smokeConfigDir, { recursive: true, force: true });
+    } catch {
+      /* ignore */
+    }
+  })();
+  return cleanupPromise;
+}
+
+function failExitCode(signal) {
+  if (signal === "SIGINT") return 130;
+  if (signal === "SIGTERM") return 143;
+  return STRICT ? 1 : 0;
+}
+
+function handleSignal(signal) {
+  void cleanup().finally(() => {
+    if (configRestoreError) process.exit(1);
+    process.exit(failExitCode(signal));
+  });
+}
+process.once("SIGINT", () => handleSignal("SIGINT"));
+process.once("SIGTERM", () => handleSignal("SIGTERM"));
+process.once("SIGHUP", () => handleSignal("SIGHUP"));
+
+try {
+  await runJobControlSmoke();
+  console.log("PASS: pinned mcporter agent smoke (incl. job policy path)");
+  await cleanup();
+  if (configRestoreError) {
+    console.error(
+      "FAIL: Studio config restore failed after smoke:",
+      configRestoreError instanceof Error
+        ? configRestoreError.message
+        : configRestoreError,
+    );
+    process.exit(1);
+  }
+  process.exit(0);
+} catch (err) {
+  console.error("FAIL:", err instanceof Error ? err.message : err);
+  await cleanup();
+  if (configRestoreError) {
+    console.error(
+      "FAIL: Studio config restore also failed:",
+      configRestoreError instanceof Error
+        ? configRestoreError.message
+        : configRestoreError,
+    );
+  }
+  process.exit(failExitCode());
+}

--- a/scripts/mcp-agent-smoke.mjs
+++ b/scripts/mcp-agent-smoke.mjs
@@ -28,8 +28,10 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import {
+  assertNoLiveForeignSmokeOwner,
   readStudioConfigFileContents,
   restoreStudioConfigFile,
+  SMOKE_OWNER_KEY,
   snapshotStudioConfigFile,
 } from "./studioConfigSnapshot.mjs";
 import {
@@ -120,6 +122,10 @@ function readStudioDiskConfig() {
 function patchAgentAccessDisk(patch) {
   const cfg = readStudioDiskConfig();
   cfg.agentAccess = { ...(cfg.agentAccess || {}), ...patch };
+  cfg[SMOKE_OWNER_KEY] = {
+    pid: process.pid,
+    startedAt: new Date().toISOString(),
+  };
   mkdirSync(path.dirname(STUDIO_CONFIG_PATH), { recursive: true });
   writeFileSync(STUDIO_CONFIG_PATH, JSON.stringify(cfg, null, 2), "utf8");
   // Remember exact bytes we wrote so cleanup can refuse to clobber concurrent edits.
@@ -390,6 +396,8 @@ async function runJobControlSmoke() {
 
   // Snapshot only after the lock is held (exact bytes + existence).
   configSnapshot = snapshotStudioConfigFile(STUDIO_CONFIG_PATH);
+  // Belt-and-suspenders with the pid lock: refuse if a live peer still stamps ownership.
+  assertNoLiveForeignSmokeOwner(STUDIO_CONFIG_PATH, process.pid);
 
   // Denied path: submission off before Studio boots (no PUT / rate-limit burn).
   patchAgentAccessDisk({
@@ -592,6 +600,8 @@ async function cleanup() {
         }
       },
     );
+    // Restoration errors must fail cleanup itself (not only a later flag check).
+    if (configRestoreError) throw configRestoreError;
   })();
   return cleanupPromise;
 }
@@ -616,19 +626,14 @@ try {
   await runJobControlSmoke();
   console.log("PASS: pinned mcporter agent smoke (incl. job policy path)");
   await cleanup();
-  if (configRestoreError) {
-    console.error(
-      "FAIL: Studio config restore failed after smoke:",
-      configRestoreError instanceof Error
-        ? configRestoreError.message
-        : configRestoreError,
-    );
-    process.exit(1);
-  }
   process.exit(0);
 } catch (err) {
   console.error("FAIL:", err instanceof Error ? err.message : err);
-  await cleanup();
+  try {
+    await cleanup();
+  } catch {
+    /* cleanup may already have rejected for restore failure */
+  }
   if (configRestoreError) {
     console.error(
       "FAIL: Studio config restore also failed:",

--- a/scripts/mcp-agent-smoke.mjs
+++ b/scripts/mcp-agent-smoke.mjs
@@ -28,6 +28,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import {
+  readStudioConfigFileContents,
   restoreStudioConfigFile,
   snapshotStudioConfigFile,
 } from "./studioConfigSnapshot.mjs";
@@ -111,6 +112,8 @@ function patchAgentAccessDisk(patch) {
   cfg.agentAccess = { ...(cfg.agentAccess || {}), ...patch };
   mkdirSync(path.dirname(STUDIO_CONFIG_PATH), { recursive: true });
   writeFileSync(STUDIO_CONFIG_PATH, JSON.stringify(cfg, null, 2), "utf8");
+  // Remember exact bytes we wrote so cleanup can refuse to clobber concurrent edits.
+  lastSmokeConfigBytes = readStudioConfigFileContents(STUDIO_CONFIG_PATH);
   return cfg.agentAccess;
 }
 
@@ -354,6 +357,12 @@ const { dir: smokeConfigDir, configPath: smokeConfigPath } = writeSmokeMcporterC
 let studioChild = null;
 /** @type {import("./studioConfigSnapshot.mjs").StudioConfigSnapshot | null} */
 let configSnapshot = null;
+/**
+ * Exact bytes last written by this smoke (`null` if we observed absence after a write path).
+ * `undefined` means we have not mutated the file yet.
+ * @type {string | null | undefined}
+ */
+let lastSmokeConfigBytes = undefined;
 /** Set when snapshot restore throws so callers cannot exit 0 with a dirty policy file. */
 let configRestoreError = /** @type {unknown | null} */ (null);
 
@@ -516,7 +525,13 @@ async function cleanup() {
     await stopStudio(studioChild);
     studioChild = null;
     try {
-      restoreStudioConfigFile(STUDIO_CONFIG_PATH, configSnapshot);
+      if (lastSmokeConfigBytes !== undefined) {
+        restoreStudioConfigFile(STUDIO_CONFIG_PATH, configSnapshot, {
+          expectedContents: lastSmokeConfigBytes,
+        });
+      } else {
+        restoreStudioConfigFile(STUDIO_CONFIG_PATH, configSnapshot);
+      }
       configRestoreError = null;
     } catch (e) {
       configRestoreError = e;

--- a/scripts/resolvePython.mjs
+++ b/scripts/resolvePython.mjs
@@ -1,0 +1,58 @@
+/**
+ * Resolve a Python interpreter for MCP smoke / local tooling.
+ * Prefers project venvs, then the first PATH command that responds to --version.
+ */
+import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import path from "node:path";
+
+/**
+ * @param {string} cmd
+ * @param {{ spawnSync?: typeof spawnSync, platform?: NodeJS.Platform }} [deps]
+ */
+export function commandOnPath(cmd, deps = {}) {
+  const spawn = deps.spawnSync ?? spawnSync;
+  const platform = deps.platform ?? process.platform;
+  const r = spawn(cmd, ["--version"], {
+    encoding: "utf8",
+    timeout: 5_000,
+    shell: platform === "win32",
+  });
+  return r.status === 0;
+}
+
+/**
+ * @param {string} root repo root
+ * @param {{
+ *   existsSync?: typeof existsSync,
+ *   spawnSync?: typeof spawnSync,
+ *   platform?: NodeJS.Platform,
+ * }} [deps]
+ * @returns {string} absolute venv python path or a PATH command name
+ */
+export function resolvePython(root, deps = {}) {
+  const exists = deps.existsSync ?? existsSync;
+  const platform = deps.platform ?? process.platform;
+  const candidates = [
+    path.join(root, "olive-mcp-server", ".venv", "bin", "python"),
+    path.join(root, "olive-mcp-server", ".venv", "Scripts", "python.exe"),
+    path.join(root, ".venv", "bin", "python"),
+    path.join(root, ".venv", "Scripts", "python.exe"),
+    // Prefer python3 on Unix CI images; still probe `python` for Windows / py-launcher hosts.
+    "python3",
+    "python",
+  ];
+
+  for (const c of candidates) {
+    const isBare = c === "python3" || c === "python";
+    if (isBare) {
+      if (commandOnPath(c, { spawnSync: deps.spawnSync, platform })) return c;
+      continue;
+    }
+    if (exists(c)) return c;
+  }
+
+  throw new Error(
+    "No Python interpreter found (checked project .venv, python3, and python on PATH)",
+  );
+}

--- a/scripts/stopStudioThenAlways.mjs
+++ b/scripts/stopStudioThenAlways.mjs
@@ -1,0 +1,16 @@
+/**
+ * Ensure Studio shutdown always runs config/temp cleanup afterward.
+ * Used by mcp-agent-smoke so a stopStudio rejection cannot skip restore.
+ *
+ * @template T
+ * @param {() => Promise<T> | T} stopStudio
+ * @param {() => Promise<void> | void} afterStop
+ * @returns {Promise<T | undefined>}
+ */
+export async function stopStudioThenAlways(stopStudio, afterStop) {
+  try {
+    return await stopStudio();
+  } finally {
+    await afterStop();
+  }
+}

--- a/scripts/studioConfigSmokeLock.mjs
+++ b/scripts/studioConfigSmokeLock.mjs
@@ -1,0 +1,122 @@
+/**
+ * Inter-process exclusive lock for mcp-agent-smoke config mutation.
+ * Prevents overlapping smokes from snapshotting each other's temporary
+ * allowJobSubmission / cancellation policy patches.
+ */
+import {
+  closeSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  rmSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import path from "node:path";
+
+/**
+ * @param {number} pid
+ * @returns {boolean}
+ */
+export function isProcessAlive(pid) {
+  if (!Number.isFinite(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * @param {string} lockPath
+ * @param {{
+ *   openSync?: typeof openSync,
+ *   closeSync?: typeof closeSync,
+ *   writeFileSync?: typeof writeFileSync,
+ *   readFileSync?: typeof readFileSync,
+ *   unlinkSync?: typeof unlinkSync,
+ *   mkdirSync?: typeof mkdirSync,
+ *   isProcessAlive?: (pid: number) => boolean,
+ *   pid?: number,
+ *   timeoutMs?: number,
+ *   pollMs?: number,
+ *   sleep?: (ms: number) => Promise<void>,
+ * }} [deps]
+ * @returns {Promise<{ release: () => void }>}
+ */
+export async function acquireStudioConfigSmokeLock(lockPath, deps = {}) {
+  const open = deps.openSync ?? openSync;
+  const close = deps.closeSync ?? closeSync;
+  const write = deps.writeFileSync ?? writeFileSync;
+  const read = deps.readFileSync ?? readFileSync;
+  const unlink = deps.unlinkSync ?? unlinkSync;
+  const mkdir = deps.mkdirSync ?? mkdirSync;
+  const alive = deps.isProcessAlive ?? isProcessAlive;
+  const myPid = deps.pid ?? process.pid;
+  const timeoutMs = deps.timeoutMs ?? 120_000;
+  const pollMs = deps.pollMs ?? 250;
+  const sleep =
+    deps.sleep ?? ((ms) => new Promise((resolve) => setTimeout(resolve, ms)));
+
+  mkdir(path.dirname(lockPath), { recursive: true });
+  const deadline = Date.now() + timeoutMs;
+
+  while (Date.now() < deadline) {
+    try {
+      const fd = open(lockPath, "wx");
+      try {
+        write(fd, `${myPid}\n`);
+      } finally {
+        close(fd);
+      }
+      return {
+        release() {
+          try {
+            const body = read(lockPath, "utf8");
+            const holder = Number.parseInt(String(body).trim().split(/\r?\n/)[0] ?? "", 10);
+            if (holder === myPid) unlink(lockPath);
+          } catch {
+            /* already gone or not ours */
+          }
+        },
+      };
+    } catch (e) {
+      const code = e && typeof e === "object" && "code" in e ? e.code : undefined;
+      if (code !== "EEXIST") throw e;
+      try {
+        const body = read(lockPath, "utf8");
+        const holder = Number.parseInt(String(body).trim().split(/\r?\n/)[0] ?? "", 10);
+        if (Number.isFinite(holder) && !alive(holder)) {
+          try {
+            unlink(lockPath);
+          } catch {
+            /* lost race to another reclaim */
+          }
+          continue;
+        }
+      } catch {
+        /* lock vanished mid-read */
+      }
+      await sleep(pollMs);
+    }
+  }
+
+  throw new Error(
+    `could not acquire Studio config smoke lock within ${timeoutMs}ms (${lockPath})`,
+  );
+}
+
+/**
+ * Best-effort removal of an empty `.olive-studio` dir after the lock file is gone.
+ * @param {string} dir
+ * @param {{ rmSync?: typeof rmSync }} [deps]
+ */
+export function tryRemoveEmptyStudioConfigDir(dir, deps = {}) {
+  const rm = deps.rmSync ?? rmSync;
+  try {
+    rm(dir, { recursive: false });
+  } catch {
+    /* not empty, missing, or busy */
+  }
+}

--- a/scripts/studioConfigSnapshot.mjs
+++ b/scripts/studioConfigSnapshot.mjs
@@ -26,12 +26,36 @@ export function snapshotStudioConfigFile(configPath) {
 }
 
 /**
+ * Read current on-disk bytes, or null when the file is absent.
+ * @param {string} configPath
+ * @returns {string | null}
+ */
+export function readStudioConfigFileContents(configPath) {
+  if (!existsSync(configPath)) return null;
+  return readFileSync(configPath, "utf8");
+}
+
+/**
  * Restore a prior snapshot: rewrite exact contents, or delete a file the smoke created.
+ *
+ * When `expectedContents` is provided (including `null` for "file must be absent"),
+ * restore only if the on-disk bytes still match. Otherwise throw so callers do not
+ * clobber a concurrent update from another Studio process or administrator.
+ *
  * @param {string} configPath
  * @param {StudioConfigSnapshot | null | undefined} snapshot
+ * @param {{ expectedContents?: string | null }} [opts]
  */
-export function restoreStudioConfigFile(configPath, snapshot) {
+export function restoreStudioConfigFile(configPath, snapshot, opts = {}) {
   if (!snapshot) return;
+  if (Object.prototype.hasOwnProperty.call(opts, "expectedContents")) {
+    const current = readStudioConfigFileContents(configPath);
+    if (current !== opts.expectedContents) {
+      throw new Error(
+        `refusing to restore Studio config: on-disk bytes changed since smoke last wrote them (${configPath})`,
+      );
+    }
+  }
   if (!snapshot.existed) {
     if (existsSync(configPath)) {
       rmSync(configPath, { force: true });

--- a/scripts/studioConfigSnapshot.mjs
+++ b/scripts/studioConfigSnapshot.mjs
@@ -6,8 +6,12 @@
 import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import path from "node:path";
 
+/** Top-level marker written while mcp-agent-smoke owns policy patches. */
+export const SMOKE_OWNER_KEY = "__mcpAgentSmokeOwner";
+
 /**
  * @typedef {{ existed: false, contents: null } | { existed: true, contents: string }} StudioConfigSnapshot
+ * @typedef {{ pid: number, startedAt: string }} SmokeOwnerStamp
  */
 
 /**
@@ -33,6 +37,54 @@ export function snapshotStudioConfigFile(configPath) {
 export function readStudioConfigFileContents(configPath) {
   if (!existsSync(configPath)) return null;
   return readFileSync(configPath, "utf8");
+}
+
+/**
+ * @param {string} configPath
+ * @returns {SmokeOwnerStamp | null}
+ */
+export function readSmokeOwnerStamp(configPath) {
+  const raw = readStudioConfigFileContents(configPath);
+  if (raw == null) return null;
+  try {
+    const parsed = JSON.parse(raw);
+    const stamp = parsed?.[SMOKE_OWNER_KEY];
+    if (!stamp || typeof stamp !== "object") return null;
+    const pid = Number(stamp.pid);
+    if (!Number.isFinite(pid) || pid <= 0) return null;
+    return {
+      pid,
+      startedAt: typeof stamp.startedAt === "string" ? stamp.startedAt : "",
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Refuse to proceed when another live smoke still stamps this config.
+ * @param {string} configPath
+ * @param {number} myPid
+ * @param {(pid: number) => boolean} [isAlive]
+ */
+export function assertNoLiveForeignSmokeOwner(
+  configPath,
+  myPid,
+  isAlive = (pid) => {
+    try {
+      process.kill(pid, 0);
+      return true;
+    } catch {
+      return false;
+    }
+  },
+) {
+  const owner = readSmokeOwnerStamp(configPath);
+  if (!owner || owner.pid === myPid) return;
+  if (!isAlive(owner.pid)) return;
+  throw new Error(
+    `refusing to mutate Studio config: live mcp-agent-smoke owner pid=${owner.pid} still stamped on ${configPath}`,
+  );
 }
 
 /**

--- a/scripts/studioConfigSnapshot.mjs
+++ b/scripts/studioConfigSnapshot.mjs
@@ -1,0 +1,50 @@
+/**
+ * Exact on-disk snapshot/restore for `.olive-studio/config.json`.
+ * Used by mcp-agent-smoke so policy patches never leave lossy booleans or a
+ * newly created config file behind.
+ */
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import path from "node:path";
+
+/**
+ * @typedef {{ existed: false, contents: null } | { existed: true, contents: string }} StudioConfigSnapshot
+ */
+
+/**
+ * Capture whether the Studio config file exists and its exact bytes.
+ * @param {string} configPath
+ * @returns {StudioConfigSnapshot}
+ */
+export function snapshotStudioConfigFile(configPath) {
+  if (!existsSync(configPath)) {
+    return { existed: false, contents: null };
+  }
+  return {
+    existed: true,
+    contents: readFileSync(configPath, "utf8"),
+  };
+}
+
+/**
+ * Restore a prior snapshot: rewrite exact contents, or delete a file the smoke created.
+ * @param {string} configPath
+ * @param {StudioConfigSnapshot | null | undefined} snapshot
+ */
+export function restoreStudioConfigFile(configPath, snapshot) {
+  if (!snapshot) return;
+  if (!snapshot.existed) {
+    if (existsSync(configPath)) {
+      rmSync(configPath, { force: true });
+    }
+    // If smoke created `.olive-studio/` solely for the patch, drop the empty dir.
+    const dir = path.dirname(configPath);
+    try {
+      rmSync(dir, { recursive: false });
+    } catch {
+      /* dir missing, not empty, or not removable — leave alone */
+    }
+    return;
+  }
+  mkdirSync(path.dirname(configPath), { recursive: true });
+  writeFileSync(configPath, snapshot.contents, "utf8");
+}

--- a/src/lib/__tests__/resolvePython.test.ts
+++ b/src/lib/__tests__/resolvePython.test.ts
@@ -2,6 +2,7 @@
  * resolvePython: first executable candidate wins (no blind python3 fallback).
  */
 import { describe, expect, it, vi } from "vitest";
+import type { PathLike } from "node:fs";
 import path from "node:path";
 import { commandOnPath, resolvePython } from "../../../scripts/resolvePython.mjs";
 
@@ -10,7 +11,7 @@ describe("resolvePython", () => {
 
   it("returns the first existing venv python", () => {
     const wanted = path.join(root, "olive-mcp-server", ".venv", "bin", "python");
-    const existsSync = vi.fn((p: string) => p === wanted);
+    const existsSync = vi.fn((p: PathLike) => String(p) === wanted);
     expect(
       resolvePython(root, {
         existsSync,

--- a/src/lib/__tests__/resolvePython.test.ts
+++ b/src/lib/__tests__/resolvePython.test.ts
@@ -1,0 +1,79 @@
+/**
+ * resolvePython: first executable candidate wins (no blind python3 fallback).
+ */
+import { describe, expect, it, vi } from "vitest";
+import path from "node:path";
+import { commandOnPath, resolvePython } from "../../../scripts/resolvePython.mjs";
+
+describe("resolvePython", () => {
+  const root = "/repo";
+
+  it("returns the first existing venv python", () => {
+    const wanted = path.join(root, "olive-mcp-server", ".venv", "bin", "python");
+    const existsSync = vi.fn((p: string) => p === wanted);
+    expect(
+      resolvePython(root, {
+        existsSync,
+        spawnSync: vi.fn(() => ({ status: 1 })) as never,
+        platform: "linux",
+      }),
+    ).toBe(wanted);
+  });
+
+  it("uses python when only python is on PATH", () => {
+    const spawnSync = vi.fn((cmd: string) => ({
+      status: cmd === "python" ? 0 : 1,
+    }));
+    expect(
+      resolvePython(root, {
+        existsSync: () => false,
+        spawnSync: spawnSync as never,
+        platform: "win32",
+      }),
+    ).toBe("python");
+    expect(spawnSync).toHaveBeenCalledWith(
+      "python3",
+      ["--version"],
+      expect.objectContaining({ shell: true }),
+    );
+    expect(spawnSync).toHaveBeenCalledWith(
+      "python",
+      ["--version"],
+      expect.objectContaining({ shell: true }),
+    );
+  });
+
+  it("uses python3 when python3 is on PATH", () => {
+    const spawnSync = vi.fn((cmd: string) => ({
+      status: cmd === "python3" ? 0 : 1,
+    }));
+    expect(
+      resolvePython(root, {
+        existsSync: () => false,
+        spawnSync: spawnSync as never,
+        platform: "linux",
+      }),
+    ).toBe("python3");
+  });
+
+  it("throws when no candidate is executable", () => {
+    expect(() =>
+      resolvePython(root, {
+        existsSync: () => false,
+        spawnSync: vi.fn(() => ({ status: 1 })) as never,
+        platform: "linux",
+      }),
+    ).toThrow(/No Python interpreter found/);
+  });
+});
+
+describe("commandOnPath", () => {
+  it("treats status 0 as present", () => {
+    expect(
+      commandOnPath("python", {
+        spawnSync: vi.fn(() => ({ status: 0 })) as never,
+        platform: "linux",
+      }),
+    ).toBe(true);
+  });
+});

--- a/src/lib/__tests__/stopStudioThenAlways.test.ts
+++ b/src/lib/__tests__/stopStudioThenAlways.test.ts
@@ -1,0 +1,23 @@
+/**
+ * stopStudioThenAlways: config restore must run even when shutdown rejects.
+ */
+import { describe, expect, it, vi } from "vitest";
+import { stopStudioThenAlways } from "../../../scripts/stopStudioThenAlways.mjs";
+
+describe("stopStudioThenAlways", () => {
+  it("runs afterStop when stopStudio succeeds", async () => {
+    const afterStop = vi.fn(async () => undefined);
+    await stopStudioThenAlways(async () => "ok", afterStop);
+    expect(afterStop).toHaveBeenCalledOnce();
+  });
+
+  it("runs afterStop when stopStudio rejects", async () => {
+    const afterStop = vi.fn(async () => undefined);
+    await expect(
+      stopStudioThenAlways(async () => {
+        throw new Error("studio hung");
+      }, afterStop),
+    ).rejects.toThrow(/studio hung/);
+    expect(afterStop).toHaveBeenCalledOnce();
+  });
+});

--- a/src/lib/__tests__/studioConfigSmokeLock.test.ts
+++ b/src/lib/__tests__/studioConfigSmokeLock.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Inter-process smoke lock for Studio config mutation.
+ */
+import { describe, expect, it, vi } from "vitest";
+import {
+  acquireStudioConfigSmokeLock,
+  isProcessAlive,
+  tryRemoveEmptyStudioConfigDir,
+} from "../../../scripts/studioConfigSmokeLock.mjs";
+
+describe("studioConfigSmokeLock", () => {
+  it("acquires with wx and releases only own pid", async () => {
+    const store = new Map<string, string>();
+    let nextFd = 1;
+    const fds = new Map<number, string>();
+
+    const openSync = vi.fn((p: string, flag: string) => {
+      if (flag === "wx" && store.has(p)) {
+        const err = Object.assign(new Error("EEXIST"), { code: "EEXIST" });
+        throw err;
+      }
+      if (flag === "wx") store.set(p, "");
+      const fd = nextFd++;
+      fds.set(fd, p);
+      return fd;
+    });
+    const writeFileSync = vi.fn((fd: number, body: string) => {
+      const p = fds.get(fd);
+      if (p) store.set(p, body);
+    });
+    const closeSync = vi.fn();
+    const readFileSync = vi.fn((p: string) => {
+      if (!store.has(p)) {
+        const err = Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+        throw err;
+      }
+      return store.get(p) ?? "";
+    });
+    const unlinkSync = vi.fn((p: string) => {
+      store.delete(p);
+    });
+    const mkdirSync = vi.fn();
+
+    const lock = await acquireStudioConfigSmokeLock("/tmp/lock", {
+      openSync: openSync as never,
+      closeSync: closeSync as never,
+      writeFileSync: writeFileSync as never,
+      readFileSync: readFileSync as never,
+      unlinkSync: unlinkSync as never,
+      mkdirSync: mkdirSync as never,
+      pid: 4242,
+      timeoutMs: 1_000,
+      pollMs: 10,
+    });
+    expect(store.get("/tmp/lock")).toBe("4242\n");
+    lock.release();
+    expect(store.has("/tmp/lock")).toBe(false);
+  });
+
+  it("reclaims a stale lock from a dead pid", async () => {
+    const store = new Map<string, string>([["/tmp/lock", "111\n"]]);
+    let nextFd = 1;
+    const fds = new Map<number, string>();
+    const openSync = vi.fn((p: string, flag: string) => {
+      if (flag === "wx" && store.has(p)) {
+        throw Object.assign(new Error("EEXIST"), { code: "EEXIST" });
+      }
+      if (flag === "wx") store.set(p, "");
+      const fd = nextFd++;
+      fds.set(fd, p);
+      return fd;
+    });
+
+    const lock = await acquireStudioConfigSmokeLock("/tmp/lock", {
+      openSync: openSync as never,
+      closeSync: vi.fn() as never,
+      writeFileSync: vi.fn((fd: number, body: string) => {
+        const p = fds.get(fd);
+        if (p) store.set(p, body);
+      }) as never,
+      readFileSync: vi.fn((p: string) => {
+        if (!store.has(p)) throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+        return store.get(p) ?? "";
+      }) as never,
+      unlinkSync: vi.fn((p: string) => {
+        store.delete(p);
+      }) as never,
+      mkdirSync: vi.fn() as never,
+      isProcessAlive: (pid) => pid !== 111,
+      pid: 999,
+      timeoutMs: 1_000,
+      pollMs: 5,
+      sleep: async () => undefined,
+    });
+    expect(store.get("/tmp/lock")).toBe("999\n");
+    lock.release();
+  });
+
+  it("reports process liveness via kill(pid, 0)", () => {
+    expect(isProcessAlive(process.pid)).toBe(true);
+    expect(isProcessAlive(-1)).toBe(false);
+  });
+
+  it("tryRemoveEmptyStudioConfigDir ignores busy dirs", () => {
+    const rmSync = vi.fn(() => {
+      throw Object.assign(new Error("ENOTEMPTY"), { code: "ENOTEMPTY" });
+    });
+    expect(() => tryRemoveEmptyStudioConfigDir("/x", { rmSync: rmSync as never })).not.toThrow();
+  });
+});

--- a/src/lib/__tests__/studioConfigSnapshot.test.ts
+++ b/src/lib/__tests__/studioConfigSnapshot.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Exact Studio config snapshot/restore (mcp-agent-smoke contract).
+ */
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import {
+  restoreStudioConfigFile,
+  snapshotStudioConfigFile,
+} from "../../../scripts/studioConfigSnapshot.mjs";
+
+describe("studioConfigSnapshot", () => {
+  /** @type {string} */
+  let root;
+  /** @type {string} */
+  let configPath;
+
+  beforeEach(() => {
+    root = mkdtempSync(path.join(tmpdir(), "olive-studio-cfg-snap-"));
+    configPath = path.join(root, ".olive-studio", "config.json");
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("restores exact bytes including omitted agentAccess fields", () => {
+    mkdirSync(path.dirname(configPath), { recursive: true });
+    const original = '{\n  "hfToken": null\n}\n';
+    writeFileSync(configPath, original, "utf8");
+
+    const snap = snapshotStudioConfigFile(configPath);
+    writeFileSync(
+      configPath,
+      JSON.stringify(
+        {
+          hfToken: null,
+          agentAccess: { allowJobSubmission: true, allowJobCancellation: true },
+        },
+        null,
+        2,
+      ),
+      "utf8",
+    );
+
+    restoreStudioConfigFile(configPath, snap);
+    expect(readFileSync(configPath, "utf8")).toBe(original);
+    expect(JSON.parse(readFileSync(configPath, "utf8")).agentAccess).toBeUndefined();
+  });
+
+  it("removes a config file that did not exist before the smoke", () => {
+    expect(existsSync(configPath)).toBe(false);
+    const snap = snapshotStudioConfigFile(configPath);
+
+    mkdirSync(path.dirname(configPath), { recursive: true });
+    writeFileSync(
+      configPath,
+      JSON.stringify({ agentAccess: { allowJobSubmission: true } }, null, 2),
+      "utf8",
+    );
+    expect(existsSync(configPath)).toBe(true);
+
+    restoreStudioConfigFile(configPath, snap);
+    expect(existsSync(configPath)).toBe(false);
+  });
+});

--- a/src/lib/__tests__/studioConfigSnapshot.test.ts
+++ b/src/lib/__tests__/studioConfigSnapshot.test.ts
@@ -13,8 +13,10 @@ import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import {
+  assertNoLiveForeignSmokeOwner,
   restoreStudioConfigFile,
   snapshotStudioConfigFile,
+  SMOKE_OWNER_KEY,
 } from "../../../scripts/studioConfigSnapshot.mjs";
 
 describe("studioConfigSnapshot", () => {
@@ -90,5 +92,22 @@ describe("studioConfigSnapshot", () => {
       restoreStudioConfigFile(configPath, snap, { expectedContents: smokeWrite }),
     ).toThrow(/on-disk bytes changed/);
     expect(readFileSync(configPath, "utf8")).toBe('{\n  "hfToken": "admin"\n}\n');
+  });
+
+  it("refuses mutation when another live smoke owner is stamped", () => {
+    mkdirSync(path.dirname(configPath), { recursive: true });
+    writeFileSync(
+      configPath,
+      JSON.stringify({
+        [SMOKE_OWNER_KEY]: { pid: 12345, startedAt: "2026-01-01T00:00:00.000Z" },
+      }),
+      "utf8",
+    );
+    expect(() =>
+      assertNoLiveForeignSmokeOwner(configPath, 999, (pid) => pid === 12345),
+    ).toThrow(/live mcp-agent-smoke owner/);
+    expect(() =>
+      assertNoLiveForeignSmokeOwner(configPath, 999, () => false),
+    ).not.toThrow();
   });
 });

--- a/src/lib/__tests__/studioConfigSnapshot.test.ts
+++ b/src/lib/__tests__/studioConfigSnapshot.test.ts
@@ -18,10 +18,8 @@ import {
 } from "../../../scripts/studioConfigSnapshot.mjs";
 
 describe("studioConfigSnapshot", () => {
-  /** @type {string} */
-  let root;
-  /** @type {string} */
-  let configPath;
+  let root: string;
+  let configPath: string;
 
   beforeEach(() => {
     root = mkdtempSync(path.join(tmpdir(), "olive-studio-cfg-snap-"));

--- a/src/lib/__tests__/studioConfigSnapshot.test.ts
+++ b/src/lib/__tests__/studioConfigSnapshot.test.ts
@@ -69,4 +69,26 @@ describe("studioConfigSnapshot", () => {
     restoreStudioConfigFile(configPath, snap);
     expect(existsSync(configPath)).toBe(false);
   });
+
+  it("refuses to restore when on-disk bytes changed since the last smoke write", () => {
+    mkdirSync(path.dirname(configPath), { recursive: true });
+    const original = '{\n  "hfToken": null\n}\n';
+    writeFileSync(configPath, original, "utf8");
+    const snap = snapshotStudioConfigFile(configPath);
+
+    const smokeWrite = JSON.stringify(
+      { hfToken: null, agentAccess: { allowJobSubmission: true } },
+      null,
+      2,
+    );
+    writeFileSync(configPath, smokeWrite, "utf8");
+
+    // Concurrent update after smoke's last write.
+    writeFileSync(configPath, '{\n  "hfToken": "admin"\n}\n', "utf8");
+
+    expect(() =>
+      restoreStudioConfigFile(configPath, snap, { expectedContents: smokeWrite }),
+    ).toThrow(/on-disk bytes changed/);
+    expect(readFileSync(configPath, "utf8")).toBe('{\n  "hfToken": "admin"\n}\n');
+  });
 });

--- a/src/server/__tests__/routes.integration.test.ts
+++ b/src/server/__tests__/routes.integration.test.ts
@@ -10,11 +10,12 @@
 import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from "vitest";
 import type { Server } from "http";
 
-import { stubGlobalFetch, restoreGlobalFetch } from "./setup.integration.ts";
+import { stubGlobalFetch, restoreGlobalFetch, clearChildProcessLaunchLog, childProcessLaunchLog } from "./setup.integration.ts";
 import { resetMcpBreaker } from "../services/mcp/breaker.ts";
 import { resetLocalEngineRuntime } from "../services/ai/localEngineState.ts";
 import { app, markServerReady } from "../../../server.ts";
-import { jobRegistry } from "../services/olive/state.ts";
+import { jobRegistry, resetJobRegistry } from "../services/olive/state.ts";
+import { isAllowedMcpToolName } from "../services/mcp/allowedTools.ts";
 
 let server: Server;
 let baseUrl: string;
@@ -54,6 +55,8 @@ afterAll(async () => {
 beforeEach(() => {
   resetMcpBreaker();
   resetLocalEngineRuntime();
+  resetJobRegistry();
+  clearChildProcessLaunchLog();
 });
 
 describe("Route integration tests", () => {
@@ -620,18 +623,21 @@ describe("Route integration tests", () => {
     });
 
     it("rejects toolName with command injection characters", async () => {
+      const unsafeToolName = "pass_catalog; rm -rf /";
+      // Protection is exact allowlist match (isAllowedMcpToolName), not regex sanitization.
+      expect(isAllowedMcpToolName(unsafeToolName)).toBe(false);
+
+      const launchesBefore = childProcessLaunchLog.length;
       const res = await fetch(`${baseUrl}/api/mcp/tool`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ toolName: "pass_catalog; rm -rf /", args: {} }),
+        body: JSON.stringify({ toolName: unsafeToolName, args: {} }),
       });
 
-      // The sanitizer strips special chars, so the resulting tool name "pass_catalogrmrf"
-      // won't be found, but it should still be a valid call (will fail at Python level).
-      // The server should not return 400 for the toolName itself after sanitization.
-      // It may return an error from Python execution (500) or succeed.
-      expect(res.status).toBeGreaterThanOrEqual(200);
-      expect(res.status).toBeLessThan(600);
+      // Rejected at the allowlist gate — no Python/MCP launch.
+      expect(res.status).toBe(400);
+      expect(await res.json()).toEqual({ error: "Unknown toolName" });
+      expect(childProcessLaunchLog.slice(launchesBefore)).toEqual([]);
     });
 
     it("attempts to call a valid tool and returns JSON", async () => {

--- a/src/server/__tests__/setup.integration.ts
+++ b/src/server/__tests__/setup.integration.ts
@@ -16,12 +16,20 @@
 import { EventEmitter } from "events";
 import { vi } from "vitest";
 
+/** Recorded child_process launches for assertions (MCP injection tests, etc.). */
+export const childProcessLaunchLog: { fn: "execFile" | "spawn"; args: unknown[] }[] = [];
+
+export function clearChildProcessLaunchLog(): void {
+  childProcessLaunchLog.length = 0;
+}
+
 // ─── child_process: mock execFile + spawn ─────────────────────────────────
 
 vi.mock("child_process", async (importOriginal) => {
   const actual = await importOriginal<typeof import("child_process")>();
 
   function mockExecFile(...execArgs: unknown[]): ReturnType<typeof actual.execFile> {
+    childProcessLaunchLog.push({ fn: "execFile", args: execArgs });
     const lastArg = execArgs[execArgs.length - 1];
     if (typeof lastArg === "function") {
       lastArg(null, "", "");
@@ -31,7 +39,8 @@ vi.mock("child_process", async (importOriginal) => {
     return (actual.execFile as any)(...execArgs);
   }
 
-  function mockSpawn(): ReturnType<typeof actual.spawn> {
+  function mockSpawn(...spawnArgs: unknown[]): ReturnType<typeof actual.spawn> {
+    childProcessLaunchLog.push({ fn: "spawn", args: spawnArgs });
     const proc = new EventEmitter() as unknown as ReturnType<typeof actual.spawn>;
     proc.stdout = new EventEmitter() as unknown as ReturnType<typeof actual.spawn>["stdout"];
     proc.stderr = new EventEmitter() as unknown as ReturnType<typeof actual.spawn>["stderr"];

--- a/src/server/routes/mcp.test.ts
+++ b/src/server/routes/mcp.test.ts
@@ -230,8 +230,14 @@ describe("POST /api/mcp/tool", () => {
 });
 
 describe("POST /api/mcp/studio-recipe mcpAccess", () => {
+  const previousOliveMcpAccess = process.env.OLIVE_MCP_ACCESS;
+
   afterEach(() => {
-    delete process.env.OLIVE_MCP_ACCESS;
+    if (previousOliveMcpAccess === undefined) {
+      delete process.env.OLIVE_MCP_ACCESS;
+    } else {
+      process.env.OLIVE_MCP_ACCESS = previousOliveMcpAccess;
+    }
   });
 
   it("returns 403 when master mcpAccess is disabled", async () => {

--- a/src/server/routes/olive.stream.test.ts
+++ b/src/server/routes/olive.stream.test.ts
@@ -8,10 +8,12 @@ import express from "express";
 import type { Server } from "http";
 import type { OliveJob } from "../types.ts";
 import type { GpuMetrics } from "../../lib/gpuMetrics.ts";
+import { writeStudioConfig } from "../config.ts";
 import { pushGpuMetrics, pushLog } from "../services/olive/gpu.ts";
 import { finalizeJob, jobRegistry } from "../services/olive/state.ts";
 
 // Keep agent-access policy mutations out of the real `.olive-studio/config.json`.
+// vi.mock is hoisted, so the static import above resolves to this fake.
 vi.mock("../config.ts", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../config.ts")>();
   let cfg: Record<string, unknown> = {};
@@ -24,8 +26,6 @@ vi.mock("../config.ts", async (importOriginal) => {
     },
   };
 });
-
-import { writeStudioConfig } from "../config.ts";
 
 const { mountOliveRoutes } = await import("./olive.ts");
 

--- a/src/server/services/olive/jobIdempotency.test.ts
+++ b/src/server/services/olive/jobIdempotency.test.ts
@@ -88,7 +88,7 @@ describe("jobIdempotency", () => {
     expect(findJobByIdempotency({ fingerprint: "fp-shared" })).toEqual({ kind: "hit", job: mcp });
   });
 
-  it("does not fall back to fingerprint when an explicit new key misses", () => {
+  it("does not fall back to fingerprint when an explicit new key misses a keyed job", () => {
     const job = makeJob("j-old", {
       fingerprint: "fp-rerun",
       idempotencyKey: "old-key",
@@ -100,6 +100,19 @@ describe("jobIdempotency", () => {
     expect(
       findJobByIdempotency({ idempotencyKey: "new-key", fingerprint: "fp-rerun" }),
     ).toEqual({ kind: "miss" });
+  });
+
+  it("reuses a fingerprint-only job when a keyed submit arrives later", () => {
+    const job = makeJob("j-fp-only", {
+      fingerprint: "fp-adopt",
+      source: "mcp",
+      status: "setting_up",
+    });
+    jobRegistry.set(job.id, job);
+    rememberIdempotencyKeys(job);
+    expect(
+      findJobByIdempotency({ idempotencyKey: "late-key", fingerprint: "fp-adopt" }),
+    ).toEqual({ kind: "hit", job });
   });
 
   it("ignores default/undefined source as non-MCP", () => {

--- a/src/server/services/olive/jobIdempotency.ts
+++ b/src/server/services/olive/jobIdempotency.ts
@@ -11,6 +11,8 @@
  * - Fingerprint only: reuse an MCP job with that recipe fingerprint.
  * - Key + fingerprint: key wins; if the stored job has a different fingerprint,
  *   treat as conflict (caller should return 409) — never reuse the wrong job.
+ * - Key miss + fingerprint that maps to a fingerprint-only job: hit (adopt).
+ * - Key miss + fingerprint owned by a different keyed job: miss (new run).
  * - Failed/cancelled indexed jobs are treated as a miss so agents can retry.
  */
 import { jobRegistry } from "./state.ts";
@@ -124,8 +126,16 @@ export function findJobByIdempotency(opts: {
       }
       return { kind: "hit", job: byKey };
     }
-    // Explicit key with no prior mapping: do not fall through to fingerprint
-    // reuse — a new key must start a new run even for the same recipe.
+    // Key miss: reuse a fingerprint-only MCP job (no attached key) so a later
+    // keyed submit can adopt the in-flight admission. Do not reuse when the
+    // fingerprint is already owned by a different keyed job — that keeps
+    // sequential distinct-key behavior intact.
+    if (opts.fingerprint) {
+      const byFp = resolveJobForIndexKey(`fp:${opts.fingerprint}`);
+      if (byFp && !byFp.idempotencyKey) {
+        return { kind: "hit", job: byFp };
+      }
+    }
     return { kind: "miss" };
   }
 

--- a/src/server/services/olive/jobPreflight.test.ts
+++ b/src/server/services/olive/jobPreflight.test.ts
@@ -1,7 +1,15 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { resolveQnnHostMode } from "../../../lib/qnnDeps.ts";
 import { fingerprintRecipe, preflightOliveRecipe } from "./jobPreflight.ts";
 import type { OliveRecipe } from "../../types.ts";
+
+vi.mock("../../../lib/qnnDeps.ts", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../../lib/qnnDeps.ts")>();
+  return {
+    ...actual,
+    resolveQnnHostMode: vi.fn(actual.resolveQnnHostMode),
+  };
+});
 
 function minimalRecipe(ep = "CPUExecutionProvider"): OliveRecipe {
   // Cast via unknown: server OliveRecipe accelerators omit optional `device`.
@@ -113,16 +121,22 @@ describe("preflightOliveRecipe", () => {
     expect(fingerprintRecipe(withUndef, "auto")).toBe(fingerprintRecipe(without, "auto"));
   });
 
-  it("QNN validate stays structural: no probe means no NPU/runtime hard-fail here", () => {
+  it("QNN validate stays structural: deferred readiness warning on local-inference", () => {
+    vi.mocked(resolveQnnHostMode).mockReturnValue("local-inference");
     const pre = preflightOliveRecipe(minimalRecipe("QNNExecutionProvider"));
     // Missing NPU/runtime must not fail sync validate (probe is deferred to startOliveJob).
     expect(pre.errors.some((e) => /npu|runtime not ready/i.test(e))).toBe(false);
-    // On local-inference hosts, surface an explicit deferred-probe warning.
-    const mode = resolveQnnHostMode({ platform: process.platform, arch: process.arch });
-    if (mode === "local-inference") {
-      expect(pre.warnings.some((w) => /npu\/runtime readiness is not checked at validate/i.test(w))).toBe(
-        true,
-      );
-    }
+    expect(pre.warnings.some((w) => /npu\/runtime readiness is not checked at validate/i.test(w))).toBe(
+      true,
+    );
+  });
+
+  it("QNN out-of-scope host skips deferred-readiness warning without NPU hard-fail", () => {
+    vi.mocked(resolveQnnHostMode).mockReturnValue("out-of-scope");
+    const pre = preflightOliveRecipe(minimalRecipe("QNNExecutionProvider"));
+    expect(pre.errors.some((e) => /npu|runtime not ready/i.test(e))).toBe(false);
+    expect(pre.warnings.some((w) => /npu\/runtime readiness is not checked at validate/i.test(w))).toBe(
+      false,
+    );
   });
 });

--- a/src/server/services/olive/jobRunner.idempotency.test.ts
+++ b/src/server/services/olive/jobRunner.idempotency.test.ts
@@ -16,12 +16,17 @@ vi.mock("./jobPreflight.ts", () => ({
 }));
 
 vi.mock("../venv/index.ts", () => ({
-  ensureProviderCapability: vi.fn(async () => ({ ok: true })),
+  ensureProviderCapability: vi.fn(async () => ({
+    ok: true,
+    python: "python",
+    family: "default",
+  })),
   buildOliveRunEnvironment: vi.fn(() => ({})),
-  resolveOliveCommand: vi.fn(() => ({ cmd: "echo", args: ["ok"] })),
+  resolveOliveCommand: vi.fn(() => ({ executable: "echo", args: ["ok"] })),
 }));
 
-import { startOliveJob } from "./jobRunner.ts";
+import { preflightOliveRecipe } from "./jobPreflight.ts";
+import { mcpSubmitLockTailCount, startOliveJob } from "./jobRunner.ts";
 import { clearIdempotencyIndex } from "./jobIdempotency.ts";
 import { jobRegistry } from "./state.ts";
 
@@ -29,6 +34,15 @@ afterEach(() => {
   jobRegistry.clear();
   clearIdempotencyIndex();
   vi.clearAllMocks();
+  vi.mocked(preflightOliveRecipe).mockImplementation(() => ({
+    valid: true,
+    provider: "CPUExecutionProvider",
+    fingerprint: "fp-concurrent",
+    errors: [] as string[],
+    warnings: [] as string[],
+    cudaVersion: "auto",
+    recipe: { input_model: {}, passes: {}, engine: {}, systems: {} },
+  }));
 });
 
 describe("startOliveJob MCP idempotency lock", () => {
@@ -41,22 +55,107 @@ describe("startOliveJob MCP idempotency lock", () => {
     expect(a.ok).toBe(true);
     expect(b.ok).toBe(true);
     if (!a.ok || !b.ok) return;
-    // Lock shares one promise: identical payload, single registry entry.
     expect(a.jobId).toBe(b.jobId);
-    expect(a.reused).toBe(b.reused);
     expect([...jobRegistry.keys()]).toHaveLength(1);
+    // Sequential critical section: one fresh submit, one reuse.
+    expect([a.reused, b.reused].filter(Boolean)).toHaveLength(1);
+    expect(mcpSubmitLockTailCount()).toBe(0);
   });
 
-  it("serializes concurrent key-only and fingerprint-only submits for the same recipe", async () => {
+  it("serializes key-bearing and fingerprint-only submits for the same recipe", async () => {
     const recipe = { input_model: {}, passes: {}, engine: {}, systems: {} } as never;
-    const [withKey, fingerprintOnly] = await Promise.all([
-      startOliveJob({ recipe, source: "mcp", idempotencyKey: "race-key" }),
+    const [withKey, fpOnly] = await Promise.all([
+      startOliveJob({ recipe, source: "mcp", idempotencyKey: "agent-key-1" }),
       startOliveJob({ recipe, source: "mcp" }),
     ]);
     expect(withKey.ok).toBe(true);
-    expect(fingerprintOnly.ok).toBe(true);
-    if (!withKey.ok || !fingerprintOnly.ok) return;
-    expect(withKey.jobId).toBe(fingerprintOnly.jobId);
+    expect(fpOnly.ok).toBe(true);
+    if (!withKey.ok || !fpOnly.ok) return;
+    // Fingerprint-only must reuse the in-flight/keyed job (not spawn a second GPU run).
+    expect(withKey.jobId).toBe(fpOnly.jobId);
     expect([...jobRegistry.keys()]).toHaveLength(1);
+    expect(mcpSubmitLockTailCount()).toBe(0);
+  });
+
+  it("reuses a fingerprint-only admission when a keyed submit arrives afterward", async () => {
+    const recipe = { input_model: {}, passes: {}, engine: {}, systems: {} } as never;
+    const fpOnly = await startOliveJob({ recipe, source: "mcp" });
+    const withKey = await startOliveJob({
+      recipe,
+      source: "mcp",
+      idempotencyKey: "after-fp-key",
+    });
+    expect(fpOnly.ok).toBe(true);
+    expect(withKey.ok).toBe(true);
+    if (!fpOnly.ok || !withKey.ok) return;
+    expect(withKey.jobId).toBe(fpOnly.jobId);
+    expect(withKey.reused).toBe(true);
+    expect([...jobRegistry.keys()]).toHaveLength(1);
+    expect(mcpSubmitLockTailCount()).toBe(0);
+  });
+
+  it("still allows a distinct idempotency key to start a new job after the first settles", async () => {
+    const recipe = { input_model: {}, passes: {}, engine: {}, systems: {} } as never;
+    const first = await startOliveJob({ recipe, source: "mcp", idempotencyKey: "key-a" });
+    const second = await startOliveJob({ recipe, source: "mcp", idempotencyKey: "key-b" });
+    expect(first.ok).toBe(true);
+    expect(second.ok).toBe(true);
+    if (!first.ok || !second.ok) return;
+    expect(first.jobId).not.toBe(second.jobId);
+    expect([...jobRegistry.keys()]).toHaveLength(2);
+    expect(mcpSubmitLockTailCount()).toBe(0);
+  });
+
+  it("evicts completed lock tails and does not retain unique keys forever", async () => {
+    const recipe = { input_model: {}, passes: {}, engine: {}, systems: {} } as never;
+    let n = 0;
+    vi.mocked(preflightOliveRecipe).mockImplementation(() => {
+      n += 1;
+      return {
+        valid: true,
+        provider: "CPUExecutionProvider",
+        fingerprint: `fp-unique-${n}`,
+        errors: [] as string[],
+        warnings: [] as string[],
+        cudaVersion: "auto",
+        recipe: { input_model: {}, passes: {}, engine: {}, systems: {} },
+      };
+    });
+
+    for (let i = 0; i < 20; i += 1) {
+      const result = await startOliveJob({
+        recipe,
+        source: "mcp",
+        idempotencyKey: `unique-key-${i}`,
+      });
+      expect(result.ok).toBe(true);
+      // Idle between submits: map must not accumulate completed tails.
+      expect(mcpSubmitLockTailCount()).toBe(0);
+    }
+    expect([...jobRegistry.keys()]).toHaveLength(20);
+  });
+
+  it("evicts only owned tails so overlapping waiters still drain the map", async () => {
+    const recipe = { input_model: {}, passes: {}, engine: {}, systems: {} } as never;
+
+    vi.mocked(preflightOliveRecipe).mockImplementation(() => ({
+      valid: true,
+      provider: "CPUExecutionProvider",
+      fingerprint: "fp-hold",
+      errors: [] as string[],
+      warnings: [] as string[],
+      cudaVersion: "auto",
+      recipe: { input_model: {}, passes: {}, engine: {}, systems: {} },
+    }));
+
+    // Distinct keys share fp:fp-hold lock; second replaces the map entry while first still holds.
+    // First release must not delete the newer tail (ownership check); both finish and map is empty.
+    const results = await Promise.all([
+      startOliveJob({ recipe, source: "mcp", idempotencyKey: "hold-1" }),
+      startOliveJob({ recipe, source: "mcp", idempotencyKey: "hold-2" }),
+      startOliveJob({ recipe, source: "mcp" }), // fingerprint-only overlaps fp lock
+    ]);
+    expect(results.every((r) => r.ok)).toBe(true);
+    expect(mcpSubmitLockTailCount()).toBe(0);
   });
 });

--- a/src/server/services/olive/jobRunner.idempotency.test.ts
+++ b/src/server/services/olive/jobRunner.idempotency.test.ts
@@ -2,6 +2,10 @@
  * Concurrent MCP submit locking + idempotent reuse via startOliveJob.
  */
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { preflightOliveRecipe } from "./jobPreflight.ts";
+import { mcpSubmitLockTailCount, startOliveJob } from "./jobRunner.ts";
+import { clearIdempotencyIndex } from "./jobIdempotency.ts";
+import { jobRegistry } from "./state.ts";
 
 vi.mock("./jobPreflight.ts", () => ({
   preflightOliveRecipe: vi.fn(() => ({
@@ -24,11 +28,6 @@ vi.mock("../venv/index.ts", () => ({
   buildOliveRunEnvironment: vi.fn(() => ({})),
   resolveOliveCommand: vi.fn(() => ({ executable: "echo", args: ["ok"] })),
 }));
-
-import { preflightOliveRecipe } from "./jobPreflight.ts";
-import { mcpSubmitLockTailCount, startOliveJob } from "./jobRunner.ts";
-import { clearIdempotencyIndex } from "./jobIdempotency.ts";
-import { jobRegistry } from "./state.ts";
 
 afterEach(() => {
   jobRegistry.clear();

--- a/src/server/services/olive/jobRunner.idempotency.test.ts
+++ b/src/server/services/olive/jobRunner.idempotency.test.ts
@@ -89,6 +89,17 @@ describe("startOliveJob MCP idempotency lock", () => {
     if (!fpOnly.ok || !withKey.ok) return;
     expect(withKey.jobId).toBe(fpOnly.jobId);
     expect(withKey.reused).toBe(true);
+
+    // Same adopted key must replay onto the fingerprint-only job.
+    const replay = await startOliveJob({
+      recipe,
+      source: "mcp",
+      idempotencyKey: "after-fp-key",
+    });
+    expect(replay.ok).toBe(true);
+    if (!replay.ok) return;
+    expect(replay.jobId).toBe(fpOnly.jobId);
+    expect(replay.reused).toBe(true);
     expect([...jobRegistry.keys()]).toHaveLength(1);
     expect(mcpSubmitLockTailCount()).toBe(0);
   });

--- a/src/server/services/olive/jobRunner.ts
+++ b/src/server/services/olive/jobRunner.ts
@@ -62,8 +62,54 @@ export type StartOliveJobResult =
       jobId?: string;
     };
 
-/** In-flight MCP submits keyed by idempotency key or fingerprint (serialize check-then-act). */
-const mcpSubmitLocks = new Map<string, Promise<StartOliveJobResult>>();
+/** Per-key promise tails that serialize MCP submit critical sections. */
+const mcpSubmitLockTails = new Map<string, Promise<void>>();
+
+/** Test helper: number of live MCP submit-lock tails (should be 0 when idle). */
+export function mcpSubmitLockTailCount(): number {
+  return mcpSubmitLockTails.size;
+}
+
+/**
+ * Acquire exclusive tails for the given lock keys (sorted to avoid deadlocks).
+ * Callers with overlapping fingerprint/key sets cannot both pass lookup-and-register.
+ */
+async function withMcpSubmitLocks<T>(keys: string[], fn: () => Promise<T>): Promise<T> {
+  const sorted = [...new Set(keys)].sort();
+  const releases: Array<() => void> = [];
+  /** Tails we installed; delete only if still ours (a newer waiter may have replaced them). */
+  const installed: Array<{ key: string; tail: Promise<void> }> = [];
+  try {
+    for (const key of sorted) {
+      let release!: () => void;
+      const held = new Promise<void>((resolve) => {
+        release = resolve;
+      });
+      const prev = mcpSubmitLockTails.get(key) ?? Promise.resolve();
+      // Chain: next waiter awaits prev, then our held promise until we release.
+      const tail = prev.then(
+        () => held,
+        () => held,
+      );
+      mcpSubmitLockTails.set(key, tail);
+      installed.push({ key, tail });
+      await prev;
+      releases.push(release);
+    }
+    return await fn();
+  } finally {
+    while (releases.length > 0) {
+      releases.pop()!();
+    }
+    // Evict only our installed tails. If a newer waiter replaced the map entry,
+    // leave theirs in place so cleanup never drops an active chain link.
+    for (const { key, tail } of installed) {
+      if (mcpSubmitLockTails.get(key) === tail) {
+        mcpSubmitLockTails.delete(key);
+      }
+    }
+  }
+}
 
 /**
  * Validates a recipe, prepares its execution environment, and starts an Olive job or reuses an idempotent MCP submission.
@@ -101,30 +147,20 @@ export async function startOliveJob(opts: StartOliveJobOpts): Promise<StartOlive
 
   // Idempotency is for MCP/agent submit only — UI re-runs should always spawn.
   if (opts.source === "mcp") {
+    // Always lock the recipe fingerprint so key-bearing and fingerprint-only
+    // callers cannot both observe a miss and spawn duplicate jobs. Also lock
+    // the idempotency key when present so same-key conflict checks serialize.
     const lockKeys = [`fp:${fingerprint}`];
     if (opts.idempotencyKey) lockKeys.push(`key:${opts.idempotencyKey}`);
-
-    for (const lockKey of lockKeys) {
-      const inflight = mcpSubmitLocks.get(lockKey);
-      if (inflight) return inflight;
-    }
-
-    const work = startMcpOliveJobLocked({
-      recipe,
-      provider,
-      cudaVersion,
-      fingerprint,
-      idempotencyKey: opts.idempotencyKey,
-    });
-    for (const lockKey of lockKeys) mcpSubmitLocks.set(lockKey, work);
-    try {
-      return await work;
-    } finally {
-      // Only clear slots we still own (avoid deleting a newer waiter's promise).
-      for (const lockKey of lockKeys) {
-        if (mcpSubmitLocks.get(lockKey) === work) mcpSubmitLocks.delete(lockKey);
-      }
-    }
+    return withMcpSubmitLocks(lockKeys, () =>
+      startMcpOliveJobLocked({
+        recipe,
+        provider,
+        cudaVersion,
+        fingerprint,
+        idempotencyKey: opts.idempotencyKey,
+      }),
+    );
   }
 
   return registerAndStartOliveJob({
@@ -158,6 +194,12 @@ async function startMcpOliveJobLocked(opts: {
     };
   }
   if (lookup.kind === "hit") {
+    // Attach the arriving key onto a fingerprint-only job so later same-key
+    // replays hit the key index directly.
+    if (opts.idempotencyKey && !lookup.job.idempotencyKey) {
+      lookup.job.idempotencyKey = opts.idempotencyKey;
+      rememberIdempotencyKeys(lookup.job);
+    }
     const submittedAt = lookup.job.submittedAt ?? Date.now();
     if (lookup.job.submittedAt == null) lookup.job.submittedAt = submittedAt;
     return {
@@ -263,6 +305,28 @@ async function continueOliveJobSetup(
   const jobId = job.id;
   const submittedAt = job.submittedAt ?? Date.now();
   const bailIfCancelled = (): boolean => job.status === "cancelled";
+
+  // Smoke/CI: park in setting_up without venv/model downloads or `olive run`.
+  // Cancel (or external finalize) ends the wait. See scripts/mcp-agent-smoke.mjs.
+  const stubSetup = ["1", "true", "yes", "on"].includes(
+    (process.env.OLIVE_JOB_SETUP_STUB ?? "").trim().toLowerCase(),
+  );
+  if (stubSetup) {
+    pushLog(job, "[stub] Olive job setup stubbed; waiting for cancel.");
+    while (job.status === "setting_up") {
+      await new Promise((r) => setTimeout(r, 200));
+    }
+    cleanupJobArtifacts(job);
+    finalizeJob(job);
+    return {
+      ok: true,
+      jobId,
+      reused: false,
+      fingerprint,
+      status: job.status,
+      submittedAt,
+    };
+  }
 
   try {
     const venvListener = (line: string) => pushLog(job, line);

--- a/src/server/services/olive/jobRunner.ts
+++ b/src/server/services/olive/jobRunner.ts
@@ -313,11 +313,12 @@ async function continueOliveJobSetup(
   );
   if (stubSetup) {
     pushLog(job, "[stub] Olive job setup stubbed; waiting for cancel.");
-    while (job.status === "setting_up") {
+    // Exit when cancelled or when another path finalizes the job without a status flip.
+    while (job.status === "setting_up" && job.finishedAt == null) {
       await new Promise((r) => setTimeout(r, 200));
     }
     cleanupJobArtifacts(job);
-    finalizeJob(job);
+    if (job.finishedAt == null) finalizeJob(job);
     return {
       ok: true,
       jobId,

--- a/src/server/services/olive/state.test.ts
+++ b/src/server/services/olive/state.test.ts
@@ -203,6 +203,22 @@ describe("olive job registry cleanup", () => {
       expect(job.venvListener).toBeUndefined();
       expect(job.metricsTimer).toBeNull();
       expect(job.sampling).toBe(false);
+      expect(job.status).toBe("cancelled");
+      expect(jobRegistry.size).toBe(0);
+    });
+
+    it("cancels setting_up jobs so stub setup loops can exit", () => {
+      const job = makeJob("setting-up", {
+        status: "setting_up",
+        finishedAt: null,
+        process: null,
+      });
+      jobRegistry.set(job.id, job);
+
+      resetJobRegistry();
+
+      expect(job.status).toBe("cancelled");
+      expect(job.finishedAt).toBeTypeOf("number");
       expect(jobRegistry.size).toBe(0);
     });
   });

--- a/src/server/services/olive/state.test.ts
+++ b/src/server/services/olive/state.test.ts
@@ -188,6 +188,7 @@ describe("olive job registry cleanup", () => {
     it("detaches venv listeners and clears GPU metrics timers before finalize", () => {
       const listener = vi.fn();
       const handle = setInterval(() => {}, 60_000);
+      const clearSpy = vi.spyOn(globalThis, "clearInterval");
       const job = makeJob("reset-resources", {
         status: "running",
         finishedAt: null,
@@ -201,6 +202,7 @@ describe("olive job registry cleanup", () => {
 
       expect(detachVenvListener).toHaveBeenCalledWith(listener);
       expect(job.venvListener).toBeUndefined();
+      expect(clearSpy).toHaveBeenCalledWith(handle);
       expect(job.metricsTimer).toBeNull();
       expect(job.sampling).toBe(false);
       expect(job.status).toBe("cancelled");

--- a/src/server/services/olive/state.test.ts
+++ b/src/server/services/olive/state.test.ts
@@ -1,15 +1,24 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { jobRegistry, cleanupJobArtifacts, sweepJobRegistry, finalizeJob } from "./state.ts";
+import type { OliveJob } from "../../types.ts";
+import fs from "fs";
+import os from "os";
+import path from "path";
+
+const { detachVenvListener } = vi.hoisted(() => ({
+  detachVenvListener: vi.fn(),
+}));
+
+vi.mock("../venv/index.ts", () => ({
+  detachVenvListener: (...args: unknown[]) => detachVenvListener(...args),
+}));
+
+import { jobRegistry, cleanupJobArtifacts, sweepJobRegistry, finalizeJob, resetJobRegistry } from "./state.ts";
 import {
   clearIdempotencyIndex,
   findJobByIdempotency,
   idempotencyIndexSize,
   rememberIdempotencyKeys,
 } from "./jobIdempotency.ts";
-import type { OliveJob } from "../../types.ts";
-import fs from "fs";
-import os from "os";
-import path from "path";
 
 function makeJob(id: string, overrides: Partial<OliveJob> = {}): OliveJob {
   return {
@@ -34,11 +43,13 @@ describe("olive job registry cleanup", () => {
   beforeEach(() => {
     jobRegistry.clear();
     clearIdempotencyIndex();
+    detachVenvListener.mockClear();
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
     clearIdempotencyIndex();
+    resetJobRegistry();
   });
 
   describe("sweepJobRegistry", () => {
@@ -139,6 +150,60 @@ describe("olive job registry cleanup", () => {
       vi.spyOn(fs, "rmSync").mockImplementation(() => undefined);
       expect(sweepJobRegistry(now)).toBe(1);
       expect(jobRegistry.has("stuck")).toBe(false);
+    });
+  });
+
+  describe("resetJobRegistry", () => {
+    it("kills active children, clears artifacts, registry, and MCP idempotency keys", () => {
+      const kill = vi.fn();
+      const tmp = path.join(os.tmpdir(), `olive-reset-test-${Date.now()}.json`);
+      fs.writeFileSync(tmp, "{}", "utf-8");
+      const job = makeJob("live", {
+        status: "running",
+        finishedAt: null,
+        exitCode: null,
+        source: "mcp",
+        fingerprint: "fp-reset",
+        idempotencyKey: "k-reset",
+        tempRecipePath: tmp,
+        process: {
+          kill,
+          exitCode: null,
+          signalCode: null,
+        } as unknown as OliveJob["process"],
+      });
+      jobRegistry.set(job.id, job);
+      rememberIdempotencyKeys(job);
+      expect(idempotencyIndexSize()).toBeGreaterThan(0);
+
+      resetJobRegistry();
+
+      expect(kill).toHaveBeenCalledWith("SIGKILL");
+      expect(jobRegistry.size).toBe(0);
+      expect(idempotencyIndexSize()).toBe(0);
+      expect(fs.existsSync(tmp)).toBe(false);
+      expect(findJobByIdempotency({ idempotencyKey: "k-reset" }).kind).toBe("miss");
+    });
+
+    it("detaches venv listeners and clears GPU metrics timers before finalize", () => {
+      const listener = vi.fn();
+      const handle = setInterval(() => {}, 60_000);
+      const job = makeJob("reset-resources", {
+        status: "running",
+        finishedAt: null,
+        venvListener: listener as unknown as OliveJob["venvListener"],
+        metricsTimer: handle,
+        sampling: true,
+      });
+      jobRegistry.set(job.id, job);
+
+      resetJobRegistry();
+
+      expect(detachVenvListener).toHaveBeenCalledWith(listener);
+      expect(job.venvListener).toBeUndefined();
+      expect(job.metricsTimer).toBeNull();
+      expect(job.sampling).toBe(false);
+      expect(jobRegistry.size).toBe(0);
     });
   });
 

--- a/src/server/services/olive/state.ts
+++ b/src/server/services/olive/state.ts
@@ -78,6 +78,15 @@ export function resetJobRegistry(): void {
     }
     stopGpuMetricsTimer(job);
     job.sampling = false;
+    // Mark cancelled before finalize so stub/setup loops watching
+    // `status === "setting_up"` exit even when no child process exists.
+    if (
+      job.status !== "completed" &&
+      job.status !== "failed" &&
+      job.status !== "cancelled"
+    ) {
+      job.status = "cancelled";
+    }
     const proc = job.process;
     if (proc) {
       try {

--- a/src/server/services/olive/state.ts
+++ b/src/server/services/olive/state.ts
@@ -1,7 +1,13 @@
 import fs from "fs";
 import type { OliveJob } from "../../types.ts";
 import { appConfig } from "../../config.ts";
-import { forgetIdempotencyKeysForJobId, pruneIdempotencyIndex } from "./jobIdempotency.ts";
+import {
+  clearIdempotencyIndex,
+  forgetIdempotencyKeysForJobId,
+  pruneIdempotencyIndex,
+} from "./jobIdempotency.ts";
+import { detachVenvListener } from "../venv/index.ts";
+import { stopGpuMetricsTimer } from "./gpu.ts";
 
 /** Central job registry — all active Olive jobs. */
 export const jobRegistry = new Map<string, OliveJob>();
@@ -54,6 +60,40 @@ export function cleanupJobArtifacts(job: OliveJob): boolean {
   } catch {
     return false;
   }
+}
+
+/**
+ * Test helper: terminate active Olive children, reclaim artifacts, and clear
+ * the registry plus MCP idempotency index so cases cannot leak across tests.
+ */
+export function resetJobRegistry(): void {
+  for (const job of [...jobRegistry.values()]) {
+    if (job.venvListener) {
+      try {
+        detachVenvListener(job.venvListener);
+      } catch {
+        /* mock / already detached */
+      }
+      job.venvListener = undefined;
+    }
+    stopGpuMetricsTimer(job);
+    job.sampling = false;
+    const proc = job.process;
+    if (proc) {
+      try {
+        if (proc.exitCode === null && proc.signalCode === null) {
+          proc.kill("SIGKILL");
+        }
+      } catch {
+        /* already exited / not killable in mocks */
+      }
+      job.process = null;
+    }
+    cleanupJobArtifacts(job);
+    finalizeJob(job);
+  }
+  jobRegistry.clear();
+  clearIdempotencyIndex();
 }
 
 /**


### PR DESCRIPTION
## Summary

Rebuilds the squashed MCP_harden review follow-ups on current `MCP_harden` and addresses Codex review findings on this PR.

## Codex findings addressed

| Severity | Finding | Fix |
| --- | --- | --- |
| P1 | Smoke could start real Olive setup / downloads | Studio child runs with `OLIVE_JOB_SETUP_STUB=1`; setup parks in `setting_up` until cancel |
| P1 | SIGINT/SIGTERM left permissive agent policy on disk | Exact config file snapshot/restore + signal handlers that always `cleanup()` |
| P2 | Inherited `OLIVE_MCP_ALLOW_JOBS` broke deny-path asserts | Deleted from Studio child env and mcporter `studioEnv` |
| P2 | MCP submit lock tails grew without bound | `withMcpSubmitLocks` evicts installed tails when still owned |

## Also included (former #175–#183)

| Former PR | Change |
| --- | --- |
| #175 | mcporter smoke: policy-gated submit / status / cancel / idempotent reuse |
| #176 | pytest conftest: central semantic inflight drain |
| #177 | `resetJobRegistry()` (detaches venv listeners) in integration `beforeEach` |
| #178 | MCP tool injection: allowlist + no child_process launch asserts |
| #179 | restore `OLIVE_MCP_ACCESS` after mcpAccess suite |
| #180 | hoist `writeStudioConfig` import in olive.stream tests |
| #181 | deterministic QNN preflight host-mode mocks |
| #182 | jobRunner idempotency mocks (`executable` + `python`) |
| #183 | MCP submit lock on fingerprint + idempotency key |

## Validation

```bash
node --check scripts/mcp-agent-smoke.mjs
pnpm vitest run --config vitest.server.config.ts \
  src/server/services/olive/jobRunner.idempotency.test.ts \
  src/server/services/olive/jobPreflight.test.ts \
  src/server/services/olive/state.test.ts \
  src/server/routes/olive.stream.test.ts \
  src/server/routes/mcp.test.ts
```

## Base

Stacked on latest `MCP_harden` (`2962d4f`).