### PR TITLE
fix(mcp): MCP_harden inline review follow-ups

### DIFF
--- a/scripts/mcp-agent-smoke.mjs
+++ b/scripts/mcp-agent-smoke.mjs
@@ -10,6 +10,10 @@
  * Studio is started with OLIVE_JOB_SETUP_STUB=1 so submits never download models
  * or run Olive (AGENTS.md: no real Olive execute in CI/VM).
  *
+ * Mcporter is installed once into a temp prefix, then invoked via
+ * `node <cli> …` with `shell: false` so Windows does not strip quotes from
+ * `--args` JSON (npx+cmd was corrupting submit payloads).
+ *
  * Usage (repo root):
  *   node scripts/mcp-agent-smoke.mjs
  *   pnpm mcp:agent-smoke
@@ -51,6 +55,83 @@ const STUDIO_CONFIG_SMOKE_LOCK = path.join(
   "mcp-agent-smoke.lock",
 );
 const STRICT = process.env.MCP_SMOKE_STRICT === "1";
+
+/** Resolved once: `node <cli> …` keeps argv intact on Windows (no cmd re-parse). */
+let mcporterCliPath = /** @type {string | null} */ (null);
+
+/**
+ * Install pinned mcporter into a stable temp prefix and return its CLI entry.
+ * Invocations then use `process.execPath` with `shell: false` so `--args` JSON
+ * is not stripped by cmd.exe (which is what breaks submit on Windows).
+ * @returns {string}
+ */
+function ensureMcporterCli() {
+  if (mcporterCliPath) return mcporterCliPath;
+  const pinDir = path.join(
+    tmpdir(),
+    `olive-studio-${MCPORTER.replace(/[^a-zA-Z0-9._-]+/g, "-")}`,
+  );
+  const cli = path.join(pinDir, "node_modules", "mcporter", "dist", "cli.js");
+  if (!existsSync(cli)) {
+    mkdirSync(pinDir, { recursive: true });
+    // One-time prefix install may need shell on Windows for npm.cmd only.
+    const npmCmd = process.platform === "win32" ? "npm.cmd" : "npm";
+    const install = spawnSync(
+      npmCmd,
+      [
+        "install",
+        "--prefix",
+        pinDir,
+        MCPORTER,
+        "--no-save",
+        "--no-package-lock",
+        "--no-fund",
+        "--no-audit",
+        "--loglevel=error",
+      ],
+      {
+        encoding: "utf8",
+        timeout: 180_000,
+        shell: process.platform === "win32",
+        env: { ...process.env },
+      },
+    );
+    if (install.status !== 0) {
+      throw new Error(
+        `failed to install ${MCPORTER}: ${(install.stderr || install.stdout || "").slice(0, 800)}`,
+      );
+    }
+  }
+  if (!existsSync(cli)) {
+    throw new Error(`mcporter CLI missing after install: ${cli}`);
+  }
+  mcporterCliPath = cli;
+  return cli;
+}
+
+/**
+ * @param {string[]} args mcporter argv (without node/cli)
+ * @param {{ timeoutMs?: number, env?: NodeJS.ProcessEnv, expectOk?: boolean }} [opts]
+ */
+function runMcporterSync(args, opts = {}) {
+  const { timeoutMs = 90_000, env = process.env, expectOk = true } = opts;
+  const cli = ensureMcporterCli();
+  const full = [...args, "--config", smokeConfigPath];
+  console.log(`$ node ${path.basename(path.dirname(path.dirname(cli)))}/dist/cli.js ${full.join(" ")}`);
+  const r = spawnSync(process.execPath, [cli, ...full], {
+    cwd: root,
+    encoding: "utf8",
+    timeout: timeoutMs,
+    shell: false,
+    env: { ...env },
+  });
+  if (r.stdout) process.stdout.write(r.stdout);
+  if (r.stderr) process.stderr.write(r.stderr);
+  if (expectOk && r.status !== 0) {
+    throw new Error(`mcporter failed status=${r.status} signal=${r.signal}`);
+  }
+  return r;
+}
 
 /** Minimal CPU recipe accepted by Studio preflight (no real Olive execute required). */
 const SMOKE_RECIPE = {
@@ -139,22 +220,7 @@ function patchAgentAccessDisk(patch) {
  * @param {{ timeoutMs?: number, env?: NodeJS.ProcessEnv, expectOk?: boolean }} [opts]
  */
 function run(args, opts = {}) {
-  const { timeoutMs = 90_000, env = process.env, expectOk = true } = opts;
-  const full = ["--yes", MCPORTER, ...args, "--config", smokeConfigPath];
-  console.log(`$ npx ${full.join(" ")}`);
-  const r = spawnSync("npx", full, {
-    cwd: root,
-    encoding: "utf8",
-    timeout: timeoutMs,
-    shell: process.platform === "win32",
-    env: { ...env },
-  });
-  if (r.stdout) process.stdout.write(r.stdout);
-  if (r.stderr) process.stderr.write(r.stderr);
-  if (expectOk && r.status !== 0) {
-    throw new Error(`mcporter failed status=${r.status} signal=${r.signal}`);
-  }
-  return r;
+  return runMcporterSync(args, opts);
 }
 
 /** @param {string} stdout */
@@ -185,14 +251,17 @@ function callToolAsync(selector, toolArgs, opts = {}) {
     args.push("--args", JSON.stringify(toolArgs));
   }
   args.push("--timeout", String(timeoutMs), "--output", "json");
-  const full = ["--yes", MCPORTER, ...args, "--config", smokeConfigPath];
-  console.log(`$ npx ${full.join(" ")}`);
+  const cli = ensureMcporterCli();
+  const full = [...args, "--config", smokeConfigPath];
+  console.log(
+    `$ node ${path.basename(path.dirname(path.dirname(cli)))}/dist/cli.js ${full.join(" ")}`,
+  );
 
   return new Promise((resolve, reject) => {
-    const child = spawn("npx", full, {
+    const child = spawn(process.execPath, [cli, ...full], {
       cwd: root,
       env: { ...(opts.env ?? process.env) },
-      shell: process.platform === "win32",
+      shell: false,
     });
     let stdout = "";
     let stderr = "";

--- a/scripts/mcp-agent-smoke.mjs
+++ b/scripts/mcp-agent-smoke.mjs
@@ -10,8 +10,8 @@
  * Studio is started with OLIVE_JOB_SETUP_STUB=1 so submits never download models
  * or run Olive (AGENTS.md: no real Olive execute in CI/VM).
  *
- * Mcporter is installed once into a temp prefix, then invoked via
- * `node <cli> …` with `shell: false` so Windows does not strip quotes from
+ * Mcporter is installed once into a unique temp prefix (mkdtemp), then invoked
+ * via `node <cli> …` with `shell: false` so Windows does not strip quotes from
  * `--args` JSON (npx+cmd was corrupting submit payloads).
  *
  * Usage (repo root):
@@ -60,53 +60,72 @@ const STRICT = process.env.MCP_SMOKE_STRICT === "1";
 let mcporterCliPath = /** @type {string | null} */ (null);
 
 /**
- * Install pinned mcporter into a stable temp prefix and return its CLI entry.
+ * Install pinned mcporter into a unique per-run temp prefix and return its CLI.
  * Invocations then use `process.execPath` with `shell: false` so `--args` JSON
  * is not stripped by cmd.exe (which is what breaks submit on Windows).
+ * Uses mkdtempSync so concurrent smokes never share a half-installed tree.
  * @returns {string}
  */
 function ensureMcporterCli() {
   if (mcporterCliPath) return mcporterCliPath;
-  const pinDir = path.join(
-    tmpdir(),
-    `olive-studio-${MCPORTER.replace(/[^a-zA-Z0-9._-]+/g, "-")}`,
-  );
+  const pinDir = mkdtempSync(path.join(tmpdir(), "olive-studio-mcporter-"));
   const cli = path.join(pinDir, "node_modules", "mcporter", "dist", "cli.js");
-  if (!existsSync(cli)) {
-    mkdirSync(pinDir, { recursive: true });
-    // One-time prefix install may need shell on Windows for npm.cmd only.
-    const npmCmd = process.platform === "win32" ? "npm.cmd" : "npm";
-    const install = spawnSync(
-      npmCmd,
-      [
-        "install",
-        "--prefix",
-        pinDir,
-        MCPORTER,
-        "--no-save",
-        "--no-package-lock",
-        "--no-fund",
-        "--no-audit",
-        "--loglevel=error",
-      ],
-      {
-        encoding: "utf8",
-        timeout: 180_000,
-        shell: process.platform === "win32",
-        env: { ...process.env },
-      },
-    );
-    if (install.status !== 0) {
-      throw new Error(
-        `failed to install ${MCPORTER}: ${(install.stderr || install.stdout || "").slice(0, 800)}`,
-      );
+  // Fresh dir: install may need shell on Windows for npm.cmd only.
+  const npmCmd = process.platform === "win32" ? "npm.cmd" : "npm";
+  const install = spawnSync(
+    npmCmd,
+    [
+      "install",
+      "--prefix",
+      pinDir,
+      MCPORTER,
+      "--no-save",
+      "--no-package-lock",
+      "--no-fund",
+      "--no-audit",
+      "--loglevel=error",
+    ],
+    {
+      encoding: "utf8",
+      timeout: 180_000,
+      shell: process.platform === "win32",
+      env: { ...process.env },
+    },
+  );
+  if (install.status !== 0) {
+    try {
+      rmSync(pinDir, { recursive: true, force: true });
+    } catch {
+      /* best-effort */
     }
+    throw new Error(
+      `failed to install ${MCPORTER}: ${(install.stderr || install.stdout || "").slice(0, 800)}`,
+    );
   }
   if (!existsSync(cli)) {
+    try {
+      rmSync(pinDir, { recursive: true, force: true });
+    } catch {
+      /* best-effort */
+    }
     throw new Error(`mcporter CLI missing after install: ${cli}`);
   }
   mcporterCliPath = cli;
   return cli;
+}
+
+/**
+ * Resolve the pinned CLI, append `--config`, and log the invocation banner.
+ * @param {string[]} args mcporter argv (without node/cli/`--config`)
+ * @returns {{ cli: string, full: string[] }}
+ */
+function prepareMcporterInvocation(args) {
+  const cli = ensureMcporterCli();
+  const full = [...args, "--config", smokeConfigPath];
+  console.log(
+    `$ node ${path.basename(path.dirname(path.dirname(cli)))}/dist/cli.js ${full.join(" ")}`,
+  );
+  return { cli, full };
 }
 
 /**
@@ -115,9 +134,7 @@ function ensureMcporterCli() {
  */
 function runMcporterSync(args, opts = {}) {
   const { timeoutMs = 90_000, env = process.env, expectOk = true } = opts;
-  const cli = ensureMcporterCli();
-  const full = [...args, "--config", smokeConfigPath];
-  console.log(`$ node ${path.basename(path.dirname(path.dirname(cli)))}/dist/cli.js ${full.join(" ")}`);
+  const { cli, full } = prepareMcporterInvocation(args);
   const r = spawnSync(process.execPath, [cli, ...full], {
     cwd: root,
     encoding: "utf8",
@@ -251,11 +268,7 @@ function callToolAsync(selector, toolArgs, opts = {}) {
     args.push("--args", JSON.stringify(toolArgs));
   }
   args.push("--timeout", String(timeoutMs), "--output", "json");
-  const cli = ensureMcporterCli();
-  const full = [...args, "--config", smokeConfigPath];
-  console.log(
-    `$ node ${path.basename(path.dirname(path.dirname(cli)))}/dist/cli.js ${full.join(" ")}`,
-  );
+  const { cli, full } = prepareMcporterInvocation(args);
 
   return new Promise((resolve, reject) => {
     const child = spawn(process.execPath, [cli, ...full], {

--- a/scripts/mcp-agent-smoke.mjs
+++ b/scripts/mcp-agent-smoke.mjs
@@ -609,6 +609,7 @@ async function cleanup() {
 function failExitCode(signal) {
   if (signal === "SIGINT") return 130;
   if (signal === "SIGTERM") return 143;
+  if (signal === "SIGHUP") return 129;
   return STRICT ? 1 : 0;
 }
 

--- a/scripts/studioConfigSmokeLock.mjs
+++ b/scripts/studioConfigSmokeLock.mjs
@@ -147,7 +147,10 @@ export async function acquireStudioConfigSmokeLock(lockPath, deps = {}) {
       const code = e && typeof e === "object" && "code" in e ? e.code : undefined;
       if (code !== "EEXIST") throw e;
       try {
-        const holder = parsePublishedLockPid(read(lockPath, "utf8"));
+        // Snapshot the exact bytes we classified. Concurrent reclaim must only
+        // unlink that same body — never a peer's newly published PID lock.
+        const observed = read(lockPath, "utf8");
+        const holder = parsePublishedLockPid(observed);
         // Incomplete bodies (empty, partial digits, parseInt prefixes) may mean
         // a concurrent publisher is still writing. Only reclaim after grace.
         // Fully published finite dead PIDs reclaim immediately.
@@ -165,8 +168,13 @@ export async function acquireStudioConfigSmokeLock(lockPath, deps = {}) {
         // cannot busy-spin.
         if (reclaimable) {
           try {
-            unlink(lockPath);
-            continue;
+            const still = read(lockPath, "utf8");
+            if (still !== observed) {
+              /* peer replaced the lock between classify and reclaim */
+            } else {
+              unlink(lockPath);
+              continue;
+            }
           } catch {
             /* lost race / still held — fall through to poll */
           }

--- a/scripts/studioConfigSmokeLock.mjs
+++ b/scripts/studioConfigSmokeLock.mjs
@@ -108,10 +108,10 @@ function publishLockFile(lockPath, body, deps) {
  *
  * - Complete PID + alive: leave alone (active reclaimer).
  * - Complete PID + dead: clear (crashed after publishing ownership).
- * - Incomplete body: clear only after publishGraceMs (crashed mid-write orphan).
- *   Fresh incomplete markers are left alone so a concurrent writer is not
- *   stripped mid-publish; reclaimers still re-verify gate ownership before
- *   unlinking the main lock.
+ * - Incomplete body: clear only after publishGraceMs (crash orphan). Safe for
+ *   live publishers because the gate is published via temp+link (or exclusive
+ *   full-body `wx` fallback), so `reclaimPath` never appears incomplete while
+ *   a live owner still holds the critical section.
  * @param {string} reclaimPath
  * @param {{
  *   readFileSync: typeof readFileSync,
@@ -155,6 +155,7 @@ function tryClearOrphanedReclaimMutex(reclaimPath, deps) {
  * @param {number} myPid
  * @param {{
  *   writeFileSync: typeof writeFileSync,
+ *   linkSync: typeof linkSync,
  *   readFileSync: typeof readFileSync,
  *   unlinkSync: typeof unlinkSync,
  *   mkdirSync: typeof mkdirSync,
@@ -162,12 +163,14 @@ function tryClearOrphanedReclaimMutex(reclaimPath, deps) {
  *   isProcessAlive: (pid: number) => boolean,
  *   now: () => number,
  *   publishGraceMs: number,
+ *   randomId: () => string,
  * }} deps
  * @returns {boolean}
  */
 function tryReclaimObservedLock(lockPath, observed, myPid, deps) {
   const {
     writeFileSync: write,
+    linkSync: link,
     readFileSync: read,
     unlinkSync: unlink,
     mkdirSync: mkdir,
@@ -175,23 +178,25 @@ function tryReclaimObservedLock(lockPath, observed, myPid, deps) {
     isProcessAlive: alive,
     now,
     publishGraceMs,
+    randomId,
   } = deps;
   const reclaimPath = `${lockPath}.reclaim`;
 
   const ownsReclaimGate = () => parsePublishedLockPid(read(reclaimPath, "utf8")) === myPid;
 
   const tryAcquireReclaimGate = () => {
-    try {
-      write(reclaimPath, `${myPid}\n`, { flag: "wx" });
-      return true;
-    } catch (e) {
-      if (errorCode(e) === "ENOENT") {
-        mkdir(path.dirname(lockPath), { recursive: true });
-        write(reclaimPath, `${myPid}\n`, { flag: "wx" });
-        return true;
-      }
-      throw e;
-    }
+    const tempPath = path.join(
+      path.dirname(reclaimPath),
+      `.${path.basename(reclaimPath)}.${myPid}.${randomId()}.tmp`,
+    );
+    publishLockFile(reclaimPath, `${myPid}\n`, {
+      writeFileSync: write,
+      linkSync: link,
+      unlinkSync: unlink,
+      mkdirSync: mkdir,
+      tempPath,
+    });
+    return true;
   };
 
   try {
@@ -329,12 +334,14 @@ export async function acquireStudioConfigSmokeLock(lockPath, deps = {}) {
             /* unable to establish age — leave the lock in place */
           }
         }
-        // Serialize reclaimers via lockPath.reclaim (wx). Only skip the poll
-        // sleep after unlink succeeds so failed reclaim cannot busy-spin.
+        // Serialize reclaimers via lockPath.reclaim (temp+link publish). Only
+        // skip the poll sleep after unlink succeeds so failed reclaim cannot
+        // busy-spin.
         if (
           reclaimable &&
           tryReclaimObservedLock(lockPath, observed, myPid, {
             writeFileSync: write,
+            linkSync: link,
             readFileSync: read,
             unlinkSync: unlink,
             mkdirSync: mkdir,
@@ -342,6 +349,7 @@ export async function acquireStudioConfigSmokeLock(lockPath, deps = {}) {
             isProcessAlive: alive,
             now,
             publishGraceMs,
+            randomId,
           })
         ) {
           continue;

--- a/scripts/studioConfigSmokeLock.mjs
+++ b/scripts/studioConfigSmokeLock.mjs
@@ -4,9 +4,7 @@
  * allowJobSubmission / cancellation policy patches.
  */
 import {
-  closeSync,
   mkdirSync,
-  openSync,
   readFileSync,
   rmdirSync,
   statSync,
@@ -32,8 +30,6 @@ export function isProcessAlive(pid) {
 /**
  * @param {string} lockPath
  * @param {{
- *   openSync?: typeof openSync,
- *   closeSync?: typeof closeSync,
  *   writeFileSync?: typeof writeFileSync,
  *   readFileSync?: typeof readFileSync,
  *   statSync?: typeof statSync,
@@ -43,13 +39,16 @@ export function isProcessAlive(pid) {
  *   pid?: number,
  *   timeoutMs?: number,
  *   pollMs?: number,
+ *   publishGraceMs?: number,
  *   sleep?: (ms: number) => Promise<void>,
+ *   now?: () => number,
  * }} [deps]
  * @returns {Promise<{ release: () => void }>}
  */
 export async function acquireStudioConfigSmokeLock(lockPath, deps = {}) {
-  const open = deps.openSync ?? openSync;
-  const close = deps.closeSync ?? closeSync;
+  // Atomic create+publish: write PID with O_EXCL so waiters never observe an
+  // empty live lock from this process. Malformed bodies still get a grace
+  // window for abandoned mid-write files from older crash paths.
   const write = deps.writeFileSync ?? writeFileSync;
   const read = deps.readFileSync ?? readFileSync;
   const stat = deps.statSync ?? statSync;
@@ -59,20 +58,17 @@ export async function acquireStudioConfigSmokeLock(lockPath, deps = {}) {
   const myPid = deps.pid ?? process.pid;
   const timeoutMs = deps.timeoutMs ?? 120_000;
   const pollMs = deps.pollMs ?? 250;
+  const publishGraceMs = deps.publishGraceMs ?? Math.max(1_000, pollMs * 4);
+  const now = deps.now ?? Date.now;
   const sleep =
     deps.sleep ?? ((ms) => new Promise((resolve) => setTimeout(resolve, ms)));
 
   mkdir(path.dirname(lockPath), { recursive: true });
-  const deadline = Date.now() + timeoutMs;
+  const deadline = now() + timeoutMs;
 
-  while (Date.now() < deadline) {
+  while (now() < deadline) {
     try {
-      const fd = open(lockPath, "wx");
-      try {
-        write(fd, `${myPid}\n`);
-      } finally {
-        close(fd);
-      }
+      write(lockPath, `${myPid}\n`, { flag: "wx" });
       return {
         release() {
           try {
@@ -90,15 +86,14 @@ export async function acquireStudioConfigSmokeLock(lockPath, deps = {}) {
       try {
         const body = read(lockPath, "utf8");
         const holder = Number.parseInt(String(body).trim().split(/\r?\n/)[0] ?? "", 10);
-        // A freshly-created lock can be temporarily empty before its creator
-        // writes the PID. Give malformed locks a grace period before reclaiming
-        // them, while still reclaiming dead finite holders immediately.
+        // Fresh empty/malformed bodies can mean "writer still publishing" (legacy
+        // open-then-write callers / crash mid-write). Only reclaim after grace.
         const malformed = !Number.isFinite(holder);
         let reclaimable = !malformed && !alive(holder);
         if (malformed) {
           try {
-            const ageMs = Date.now() - stat(lockPath).mtimeMs;
-            reclaimable = ageMs >= Math.max(1_000, pollMs * 4);
+            const ageMs = now() - stat(lockPath).mtimeMs;
+            reclaimable = ageMs >= publishGraceMs;
           } catch {
             /* unable to establish age — leave the lock in place */
           }

--- a/scripts/studioConfigSmokeLock.mjs
+++ b/scripts/studioConfigSmokeLock.mjs
@@ -9,6 +9,7 @@ import {
   openSync,
   readFileSync,
   rmdirSync,
+  statSync,
   unlinkSync,
   writeFileSync,
 } from "node:fs";
@@ -35,6 +36,7 @@ export function isProcessAlive(pid) {
  *   closeSync?: typeof closeSync,
  *   writeFileSync?: typeof writeFileSync,
  *   readFileSync?: typeof readFileSync,
+ *   statSync?: typeof statSync,
  *   unlinkSync?: typeof unlinkSync,
  *   mkdirSync?: typeof mkdirSync,
  *   isProcessAlive?: (pid: number) => boolean,
@@ -50,6 +52,7 @@ export async function acquireStudioConfigSmokeLock(lockPath, deps = {}) {
   const close = deps.closeSync ?? closeSync;
   const write = deps.writeFileSync ?? writeFileSync;
   const read = deps.readFileSync ?? readFileSync;
+  const stat = deps.statSync ?? statSync;
   const unlink = deps.unlinkSync ?? unlinkSync;
   const mkdir = deps.mkdirSync ?? mkdirSync;
   const alive = deps.isProcessAlive ?? isProcessAlive;
@@ -87,9 +90,21 @@ export async function acquireStudioConfigSmokeLock(lockPath, deps = {}) {
       try {
         const body = read(lockPath, "utf8");
         const holder = Number.parseInt(String(body).trim().split(/\r?\n/)[0] ?? "", 10);
-        // Empty/malformed bodies and dead holders are reclaimable. Only skip the
-        // poll sleep after unlink succeeds so failed reclaim cannot busy-spin.
-        const reclaimable = !Number.isFinite(holder) || !alive(holder);
+        // A freshly-created lock can be temporarily empty before its creator
+        // writes the PID. Give malformed locks a grace period before reclaiming
+        // them, while still reclaiming dead finite holders immediately.
+        const malformed = !Number.isFinite(holder);
+        let reclaimable = !malformed && !alive(holder);
+        if (malformed) {
+          try {
+            const ageMs = Date.now() - stat(lockPath).mtimeMs;
+            reclaimable = ageMs >= Math.max(1_000, pollMs * 4);
+          } catch {
+            /* unable to establish age — leave the lock in place */
+          }
+        }
+        // Only skip the poll sleep after unlink succeeds so failed reclaim
+        // cannot busy-spin.
         if (reclaimable) {
           try {
             unlink(lockPath);

--- a/scripts/studioConfigSmokeLock.mjs
+++ b/scripts/studioConfigSmokeLock.mjs
@@ -53,14 +53,15 @@ function errorCode(err) {
 }
 
 /**
- * Publish a fully-written lock file at `lockPath` without an empty-body window.
+ * Publish a fully-written lock file at `lockPath` without replacing a live peer.
  * Prefer hard-linking a temp file (link fails with EEXIST and never overwrites).
- * When hardlinks are unsupported, `renameSync` the already-complete temp onto
- * `lockPath` so the final pathname never exists with a partial body (unlike
- * `copyFile` / `wx` writes, which create the dest then stream bytes).
  *
- * Note: on POSIX, rename replaces an existing dest; exclusivity still relies on
- * hardlinks when available. On Windows, rename fails if dest exists (exclusive).
+ * When hardlinks are unsupported:
+ * - Windows: `renameSync` of the complete temp (fails if dest exists; dest appears
+ *   only with already-complete bytes).
+ * - POSIX: exclusive `write(..., { flag: "wx" })` of the full body. Never use
+ *   rename here — POSIX rename replaces an existing dest and would steal a live
+ *   peer lock.
  *
  * @param {string} lockPath
  * @param {string} body
@@ -71,6 +72,7 @@ function errorCode(err) {
  *   unlinkSync: typeof unlinkSync,
  *   mkdirSync: typeof mkdirSync,
  *   tempPath: string,
+ *   platform?: NodeJS.Platform,
  * }} deps
  */
 function publishLockFile(lockPath, body, deps) {
@@ -81,6 +83,7 @@ function publishLockFile(lockPath, body, deps) {
     unlinkSync: unlink,
     mkdirSync: mkdir,
     tempPath,
+    platform = process.platform,
   } = deps;
 
   const attempt = () => {
@@ -92,9 +95,14 @@ function publishLockFile(lockPath, body, deps) {
       } catch (e) {
         const code = errorCode(e);
         if (code === "EEXIST") throw e;
-        // ENOTSUP / EPERM / EINVAL / EXDEV: dest appears only with complete bytes.
-        rename(tempPath, lockPath);
-        return;
+        // ENOTSUP / EPERM / EINVAL / EXDEV
+        if (platform === "win32") {
+          // Exclusive on Windows; dest appears with complete temp bytes.
+          rename(tempPath, lockPath);
+          return;
+        }
+        // POSIX rename would overwrite a live peer — refuse that.
+        write(lockPath, body, { flag: "wx" });
       }
     } finally {
       try {
@@ -122,9 +130,8 @@ function publishLockFile(lockPath, body, deps) {
  * - Complete PID + alive: leave alone (active reclaimer).
  * - Complete PID + dead: clear (crashed after publishing ownership).
  * - Incomplete body: clear only after publishGraceMs (crash orphan). Safe for
- *   live publishers because the gate is published via temp+link (or rename of a
- *   fully written temp), so `reclaimPath` never appears with a partial body while
- *   a live owner is still copying into it.
+ *   live publishers on the hardlink / Windows-rename paths (final path never
+ *   appears mid-stream). POSIX `wx` fallback is exclusive (never steals a peer).
  * @param {string} reclaimPath
  * @param {{
  *   readFileSync: typeof readFileSync,
@@ -178,6 +185,7 @@ function tryClearOrphanedReclaimMutex(reclaimPath, deps) {
  *   now: () => number,
  *   publishGraceMs: number,
  *   randomId: () => string,
+ *   platform: NodeJS.Platform,
  * }} deps
  * @returns {boolean}
  */
@@ -194,6 +202,7 @@ function tryReclaimObservedLock(lockPath, observed, myPid, deps) {
     now,
     publishGraceMs,
     randomId,
+    platform,
   } = deps;
   const reclaimPath = `${lockPath}.reclaim`;
 
@@ -211,6 +220,7 @@ function tryReclaimObservedLock(lockPath, observed, myPid, deps) {
       unlinkSync: unlink,
       mkdirSync: mkdir,
       tempPath,
+      platform,
     });
     return true;
   };
@@ -272,6 +282,7 @@ function tryReclaimObservedLock(lockPath, observed, myPid, deps) {
  *   sleep?: (ms: number) => Promise<void>,
  *   now?: () => number,
  *   randomId?: () => string,
+ *   platform?: NodeJS.Platform,
  * }} [deps]
  * @returns {Promise<{ release: () => void }>}
  */
@@ -290,6 +301,7 @@ export async function acquireStudioConfigSmokeLock(lockPath, deps = {}) {
   const publishGraceMs = deps.publishGraceMs ?? Math.max(1_000, pollMs * 4);
   const now = deps.now ?? Date.now;
   const randomId = deps.randomId ?? (() => randomBytes(6).toString("hex"));
+  const platform = deps.platform ?? process.platform;
   const sleep =
     deps.sleep ?? ((ms) => new Promise((resolve) => setTimeout(resolve, ms)));
 
@@ -310,6 +322,7 @@ export async function acquireStudioConfigSmokeLock(lockPath, deps = {}) {
         unlinkSync: unlink,
         mkdirSync: mkdir,
         tempPath,
+        platform,
       });
       // Lost reclaim race? Another owner may have replaced the path after we linked.
       const published = parsePublishedLockPid(read(lockPath, "utf8"));
@@ -370,6 +383,7 @@ export async function acquireStudioConfigSmokeLock(lockPath, deps = {}) {
             now,
             publishGraceMs,
             randomId,
+            platform,
           })
         ) {
           continue;

--- a/scripts/studioConfigSmokeLock.mjs
+++ b/scripts/studioConfigSmokeLock.mjs
@@ -5,11 +5,10 @@
  */
 import { randomBytes } from "node:crypto";
 import {
-  constants as fsConstants,
-  copyFileSync,
   linkSync,
   mkdirSync,
   readFileSync,
+  renameSync,
   rmdirSync,
   statSync,
   unlinkSync,
@@ -56,16 +55,19 @@ function errorCode(err) {
 /**
  * Publish a fully-written lock file at `lockPath` without an empty-body window.
  * Prefer hard-linking a temp file (link fails with EEXIST and never overwrites).
- * When hardlinks are unsupported, exclusively copy the already-complete temp
- * file (`COPYFILE_EXCL`) so the final pathname never receives a streaming
- * `wx` write that could expose an incomplete body to concurrent reclaimers.
+ * When hardlinks are unsupported, `renameSync` the already-complete temp onto
+ * `lockPath` so the final pathname never exists with a partial body (unlike
+ * `copyFile` / `wx` writes, which create the dest then stream bytes).
+ *
+ * Note: on POSIX, rename replaces an existing dest; exclusivity still relies on
+ * hardlinks when available. On Windows, rename fails if dest exists (exclusive).
  *
  * @param {string} lockPath
  * @param {string} body
  * @param {{
  *   writeFileSync: typeof writeFileSync,
  *   linkSync: typeof linkSync,
- *   copyFileSync?: typeof copyFileSync,
+ *   renameSync?: typeof renameSync,
  *   unlinkSync: typeof unlinkSync,
  *   mkdirSync: typeof mkdirSync,
  *   tempPath: string,
@@ -75,7 +77,7 @@ function publishLockFile(lockPath, body, deps) {
   const {
     writeFileSync: write,
     linkSync: link,
-    copyFileSync: copyFile = copyFileSync,
+    renameSync: rename = renameSync,
     unlinkSync: unlink,
     mkdirSync: mkdir,
     tempPath,
@@ -90,15 +92,15 @@ function publishLockFile(lockPath, body, deps) {
       } catch (e) {
         const code = errorCode(e);
         if (code === "EEXIST") throw e;
-        // ENOTSUP / EPERM / EINVAL / EXDEV: publish the complete temp bytes
-        // exclusively without a partial write at the final path.
-        copyFile(tempPath, lockPath, fsConstants.COPYFILE_EXCL);
+        // ENOTSUP / EPERM / EINVAL / EXDEV: dest appears only with complete bytes.
+        rename(tempPath, lockPath);
+        return;
       }
     } finally {
       try {
         unlink(tempPath);
       } catch {
-        /* temp already gone */
+        /* temp already moved or gone */
       }
     }
   };
@@ -120,9 +122,9 @@ function publishLockFile(lockPath, body, deps) {
  * - Complete PID + alive: leave alone (active reclaimer).
  * - Complete PID + dead: clear (crashed after publishing ownership).
  * - Incomplete body: clear only after publishGraceMs (crash orphan). Safe for
- *   live publishers because the gate is published via temp+link (or exclusive
- *   full-body `wx` fallback), so `reclaimPath` never appears incomplete while
- *   a live owner still holds the critical section.
+ *   live publishers because the gate is published via temp+link (or rename of a
+ *   fully written temp), so `reclaimPath` never appears with a partial body while
+ *   a live owner is still copying into it.
  * @param {string} reclaimPath
  * @param {{
  *   readFileSync: typeof readFileSync,
@@ -167,7 +169,7 @@ function tryClearOrphanedReclaimMutex(reclaimPath, deps) {
  * @param {{
  *   writeFileSync: typeof writeFileSync,
  *   linkSync: typeof linkSync,
- *   copyFileSync: typeof copyFileSync,
+ *   renameSync: typeof renameSync,
  *   readFileSync: typeof readFileSync,
  *   unlinkSync: typeof unlinkSync,
  *   mkdirSync: typeof mkdirSync,
@@ -183,7 +185,7 @@ function tryReclaimObservedLock(lockPath, observed, myPid, deps) {
   const {
     writeFileSync: write,
     linkSync: link,
-    copyFileSync: copyFile,
+    renameSync: rename,
     readFileSync: read,
     unlinkSync: unlink,
     mkdirSync: mkdir,
@@ -204,7 +206,7 @@ function tryReclaimObservedLock(lockPath, observed, myPid, deps) {
     );
     publishLockFile(reclaimPath, `${myPid}\n`, {
       writeFileSync: write,
-      copyFileSync: copyFile,
+      renameSync: rename,
       linkSync: link,
       unlinkSync: unlink,
       mkdirSync: mkdir,
@@ -257,7 +259,7 @@ function tryReclaimObservedLock(lockPath, observed, myPid, deps) {
  * @param {{
  *   writeFileSync?: typeof writeFileSync,
  *   linkSync?: typeof linkSync,
- *   copyFileSync?: typeof copyFileSync,
+ *   renameSync?: typeof renameSync,
  *   readFileSync?: typeof readFileSync,
  *   statSync?: typeof statSync,
  *   unlinkSync?: typeof unlinkSync,
@@ -276,7 +278,7 @@ function tryReclaimObservedLock(lockPath, observed, myPid, deps) {
 export async function acquireStudioConfigSmokeLock(lockPath, deps = {}) {
   const write = deps.writeFileSync ?? writeFileSync;
   const link = deps.linkSync ?? linkSync;
-  const copyFile = deps.copyFileSync ?? copyFileSync;
+  const rename = deps.renameSync ?? renameSync;
   const read = deps.readFileSync ?? readFileSync;
   const stat = deps.statSync ?? statSync;
   const unlink = deps.unlinkSync ?? unlinkSync;
@@ -304,7 +306,7 @@ export async function acquireStudioConfigSmokeLock(lockPath, deps = {}) {
       publishLockFile(lockPath, body, {
         writeFileSync: write,
         linkSync: link,
-        copyFileSync: copyFile,
+        renameSync: rename,
         unlinkSync: unlink,
         mkdirSync: mkdir,
         tempPath,
@@ -359,7 +361,7 @@ export async function acquireStudioConfigSmokeLock(lockPath, deps = {}) {
           tryReclaimObservedLock(lockPath, observed, myPid, {
             writeFileSync: write,
             linkSync: link,
-            copyFileSync: copyFile,
+            renameSync: rename,
             readFileSync: read,
             unlinkSync: unlink,
             mkdirSync: mkdir,

--- a/scripts/studioConfigSmokeLock.mjs
+++ b/scripts/studioConfigSmokeLock.mjs
@@ -9,7 +9,6 @@ import {
   mkdirSync,
   readFileSync,
   rmdirSync,
-  statSync,
   unlinkSync,
   writeFileSync,
 } from "node:fs";
@@ -57,6 +56,8 @@ function errorCode(err) {
  * When hardlinks are unsupported, exclusive `write(..., { flag: "wx" })` of the
  * full body (all platforms). Never rename onto the final path — POSIX rename
  * replaces an existing dest, and a guarded exists-check would be TOCTOU.
+ * Incomplete bodies at the final path are never age-reclaimed (a paused wx
+ * publisher must keep exclusivity until timeout).
  *
  * @param {string} lockPath
  * @param {string} body
@@ -114,16 +115,14 @@ function publishLockFile(lockPath, body, deps) {
  *
  * - Complete PID + alive: leave alone (active reclaimer).
  * - Complete PID + dead: clear (crashed after publishing ownership).
- * - Incomplete body: clear only after publishGraceMs (crash orphan). Live
- *   publishers prefer temp+link (complete at appear); wx fallback is exclusive.
+ * - Incomplete body: never clear. A live `wx` publisher may be paused mid-write
+ *   past `publishGraceMs`; age-clearing would steal the name and break exclusivity.
+ *   Smokers wait out `timeoutMs` instead.
  * @param {string} reclaimPath
  * @param {{
  *   readFileSync: typeof readFileSync,
  *   unlinkSync: typeof unlinkSync,
- *   statSync: typeof statSync,
  *   isProcessAlive: (pid: number) => boolean,
- *   now: () => number,
- *   publishGraceMs: number,
  * }} deps
  * @returns {boolean}
  */
@@ -131,20 +130,13 @@ function tryClearOrphanedReclaimMutex(reclaimPath, deps) {
   const {
     readFileSync: read,
     unlinkSync: unlink,
-    statSync: stat,
     isProcessAlive: alive,
-    now,
-    publishGraceMs,
   } = deps;
   try {
     const holder = parsePublishedLockPid(read(reclaimPath, "utf8"));
-    if (holder != null) {
-      if (alive(holder)) return false;
-      unlink(reclaimPath);
-      return true;
-    }
-    const ageMs = now() - stat(reclaimPath).mtimeMs;
-    if (ageMs < publishGraceMs) return false;
+    // Incomplete: leave in place (may be a delayed live wx publish).
+    if (holder == null) return false;
+    if (alive(holder)) return false;
     unlink(reclaimPath);
     return true;
   } catch {
@@ -163,10 +155,7 @@ function tryClearOrphanedReclaimMutex(reclaimPath, deps) {
  *   readFileSync: typeof readFileSync,
  *   unlinkSync: typeof unlinkSync,
  *   mkdirSync: typeof mkdirSync,
- *   statSync: typeof statSync,
  *   isProcessAlive: (pid: number) => boolean,
- *   now: () => number,
- *   publishGraceMs: number,
  *   randomId: () => string,
  * }} deps
  * @returns {boolean}
@@ -178,10 +167,7 @@ function tryReclaimObservedLock(lockPath, observed, myPid, deps) {
     readFileSync: read,
     unlinkSync: unlink,
     mkdirSync: mkdir,
-    statSync: stat,
     isProcessAlive: alive,
-    now,
-    publishGraceMs,
     randomId,
   } = deps;
   const reclaimPath = `${lockPath}.reclaim`;
@@ -209,10 +195,7 @@ function tryReclaimObservedLock(lockPath, observed, myPid, deps) {
     const cleared = tryClearOrphanedReclaimMutex(reclaimPath, {
       readFileSync: read,
       unlinkSync: unlink,
-      statSync: stat,
       isProcessAlive: alive,
-      now,
-      publishGraceMs,
     });
     if (!cleared) return false;
     try {
@@ -247,14 +230,12 @@ function tryReclaimObservedLock(lockPath, observed, myPid, deps) {
  *   writeFileSync?: typeof writeFileSync,
  *   linkSync?: typeof linkSync,
  *   readFileSync?: typeof readFileSync,
- *   statSync?: typeof statSync,
  *   unlinkSync?: typeof unlinkSync,
  *   mkdirSync?: typeof mkdirSync,
  *   isProcessAlive?: (pid: number) => boolean,
  *   pid?: number,
  *   timeoutMs?: number,
  *   pollMs?: number,
- *   publishGraceMs?: number,
  *   sleep?: (ms: number) => Promise<void>,
  *   now?: () => number,
  *   randomId?: () => string,
@@ -265,14 +246,12 @@ export async function acquireStudioConfigSmokeLock(lockPath, deps = {}) {
   const write = deps.writeFileSync ?? writeFileSync;
   const link = deps.linkSync ?? linkSync;
   const read = deps.readFileSync ?? readFileSync;
-  const stat = deps.statSync ?? statSync;
   const unlink = deps.unlinkSync ?? unlinkSync;
   const mkdir = deps.mkdirSync ?? mkdirSync;
   const alive = deps.isProcessAlive ?? isProcessAlive;
   const myPid = deps.pid ?? process.pid;
   const timeoutMs = deps.timeoutMs ?? 120_000;
   const pollMs = deps.pollMs ?? 250;
-  const publishGraceMs = deps.publishGraceMs ?? Math.max(1_000, pollMs * 4);
   const now = deps.now ?? Date.now;
   const randomId = deps.randomId ?? (() => randomBytes(6).toString("hex"));
   const sleep =
@@ -324,19 +303,11 @@ export async function acquireStudioConfigSmokeLock(lockPath, deps = {}) {
         // unlink that same body — never a peer's newly published PID lock.
         const observed = read(lockPath, "utf8");
         const holder = parsePublishedLockPid(observed);
-        // Incomplete bodies (empty, partial digits, parseInt prefixes) may mean
-        // a concurrent publisher is still writing. Only reclaim after grace.
+        // Incomplete bodies (empty, partial digits) may be a live wx publish.
+        // Never age-reclaim them — peers wait out timeoutMs instead.
         // Fully published finite dead PIDs reclaim immediately.
         const incomplete = holder == null;
-        let reclaimable = !incomplete && !alive(holder);
-        if (incomplete) {
-          try {
-            const ageMs = now() - stat(lockPath).mtimeMs;
-            reclaimable = ageMs >= publishGraceMs;
-          } catch {
-            /* unable to establish age — leave the lock in place */
-          }
-        }
+        const reclaimable = !incomplete && !alive(holder);
         // Serialize reclaimers via lockPath.reclaim (temp+link publish). Only
         // skip the poll sleep after unlink succeeds so failed reclaim cannot
         // busy-spin.
@@ -348,10 +319,7 @@ export async function acquireStudioConfigSmokeLock(lockPath, deps = {}) {
             readFileSync: read,
             unlinkSync: unlink,
             mkdirSync: mkdir,
-            statSync: stat,
             isProcessAlive: alive,
-            now,
-            publishGraceMs,
             randomId,
           })
         ) {

--- a/scripts/studioConfigSmokeLock.mjs
+++ b/scripts/studioConfigSmokeLock.mjs
@@ -5,6 +5,8 @@
  */
 import { randomBytes } from "node:crypto";
 import {
+  constants as fsConstants,
+  copyFileSync,
   linkSync,
   mkdirSync,
   readFileSync,
@@ -54,22 +56,30 @@ function errorCode(err) {
 /**
  * Publish a fully-written lock file at `lockPath` without an empty-body window.
  * Prefer hard-linking a temp file (link fails with EEXIST and never overwrites).
- * Fall back to exclusive `write(..., { flag: "wx" })` of the same PID bytes when
- * hardlinks are unsupported.
+ * When hardlinks are unsupported, exclusively copy the already-complete temp
+ * file (`COPYFILE_EXCL`) so the final pathname never receives a streaming
+ * `wx` write that could expose an incomplete body to concurrent reclaimers.
  *
  * @param {string} lockPath
  * @param {string} body
  * @param {{
  *   writeFileSync: typeof writeFileSync,
  *   linkSync: typeof linkSync,
+ *   copyFileSync?: typeof copyFileSync,
  *   unlinkSync: typeof unlinkSync,
  *   mkdirSync: typeof mkdirSync,
  *   tempPath: string,
  * }} deps
  */
 function publishLockFile(lockPath, body, deps) {
-  const { writeFileSync: write, linkSync: link, unlinkSync: unlink, mkdirSync: mkdir, tempPath } =
-    deps;
+  const {
+    writeFileSync: write,
+    linkSync: link,
+    copyFileSync: copyFile = copyFileSync,
+    unlinkSync: unlink,
+    mkdirSync: mkdir,
+    tempPath,
+  } = deps;
 
   const attempt = () => {
     write(tempPath, body);
@@ -80,8 +90,9 @@ function publishLockFile(lockPath, body, deps) {
       } catch (e) {
         const code = errorCode(e);
         if (code === "EEXIST") throw e;
-        // ENOTSUP / EPERM / EINVAL / EXDEV: still publish full content exclusively.
-        write(lockPath, body, { flag: "wx" });
+        // ENOTSUP / EPERM / EINVAL / EXDEV: publish the complete temp bytes
+        // exclusively without a partial write at the final path.
+        copyFile(tempPath, lockPath, fsConstants.COPYFILE_EXCL);
       }
     } finally {
       try {
@@ -156,6 +167,7 @@ function tryClearOrphanedReclaimMutex(reclaimPath, deps) {
  * @param {{
  *   writeFileSync: typeof writeFileSync,
  *   linkSync: typeof linkSync,
+ *   copyFileSync: typeof copyFileSync,
  *   readFileSync: typeof readFileSync,
  *   unlinkSync: typeof unlinkSync,
  *   mkdirSync: typeof mkdirSync,
@@ -171,6 +183,7 @@ function tryReclaimObservedLock(lockPath, observed, myPid, deps) {
   const {
     writeFileSync: write,
     linkSync: link,
+    copyFileSync: copyFile,
     readFileSync: read,
     unlinkSync: unlink,
     mkdirSync: mkdir,
@@ -191,6 +204,7 @@ function tryReclaimObservedLock(lockPath, observed, myPid, deps) {
     );
     publishLockFile(reclaimPath, `${myPid}\n`, {
       writeFileSync: write,
+      copyFileSync: copyFile,
       linkSync: link,
       unlinkSync: unlink,
       mkdirSync: mkdir,
@@ -243,6 +257,7 @@ function tryReclaimObservedLock(lockPath, observed, myPid, deps) {
  * @param {{
  *   writeFileSync?: typeof writeFileSync,
  *   linkSync?: typeof linkSync,
+ *   copyFileSync?: typeof copyFileSync,
  *   readFileSync?: typeof readFileSync,
  *   statSync?: typeof statSync,
  *   unlinkSync?: typeof unlinkSync,
@@ -261,6 +276,7 @@ function tryReclaimObservedLock(lockPath, observed, myPid, deps) {
 export async function acquireStudioConfigSmokeLock(lockPath, deps = {}) {
   const write = deps.writeFileSync ?? writeFileSync;
   const link = deps.linkSync ?? linkSync;
+  const copyFile = deps.copyFileSync ?? copyFileSync;
   const read = deps.readFileSync ?? readFileSync;
   const stat = deps.statSync ?? statSync;
   const unlink = deps.unlinkSync ?? unlinkSync;
@@ -288,6 +304,7 @@ export async function acquireStudioConfigSmokeLock(lockPath, deps = {}) {
       publishLockFile(lockPath, body, {
         writeFileSync: write,
         linkSync: link,
+        copyFileSync: copyFile,
         unlinkSync: unlink,
         mkdirSync: mkdir,
         tempPath,
@@ -342,6 +359,7 @@ export async function acquireStudioConfigSmokeLock(lockPath, deps = {}) {
           tryReclaimObservedLock(lockPath, observed, myPid, {
             writeFileSync: write,
             linkSync: link,
+            copyFileSync: copyFile,
             readFileSync: read,
             unlinkSync: unlink,
             mkdirSync: mkdir,

--- a/scripts/studioConfigSmokeLock.mjs
+++ b/scripts/studioConfigSmokeLock.mjs
@@ -8,7 +8,6 @@ import {
   linkSync,
   mkdirSync,
   readFileSync,
-  renameSync,
   rmdirSync,
   statSync,
   unlinkSync,
@@ -55,35 +54,27 @@ function errorCode(err) {
 /**
  * Publish a fully-written lock file at `lockPath` without replacing a live peer.
  * Prefer hard-linking a temp file (link fails with EEXIST and never overwrites).
- *
- * When hardlinks are unsupported:
- * - Windows: `renameSync` of the complete temp (fails if dest exists; dest appears
- *   only with already-complete bytes).
- * - POSIX: exclusive `write(..., { flag: "wx" })` of the full body. Never use
- *   rename here — POSIX rename replaces an existing dest and would steal a live
- *   peer lock.
+ * When hardlinks are unsupported, exclusive `write(..., { flag: "wx" })` of the
+ * full body (all platforms). Never rename onto the final path — POSIX rename
+ * replaces an existing dest, and a guarded exists-check would be TOCTOU.
  *
  * @param {string} lockPath
  * @param {string} body
  * @param {{
  *   writeFileSync: typeof writeFileSync,
  *   linkSync: typeof linkSync,
- *   renameSync?: typeof renameSync,
  *   unlinkSync: typeof unlinkSync,
  *   mkdirSync: typeof mkdirSync,
  *   tempPath: string,
- *   platform?: NodeJS.Platform,
  * }} deps
  */
 function publishLockFile(lockPath, body, deps) {
   const {
     writeFileSync: write,
     linkSync: link,
-    renameSync: rename = renameSync,
     unlinkSync: unlink,
     mkdirSync: mkdir,
     tempPath,
-    platform = process.platform,
   } = deps;
 
   const attempt = () => {
@@ -95,20 +86,14 @@ function publishLockFile(lockPath, body, deps) {
       } catch (e) {
         const code = errorCode(e);
         if (code === "EEXIST") throw e;
-        // ENOTSUP / EPERM / EINVAL / EXDEV
-        if (platform === "win32") {
-          // Exclusive on Windows; dest appears with complete temp bytes.
-          rename(tempPath, lockPath);
-          return;
-        }
-        // POSIX rename would overwrite a live peer — refuse that.
+        // ENOTSUP / EPERM / EINVAL / EXDEV: exclusive create, never overwrite.
         write(lockPath, body, { flag: "wx" });
       }
     } finally {
       try {
         unlink(tempPath);
       } catch {
-        /* temp already moved or gone */
+        /* temp already gone */
       }
     }
   };
@@ -129,9 +114,8 @@ function publishLockFile(lockPath, body, deps) {
  *
  * - Complete PID + alive: leave alone (active reclaimer).
  * - Complete PID + dead: clear (crashed after publishing ownership).
- * - Incomplete body: clear only after publishGraceMs (crash orphan). Safe for
- *   live publishers on the hardlink / Windows-rename paths (final path never
- *   appears mid-stream). POSIX `wx` fallback is exclusive (never steals a peer).
+ * - Incomplete body: clear only after publishGraceMs (crash orphan). Live
+ *   publishers prefer temp+link (complete at appear); wx fallback is exclusive.
  * @param {string} reclaimPath
  * @param {{
  *   readFileSync: typeof readFileSync,
@@ -176,7 +160,6 @@ function tryClearOrphanedReclaimMutex(reclaimPath, deps) {
  * @param {{
  *   writeFileSync: typeof writeFileSync,
  *   linkSync: typeof linkSync,
- *   renameSync: typeof renameSync,
  *   readFileSync: typeof readFileSync,
  *   unlinkSync: typeof unlinkSync,
  *   mkdirSync: typeof mkdirSync,
@@ -185,7 +168,6 @@ function tryClearOrphanedReclaimMutex(reclaimPath, deps) {
  *   now: () => number,
  *   publishGraceMs: number,
  *   randomId: () => string,
- *   platform: NodeJS.Platform,
  * }} deps
  * @returns {boolean}
  */
@@ -193,7 +175,6 @@ function tryReclaimObservedLock(lockPath, observed, myPid, deps) {
   const {
     writeFileSync: write,
     linkSync: link,
-    renameSync: rename,
     readFileSync: read,
     unlinkSync: unlink,
     mkdirSync: mkdir,
@@ -202,31 +183,27 @@ function tryReclaimObservedLock(lockPath, observed, myPid, deps) {
     now,
     publishGraceMs,
     randomId,
-    platform,
   } = deps;
   const reclaimPath = `${lockPath}.reclaim`;
 
   const ownsReclaimGate = () => parsePublishedLockPid(read(reclaimPath, "utf8")) === myPid;
 
-  const tryAcquireReclaimGate = () => {
+  const acquireReclaimGate = () => {
     const tempPath = path.join(
       path.dirname(reclaimPath),
       `.${path.basename(reclaimPath)}.${myPid}.${randomId()}.tmp`,
     );
     publishLockFile(reclaimPath, `${myPid}\n`, {
       writeFileSync: write,
-      renameSync: rename,
       linkSync: link,
       unlinkSync: unlink,
       mkdirSync: mkdir,
       tempPath,
-      platform,
     });
-    return true;
   };
 
   try {
-    if (!tryAcquireReclaimGate()) return false;
+    acquireReclaimGate();
   } catch (e) {
     if (errorCode(e) !== "EEXIST") throw e;
     const cleared = tryClearOrphanedReclaimMutex(reclaimPath, {
@@ -239,7 +216,7 @@ function tryReclaimObservedLock(lockPath, observed, myPid, deps) {
     });
     if (!cleared) return false;
     try {
-      if (!tryAcquireReclaimGate()) return false;
+      acquireReclaimGate();
     } catch {
       return false;
     }
@@ -269,7 +246,6 @@ function tryReclaimObservedLock(lockPath, observed, myPid, deps) {
  * @param {{
  *   writeFileSync?: typeof writeFileSync,
  *   linkSync?: typeof linkSync,
- *   renameSync?: typeof renameSync,
  *   readFileSync?: typeof readFileSync,
  *   statSync?: typeof statSync,
  *   unlinkSync?: typeof unlinkSync,
@@ -282,14 +258,12 @@ function tryReclaimObservedLock(lockPath, observed, myPid, deps) {
  *   sleep?: (ms: number) => Promise<void>,
  *   now?: () => number,
  *   randomId?: () => string,
- *   platform?: NodeJS.Platform,
  * }} [deps]
  * @returns {Promise<{ release: () => void }>}
  */
 export async function acquireStudioConfigSmokeLock(lockPath, deps = {}) {
   const write = deps.writeFileSync ?? writeFileSync;
   const link = deps.linkSync ?? linkSync;
-  const rename = deps.renameSync ?? renameSync;
   const read = deps.readFileSync ?? readFileSync;
   const stat = deps.statSync ?? statSync;
   const unlink = deps.unlinkSync ?? unlinkSync;
@@ -301,7 +275,6 @@ export async function acquireStudioConfigSmokeLock(lockPath, deps = {}) {
   const publishGraceMs = deps.publishGraceMs ?? Math.max(1_000, pollMs * 4);
   const now = deps.now ?? Date.now;
   const randomId = deps.randomId ?? (() => randomBytes(6).toString("hex"));
-  const platform = deps.platform ?? process.platform;
   const sleep =
     deps.sleep ?? ((ms) => new Promise((resolve) => setTimeout(resolve, ms)));
 
@@ -318,11 +291,9 @@ export async function acquireStudioConfigSmokeLock(lockPath, deps = {}) {
       publishLockFile(lockPath, body, {
         writeFileSync: write,
         linkSync: link,
-        renameSync: rename,
         unlinkSync: unlink,
         mkdirSync: mkdir,
         tempPath,
-        platform,
       });
       // Lost reclaim race? Another owner may have replaced the path after we linked.
       const published = parsePublishedLockPid(read(lockPath, "utf8"));
@@ -374,7 +345,6 @@ export async function acquireStudioConfigSmokeLock(lockPath, deps = {}) {
           tryReclaimObservedLock(lockPath, observed, myPid, {
             writeFileSync: write,
             linkSync: link,
-            renameSync: rename,
             readFileSync: read,
             unlinkSync: unlink,
             mkdirSync: mkdir,
@@ -383,7 +353,6 @@ export async function acquireStudioConfigSmokeLock(lockPath, deps = {}) {
             now,
             publishGraceMs,
             randomId,
-            platform,
           })
         ) {
           continue;

--- a/scripts/studioConfigSmokeLock.mjs
+++ b/scripts/studioConfigSmokeLock.mjs
@@ -106,22 +106,41 @@ function publishLockFile(lockPath, body, deps) {
  * Drop an abandoned `lockPath.reclaim` gate so later smokers are not stuck
  * waiting for a dead owner's mutex forever.
  *
- * Only complete published PIDs that are no longer alive are cleared. Incomplete
- * / age-only reclaim bodies are left alone so a live reclaimer mid-critical-
- * section is never stripped of its mutex by a concurrent waiter.
+ * - Complete PID + alive: leave alone (active reclaimer).
+ * - Complete PID + dead: clear (crashed after publishing ownership).
+ * - Incomplete body: clear only after publishGraceMs (crashed mid-write orphan).
+ *   Fresh incomplete markers are left alone so a concurrent writer is not
+ *   stripped mid-publish; reclaimers still re-verify gate ownership before
+ *   unlinking the main lock.
  * @param {string} reclaimPath
  * @param {{
  *   readFileSync: typeof readFileSync,
  *   unlinkSync: typeof unlinkSync,
+ *   statSync: typeof statSync,
  *   isProcessAlive: (pid: number) => boolean,
+ *   now: () => number,
+ *   publishGraceMs: number,
  * }} deps
  * @returns {boolean}
  */
 function tryClearOrphanedReclaimMutex(reclaimPath, deps) {
-  const { readFileSync: read, unlinkSync: unlink, isProcessAlive: alive } = deps;
+  const {
+    readFileSync: read,
+    unlinkSync: unlink,
+    statSync: stat,
+    isProcessAlive: alive,
+    now,
+    publishGraceMs,
+  } = deps;
   try {
     const holder = parsePublishedLockPid(read(reclaimPath, "utf8"));
-    if (holder == null || alive(holder)) return false;
+    if (holder != null) {
+      if (alive(holder)) return false;
+      unlink(reclaimPath);
+      return true;
+    }
+    const ageMs = now() - stat(reclaimPath).mtimeMs;
+    if (ageMs < publishGraceMs) return false;
     unlink(reclaimPath);
     return true;
   } catch {
@@ -152,7 +171,10 @@ function tryReclaimObservedLock(lockPath, observed, myPid, deps) {
     readFileSync: read,
     unlinkSync: unlink,
     mkdirSync: mkdir,
+    statSync: stat,
     isProcessAlive: alive,
+    now,
+    publishGraceMs,
   } = deps;
   const reclaimPath = `${lockPath}.reclaim`;
 
@@ -179,7 +201,10 @@ function tryReclaimObservedLock(lockPath, observed, myPid, deps) {
     const cleared = tryClearOrphanedReclaimMutex(reclaimPath, {
       readFileSync: read,
       unlinkSync: unlink,
+      statSync: stat,
       isProcessAlive: alive,
+      now,
+      publishGraceMs,
     });
     if (!cleared) return false;
     try {

--- a/scripts/studioConfigSmokeLock.mjs
+++ b/scripts/studioConfigSmokeLock.mjs
@@ -30,6 +30,20 @@ export function isProcessAlive(pid) {
 }
 
 /**
+ * Parse a fully published lock body (`"<pid>\\n"`). Rejects parseInt prefixes and
+ * partial numeric writes (e.g. `"12"` while `"12345\\n"` is still publishing).
+ * @param {string} raw
+ * @returns {number | null} holder pid, or null when incomplete/malformed
+ */
+export function parsePublishedLockPid(raw) {
+  const match = String(raw).match(/^(\d+)\n$/);
+  if (!match) return null;
+  const pid = Number(match[1]);
+  if (!Number.isSafeInteger(pid) || pid <= 0) return null;
+  return pid;
+}
+
+/**
  * Publish a fully-written lock file at `lockPath` without an empty-body window.
  * Prefer hard-linking a temp file (link fails with EEXIST and never overwrites).
  * Fall back to exclusive `write(..., { flag: "wx" })` of the same PID bytes when
@@ -122,8 +136,7 @@ export async function acquireStudioConfigSmokeLock(lockPath, deps = {}) {
       return {
         release() {
           try {
-            const current = read(lockPath, "utf8");
-            const holder = Number.parseInt(String(current).trim().split(/\r?\n/)[0] ?? "", 10);
+            const holder = parsePublishedLockPid(read(lockPath, "utf8"));
             if (holder === myPid) unlink(lockPath);
           } catch {
             /* already gone or not ours */
@@ -134,14 +147,13 @@ export async function acquireStudioConfigSmokeLock(lockPath, deps = {}) {
       const code = e && typeof e === "object" && "code" in e ? e.code : undefined;
       if (code !== "EEXIST") throw e;
       try {
-        const current = read(lockPath, "utf8");
-        const holder = Number.parseInt(String(current).trim().split(/\r?\n/)[0] ?? "", 10);
-        // Fresh empty/malformed bodies can mean a concurrent publisher has not
-        // finished yet (or a crash left an empty legacy lock). Only reclaim
-        // after publishGraceMs. Finite dead PIDs reclaim immediately.
-        const malformed = !Number.isFinite(holder);
-        let reclaimable = !malformed && !alive(holder);
-        if (malformed) {
+        const holder = parsePublishedLockPid(read(lockPath, "utf8"));
+        // Incomplete bodies (empty, partial digits, parseInt prefixes) may mean
+        // a concurrent publisher is still writing. Only reclaim after grace.
+        // Fully published finite dead PIDs reclaim immediately.
+        const incomplete = holder == null;
+        let reclaimable = !incomplete && !alive(holder);
+        if (incomplete) {
           try {
             const ageMs = now() - stat(lockPath).mtimeMs;
             reclaimable = ageMs >= publishGraceMs;

--- a/scripts/studioConfigSmokeLock.mjs
+++ b/scripts/studioConfigSmokeLock.mjs
@@ -8,7 +8,7 @@ import {
   mkdirSync,
   openSync,
   readFileSync,
-  rmSync,
+  rmdirSync,
   unlinkSync,
   writeFileSync,
 } from "node:fs";
@@ -87,13 +87,16 @@ export async function acquireStudioConfigSmokeLock(lockPath, deps = {}) {
       try {
         const body = read(lockPath, "utf8");
         const holder = Number.parseInt(String(body).trim().split(/\r?\n/)[0] ?? "", 10);
-        if (Number.isFinite(holder) && !alive(holder)) {
+        // Empty/malformed bodies and dead holders are reclaimable. Only skip the
+        // poll sleep after unlink succeeds so failed reclaim cannot busy-spin.
+        const reclaimable = !Number.isFinite(holder) || !alive(holder);
+        if (reclaimable) {
           try {
             unlink(lockPath);
+            continue;
           } catch {
-            /* lost race to another reclaim */
+            /* lost race / still held — fall through to poll */
           }
-          continue;
         }
       } catch {
         /* lock vanished mid-read */
@@ -110,12 +113,12 @@ export async function acquireStudioConfigSmokeLock(lockPath, deps = {}) {
 /**
  * Best-effort removal of an empty `.olive-studio` dir after the lock file is gone.
  * @param {string} dir
- * @param {{ rmSync?: typeof rmSync }} [deps]
+ * @param {{ rmdirSync?: typeof rmdirSync }} [deps]
  */
 export function tryRemoveEmptyStudioConfigDir(dir, deps = {}) {
-  const rm = deps.rmSync ?? rmSync;
+  const rmdir = deps.rmdirSync ?? rmdirSync;
   try {
-    rm(dir, { recursive: false });
+    rmdir(dir);
   } catch {
     /* not empty, missing, or busy */
   }

--- a/scripts/studioConfigSmokeLock.mjs
+++ b/scripts/studioConfigSmokeLock.mjs
@@ -103,6 +103,46 @@ function publishLockFile(lockPath, body, deps) {
 }
 
 /**
+ * Drop an abandoned `lockPath.reclaim` gate so later smokers are not stuck
+ * waiting for a dead owner's mutex forever.
+ * @param {string} reclaimPath
+ * @param {{
+ *   readFileSync: typeof readFileSync,
+ *   unlinkSync: typeof unlinkSync,
+ *   statSync: typeof statSync,
+ *   isProcessAlive: (pid: number) => boolean,
+ *   now: () => number,
+ *   publishGraceMs: number,
+ * }} deps
+ * @returns {boolean}
+ */
+function tryClearOrphanedReclaimMutex(reclaimPath, deps) {
+  const {
+    readFileSync: read,
+    unlinkSync: unlink,
+    statSync: stat,
+    isProcessAlive: alive,
+    now,
+    publishGraceMs,
+  } = deps;
+  try {
+    const body = read(reclaimPath, "utf8");
+    const holder = parsePublishedLockPid(body);
+    if (holder != null) {
+      if (alive(holder)) return false;
+      unlink(reclaimPath);
+      return true;
+    }
+    const ageMs = now() - stat(reclaimPath).mtimeMs;
+    if (ageMs < publishGraceMs) return false;
+    unlink(reclaimPath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Serialize reclaimers so only one waiter may unlink a classified body.
  * @param {string} lockPath
  * @param {string} observed
@@ -112,26 +152,58 @@ function publishLockFile(lockPath, body, deps) {
  *   readFileSync: typeof readFileSync,
  *   unlinkSync: typeof unlinkSync,
  *   mkdirSync: typeof mkdirSync,
+ *   statSync: typeof statSync,
+ *   isProcessAlive: (pid: number) => boolean,
+ *   now: () => number,
+ *   publishGraceMs: number,
  * }} deps
  * @returns {boolean}
  */
 function tryReclaimObservedLock(lockPath, observed, myPid, deps) {
-  const { writeFileSync: write, readFileSync: read, unlinkSync: unlink, mkdirSync: mkdir } = deps;
+  const {
+    writeFileSync: write,
+    readFileSync: read,
+    unlinkSync: unlink,
+    mkdirSync: mkdir,
+    statSync: stat,
+    isProcessAlive: alive,
+    now,
+    publishGraceMs,
+  } = deps;
   const reclaimPath = `${lockPath}.reclaim`;
-  try {
+
+  const tryAcquireReclaimGate = () => {
     try {
       write(reclaimPath, `${myPid}\n`, { flag: "wx" });
+      return true;
     } catch (e) {
       if (errorCode(e) === "ENOENT") {
         mkdir(path.dirname(lockPath), { recursive: true });
         write(reclaimPath, `${myPid}\n`, { flag: "wx" });
-      } else {
-        throw e;
+        return true;
       }
+      throw e;
     }
+  };
+
+  try {
+    if (!tryAcquireReclaimGate()) return false;
   } catch (e) {
-    if (errorCode(e) === "EEXIST") return false;
-    throw e;
+    if (errorCode(e) !== "EEXIST") throw e;
+    const cleared = tryClearOrphanedReclaimMutex(reclaimPath, {
+      readFileSync: read,
+      unlinkSync: unlink,
+      statSync: stat,
+      isProcessAlive: alive,
+      now,
+      publishGraceMs,
+    });
+    if (!cleared) return false;
+    try {
+      if (!tryAcquireReclaimGate()) return false;
+    } catch {
+      return false;
+    }
   }
   try {
     const still = read(lockPath, "utf8");
@@ -254,6 +326,10 @@ export async function acquireStudioConfigSmokeLock(lockPath, deps = {}) {
             readFileSync: read,
             unlinkSync: unlink,
             mkdirSync: mkdir,
+            statSync: stat,
+            isProcessAlive: alive,
+            now,
+            publishGraceMs,
           })
         ) {
           continue;

--- a/scripts/studioConfigSmokeLock.mjs
+++ b/scripts/studioConfigSmokeLock.mjs
@@ -3,7 +3,9 @@
  * Prevents overlapping smokes from snapshotting each other's temporary
  * allowJobSubmission / cancellation policy patches.
  */
+import { randomBytes } from "node:crypto";
 import {
+  linkSync,
   mkdirSync,
   readFileSync,
   rmdirSync,
@@ -28,9 +30,47 @@ export function isProcessAlive(pid) {
 }
 
 /**
+ * Publish a fully-written lock file at `lockPath` without an empty-body window.
+ * Prefer hard-linking a temp file (link fails with EEXIST and never overwrites).
+ * Fall back to exclusive `write(..., { flag: "wx" })` of the same PID bytes when
+ * hardlinks are unsupported.
+ *
+ * @param {string} lockPath
+ * @param {string} body
+ * @param {{
+ *   writeFileSync: typeof writeFileSync,
+ *   linkSync: typeof linkSync,
+ *   unlinkSync: typeof unlinkSync,
+ *   tempPath: string,
+ * }} deps
+ */
+function publishLockFile(lockPath, body, deps) {
+  const { writeFileSync: write, linkSync: link, unlinkSync: unlink, tempPath } = deps;
+  write(tempPath, body);
+  try {
+    try {
+      link(tempPath, lockPath);
+      return;
+    } catch (e) {
+      const code = e && typeof e === "object" && "code" in e ? e.code : undefined;
+      if (code === "EEXIST") throw e;
+      // ENOTSUP / EPERM / EINVAL / EXDEV: still publish full content exclusively.
+      write(lockPath, body, { flag: "wx" });
+    }
+  } finally {
+    try {
+      unlink(tempPath);
+    } catch {
+      /* temp already gone */
+    }
+  }
+}
+
+/**
  * @param {string} lockPath
  * @param {{
  *   writeFileSync?: typeof writeFileSync,
+ *   linkSync?: typeof linkSync,
  *   readFileSync?: typeof readFileSync,
  *   statSync?: typeof statSync,
  *   unlinkSync?: typeof unlinkSync,
@@ -42,14 +82,13 @@ export function isProcessAlive(pid) {
  *   publishGraceMs?: number,
  *   sleep?: (ms: number) => Promise<void>,
  *   now?: () => number,
+ *   randomId?: () => string,
  * }} [deps]
  * @returns {Promise<{ release: () => void }>}
  */
 export async function acquireStudioConfigSmokeLock(lockPath, deps = {}) {
-  // Atomic create+publish: write PID with O_EXCL so waiters never observe an
-  // empty live lock from this process. Malformed bodies still get a grace
-  // window for abandoned mid-write files from older crash paths.
   const write = deps.writeFileSync ?? writeFileSync;
+  const link = deps.linkSync ?? linkSync;
   const read = deps.readFileSync ?? readFileSync;
   const stat = deps.statSync ?? statSync;
   const unlink = deps.unlinkSync ?? unlinkSync;
@@ -60,20 +99,31 @@ export async function acquireStudioConfigSmokeLock(lockPath, deps = {}) {
   const pollMs = deps.pollMs ?? 250;
   const publishGraceMs = deps.publishGraceMs ?? Math.max(1_000, pollMs * 4);
   const now = deps.now ?? Date.now;
+  const randomId = deps.randomId ?? (() => randomBytes(6).toString("hex"));
   const sleep =
     deps.sleep ?? ((ms) => new Promise((resolve) => setTimeout(resolve, ms)));
 
   mkdir(path.dirname(lockPath), { recursive: true });
   const deadline = now() + timeoutMs;
+  const body = `${myPid}\n`;
 
   while (now() < deadline) {
+    const tempPath = path.join(
+      path.dirname(lockPath),
+      `.${path.basename(lockPath)}.${myPid}.${randomId()}.tmp`,
+    );
     try {
-      write(lockPath, `${myPid}\n`, { flag: "wx" });
+      publishLockFile(lockPath, body, {
+        writeFileSync: write,
+        linkSync: link,
+        unlinkSync: unlink,
+        tempPath,
+      });
       return {
         release() {
           try {
-            const body = read(lockPath, "utf8");
-            const holder = Number.parseInt(String(body).trim().split(/\r?\n/)[0] ?? "", 10);
+            const current = read(lockPath, "utf8");
+            const holder = Number.parseInt(String(current).trim().split(/\r?\n/)[0] ?? "", 10);
             if (holder === myPid) unlink(lockPath);
           } catch {
             /* already gone or not ours */
@@ -84,10 +134,11 @@ export async function acquireStudioConfigSmokeLock(lockPath, deps = {}) {
       const code = e && typeof e === "object" && "code" in e ? e.code : undefined;
       if (code !== "EEXIST") throw e;
       try {
-        const body = read(lockPath, "utf8");
-        const holder = Number.parseInt(String(body).trim().split(/\r?\n/)[0] ?? "", 10);
-        // Fresh empty/malformed bodies can mean "writer still publishing" (legacy
-        // open-then-write callers / crash mid-write). Only reclaim after grace.
+        const current = read(lockPath, "utf8");
+        const holder = Number.parseInt(String(current).trim().split(/\r?\n/)[0] ?? "", 10);
+        // Fresh empty/malformed bodies can mean a concurrent publisher has not
+        // finished yet (or a crash left an empty legacy lock). Only reclaim
+        // after publishGraceMs. Finite dead PIDs reclaim immediately.
         const malformed = !Number.isFinite(holder);
         let reclaimable = !malformed && !alive(holder);
         if (malformed) {

--- a/scripts/studioConfigSmokeLock.mjs
+++ b/scripts/studioConfigSmokeLock.mjs
@@ -44,6 +44,14 @@ export function parsePublishedLockPid(raw) {
 }
 
 /**
+ * @param {unknown} err
+ * @returns {string | undefined}
+ */
+function errorCode(err) {
+  return err && typeof err === "object" && "code" in err ? /** @type {{ code?: string }} */ (err).code : undefined;
+}
+
+/**
  * Publish a fully-written lock file at `lockPath` without an empty-body window.
  * Prefer hard-linking a temp file (link fails with EEXIST and never overwrites).
  * Fall back to exclusive `write(..., { flag: "wx" })` of the same PID bytes when
@@ -55,27 +63,88 @@ export function parsePublishedLockPid(raw) {
  *   writeFileSync: typeof writeFileSync,
  *   linkSync: typeof linkSync,
  *   unlinkSync: typeof unlinkSync,
+ *   mkdirSync: typeof mkdirSync,
  *   tempPath: string,
  * }} deps
  */
 function publishLockFile(lockPath, body, deps) {
-  const { writeFileSync: write, linkSync: link, unlinkSync: unlink, tempPath } = deps;
-  write(tempPath, body);
+  const { writeFileSync: write, linkSync: link, unlinkSync: unlink, mkdirSync: mkdir, tempPath } =
+    deps;
+
+  const attempt = () => {
+    write(tempPath, body);
+    try {
+      try {
+        link(tempPath, lockPath);
+        return;
+      } catch (e) {
+        const code = errorCode(e);
+        if (code === "EEXIST") throw e;
+        // ENOTSUP / EPERM / EINVAL / EXDEV: still publish full content exclusively.
+        write(lockPath, body, { flag: "wx" });
+      }
+    } finally {
+      try {
+        unlink(tempPath);
+      } catch {
+        /* temp already gone */
+      }
+    }
+  };
+
+  try {
+    attempt();
+  } catch (e) {
+    // Peer cleanup may rmdir `.olive-studio` between our mkdir and temp create.
+    if (errorCode(e) !== "ENOENT") throw e;
+    mkdir(path.dirname(lockPath), { recursive: true });
+    attempt();
+  }
+}
+
+/**
+ * Serialize reclaimers so only one waiter may unlink a classified body.
+ * @param {string} lockPath
+ * @param {string} observed
+ * @param {number} myPid
+ * @param {{
+ *   writeFileSync: typeof writeFileSync,
+ *   readFileSync: typeof readFileSync,
+ *   unlinkSync: typeof unlinkSync,
+ *   mkdirSync: typeof mkdirSync,
+ * }} deps
+ * @returns {boolean}
+ */
+function tryReclaimObservedLock(lockPath, observed, myPid, deps) {
+  const { writeFileSync: write, readFileSync: read, unlinkSync: unlink, mkdirSync: mkdir } = deps;
+  const reclaimPath = `${lockPath}.reclaim`;
   try {
     try {
-      link(tempPath, lockPath);
-      return;
+      write(reclaimPath, `${myPid}\n`, { flag: "wx" });
     } catch (e) {
-      const code = e && typeof e === "object" && "code" in e ? e.code : undefined;
-      if (code === "EEXIST") throw e;
-      // ENOTSUP / EPERM / EINVAL / EXDEV: still publish full content exclusively.
-      write(lockPath, body, { flag: "wx" });
+      if (errorCode(e) === "ENOENT") {
+        mkdir(path.dirname(lockPath), { recursive: true });
+        write(reclaimPath, `${myPid}\n`, { flag: "wx" });
+      } else {
+        throw e;
+      }
     }
+  } catch (e) {
+    if (errorCode(e) === "EEXIST") return false;
+    throw e;
+  }
+  try {
+    const still = read(lockPath, "utf8");
+    if (still !== observed) return false;
+    unlink(lockPath);
+    return true;
+  } catch {
+    return false;
   } finally {
     try {
-      unlink(tempPath);
+      unlink(reclaimPath);
     } catch {
-      /* temp already gone */
+      /* already gone */
     }
   }
 }
@@ -131,8 +200,15 @@ export async function acquireStudioConfigSmokeLock(lockPath, deps = {}) {
         writeFileSync: write,
         linkSync: link,
         unlinkSync: unlink,
+        mkdirSync: mkdir,
         tempPath,
       });
+      // Lost reclaim race? Another owner may have replaced the path after we linked.
+      const published = parsePublishedLockPid(read(lockPath, "utf8"));
+      if (published !== myPid) {
+        await sleep(pollMs);
+        continue;
+      }
       return {
         release() {
           try {
@@ -144,7 +220,12 @@ export async function acquireStudioConfigSmokeLock(lockPath, deps = {}) {
         },
       };
     } catch (e) {
-      const code = e && typeof e === "object" && "code" in e ? e.code : undefined;
+      const code = errorCode(e);
+      if (code === "ENOENT") {
+        mkdir(path.dirname(lockPath), { recursive: true });
+        await sleep(pollMs);
+        continue;
+      }
       if (code !== "EEXIST") throw e;
       try {
         // Snapshot the exact bytes we classified. Concurrent reclaim must only
@@ -164,20 +245,18 @@ export async function acquireStudioConfigSmokeLock(lockPath, deps = {}) {
             /* unable to establish age — leave the lock in place */
           }
         }
-        // Only skip the poll sleep after unlink succeeds so failed reclaim
-        // cannot busy-spin.
-        if (reclaimable) {
-          try {
-            const still = read(lockPath, "utf8");
-            if (still !== observed) {
-              /* peer replaced the lock between classify and reclaim */
-            } else {
-              unlink(lockPath);
-              continue;
-            }
-          } catch {
-            /* lost race / still held — fall through to poll */
-          }
+        // Serialize reclaimers via lockPath.reclaim (wx). Only skip the poll
+        // sleep after unlink succeeds so failed reclaim cannot busy-spin.
+        if (
+          reclaimable &&
+          tryReclaimObservedLock(lockPath, observed, myPid, {
+            writeFileSync: write,
+            readFileSync: read,
+            unlinkSync: unlink,
+            mkdirSync: mkdir,
+          })
+        ) {
+          continue;
         }
       } catch {
         /* lock vanished mid-read */

--- a/scripts/studioConfigSmokeLock.mjs
+++ b/scripts/studioConfigSmokeLock.mjs
@@ -105,36 +105,23 @@ function publishLockFile(lockPath, body, deps) {
 /**
  * Drop an abandoned `lockPath.reclaim` gate so later smokers are not stuck
  * waiting for a dead owner's mutex forever.
+ *
+ * Only complete published PIDs that are no longer alive are cleared. Incomplete
+ * / age-only reclaim bodies are left alone so a live reclaimer mid-critical-
+ * section is never stripped of its mutex by a concurrent waiter.
  * @param {string} reclaimPath
  * @param {{
  *   readFileSync: typeof readFileSync,
  *   unlinkSync: typeof unlinkSync,
- *   statSync: typeof statSync,
  *   isProcessAlive: (pid: number) => boolean,
- *   now: () => number,
- *   publishGraceMs: number,
  * }} deps
  * @returns {boolean}
  */
 function tryClearOrphanedReclaimMutex(reclaimPath, deps) {
-  const {
-    readFileSync: read,
-    unlinkSync: unlink,
-    statSync: stat,
-    isProcessAlive: alive,
-    now,
-    publishGraceMs,
-  } = deps;
+  const { readFileSync: read, unlinkSync: unlink, isProcessAlive: alive } = deps;
   try {
-    const body = read(reclaimPath, "utf8");
-    const holder = parsePublishedLockPid(body);
-    if (holder != null) {
-      if (alive(holder)) return false;
-      unlink(reclaimPath);
-      return true;
-    }
-    const ageMs = now() - stat(reclaimPath).mtimeMs;
-    if (ageMs < publishGraceMs) return false;
+    const holder = parsePublishedLockPid(read(reclaimPath, "utf8"));
+    if (holder == null || alive(holder)) return false;
     unlink(reclaimPath);
     return true;
   } catch {
@@ -165,12 +152,11 @@ function tryReclaimObservedLock(lockPath, observed, myPid, deps) {
     readFileSync: read,
     unlinkSync: unlink,
     mkdirSync: mkdir,
-    statSync: stat,
     isProcessAlive: alive,
-    now,
-    publishGraceMs,
   } = deps;
   const reclaimPath = `${lockPath}.reclaim`;
+
+  const ownsReclaimGate = () => parsePublishedLockPid(read(reclaimPath, "utf8")) === myPid;
 
   const tryAcquireReclaimGate = () => {
     try {
@@ -193,10 +179,7 @@ function tryReclaimObservedLock(lockPath, observed, myPid, deps) {
     const cleared = tryClearOrphanedReclaimMutex(reclaimPath, {
       readFileSync: read,
       unlinkSync: unlink,
-      statSync: stat,
       isProcessAlive: alive,
-      now,
-      publishGraceMs,
     });
     if (!cleared) return false;
     try {
@@ -206,17 +189,21 @@ function tryReclaimObservedLock(lockPath, observed, myPid, deps) {
     }
   }
   try {
+    // Re-verify gate ownership before touching the main lock: another waiter
+    // must not have replaced this mutex while we were paused.
+    if (!ownsReclaimGate()) return false;
     const still = read(lockPath, "utf8");
     if (still !== observed) return false;
+    if (!ownsReclaimGate()) return false;
     unlink(lockPath);
     return true;
   } catch {
     return false;
   } finally {
     try {
-      unlink(reclaimPath);
+      if (ownsReclaimGate()) unlink(reclaimPath);
     } catch {
-      /* already gone */
+      /* already gone / not ours */
     }
   }
 }

--- a/scripts/studioConfigSnapshot.mjs
+++ b/scripts/studioConfigSnapshot.mjs
@@ -3,7 +3,14 @@
  * Used by mcp-agent-smoke so policy patches never leave lossy booleans or a
  * newly created config file behind.
  */
-import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmdirSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import path from "node:path";
 
 /** Top-level marker written while mcp-agent-smoke owns policy patches. */
@@ -115,7 +122,7 @@ export function restoreStudioConfigFile(configPath, snapshot, opts = {}) {
     // If smoke created `.olive-studio/` solely for the patch, drop the empty dir.
     const dir = path.dirname(configPath);
     try {
-      rmSync(dir, { recursive: false });
+      rmdirSync(dir);
     } catch {
       /* dir missing, not empty, or not removable — leave alone */
     }

--- a/src/lib/__tests__/resolvePython.test.ts
+++ b/src/lib/__tests__/resolvePython.test.ts
@@ -57,6 +57,27 @@ describe("resolvePython", () => {
     ).toBe("python3");
   });
 
+  it("prefers python3 over python when both are on PATH", () => {
+    const spawnSync = vi.fn(() => ({ status: 0 }));
+    expect(
+      resolvePython(root, {
+        existsSync: () => false,
+        spawnSync: spawnSync as never,
+        platform: "linux",
+      }),
+    ).toBe("python3");
+    expect(spawnSync).toHaveBeenCalledWith(
+      "python3",
+      ["--version"],
+      expect.objectContaining({ encoding: "utf8" }),
+    );
+    expect(spawnSync).not.toHaveBeenCalledWith(
+      "python",
+      ["--version"],
+      expect.anything(),
+    );
+  });
+
   it("throws when no candidate is executable", () => {
     expect(() =>
       resolvePython(root, {

--- a/src/lib/__tests__/studioConfigSmokeLock.test.ts
+++ b/src/lib/__tests__/studioConfigSmokeLock.test.ts
@@ -128,6 +128,51 @@ describe("studioConfigSmokeLock", () => {
     expect(store.get("/tmp/lock")).toBe("111\n");
   });
 
+  it("does not unlink a peer lock published between classify and reclaim", async () => {
+    // Both waiters saw the same aged incomplete body; the first already
+    // reclaimed and published before the second's pathname unlink.
+    const store: Store = new Map([["/tmp/lock", ""]]);
+    const fs = makeFs(store);
+    let lockReads = 0;
+    let t = 5_000;
+    const sleep = vi.fn(async (ms: number) => {
+      t += ms;
+    });
+    const readFileSync = vi.fn((p: string) => {
+      if (p !== "/tmp/lock") {
+        if (!store.has(p)) {
+          throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+        }
+        return store.get(p) ?? "";
+      }
+      lockReads += 1;
+      // Classify against aged empty, then observe the peer's published PID.
+      return lockReads === 1 ? "" : "4242\n";
+    });
+
+    await expect(
+      acquireStudioConfigSmokeLock("/tmp/lock", {
+        writeFileSync: fs.writeFileSync as never,
+        linkSync: fs.linkSync as never,
+        readFileSync: readFileSync as never,
+        unlinkSync: fs.unlinkSync as never,
+        mkdirSync: fs.mkdirSync as never,
+        statSync: vi.fn(() => ({ mtimeMs: 1_000 })) as never,
+        isProcessAlive: () => true,
+        pid: 999,
+        timeoutMs: 30,
+        pollMs: 10,
+        publishGraceMs: 1_000,
+        now: () => t,
+        sleep,
+        randomId: () => "cas",
+      }),
+    ).rejects.toThrow(/could not acquire/);
+
+    expect(fs.unlinkSync).not.toHaveBeenCalledWith("/tmp/lock");
+    expect(sleep).toHaveBeenCalled();
+  });
+
   it("does not reclaim a partial numeric PID body before the publish grace window", async () => {
     // Mid-publish body "12" must not be treated as live PID 12 via parseInt.
     const store: Store = new Map([["/tmp/lock", "12"]]);

--- a/src/lib/__tests__/studioConfigSmokeLock.test.ts
+++ b/src/lib/__tests__/studioConfigSmokeLock.test.ts
@@ -186,6 +186,90 @@ describe("studioConfigSmokeLock", () => {
     expect(sleep).toHaveBeenCalled();
   });
 
+  it("does not clear an aged incomplete reclaim mutex by age alone", async () => {
+    // Incomplete reclaim bodies must not be age-reaped: a live reclaimer could
+    // still be in its critical section. Only dead complete PIDs are cleared.
+    const store: Store = new Map([
+      ["/tmp/lock", "111\n"],
+      ["/tmp/lock.reclaim", ""],
+    ]);
+    const fs = makeFs(store);
+    let t = 5_000;
+    const sleep = vi.fn(async (ms: number) => {
+      t += ms;
+    });
+
+    await expect(
+      acquireStudioConfigSmokeLock("/tmp/lock", {
+        writeFileSync: fs.writeFileSync as never,
+        linkSync: fs.linkSync as never,
+        readFileSync: fs.readFileSync as never,
+        unlinkSync: fs.unlinkSync as never,
+        mkdirSync: fs.mkdirSync as never,
+        statSync: vi.fn(() => ({ mtimeMs: 1_000 })) as never,
+        isProcessAlive: () => false,
+        pid: 999,
+        timeoutMs: 30,
+        pollMs: 10,
+        publishGraceMs: 1_000,
+        now: () => t,
+        sleep,
+        randomId: () => "incomplete-reclaim",
+      }),
+    ).rejects.toThrow(/could not acquire/);
+
+    expect(store.get("/tmp/lock")).toBe("111\n");
+    expect(store.get("/tmp/lock.reclaim")).toBe("");
+    expect(fs.unlinkSync).not.toHaveBeenCalledWith("/tmp/lock");
+  });
+
+  it("does not unlink the main lock after losing reclaim gate ownership", async () => {
+    const store: Store = new Map([["/tmp/lock", "111\n"]]);
+    const fs = makeFs(store);
+    let reclaimReads = 0;
+    const readFileSync = vi.fn((p: string) => {
+      if (p === "/tmp/lock.reclaim") {
+        reclaimReads += 1;
+        // After we create the gate as 999, a peer replaces it before main unlink.
+        if (reclaimReads >= 2) return "4242\n";
+      }
+      if (!store.has(p)) {
+        throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+      }
+      return store.get(p) ?? "";
+    });
+    const writeFileSync = vi.fn((p: string, body: string, opts?: { flag?: string }) => {
+      fs.writeFileSync(p, body, opts as never);
+      if (p === "/tmp/lock.reclaim") reclaimReads = 0;
+    });
+
+    await expect(
+      acquireStudioConfigSmokeLock("/tmp/lock", {
+        writeFileSync: writeFileSync as never,
+        linkSync: fs.linkSync as never,
+        readFileSync: readFileSync as never,
+        unlinkSync: fs.unlinkSync as never,
+        mkdirSync: fs.mkdirSync as never,
+        isProcessAlive: (pid) => pid !== 111,
+        pid: 999,
+        timeoutMs: 30,
+        pollMs: 10,
+        now: (() => {
+          let t = 0;
+          return () => {
+            t += 10;
+            return t;
+          };
+        })(),
+        sleep: async () => undefined,
+        randomId: () => "lost-gate",
+      }),
+    ).rejects.toThrow(/could not acquire/);
+
+    expect(fs.unlinkSync).not.toHaveBeenCalledWith("/tmp/lock");
+    expect(store.get("/tmp/lock")).toBe("111\n");
+  });
+
   it("does not unlink a peer lock published between classify and reclaim", async () => {
     // Both waiters saw the same aged incomplete body; the first already
     // reclaimed and published before the second's body compare under reclaim gate.

--- a/src/lib/__tests__/studioConfigSmokeLock.test.ts
+++ b/src/lib/__tests__/studioConfigSmokeLock.test.ts
@@ -225,35 +225,25 @@ describe("studioConfigSmokeLock", () => {
 
   it("falls back to exclusive write when hardlinks are unsupported", async () => {
     const store: Store = new Map();
-    const writeFileSync = vi.fn((p: string, body: string, opts?: { flag?: string }) => {
-      if (opts?.flag === "wx" && store.has(p)) {
-        throw Object.assign(new Error("EEXIST"), { code: "EEXIST" });
-      }
-      store.set(p, String(body));
-    });
+    const fs = makeFs(store);
     const linkSync = vi.fn(() => {
       throw Object.assign(new Error("ENOTSUP"), { code: "ENOTSUP" });
     });
-    const unlinkSync = vi.fn((p: string) => {
-      store.delete(p);
-    });
 
     const lock = await acquireStudioConfigSmokeLock("/tmp/lock", {
-      writeFileSync: writeFileSync as never,
+      writeFileSync: fs.writeFileSync as never,
       linkSync: linkSync as never,
-      readFileSync: vi.fn((p: string) => {
-        if (!store.has(p)) throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
-        return store.get(p) ?? "";
-      }) as never,
-      unlinkSync: unlinkSync as never,
-      mkdirSync: vi.fn() as never,
+      readFileSync: fs.readFileSync as never,
+      unlinkSync: fs.unlinkSync as never,
+      mkdirSync: fs.mkdirSync as never,
       pid: 777,
       timeoutMs: 1_000,
       pollMs: 10,
       randomId: () => "fb",
     });
     expect(store.get("/tmp/lock")).toBe("777\n");
-    expect(writeFileSync).toHaveBeenCalledWith("/tmp/lock", "777\n", { flag: "wx" });
+    expect(fs.writeFileSync).toHaveBeenCalledWith("/tmp/lock", "777\n", { flag: "wx" });
+    expect([...store.keys()].some((k) => k.includes(".tmp"))).toBe(false);
     lock.release();
   });
 

--- a/src/lib/__tests__/studioConfigSmokeLock.test.ts
+++ b/src/lib/__tests__/studioConfigSmokeLock.test.ts
@@ -27,6 +27,19 @@ function makeFs(store: Store) {
     // Hard link: destination appears with the fully written temp contents.
     store.set(to, store.get(from)!);
   });
+  const copyFileSync = vi.fn((from: string, to: string, mode?: number) => {
+    if (!store.has(from)) {
+      throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+    }
+    // Mirror COPYFILE_EXCL: refuse when the destination already exists.
+    if (mode !== undefined && store.has(to)) {
+      throw Object.assign(new Error("EEXIST"), { code: "EEXIST" });
+    }
+    if (store.has(to)) {
+      throw Object.assign(new Error("EEXIST"), { code: "EEXIST" });
+    }
+    store.set(to, store.get(from)!);
+  });
   const readFileSync = vi.fn((p: string) => {
     if (!store.has(p)) {
       throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
@@ -37,7 +50,7 @@ function makeFs(store: Store) {
     store.delete(p);
   });
   const mkdirSync = vi.fn();
-  return { writeFileSync, linkSync, readFileSync, unlinkSync, mkdirSync };
+  return { writeFileSync, linkSync, copyFileSync, readFileSync, unlinkSync, mkdirSync };
 }
 
 describe("studioConfigSmokeLock", () => {
@@ -469,7 +482,7 @@ describe("studioConfigSmokeLock", () => {
     lock.release();
   });
 
-  it("falls back to exclusive write when hardlinks are unsupported", async () => {
+  it("falls back to exclusive copy when hardlinks are unsupported", async () => {
     const store: Store = new Map();
     const fs = makeFs(store);
     const linkSync = vi.fn(() => {
@@ -479,6 +492,7 @@ describe("studioConfigSmokeLock", () => {
     const lock = await acquireStudioConfigSmokeLock("/tmp/lock", {
       writeFileSync: fs.writeFileSync as never,
       linkSync: linkSync as never,
+      copyFileSync: fs.copyFileSync as never,
       readFileSync: fs.readFileSync as never,
       unlinkSync: fs.unlinkSync as never,
       mkdirSync: fs.mkdirSync as never,
@@ -488,7 +502,12 @@ describe("studioConfigSmokeLock", () => {
       randomId: () => "fb",
     });
     expect(store.get("/tmp/lock")).toBe("777\n");
-    expect(fs.writeFileSync).toHaveBeenCalledWith("/tmp/lock", "777\n", { flag: "wx" });
+    expect(fs.copyFileSync).toHaveBeenCalled();
+    const [from, to, mode] = fs.copyFileSync.mock.calls[0]!;
+    expect(String(from)).toContain(".tmp");
+    expect(to).toBe("/tmp/lock");
+    expect(typeof mode).toBe("number");
+    expect(fs.writeFileSync).not.toHaveBeenCalledWith("/tmp/lock", "777\n", { flag: "wx" });
     expect([...store.keys()].some((k) => k.includes(".tmp"))).toBe(false);
     lock.release();
   });

--- a/src/lib/__tests__/studioConfigSmokeLock.test.ts
+++ b/src/lib/__tests__/studioConfigSmokeLock.test.ts
@@ -8,37 +8,59 @@ import {
   tryRemoveEmptyStudioConfigDir,
 } from "../../../scripts/studioConfigSmokeLock.mjs";
 
-describe("studioConfigSmokeLock", () => {
-  it("acquires with wx and releases only own pid", async () => {
-    const store = new Map<string, string>();
+type Store = Map<string, string>;
 
-    const writeFileSync = vi.fn((p: string, body: string, opts?: { flag?: string }) => {
-      if (opts?.flag === "wx" && store.has(p)) {
-        throw Object.assign(new Error("EEXIST"), { code: "EEXIST" });
-      }
-      store.set(p, body);
-    });
-    const readFileSync = vi.fn((p: string) => {
-      if (!store.has(p)) {
-        throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
-      }
-      return store.get(p) ?? "";
-    });
-    const unlinkSync = vi.fn((p: string) => {
-      store.delete(p);
-    });
-    const mkdirSync = vi.fn();
+function makeFs(store: Store) {
+  const writeFileSync = vi.fn((p: string, body: string, opts?: { flag?: string }) => {
+    if (opts?.flag === "wx" && store.has(p)) {
+      throw Object.assign(new Error("EEXIST"), { code: "EEXIST" });
+    }
+    store.set(p, String(body));
+  });
+  const linkSync = vi.fn((from: string, to: string) => {
+    if (!store.has(from)) {
+      throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+    }
+    if (store.has(to)) {
+      throw Object.assign(new Error("EEXIST"), { code: "EEXIST" });
+    }
+    // Hard link: destination appears with the fully written temp contents.
+    store.set(to, store.get(from)!);
+  });
+  const readFileSync = vi.fn((p: string) => {
+    if (!store.has(p)) {
+      throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+    }
+    return store.get(p) ?? "";
+  });
+  const unlinkSync = vi.fn((p: string) => {
+    store.delete(p);
+  });
+  const mkdirSync = vi.fn();
+  return { writeFileSync, linkSync, readFileSync, unlinkSync, mkdirSync };
+}
+
+describe("studioConfigSmokeLock", () => {
+  it("acquires via temp+link and releases only own pid", async () => {
+    const store: Store = new Map();
+    const fs = makeFs(store);
 
     const lock = await acquireStudioConfigSmokeLock("/tmp/lock", {
-      writeFileSync: writeFileSync as never,
-      readFileSync: readFileSync as never,
-      unlinkSync: unlinkSync as never,
-      mkdirSync: mkdirSync as never,
+      ...fs,
+      writeFileSync: fs.writeFileSync as never,
+      linkSync: fs.linkSync as never,
+      readFileSync: fs.readFileSync as never,
+      unlinkSync: fs.unlinkSync as never,
+      mkdirSync: fs.mkdirSync as never,
       pid: 4242,
       timeoutMs: 1_000,
       pollMs: 10,
+      randomId: () => "abc",
     });
     expect(store.get("/tmp/lock")).toBe("4242\n");
+    expect(fs.linkSync).toHaveBeenCalled();
+    expect([...store.keys()].some((k) => k.includes(".tmp"))).toBe(false);
+
     // Foreign PID must not be unlinked by our release().
     store.set("/tmp/lock", "9999\n");
     lock.release();
@@ -50,60 +72,46 @@ describe("studioConfigSmokeLock", () => {
   });
 
   it("reclaims a stale lock from a dead pid", async () => {
-    const store = new Map<string, string>([["/tmp/lock", "111\n"]]);
+    const store: Store = new Map([["/tmp/lock", "111\n"]]);
+    const fs = makeFs(store);
 
     const lock = await acquireStudioConfigSmokeLock("/tmp/lock", {
-      writeFileSync: vi.fn((p: string, body: string, opts?: { flag?: string }) => {
-        if (opts?.flag === "wx" && store.has(p)) {
-          throw Object.assign(new Error("EEXIST"), { code: "EEXIST" });
-        }
-        store.set(p, body);
-      }) as never,
-      readFileSync: vi.fn((p: string) => {
-        if (!store.has(p)) throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
-        return store.get(p) ?? "";
-      }) as never,
-      unlinkSync: vi.fn((p: string) => {
-        store.delete(p);
-      }) as never,
-      mkdirSync: vi.fn() as never,
+      writeFileSync: fs.writeFileSync as never,
+      linkSync: fs.linkSync as never,
+      readFileSync: fs.readFileSync as never,
+      unlinkSync: fs.unlinkSync as never,
+      mkdirSync: fs.mkdirSync as never,
       isProcessAlive: (pid) => pid !== 111,
       pid: 999,
       timeoutMs: 1_000,
       pollMs: 5,
       sleep: async () => undefined,
+      randomId: () => "dead",
     });
     expect(store.get("/tmp/lock")).toBe("999\n");
     lock.release();
   });
 
-  it("does not reclaim a freshly empty lock (publisher still writing)", async () => {
-    const store = new Map<string, string>([["/tmp/lock", ""]]);
-    const unlinkSync = vi.fn((p: string) => {
-      store.delete(p);
-    });
+  it("does not reclaim a freshly empty lock while process A delays PID publish", async () => {
+    // Process A created the final path (legacy open/write or crash remnant) but
+    // has not written the PID yet. Process B must poll through grace, not unlink.
+    const store: Store = new Map([["/tmp/lock", ""]]);
+    const fs = makeFs(store);
     let t = 1_000;
     const sleep = vi.fn(async () => {
-      // After the first poll, the publisher finishes writing its PID.
+      // Process A finishes publishing after B's first empty-body observation.
       store.set("/tmp/lock", "4242\n");
       t += 50;
     });
 
     await expect(
       acquireStudioConfigSmokeLock("/tmp/lock", {
-        writeFileSync: vi.fn((p: string, _body: string, opts?: { flag?: string }) => {
-          if (opts?.flag === "wx" && store.has(p)) {
-            throw Object.assign(new Error("EEXIST"), { code: "EEXIST" });
-          }
-          store.set(p, _body);
-        }) as never,
-        readFileSync: vi.fn((p: string) => {
-          if (!store.has(p)) throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
-          return store.get(p) ?? "";
-        }) as never,
+        writeFileSync: fs.writeFileSync as never,
+        linkSync: fs.linkSync as never,
+        readFileSync: fs.readFileSync as never,
+        unlinkSync: fs.unlinkSync as never,
+        mkdirSync: fs.mkdirSync as never,
         statSync: vi.fn(() => ({ mtimeMs: 1_000 })) as never,
-        unlinkSync: unlinkSync as never,
-        mkdirSync: vi.fn() as never,
         isProcessAlive: () => true,
         pid: 999,
         timeoutMs: 500,
@@ -111,42 +119,71 @@ describe("studioConfigSmokeLock", () => {
         publishGraceMs: 1_000,
         now: () => t,
         sleep,
+        randomId: () => "b",
       }),
     ).rejects.toThrow(/could not acquire/);
 
-    expect(unlinkSync).not.toHaveBeenCalled();
+    // Critical: B never unlinked A's in-progress empty lock path.
+    expect(fs.unlinkSync).not.toHaveBeenCalledWith("/tmp/lock");
     expect(store.get("/tmp/lock")).toBe("4242\n");
     expect(sleep).toHaveBeenCalled();
   });
 
   it("reclaims an aged empty lock after the publish grace window", async () => {
-    const store = new Map<string, string>([["/tmp/lock", ""]]);
+    const store: Store = new Map([["/tmp/lock", ""]]);
+    const fs = makeFs(store);
     let t = 5_000;
 
     const lock = await acquireStudioConfigSmokeLock("/tmp/lock", {
-      writeFileSync: vi.fn((p: string, body: string, opts?: { flag?: string }) => {
-        if (opts?.flag === "wx" && store.has(p)) {
-          throw Object.assign(new Error("EEXIST"), { code: "EEXIST" });
-        }
-        store.set(p, body);
-      }) as never,
-      readFileSync: vi.fn((p: string) => {
-        if (!store.has(p)) throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
-        return store.get(p) ?? "";
-      }) as never,
+      writeFileSync: fs.writeFileSync as never,
+      linkSync: fs.linkSync as never,
+      readFileSync: fs.readFileSync as never,
+      unlinkSync: fs.unlinkSync as never,
+      mkdirSync: fs.mkdirSync as never,
       statSync: vi.fn(() => ({ mtimeMs: 1_000 })) as never,
-      unlinkSync: vi.fn((p: string) => {
-        store.delete(p);
-      }) as never,
-      mkdirSync: vi.fn() as never,
       pid: 999,
       timeoutMs: 1_000,
       pollMs: 5,
       publishGraceMs: 1_000,
       now: () => t,
       sleep: async () => undefined,
+      randomId: () => "aged",
     });
     expect(store.get("/tmp/lock")).toBe("999\n");
+    lock.release();
+  });
+
+  it("falls back to exclusive write when hardlinks are unsupported", async () => {
+    const store: Store = new Map();
+    const writeFileSync = vi.fn((p: string, body: string, opts?: { flag?: string }) => {
+      if (opts?.flag === "wx" && store.has(p)) {
+        throw Object.assign(new Error("EEXIST"), { code: "EEXIST" });
+      }
+      store.set(p, String(body));
+    });
+    const linkSync = vi.fn(() => {
+      throw Object.assign(new Error("ENOTSUP"), { code: "ENOTSUP" });
+    });
+    const unlinkSync = vi.fn((p: string) => {
+      store.delete(p);
+    });
+
+    const lock = await acquireStudioConfigSmokeLock("/tmp/lock", {
+      writeFileSync: writeFileSync as never,
+      linkSync: linkSync as never,
+      readFileSync: vi.fn((p: string) => {
+        if (!store.has(p)) throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+        return store.get(p) ?? "";
+      }) as never,
+      unlinkSync: unlinkSync as never,
+      mkdirSync: vi.fn() as never,
+      pid: 777,
+      timeoutMs: 1_000,
+      pollMs: 10,
+      randomId: () => "fb",
+    });
+    expect(store.get("/tmp/lock")).toBe("777\n");
+    expect(writeFileSync).toHaveBeenCalledWith("/tmp/lock", "777\n", { flag: "wx" });
     lock.release();
   });
 

--- a/src/lib/__tests__/studioConfigSmokeLock.test.ts
+++ b/src/lib/__tests__/studioConfigSmokeLock.test.ts
@@ -11,28 +11,16 @@ import {
 describe("studioConfigSmokeLock", () => {
   it("acquires with wx and releases only own pid", async () => {
     const store = new Map<string, string>();
-    let nextFd = 1;
-    const fds = new Map<number, string>();
 
-    const openSync = vi.fn((p: string, flag: string) => {
-      if (flag === "wx" && store.has(p)) {
-        const err = Object.assign(new Error("EEXIST"), { code: "EEXIST" });
-        throw err;
+    const writeFileSync = vi.fn((p: string, body: string, opts?: { flag?: string }) => {
+      if (opts?.flag === "wx" && store.has(p)) {
+        throw Object.assign(new Error("EEXIST"), { code: "EEXIST" });
       }
-      if (flag === "wx") store.set(p, "");
-      const fd = nextFd++;
-      fds.set(fd, p);
-      return fd;
+      store.set(p, body);
     });
-    const writeFileSync = vi.fn((fd: number, body: string) => {
-      const p = fds.get(fd);
-      if (p) store.set(p, body);
-    });
-    const closeSync = vi.fn();
     const readFileSync = vi.fn((p: string) => {
       if (!store.has(p)) {
-        const err = Object.assign(new Error("ENOENT"), { code: "ENOENT" });
-        throw err;
+        throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
       }
       return store.get(p) ?? "";
     });
@@ -42,8 +30,6 @@ describe("studioConfigSmokeLock", () => {
     const mkdirSync = vi.fn();
 
     const lock = await acquireStudioConfigSmokeLock("/tmp/lock", {
-      openSync: openSync as never,
-      closeSync: closeSync as never,
       writeFileSync: writeFileSync as never,
       readFileSync: readFileSync as never,
       unlinkSync: unlinkSync as never,
@@ -65,24 +51,13 @@ describe("studioConfigSmokeLock", () => {
 
   it("reclaims a stale lock from a dead pid", async () => {
     const store = new Map<string, string>([["/tmp/lock", "111\n"]]);
-    let nextFd = 1;
-    const fds = new Map<number, string>();
-    const openSync = vi.fn((p: string, flag: string) => {
-      if (flag === "wx" && store.has(p)) {
-        throw Object.assign(new Error("EEXIST"), { code: "EEXIST" });
-      }
-      if (flag === "wx") store.set(p, "");
-      const fd = nextFd++;
-      fds.set(fd, p);
-      return fd;
-    });
 
     const lock = await acquireStudioConfigSmokeLock("/tmp/lock", {
-      openSync: openSync as never,
-      closeSync: vi.fn() as never,
-      writeFileSync: vi.fn((fd: number, body: string) => {
-        const p = fds.get(fd);
-        if (p) store.set(p, body);
+      writeFileSync: vi.fn((p: string, body: string, opts?: { flag?: string }) => {
+        if (opts?.flag === "wx" && store.has(p)) {
+          throw Object.assign(new Error("EEXIST"), { code: "EEXIST" });
+        }
+        store.set(p, body);
       }) as never,
       readFileSync: vi.fn((p: string) => {
         if (!store.has(p)) throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
@@ -96,6 +71,79 @@ describe("studioConfigSmokeLock", () => {
       pid: 999,
       timeoutMs: 1_000,
       pollMs: 5,
+      sleep: async () => undefined,
+    });
+    expect(store.get("/tmp/lock")).toBe("999\n");
+    lock.release();
+  });
+
+  it("does not reclaim a freshly empty lock (publisher still writing)", async () => {
+    const store = new Map<string, string>([["/tmp/lock", ""]]);
+    const unlinkSync = vi.fn((p: string) => {
+      store.delete(p);
+    });
+    let t = 1_000;
+    const sleep = vi.fn(async () => {
+      // After the first poll, the publisher finishes writing its PID.
+      store.set("/tmp/lock", "4242\n");
+      t += 50;
+    });
+
+    await expect(
+      acquireStudioConfigSmokeLock("/tmp/lock", {
+        writeFileSync: vi.fn((p: string, _body: string, opts?: { flag?: string }) => {
+          if (opts?.flag === "wx" && store.has(p)) {
+            throw Object.assign(new Error("EEXIST"), { code: "EEXIST" });
+          }
+          store.set(p, _body);
+        }) as never,
+        readFileSync: vi.fn((p: string) => {
+          if (!store.has(p)) throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+          return store.get(p) ?? "";
+        }) as never,
+        statSync: vi.fn(() => ({ mtimeMs: 1_000 })) as never,
+        unlinkSync: unlinkSync as never,
+        mkdirSync: vi.fn() as never,
+        isProcessAlive: () => true,
+        pid: 999,
+        timeoutMs: 500,
+        pollMs: 50,
+        publishGraceMs: 1_000,
+        now: () => t,
+        sleep,
+      }),
+    ).rejects.toThrow(/could not acquire/);
+
+    expect(unlinkSync).not.toHaveBeenCalled();
+    expect(store.get("/tmp/lock")).toBe("4242\n");
+    expect(sleep).toHaveBeenCalled();
+  });
+
+  it("reclaims an aged empty lock after the publish grace window", async () => {
+    const store = new Map<string, string>([["/tmp/lock", ""]]);
+    let t = 5_000;
+
+    const lock = await acquireStudioConfigSmokeLock("/tmp/lock", {
+      writeFileSync: vi.fn((p: string, body: string, opts?: { flag?: string }) => {
+        if (opts?.flag === "wx" && store.has(p)) {
+          throw Object.assign(new Error("EEXIST"), { code: "EEXIST" });
+        }
+        store.set(p, body);
+      }) as never,
+      readFileSync: vi.fn((p: string) => {
+        if (!store.has(p)) throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+        return store.get(p) ?? "";
+      }) as never,
+      statSync: vi.fn(() => ({ mtimeMs: 1_000 })) as never,
+      unlinkSync: vi.fn((p: string) => {
+        store.delete(p);
+      }) as never,
+      mkdirSync: vi.fn() as never,
+      pid: 999,
+      timeoutMs: 1_000,
+      pollMs: 5,
+      publishGraceMs: 1_000,
+      now: () => t,
       sleep: async () => undefined,
     });
     expect(store.get("/tmp/lock")).toBe("999\n");

--- a/src/lib/__tests__/studioConfigSmokeLock.test.ts
+++ b/src/lib/__tests__/studioConfigSmokeLock.test.ts
@@ -128,6 +128,64 @@ describe("studioConfigSmokeLock", () => {
     expect(store.get("/tmp/lock")).toBe("111\n");
   });
 
+  it("clears an orphaned reclaim mutex and recovers the main lock", async () => {
+    const store: Store = new Map([
+      ["/tmp/lock", "111\n"],
+      ["/tmp/lock.reclaim", "222\n"],
+    ]);
+    const fs = makeFs(store);
+
+    const lock = await acquireStudioConfigSmokeLock("/tmp/lock", {
+      writeFileSync: fs.writeFileSync as never,
+      linkSync: fs.linkSync as never,
+      readFileSync: fs.readFileSync as never,
+      unlinkSync: fs.unlinkSync as never,
+      mkdirSync: fs.mkdirSync as never,
+      isProcessAlive: (pid) => pid !== 111 && pid !== 222,
+      pid: 999,
+      timeoutMs: 1_000,
+      pollMs: 5,
+      sleep: async () => undefined,
+      randomId: () => "orphan",
+    });
+    expect(store.get("/tmp/lock")).toBe("999\n");
+    expect(store.has("/tmp/lock.reclaim")).toBe(false);
+    lock.release();
+  });
+
+  it("does not steal a live reclaim mutex", async () => {
+    const store: Store = new Map([
+      ["/tmp/lock", "111\n"],
+      ["/tmp/lock.reclaim", "222\n"],
+    ]);
+    const fs = makeFs(store);
+    let t = 0;
+    const sleep = vi.fn(async (ms: number) => {
+      t += ms;
+    });
+
+    await expect(
+      acquireStudioConfigSmokeLock("/tmp/lock", {
+        writeFileSync: fs.writeFileSync as never,
+        linkSync: fs.linkSync as never,
+        readFileSync: fs.readFileSync as never,
+        unlinkSync: fs.unlinkSync as never,
+        mkdirSync: fs.mkdirSync as never,
+        isProcessAlive: (pid) => pid === 222, // reclaim holder still live
+        pid: 999,
+        timeoutMs: 30,
+        pollMs: 10,
+        now: () => t,
+        sleep,
+        randomId: () => "live-reclaim",
+      }),
+    ).rejects.toThrow(/could not acquire/);
+
+    expect(store.get("/tmp/lock")).toBe("111\n");
+    expect(store.get("/tmp/lock.reclaim")).toBe("222\n");
+    expect(sleep).toHaveBeenCalled();
+  });
+
   it("does not unlink a peer lock published between classify and reclaim", async () => {
     // Both waiters saw the same aged incomplete body; the first already
     // reclaimed and published before the second's body compare under reclaim gate.

--- a/src/lib/__tests__/studioConfigSmokeLock.test.ts
+++ b/src/lib/__tests__/studioConfigSmokeLock.test.ts
@@ -27,19 +27,6 @@ function makeFs(store: Store) {
     // Hard link: destination appears with the fully written temp contents.
     store.set(to, store.get(from)!);
   });
-  // rename: destination appears with already-complete temp bytes (no partial body).
-  // Mirror Windows exclusivity (fail if dest exists); POSIX overwrite is rare here
-  // because callers only rename after link failed for reasons other than EEXIST.
-  const renameSync = vi.fn((from: string, to: string) => {
-    if (!store.has(from)) {
-      throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
-    }
-    if (store.has(to)) {
-      throw Object.assign(new Error("EEXIST"), { code: "EEXIST" });
-    }
-    store.set(to, store.get(from)!);
-    store.delete(from);
-  });
   const readFileSync = vi.fn((p: string) => {
     if (!store.has(p)) {
       throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
@@ -50,7 +37,7 @@ function makeFs(store: Store) {
     store.delete(p);
   });
   const mkdirSync = vi.fn();
-  return { writeFileSync, linkSync, renameSync, readFileSync, unlinkSync, mkdirSync };
+  return { writeFileSync, linkSync, readFileSync, unlinkSync, mkdirSync };
 }
 
 describe("studioConfigSmokeLock", () => {
@@ -62,7 +49,6 @@ describe("studioConfigSmokeLock", () => {
       ...fs,
       writeFileSync: fs.writeFileSync as never,
       linkSync: fs.linkSync as never,
-      renameSync: fs.renameSync as never,
       readFileSync: fs.readFileSync as never,
       unlinkSync: fs.unlinkSync as never,
       mkdirSync: fs.mkdirSync as never,
@@ -241,6 +227,7 @@ describe("studioConfigSmokeLock", () => {
       ["/tmp/lock.reclaim", ""],
     ]);
     const fs = makeFs(store);
+    let nowMs = 5_000;
 
     const lock = await acquireStudioConfigSmokeLock("/tmp/lock", {
       writeFileSync: fs.writeFileSync as never,
@@ -254,8 +241,11 @@ describe("studioConfigSmokeLock", () => {
       timeoutMs: 1_000,
       pollMs: 5,
       publishGraceMs: 1_000,
-      now: () => 5_000,
-      sleep: async () => undefined,
+      now: () => nowMs,
+      // Advance the fake clock on sleep so a regressing acquire cannot spin forever.
+      sleep: async (ms) => {
+        nowMs += ms;
+      },
       randomId: () => "aged-incomplete-reclaim",
     });
     expect(store.get("/tmp/lock")).toBe("999\n");
@@ -483,7 +473,7 @@ describe("studioConfigSmokeLock", () => {
     lock.release();
   });
 
-  it("on Windows falls back to rename of a complete temp when hardlinks fail", async () => {
+  it("falls back to exclusive wx write when hardlinks are unsupported", async () => {
     const store: Store = new Map();
     const fs = makeFs(store);
     const linkSync = vi.fn(() => {
@@ -493,77 +483,47 @@ describe("studioConfigSmokeLock", () => {
     const lock = await acquireStudioConfigSmokeLock("/tmp/lock", {
       writeFileSync: fs.writeFileSync as never,
       linkSync: linkSync as never,
-      renameSync: fs.renameSync as never,
       readFileSync: fs.readFileSync as never,
       unlinkSync: fs.unlinkSync as never,
       mkdirSync: fs.mkdirSync as never,
-      platform: "win32",
       pid: 777,
       timeoutMs: 1_000,
       pollMs: 10,
       randomId: () => "fb",
     });
     expect(store.get("/tmp/lock")).toBe("777\n");
-    expect(fs.renameSync).toHaveBeenCalled();
-    const [from, to] = fs.renameSync.mock.calls[0]!;
-    expect(String(from)).toContain(".tmp");
-    expect(to).toBe("/tmp/lock");
-    expect(fs.writeFileSync).not.toHaveBeenCalledWith("/tmp/lock", "777\n", { flag: "wx" });
+    expect(fs.writeFileSync).toHaveBeenCalledWith("/tmp/lock", "777\n", { flag: "wx" });
     expect([...store.keys()].some((k) => k.includes(".tmp"))).toBe(false);
     lock.release();
   });
 
-  it("on POSIX uses exclusive wx write when hardlinks fail (never renames over a peer)", async () => {
-    const store: Store = new Map();
-    const fs = makeFs(store);
-    const linkSync = vi.fn(() => {
-      throw Object.assign(new Error("ENOTSUP"), { code: "ENOTSUP" });
-    });
-
-    const lock = await acquireStudioConfigSmokeLock("/tmp/lock", {
-      writeFileSync: fs.writeFileSync as never,
-      linkSync: linkSync as never,
-      renameSync: fs.renameSync as never,
-      readFileSync: fs.readFileSync as never,
-      unlinkSync: fs.unlinkSync as never,
-      mkdirSync: fs.mkdirSync as never,
-      platform: "linux",
-      pid: 778,
-      timeoutMs: 1_000,
-      pollMs: 10,
-      randomId: () => "fb-posix",
-    });
-    expect(store.get("/tmp/lock")).toBe("778\n");
-    expect(fs.renameSync).not.toHaveBeenCalled();
-    expect(fs.writeFileSync).toHaveBeenCalledWith("/tmp/lock", "778\n", { flag: "wx" });
-    lock.release();
-  });
-
-  it("on POSIX ENOTSUP fallback does not replace a live peer lock", async () => {
+  it("ENOTSUP wx fallback does not replace a live peer lock", async () => {
     const store: Store = new Map([["/tmp/lock", "111\n"]]);
     const fs = makeFs(store);
     const linkSync = vi.fn(() => {
       throw Object.assign(new Error("ENOTSUP"), { code: "ENOTSUP" });
     });
+    let nowMs = 0;
     // Peer stays alive so reclaim must not steal; acquire should time out.
     await expect(
       acquireStudioConfigSmokeLock("/tmp/lock", {
         writeFileSync: fs.writeFileSync as never,
         linkSync: linkSync as never,
-        renameSync: fs.renameSync as never,
         readFileSync: fs.readFileSync as never,
         unlinkSync: fs.unlinkSync as never,
         mkdirSync: fs.mkdirSync as never,
         isProcessAlive: () => true,
-        platform: "linux",
         pid: 779,
         timeoutMs: 80,
         pollMs: 10,
+        now: () => nowMs,
+        sleep: async (ms) => {
+          nowMs += ms;
+        },
         randomId: () => "no-steal",
       }),
     ).rejects.toThrow(/could not acquire/);
     expect(store.get("/tmp/lock")).toBe("111\n");
-    expect(fs.renameSync).not.toHaveBeenCalled();
   });
 
   it("reports process liveness via kill(pid, 0)", () => {

--- a/src/lib/__tests__/studioConfigSmokeLock.test.ts
+++ b/src/lib/__tests__/studioConfigSmokeLock.test.ts
@@ -132,7 +132,7 @@ describe("studioConfigSmokeLock", () => {
   it("reclaims an aged empty lock after the publish grace window", async () => {
     const store: Store = new Map([["/tmp/lock", ""]]);
     const fs = makeFs(store);
-    let t = 5_000;
+    const t = 5_000;
 
     const lock = await acquireStudioConfigSmokeLock("/tmp/lock", {
       writeFileSync: fs.writeFileSync as never,

--- a/src/lib/__tests__/studioConfigSmokeLock.test.ts
+++ b/src/lib/__tests__/studioConfigSmokeLock.test.ts
@@ -1,7 +1,6 @@
 /**
  * Inter-process smoke lock for Studio config mutation.
  */
-import type { PathLike } from "node:fs";
 import { describe, expect, it, vi } from "vitest";
 import {
   acquireStudioConfigSmokeLock,
@@ -28,22 +27,18 @@ function makeFs(store: Store) {
     // Hard link: destination appears with the fully written temp contents.
     store.set(to, store.get(from)!);
   });
-  // Match Node's copyFileSync PathLike params so deps typing accepts the mock
-  // when spread into acquireStudioConfigSmokeLock (tsc --noEmit in CI lint).
-  const copyFileSync = vi.fn((from: PathLike, to: PathLike, mode?: number) => {
-    const src = String(from);
-    const dest = String(to);
-    if (!store.has(src)) {
+  // rename: destination appears with already-complete temp bytes (no partial body).
+  // Mirror Windows exclusivity (fail if dest exists); POSIX overwrite is rare here
+  // because callers only rename after link failed for reasons other than EEXIST.
+  const renameSync = vi.fn((from: string, to: string) => {
+    if (!store.has(from)) {
       throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
     }
-    // Mirror COPYFILE_EXCL: refuse when the destination already exists.
-    if (mode !== undefined && store.has(dest)) {
+    if (store.has(to)) {
       throw Object.assign(new Error("EEXIST"), { code: "EEXIST" });
     }
-    if (store.has(dest)) {
-      throw Object.assign(new Error("EEXIST"), { code: "EEXIST" });
-    }
-    store.set(dest, store.get(src)!);
+    store.set(to, store.get(from)!);
+    store.delete(from);
   });
   const readFileSync = vi.fn((p: string) => {
     if (!store.has(p)) {
@@ -55,7 +50,7 @@ function makeFs(store: Store) {
     store.delete(p);
   });
   const mkdirSync = vi.fn();
-  return { writeFileSync, linkSync, copyFileSync, readFileSync, unlinkSync, mkdirSync };
+  return { writeFileSync, linkSync, renameSync, readFileSync, unlinkSync, mkdirSync };
 }
 
 describe("studioConfigSmokeLock", () => {
@@ -67,7 +62,7 @@ describe("studioConfigSmokeLock", () => {
       ...fs,
       writeFileSync: fs.writeFileSync as never,
       linkSync: fs.linkSync as never,
-      copyFileSync: fs.copyFileSync as never,
+      renameSync: fs.renameSync as never,
       readFileSync: fs.readFileSync as never,
       unlinkSync: fs.unlinkSync as never,
       mkdirSync: fs.mkdirSync as never,
@@ -488,7 +483,7 @@ describe("studioConfigSmokeLock", () => {
     lock.release();
   });
 
-  it("falls back to exclusive copy when hardlinks are unsupported", async () => {
+  it("falls back to rename of a complete temp when hardlinks are unsupported", async () => {
     const store: Store = new Map();
     const fs = makeFs(store);
     const linkSync = vi.fn(() => {
@@ -498,7 +493,7 @@ describe("studioConfigSmokeLock", () => {
     const lock = await acquireStudioConfigSmokeLock("/tmp/lock", {
       writeFileSync: fs.writeFileSync as never,
       linkSync: linkSync as never,
-      copyFileSync: fs.copyFileSync as never,
+      renameSync: fs.renameSync as never,
       readFileSync: fs.readFileSync as never,
       unlinkSync: fs.unlinkSync as never,
       mkdirSync: fs.mkdirSync as never,
@@ -508,11 +503,10 @@ describe("studioConfigSmokeLock", () => {
       randomId: () => "fb",
     });
     expect(store.get("/tmp/lock")).toBe("777\n");
-    expect(fs.copyFileSync).toHaveBeenCalled();
-    const [from, to, mode] = fs.copyFileSync.mock.calls[0]!;
+    expect(fs.renameSync).toHaveBeenCalled();
+    const [from, to] = fs.renameSync.mock.calls[0]!;
     expect(String(from)).toContain(".tmp");
     expect(to).toBe("/tmp/lock");
-    expect(typeof mode).toBe("number");
     expect(fs.writeFileSync).not.toHaveBeenCalledWith("/tmp/lock", "777\n", { flag: "wx" });
     expect([...store.keys()].some((k) => k.includes(".tmp"))).toBe(false);
     lock.release();

--- a/src/lib/__tests__/studioConfigSmokeLock.test.ts
+++ b/src/lib/__tests__/studioConfigSmokeLock.test.ts
@@ -92,6 +92,40 @@ describe("studioConfigSmokeLock", () => {
     lock.release();
   });
 
+  it("does not reclaim a partial numeric PID body before the publish grace window", async () => {
+    // Mid-publish body "12" must not be treated as live PID 12 via parseInt.
+    const store: Store = new Map([["/tmp/lock", "12"]]);
+    const fs = makeFs(store);
+    let t = 1_000;
+    const sleep = vi.fn(async () => {
+      store.set("/tmp/lock", "12345\n");
+      t += 50;
+    });
+
+    await expect(
+      acquireStudioConfigSmokeLock("/tmp/lock", {
+        writeFileSync: fs.writeFileSync as never,
+        linkSync: fs.linkSync as never,
+        readFileSync: fs.readFileSync as never,
+        unlinkSync: fs.unlinkSync as never,
+        mkdirSync: fs.mkdirSync as never,
+        statSync: vi.fn(() => ({ mtimeMs: 1_000 })) as never,
+        isProcessAlive: (pid) => pid === 12 || pid === 12345,
+        pid: 999,
+        timeoutMs: 500,
+        pollMs: 50,
+        publishGraceMs: 1_000,
+        now: () => t,
+        sleep,
+        randomId: () => "partial",
+      }),
+    ).rejects.toThrow(/could not acquire/);
+
+    expect(fs.unlinkSync).not.toHaveBeenCalledWith("/tmp/lock");
+    expect(store.get("/tmp/lock")).toBe("12345\n");
+    expect(sleep).toHaveBeenCalled();
+  });
+
   it("does not reclaim a freshly empty lock while process A delays PID publish", async () => {
     // Process A created the final path (legacy open/write or crash remnant) but
     // has not written the PID yet. Process B must poll through grace, not unlink.
@@ -132,7 +166,7 @@ describe("studioConfigSmokeLock", () => {
   it("reclaims an aged empty lock after the publish grace window", async () => {
     const store: Store = new Map([["/tmp/lock", ""]]);
     const fs = makeFs(store);
-    const t = 5_000;
+    const nowMs = 5_000;
 
     const lock = await acquireStudioConfigSmokeLock("/tmp/lock", {
       writeFileSync: fs.writeFileSync as never,
@@ -145,7 +179,7 @@ describe("studioConfigSmokeLock", () => {
       timeoutMs: 1_000,
       pollMs: 5,
       publishGraceMs: 1_000,
-      now: () => t,
+      now: () => nowMs,
       sleep: async () => undefined,
       randomId: () => "aged",
     });

--- a/src/lib/__tests__/studioConfigSmokeLock.test.ts
+++ b/src/lib/__tests__/studioConfigSmokeLock.test.ts
@@ -186,15 +186,13 @@ describe("studioConfigSmokeLock", () => {
     expect(sleep).toHaveBeenCalled();
   });
 
-  it("does not clear an aged incomplete reclaim mutex by age alone", async () => {
-    // Incomplete reclaim bodies must not be age-reaped: a live reclaimer could
-    // still be in its critical section. Only dead complete PIDs are cleared.
+  it("does not clear a fresh incomplete reclaim mutex before publishGraceMs", async () => {
     const store: Store = new Map([
       ["/tmp/lock", "111\n"],
       ["/tmp/lock.reclaim", ""],
     ]);
     const fs = makeFs(store);
-    let t = 5_000;
+    let t = 1_050; // age 50ms with mtime 1000, grace 1000
     const sleep = vi.fn(async (ms: number) => {
       t += ms;
     });
@@ -214,13 +212,41 @@ describe("studioConfigSmokeLock", () => {
         publishGraceMs: 1_000,
         now: () => t,
         sleep,
-        randomId: () => "incomplete-reclaim",
+        randomId: () => "fresh-incomplete-reclaim",
       }),
     ).rejects.toThrow(/could not acquire/);
 
-    expect(store.get("/tmp/lock")).toBe("111\n");
     expect(store.get("/tmp/lock.reclaim")).toBe("");
     expect(fs.unlinkSync).not.toHaveBeenCalledWith("/tmp/lock");
+  });
+
+  it("clears an aged incomplete orphaned reclaim mutex and recovers", async () => {
+    // Crash mid-write left an empty reclaim gate; after grace it must not pin smokers.
+    const store: Store = new Map([
+      ["/tmp/lock", "111\n"],
+      ["/tmp/lock.reclaim", ""],
+    ]);
+    const fs = makeFs(store);
+
+    const lock = await acquireStudioConfigSmokeLock("/tmp/lock", {
+      writeFileSync: fs.writeFileSync as never,
+      linkSync: fs.linkSync as never,
+      readFileSync: fs.readFileSync as never,
+      unlinkSync: fs.unlinkSync as never,
+      mkdirSync: fs.mkdirSync as never,
+      statSync: vi.fn(() => ({ mtimeMs: 1_000 })) as never,
+      isProcessAlive: (pid) => pid !== 111,
+      pid: 999,
+      timeoutMs: 1_000,
+      pollMs: 5,
+      publishGraceMs: 1_000,
+      now: () => 5_000,
+      sleep: async () => undefined,
+      randomId: () => "aged-incomplete-reclaim",
+    });
+    expect(store.get("/tmp/lock")).toBe("999\n");
+    expect(store.has("/tmp/lock.reclaim")).toBe(false);
+    lock.release();
   });
 
   it("does not unlink the main lock after losing reclaim gate ownership", async () => {

--- a/src/lib/__tests__/studioConfigSmokeLock.test.ts
+++ b/src/lib/__tests__/studioConfigSmokeLock.test.ts
@@ -186,13 +186,13 @@ describe("studioConfigSmokeLock", () => {
     expect(sleep).toHaveBeenCalled();
   });
 
-  it("does not clear a fresh incomplete reclaim mutex before publishGraceMs", async () => {
+  it("does not clear a fresh incomplete reclaim mutex", async () => {
     const store: Store = new Map([
       ["/tmp/lock", "111\n"],
       ["/tmp/lock.reclaim", ""],
     ]);
     const fs = makeFs(store);
-    let t = 1_050; // age 50ms with mtime 1000, grace 1000
+    let t = 1_050;
     const sleep = vi.fn(async (ms: number) => {
       t += ms;
     });
@@ -204,12 +204,10 @@ describe("studioConfigSmokeLock", () => {
         readFileSync: fs.readFileSync as never,
         unlinkSync: fs.unlinkSync as never,
         mkdirSync: fs.mkdirSync as never,
-        statSync: vi.fn(() => ({ mtimeMs: 1_000 })) as never,
         isProcessAlive: () => false,
         pid: 999,
         timeoutMs: 30,
         pollMs: 10,
-        publishGraceMs: 1_000,
         now: () => t,
         sleep,
         randomId: () => "fresh-incomplete-reclaim",
@@ -220,8 +218,9 @@ describe("studioConfigSmokeLock", () => {
     expect(fs.unlinkSync).not.toHaveBeenCalledWith("/tmp/lock");
   });
 
-  it("clears an aged incomplete orphaned reclaim mutex and recovers", async () => {
-    // Crash mid-write left an empty reclaim gate; after grace it must not pin smokers.
+  it("does not clear an aged incomplete reclaim mutex (wx may still be publishing)", async () => {
+    // Incomplete reclaim gates are never age-cleared: a paused wx publisher
+    // past any grace window must keep exclusivity until smokers time out.
     const store: Store = new Map([
       ["/tmp/lock", "111\n"],
       ["/tmp/lock.reclaim", ""],
@@ -229,28 +228,27 @@ describe("studioConfigSmokeLock", () => {
     const fs = makeFs(store);
     let nowMs = 5_000;
 
-    const lock = await acquireStudioConfigSmokeLock("/tmp/lock", {
-      writeFileSync: fs.writeFileSync as never,
-      linkSync: fs.linkSync as never,
-      readFileSync: fs.readFileSync as never,
-      unlinkSync: fs.unlinkSync as never,
-      mkdirSync: fs.mkdirSync as never,
-      statSync: vi.fn(() => ({ mtimeMs: 1_000 })) as never,
-      isProcessAlive: (pid) => pid !== 111,
-      pid: 999,
-      timeoutMs: 1_000,
-      pollMs: 5,
-      publishGraceMs: 1_000,
-      now: () => nowMs,
-      // Advance the fake clock on sleep so a regressing acquire cannot spin forever.
-      sleep: async (ms) => {
-        nowMs += ms;
-      },
-      randomId: () => "aged-incomplete-reclaim",
-    });
-    expect(store.get("/tmp/lock")).toBe("999\n");
-    expect(store.has("/tmp/lock.reclaim")).toBe(false);
-    lock.release();
+    await expect(
+      acquireStudioConfigSmokeLock("/tmp/lock", {
+        writeFileSync: fs.writeFileSync as never,
+        linkSync: fs.linkSync as never,
+        readFileSync: fs.readFileSync as never,
+        unlinkSync: fs.unlinkSync as never,
+        mkdirSync: fs.mkdirSync as never,
+        isProcessAlive: (pid) => pid !== 111,
+        pid: 999,
+        timeoutMs: 80,
+        pollMs: 10,
+        now: () => nowMs,
+        sleep: async (ms) => {
+          nowMs += ms;
+        },
+        randomId: () => "aged-incomplete-reclaim",
+      }),
+    ).rejects.toThrow(/could not acquire/);
+
+    expect(store.get("/tmp/lock.reclaim")).toBe("");
+    expect(store.get("/tmp/lock")).toBe("111\n");
   });
 
   it("does not unlink the main lock after losing reclaim gate ownership", async () => {
@@ -301,12 +299,12 @@ describe("studioConfigSmokeLock", () => {
   });
 
   it("does not unlink a peer lock published between classify and reclaim", async () => {
-    // Both waiters saw the same aged incomplete body; the first already
-    // reclaimed and published before the second's body compare under reclaim gate.
-    const store: Store = new Map([["/tmp/lock", ""]]);
+    // Waiter classified a dead complete PID; under the reclaim gate the body
+    // has already been replaced by a live peer publish.
+    const store: Store = new Map([["/tmp/lock", "111\n"]]);
     const fs = makeFs(store);
     let lockReads = 0;
-    let t = 5_000;
+    let t = 0;
     const sleep = vi.fn(async (ms: number) => {
       t += ms;
     });
@@ -318,8 +316,8 @@ describe("studioConfigSmokeLock", () => {
         return store.get(p) ?? "";
       }
       lockReads += 1;
-      // Classify against aged empty, then observe the peer's published PID.
-      return lockReads === 1 ? "" : "4242\n";
+      // First classify as dead 111; under reclaim gate observe peer's 4242.
+      return lockReads === 1 ? "111\n" : "4242\n";
     });
 
     await expect(
@@ -329,12 +327,10 @@ describe("studioConfigSmokeLock", () => {
         readFileSync: readFileSync as never,
         unlinkSync: fs.unlinkSync as never,
         mkdirSync: fs.mkdirSync as never,
-        statSync: vi.fn(() => ({ mtimeMs: 1_000 })) as never,
-        isProcessAlive: () => true,
+        isProcessAlive: (pid) => pid !== 111,
         pid: 999,
-        timeoutMs: 30,
+        timeoutMs: 80,
         pollMs: 10,
-        publishGraceMs: 1_000,
         now: () => t,
         sleep,
         randomId: () => "cas",
@@ -378,8 +374,9 @@ describe("studioConfigSmokeLock", () => {
     lock.release();
   });
 
-  it("does not reclaim a partial numeric PID body before the publish grace window", async () => {
-    // Mid-publish body "12" must not be treated as live PID 12 via parseInt.
+  it("does not reclaim a partial numeric PID body while a peer may still be publishing", async () => {
+    // Mid-publish body "12" must not be treated as live PID 12 via parseInt,
+    // and must not be age-cleared as incomplete.
     const store: Store = new Map([["/tmp/lock", "12"]]);
     const fs = makeFs(store);
     let t = 1_000;
@@ -395,12 +392,10 @@ describe("studioConfigSmokeLock", () => {
         readFileSync: fs.readFileSync as never,
         unlinkSync: fs.unlinkSync as never,
         mkdirSync: fs.mkdirSync as never,
-        statSync: vi.fn(() => ({ mtimeMs: 1_000 })) as never,
         isProcessAlive: (pid) => pid === 12 || pid === 12345,
         pid: 999,
         timeoutMs: 500,
         pollMs: 50,
-        publishGraceMs: 1_000,
         now: () => t,
         sleep,
         randomId: () => "partial",
@@ -413,8 +408,8 @@ describe("studioConfigSmokeLock", () => {
   });
 
   it("does not reclaim a freshly empty lock while process A delays PID publish", async () => {
-    // Process A created the final path (legacy open/write or crash remnant) but
-    // has not written the PID yet. Process B must poll through grace, not unlink.
+    // Process A created the final path (wx open) but has not finished writing.
+    // Process B must poll, not unlink, even past any former grace window.
     const store: Store = new Map([["/tmp/lock", ""]]);
     const fs = makeFs(store);
     let t = 1_000;
@@ -431,12 +426,10 @@ describe("studioConfigSmokeLock", () => {
         readFileSync: fs.readFileSync as never,
         unlinkSync: fs.unlinkSync as never,
         mkdirSync: fs.mkdirSync as never,
-        statSync: vi.fn(() => ({ mtimeMs: 1_000 })) as never,
         isProcessAlive: () => true,
         pid: 999,
         timeoutMs: 500,
         pollMs: 50,
-        publishGraceMs: 1_000,
         now: () => t,
         sleep,
         randomId: () => "b",
@@ -449,28 +442,31 @@ describe("studioConfigSmokeLock", () => {
     expect(sleep).toHaveBeenCalled();
   });
 
-  it("reclaims an aged empty lock after the publish grace window", async () => {
+  it("does not reclaim an aged empty lock (incomplete is never age-cleared)", async () => {
     const store: Store = new Map([["/tmp/lock", ""]]);
     const fs = makeFs(store);
-    const nowMs = 5_000;
+    let nowMs = 5_000;
 
-    const lock = await acquireStudioConfigSmokeLock("/tmp/lock", {
-      writeFileSync: fs.writeFileSync as never,
-      linkSync: fs.linkSync as never,
-      readFileSync: fs.readFileSync as never,
-      unlinkSync: fs.unlinkSync as never,
-      mkdirSync: fs.mkdirSync as never,
-      statSync: vi.fn(() => ({ mtimeMs: 1_000 })) as never,
-      pid: 999,
-      timeoutMs: 1_000,
-      pollMs: 5,
-      publishGraceMs: 1_000,
-      now: () => nowMs,
-      sleep: async () => undefined,
-      randomId: () => "aged",
-    });
-    expect(store.get("/tmp/lock")).toBe("999\n");
-    lock.release();
+    await expect(
+      acquireStudioConfigSmokeLock("/tmp/lock", {
+        writeFileSync: fs.writeFileSync as never,
+        linkSync: fs.linkSync as never,
+        readFileSync: fs.readFileSync as never,
+        unlinkSync: fs.unlinkSync as never,
+        mkdirSync: fs.mkdirSync as never,
+        pid: 999,
+        timeoutMs: 80,
+        pollMs: 10,
+        now: () => nowMs,
+        sleep: async (ms) => {
+          nowMs += ms;
+        },
+        randomId: () => "aged",
+      }),
+    ).rejects.toThrow(/could not acquire/);
+
+    expect(store.get("/tmp/lock")).toBe("");
+    expect(fs.unlinkSync).not.toHaveBeenCalledWith("/tmp/lock");
   });
 
   it("falls back to exclusive wx write when hardlinks are unsupported", async () => {

--- a/src/lib/__tests__/studioConfigSmokeLock.test.ts
+++ b/src/lib/__tests__/studioConfigSmokeLock.test.ts
@@ -483,7 +483,7 @@ describe("studioConfigSmokeLock", () => {
     lock.release();
   });
 
-  it("falls back to rename of a complete temp when hardlinks are unsupported", async () => {
+  it("on Windows falls back to rename of a complete temp when hardlinks fail", async () => {
     const store: Store = new Map();
     const fs = makeFs(store);
     const linkSync = vi.fn(() => {
@@ -497,6 +497,7 @@ describe("studioConfigSmokeLock", () => {
       readFileSync: fs.readFileSync as never,
       unlinkSync: fs.unlinkSync as never,
       mkdirSync: fs.mkdirSync as never,
+      platform: "win32",
       pid: 777,
       timeoutMs: 1_000,
       pollMs: 10,
@@ -510,6 +511,59 @@ describe("studioConfigSmokeLock", () => {
     expect(fs.writeFileSync).not.toHaveBeenCalledWith("/tmp/lock", "777\n", { flag: "wx" });
     expect([...store.keys()].some((k) => k.includes(".tmp"))).toBe(false);
     lock.release();
+  });
+
+  it("on POSIX uses exclusive wx write when hardlinks fail (never renames over a peer)", async () => {
+    const store: Store = new Map();
+    const fs = makeFs(store);
+    const linkSync = vi.fn(() => {
+      throw Object.assign(new Error("ENOTSUP"), { code: "ENOTSUP" });
+    });
+
+    const lock = await acquireStudioConfigSmokeLock("/tmp/lock", {
+      writeFileSync: fs.writeFileSync as never,
+      linkSync: linkSync as never,
+      renameSync: fs.renameSync as never,
+      readFileSync: fs.readFileSync as never,
+      unlinkSync: fs.unlinkSync as never,
+      mkdirSync: fs.mkdirSync as never,
+      platform: "linux",
+      pid: 778,
+      timeoutMs: 1_000,
+      pollMs: 10,
+      randomId: () => "fb-posix",
+    });
+    expect(store.get("/tmp/lock")).toBe("778\n");
+    expect(fs.renameSync).not.toHaveBeenCalled();
+    expect(fs.writeFileSync).toHaveBeenCalledWith("/tmp/lock", "778\n", { flag: "wx" });
+    lock.release();
+  });
+
+  it("on POSIX ENOTSUP fallback does not replace a live peer lock", async () => {
+    const store: Store = new Map([["/tmp/lock", "111\n"]]);
+    const fs = makeFs(store);
+    const linkSync = vi.fn(() => {
+      throw Object.assign(new Error("ENOTSUP"), { code: "ENOTSUP" });
+    });
+    // Peer stays alive so reclaim must not steal; acquire should time out.
+    await expect(
+      acquireStudioConfigSmokeLock("/tmp/lock", {
+        writeFileSync: fs.writeFileSync as never,
+        linkSync: linkSync as never,
+        renameSync: fs.renameSync as never,
+        readFileSync: fs.readFileSync as never,
+        unlinkSync: fs.unlinkSync as never,
+        mkdirSync: fs.mkdirSync as never,
+        isProcessAlive: () => true,
+        platform: "linux",
+        pid: 779,
+        timeoutMs: 80,
+        pollMs: 10,
+        randomId: () => "no-steal",
+      }),
+    ).rejects.toThrow(/could not acquire/);
+    expect(store.get("/tmp/lock")).toBe("111\n");
+    expect(fs.renameSync).not.toHaveBeenCalled();
   });
 
   it("reports process liveness via kill(pid, 0)", () => {

--- a/src/lib/__tests__/studioConfigSmokeLock.test.ts
+++ b/src/lib/__tests__/studioConfigSmokeLock.test.ts
@@ -53,6 +53,12 @@ describe("studioConfigSmokeLock", () => {
       pollMs: 10,
     });
     expect(store.get("/tmp/lock")).toBe("4242\n");
+    // Foreign PID must not be unlinked by our release().
+    store.set("/tmp/lock", "9999\n");
+    lock.release();
+    expect(store.get("/tmp/lock")).toBe("9999\n");
+    // Restore ownership and confirm own-pid release clears the lock.
+    store.set("/tmp/lock", "4242\n");
     lock.release();
     expect(store.has("/tmp/lock")).toBe(false);
   });
@@ -102,9 +108,11 @@ describe("studioConfigSmokeLock", () => {
   });
 
   it("tryRemoveEmptyStudioConfigDir ignores busy dirs", () => {
-    const rmSync = vi.fn(() => {
+    const rmdirSync = vi.fn(() => {
       throw Object.assign(new Error("ENOTEMPTY"), { code: "ENOTEMPTY" });
     });
-    expect(() => tryRemoveEmptyStudioConfigDir("/x", { rmSync: rmSync as never })).not.toThrow();
+    expect(() =>
+      tryRemoveEmptyStudioConfigDir("/x", { rmdirSync: rmdirSync as never }),
+    ).not.toThrow();
   });
 });

--- a/src/lib/__tests__/studioConfigSmokeLock.test.ts
+++ b/src/lib/__tests__/studioConfigSmokeLock.test.ts
@@ -1,6 +1,7 @@
 /**
  * Inter-process smoke lock for Studio config mutation.
  */
+import type { PathLike } from "node:fs";
 import { describe, expect, it, vi } from "vitest";
 import {
   acquireStudioConfigSmokeLock,
@@ -27,18 +28,22 @@ function makeFs(store: Store) {
     // Hard link: destination appears with the fully written temp contents.
     store.set(to, store.get(from)!);
   });
-  const copyFileSync = vi.fn((from: string, to: string, mode?: number) => {
-    if (!store.has(from)) {
+  // Match Node's copyFileSync PathLike params so deps typing accepts the mock
+  // when spread into acquireStudioConfigSmokeLock (tsc --noEmit in CI lint).
+  const copyFileSync = vi.fn((from: PathLike, to: PathLike, mode?: number) => {
+    const src = String(from);
+    const dest = String(to);
+    if (!store.has(src)) {
       throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
     }
     // Mirror COPYFILE_EXCL: refuse when the destination already exists.
-    if (mode !== undefined && store.has(to)) {
+    if (mode !== undefined && store.has(dest)) {
       throw Object.assign(new Error("EEXIST"), { code: "EEXIST" });
     }
-    if (store.has(to)) {
+    if (store.has(dest)) {
       throw Object.assign(new Error("EEXIST"), { code: "EEXIST" });
     }
-    store.set(to, store.get(from)!);
+    store.set(dest, store.get(src)!);
   });
   const readFileSync = vi.fn((p: string) => {
     if (!store.has(p)) {
@@ -62,6 +67,7 @@ describe("studioConfigSmokeLock", () => {
       ...fs,
       writeFileSync: fs.writeFileSync as never,
       linkSync: fs.linkSync as never,
+      copyFileSync: fs.copyFileSync as never,
       readFileSync: fs.readFileSync as never,
       unlinkSync: fs.unlinkSync as never,
       mkdirSync: fs.mkdirSync as never,

--- a/src/lib/__tests__/studioConfigSmokeLock.test.ts
+++ b/src/lib/__tests__/studioConfigSmokeLock.test.ts
@@ -130,7 +130,7 @@ describe("studioConfigSmokeLock", () => {
 
   it("does not unlink a peer lock published between classify and reclaim", async () => {
     // Both waiters saw the same aged incomplete body; the first already
-    // reclaimed and published before the second's pathname unlink.
+    // reclaimed and published before the second's body compare under reclaim gate.
     const store: Store = new Map([["/tmp/lock", ""]]);
     const fs = makeFs(store);
     let lockReads = 0;
@@ -171,6 +171,39 @@ describe("studioConfigSmokeLock", () => {
 
     expect(fs.unlinkSync).not.toHaveBeenCalledWith("/tmp/lock");
     expect(sleep).toHaveBeenCalled();
+  });
+
+  it("recreates the lock directory when temp publish hits ENOENT", async () => {
+    const store: Store = new Map();
+    const fs = makeFs(store);
+    let mkdirCalls = 0;
+    const mkdirSync = vi.fn((dir: string, opts?: { recursive?: boolean }) => {
+      mkdirCalls += 1;
+      return fs.mkdirSync(dir, opts as never);
+    });
+    let tempWrites = 0;
+    const writeFileSync = vi.fn((p: string, body: string, opts?: { flag?: string }) => {
+      if (String(p).includes(".tmp") && tempWrites === 0) {
+        tempWrites += 1;
+        throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+      }
+      return fs.writeFileSync(p, body, opts as never);
+    });
+
+    const lock = await acquireStudioConfigSmokeLock("/tmp/olive/.lock", {
+      writeFileSync: writeFileSync as never,
+      linkSync: fs.linkSync as never,
+      readFileSync: fs.readFileSync as never,
+      unlinkSync: fs.unlinkSync as never,
+      mkdirSync: mkdirSync as never,
+      pid: 321,
+      timeoutMs: 1_000,
+      pollMs: 10,
+      randomId: () => "enoent",
+    });
+    expect(store.get("/tmp/olive/.lock")).toBe("321\n");
+    expect(mkdirCalls).toBeGreaterThanOrEqual(2);
+    lock.release();
   });
 
   it("does not reclaim a partial numeric PID body before the publish grace window", async () => {

--- a/src/lib/__tests__/studioConfigSmokeLock.test.ts
+++ b/src/lib/__tests__/studioConfigSmokeLock.test.ts
@@ -92,6 +92,42 @@ describe("studioConfigSmokeLock", () => {
     lock.release();
   });
 
+  it("polls via sleep when reclaim unlink fails with EPERM", async () => {
+    const store: Store = new Map([["/tmp/lock", "111\n"]]);
+    const fs = makeFs(store);
+    let t = 0;
+    const sleep = vi.fn(async (ms: number) => {
+      t += ms;
+    });
+    const unlinkSync = vi.fn((p: string) => {
+      if (p === "/tmp/lock") {
+        throw Object.assign(new Error("EPERM"), { code: "EPERM" });
+      }
+      store.delete(p);
+    });
+
+    await expect(
+      acquireStudioConfigSmokeLock("/tmp/lock", {
+        writeFileSync: fs.writeFileSync as never,
+        linkSync: fs.linkSync as never,
+        readFileSync: fs.readFileSync as never,
+        unlinkSync: unlinkSync as never,
+        mkdirSync: fs.mkdirSync as never,
+        isProcessAlive: (pid) => pid !== 111,
+        pid: 999,
+        timeoutMs: 30,
+        pollMs: 10,
+        now: () => t,
+        sleep,
+        randomId: () => "eperm",
+      }),
+    ).rejects.toThrow(/could not acquire/);
+
+    expect(unlinkSync).toHaveBeenCalledWith("/tmp/lock");
+    expect(sleep).toHaveBeenCalled();
+    expect(store.get("/tmp/lock")).toBe("111\n");
+  });
+
   it("does not reclaim a partial numeric PID body before the publish grace window", async () => {
     // Mid-publish body "12" must not be treated as live PID 12 via parseInt.
     const store: Store = new Map([["/tmp/lock", "12"]]);

--- a/src/server/services/olive/jobRunner.idempotency.test.ts
+++ b/src/server/services/olive/jobRunner.idempotency.test.ts
@@ -1,12 +1,12 @@
 /**
  * Concurrent MCP submit locking + idempotent reuse via startOliveJob.
- * Keeps setup CPU-only: mocked spawn/fs, drained detached setup before cleanup.
+ * Keeps setup CPU-only: mocked spawn/fs, lifecycle teardown before registry clear.
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import fs from "fs";
 import { preflightOliveRecipe } from "./jobPreflight.ts";
 import { clearIdempotencyIndex } from "./jobIdempotency.ts";
-import { jobRegistry } from "./state.ts";
+import { finalizeJob, jobRegistry } from "./state.ts";
 
 const childProcessMocks = vi.hoisted(() => ({
   execFileImpl: null as null | ((...args: unknown[]) => unknown),
@@ -43,62 +43,86 @@ vi.mock("../venv/index.ts", () => ({
 
 const { mcpSubmitLockTailCount, startOliveJob } = await import("./jobRunner.ts");
 
-/** Waiters that ensure detached MCP setup has left `setting_up` before registry clear. */
-const pendingSetups: Promise<unknown>[] = [];
+/** Every job id created by this file's helpers (including reused lookups). */
+const trackedJobIds = new Set<string>();
 
-async function drainPendingSetups(): Promise<void> {
-  for (let i = 0; i < 20; i += 1) {
-    if (pendingSetups.length === 0) return;
-    const batch = pendingSetups.splice(0, pendingSetups.length);
-    await Promise.allSettled(batch);
-    await Promise.resolve();
+const TEARDOWN_DEADLINE_MS = 5_000;
+
+async function awaitTrackedJobsFinished(deadlineMs = TEARDOWN_DEADLINE_MS): Promise<void> {
+  const deadline = Date.now() + deadlineMs;
+  for (const id of trackedJobIds) {
+    const job = jobRegistry.get(id);
+    if (!job || job.finishedAt != null) continue;
+    if (job.status !== "completed" && job.status !== "failed" && job.status !== "cancelled") {
+      job.status = "cancelled";
+    }
+    const proc = job.process;
+    if (proc && proc.exitCode === null && proc.signalCode === null) {
+      try {
+        proc.kill("SIGKILL");
+      } catch {
+        /* mock already exited */
+      }
+    }
+  }
+
+  while (Date.now() < deadline) {
+    const unfinished = [...trackedJobIds].filter((id) => {
+      const job = jobRegistry.get(id);
+      return job != null && job.finishedAt == null;
+    });
+    if (unfinished.length === 0) return;
+    await new Promise((r) => setTimeout(r, 10));
+  }
+
+  const stuck = [...trackedJobIds].filter((id) => {
+    const job = jobRegistry.get(id);
+    return job != null && job.finishedAt == null;
+  });
+  for (const id of stuck) {
+    const job = jobRegistry.get(id);
+    if (job) finalizeJob(job);
+  }
+  if (stuck.length > 0) {
+    throw new Error(
+      `jobRunner teardown deadline (${deadlineMs}ms): unfinished jobs ${stuck.join(", ")}`,
+    );
   }
 }
 
 beforeEach(() => {
+  trackedJobIds.clear();
   vi.spyOn(fs, "mkdirSync").mockReturnValue(undefined as unknown as string);
   vi.spyOn(fs, "writeFileSync").mockReturnValue(undefined);
 });
 
 afterEach(async () => {
-  await drainPendingSetups();
-  jobRegistry.clear();
-  clearIdempotencyIndex();
-  vi.clearAllMocks();
-  vi.restoreAllMocks();
-  vi.mocked(preflightOliveRecipe).mockImplementation(() => ({
-    valid: true,
-    provider: "CPUExecutionProvider",
-    fingerprint: "fp-concurrent",
-    errors: [] as string[],
-    warnings: [] as string[],
-    cudaVersion: "auto",
-    recipe: { input_model: {}, passes: {}, engine: {}, systems: {} },
-  }));
+  try {
+    await awaitTrackedJobsFinished();
+  } finally {
+    trackedJobIds.clear();
+    jobRegistry.clear();
+    clearIdempotencyIndex();
+    vi.clearAllMocks();
+    vi.restoreAllMocks();
+    vi.mocked(preflightOliveRecipe).mockImplementation(() => ({
+      valid: true,
+      provider: "CPUExecutionProvider",
+      fingerprint: "fp-concurrent",
+      errors: [] as string[],
+      warnings: [] as string[],
+      cudaVersion: "auto",
+      recipe: { input_model: {}, passes: {}, engine: {}, systems: {} },
+    }));
+  }
 });
 
-/** Track fire-and-forget MCP setup so afterEach can drain before clearing the registry. */
+/** Track every created/reused job id so afterEach can cancel and await finishedAt. */
 async function startOliveJobTracked(
   ...args: Parameters<typeof startOliveJob>
 ): ReturnType<typeof startOliveJob> {
-  const before = new Set(jobRegistry.keys());
   const result = await startOliveJob(...args);
-  if (result.ok && !result.reused) {
-    const job = jobRegistry.get(result.jobId);
-    if (job && !before.has(result.jobId)) {
-      const settled = (async () => {
-        const deadline = Date.now() + 5_000;
-        while (Date.now() < deadline) {
-          const current = jobRegistry.get(result.jobId);
-          if (!current || current.finishedAt != null || current.status !== "setting_up") {
-            return;
-          }
-          await new Promise((r) => setTimeout(r, 10));
-        }
-      })();
-      pendingSetups.push(settled);
-    }
-  }
+  if (result.ok) trackedJobIds.add(result.jobId);
   return result;
 }
 

--- a/src/server/services/olive/jobRunner.idempotency.test.ts
+++ b/src/server/services/olive/jobRunner.idempotency.test.ts
@@ -1,11 +1,23 @@
 /**
  * Concurrent MCP submit locking + idempotent reuse via startOliveJob.
+ * Keeps setup CPU-only: mocked spawn/fs, drained detached setup before cleanup.
  */
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import fs from "fs";
 import { preflightOliveRecipe } from "./jobPreflight.ts";
-import { mcpSubmitLockTailCount, startOliveJob } from "./jobRunner.ts";
 import { clearIdempotencyIndex } from "./jobIdempotency.ts";
 import { jobRegistry } from "./state.ts";
+
+const childProcessMocks = vi.hoisted(() => ({
+  execFileImpl: null as null | ((...args: unknown[]) => unknown),
+  spawnImpl: null as null | ((...args: unknown[]) => unknown),
+  execFileCalls: [] as unknown[][],
+}));
+
+vi.mock("child_process", async (importOriginal) => {
+  const { childProcessVitestMockFactory } = await import("../../__tests__/childProcessTestMocks.ts");
+  return childProcessVitestMockFactory(childProcessMocks, { includeSpawn: true })(importOriginal);
+});
 
 vi.mock("./jobPreflight.ts", () => ({
   preflightOliveRecipe: vi.fn(() => ({
@@ -25,14 +37,35 @@ vi.mock("../venv/index.ts", () => ({
     python: "python",
     family: "default",
   })),
-  buildOliveRunEnvironment: vi.fn(() => ({})),
+  buildOliveRunEnvironment: vi.fn(async () => ({})),
   resolveOliveCommand: vi.fn(() => ({ executable: "echo", args: ["ok"] })),
 }));
 
-afterEach(() => {
+const { mcpSubmitLockTailCount, startOliveJob } = await import("./jobRunner.ts");
+
+/** Waiters that ensure detached MCP setup has left `setting_up` before registry clear. */
+const pendingSetups: Promise<unknown>[] = [];
+
+async function drainPendingSetups(): Promise<void> {
+  for (let i = 0; i < 20; i += 1) {
+    if (pendingSetups.length === 0) return;
+    const batch = pendingSetups.splice(0, pendingSetups.length);
+    await Promise.allSettled(batch);
+    await Promise.resolve();
+  }
+}
+
+beforeEach(() => {
+  vi.spyOn(fs, "mkdirSync").mockReturnValue(undefined as unknown as string);
+  vi.spyOn(fs, "writeFileSync").mockReturnValue(undefined);
+});
+
+afterEach(async () => {
+  await drainPendingSetups();
   jobRegistry.clear();
   clearIdempotencyIndex();
   vi.clearAllMocks();
+  vi.restoreAllMocks();
   vi.mocked(preflightOliveRecipe).mockImplementation(() => ({
     valid: true,
     provider: "CPUExecutionProvider",
@@ -44,12 +77,37 @@ afterEach(() => {
   }));
 });
 
+/** Track fire-and-forget MCP setup so afterEach can drain before clearing the registry. */
+async function startOliveJobTracked(
+  ...args: Parameters<typeof startOliveJob>
+): ReturnType<typeof startOliveJob> {
+  const before = new Set(jobRegistry.keys());
+  const result = await startOliveJob(...args);
+  if (result.ok && !result.reused) {
+    const job = jobRegistry.get(result.jobId);
+    if (job && !before.has(result.jobId)) {
+      const settled = (async () => {
+        const deadline = Date.now() + 5_000;
+        while (Date.now() < deadline) {
+          const current = jobRegistry.get(result.jobId);
+          if (!current || current.finishedAt != null || current.status !== "setting_up") {
+            return;
+          }
+          await new Promise((r) => setTimeout(r, 10));
+        }
+      })();
+      pendingSetups.push(settled);
+    }
+  }
+  return result;
+}
+
 describe("startOliveJob MCP idempotency lock", () => {
   it("serializes concurrent submits with the same idempotency key into one job", async () => {
     const recipe = { input_model: {}, passes: {}, engine: {}, systems: {} } as never;
     const [a, b] = await Promise.all([
-      startOliveJob({ recipe, source: "mcp", idempotencyKey: "same-key" }),
-      startOliveJob({ recipe, source: "mcp", idempotencyKey: "same-key" }),
+      startOliveJobTracked({ recipe, source: "mcp", idempotencyKey: "same-key" }),
+      startOliveJobTracked({ recipe, source: "mcp", idempotencyKey: "same-key" }),
     ]);
     expect(a.ok).toBe(true);
     expect(b.ok).toBe(true);
@@ -64,8 +122,8 @@ describe("startOliveJob MCP idempotency lock", () => {
   it("serializes key-bearing and fingerprint-only submits for the same recipe", async () => {
     const recipe = { input_model: {}, passes: {}, engine: {}, systems: {} } as never;
     const [withKey, fpOnly] = await Promise.all([
-      startOliveJob({ recipe, source: "mcp", idempotencyKey: "agent-key-1" }),
-      startOliveJob({ recipe, source: "mcp" }),
+      startOliveJobTracked({ recipe, source: "mcp", idempotencyKey: "agent-key-1" }),
+      startOliveJobTracked({ recipe, source: "mcp" }),
     ]);
     expect(withKey.ok).toBe(true);
     expect(fpOnly.ok).toBe(true);
@@ -78,8 +136,8 @@ describe("startOliveJob MCP idempotency lock", () => {
 
   it("reuses a fingerprint-only admission when a keyed submit arrives afterward", async () => {
     const recipe = { input_model: {}, passes: {}, engine: {}, systems: {} } as never;
-    const fpOnly = await startOliveJob({ recipe, source: "mcp" });
-    const withKey = await startOliveJob({
+    const fpOnly = await startOliveJobTracked({ recipe, source: "mcp" });
+    const withKey = await startOliveJobTracked({
       recipe,
       source: "mcp",
       idempotencyKey: "after-fp-key",
@@ -91,7 +149,7 @@ describe("startOliveJob MCP idempotency lock", () => {
     expect(withKey.reused).toBe(true);
 
     // Same adopted key must replay onto the fingerprint-only job.
-    const replay = await startOliveJob({
+    const replay = await startOliveJobTracked({
       recipe,
       source: "mcp",
       idempotencyKey: "after-fp-key",
@@ -106,8 +164,8 @@ describe("startOliveJob MCP idempotency lock", () => {
 
   it("still allows a distinct idempotency key to start a new job after the first settles", async () => {
     const recipe = { input_model: {}, passes: {}, engine: {}, systems: {} } as never;
-    const first = await startOliveJob({ recipe, source: "mcp", idempotencyKey: "key-a" });
-    const second = await startOliveJob({ recipe, source: "mcp", idempotencyKey: "key-b" });
+    const first = await startOliveJobTracked({ recipe, source: "mcp", idempotencyKey: "key-a" });
+    const second = await startOliveJobTracked({ recipe, source: "mcp", idempotencyKey: "key-b" });
     expect(first.ok).toBe(true);
     expect(second.ok).toBe(true);
     if (!first.ok || !second.ok) return;
@@ -133,7 +191,7 @@ describe("startOliveJob MCP idempotency lock", () => {
     });
 
     for (let i = 0; i < 20; i += 1) {
-      const result = await startOliveJob({
+      const result = await startOliveJobTracked({
         recipe,
         source: "mcp",
         idempotencyKey: `unique-key-${i}`,
@@ -160,12 +218,20 @@ describe("startOliveJob MCP idempotency lock", () => {
 
     // Distinct keys share fp:fp-hold lock; second replaces the map entry while first still holds.
     // First release must not delete the newer tail (ownership check); both finish and map is empty.
-    const results = await Promise.all([
-      startOliveJob({ recipe, source: "mcp", idempotencyKey: "hold-1" }),
-      startOliveJob({ recipe, source: "mcp", idempotencyKey: "hold-2" }),
-      startOliveJob({ recipe, source: "mcp" }), // fingerprint-only overlaps fp lock
+    // Serialized waiters: hold-1 then hold-2 create distinct jobs; fingerprint-only reuses hold-2.
+    const [hold1, hold2, fpOnly] = await Promise.all([
+      startOliveJobTracked({ recipe, source: "mcp", idempotencyKey: "hold-1" }),
+      startOliveJobTracked({ recipe, source: "mcp", idempotencyKey: "hold-2" }),
+      startOliveJobTracked({ recipe, source: "mcp" }),
     ]);
-    expect(results.every((r) => r.ok)).toBe(true);
+    expect(hold1.ok && hold2.ok && fpOnly.ok).toBe(true);
+    if (!hold1.ok || !hold2.ok || !fpOnly.ok) return;
+    expect(hold1.jobId).not.toBe(hold2.jobId);
+    expect(hold1.reused).toBe(false);
+    expect(hold2.reused).toBe(false);
+    expect(fpOnly.reused).toBe(true);
+    expect(fpOnly.jobId).toBe(hold2.jobId);
+    expect([...jobRegistry.keys()].sort()).toEqual([hold1.jobId, hold2.jobId].sort());
     expect(mcpSubmitLockTailCount()).toBe(0);
   });
 });

--- a/src/server/services/olive/jobRunner.stubSetup.test.ts
+++ b/src/server/services/olive/jobRunner.stubSetup.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Deterministic coverage for OLIVE_JOB_SETUP_STUB timeout / fallback.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { preflightOliveRecipe } from "./jobPreflight.ts";
+import { clearIdempotencyIndex } from "./jobIdempotency.ts";
+import { finalizeJob, jobRegistry } from "./state.ts";
+
+vi.mock("./jobPreflight.ts", () => ({
+  preflightOliveRecipe: vi.fn(() => ({
+    valid: true,
+    provider: "CPUExecutionProvider",
+    fingerprint: "fp-stub-timeout",
+    errors: [] as string[],
+    warnings: [] as string[],
+    cudaVersion: "auto",
+    recipe: { input_model: {}, passes: {}, engine: {}, systems: {} },
+  })),
+}));
+
+vi.mock("../venv/index.ts", () => ({
+  ensureProviderCapability: vi.fn(async () => ({
+    ok: true,
+    python: "python",
+    family: "default",
+  })),
+  buildOliveRunEnvironment: vi.fn(async () => ({})),
+  resolveOliveCommand: vi.fn(() => ({ executable: "echo", args: ["ok"] })),
+}));
+
+const { startOliveJob } = await import("./jobRunner.ts");
+
+const trackedJobIds = new Set<string>();
+
+beforeEach(() => {
+  trackedJobIds.clear();
+  vi.useFakeTimers();
+  process.env.OLIVE_JOB_SETUP_STUB = "1";
+  delete process.env.OLIVE_JOB_SETUP_STUB_TIMEOUT_MS;
+  vi.mocked(preflightOliveRecipe).mockImplementation(() => ({
+    valid: true,
+    provider: "CPUExecutionProvider",
+    fingerprint: "fp-stub-timeout",
+    errors: [] as string[],
+    warnings: [] as string[],
+    cudaVersion: "auto",
+    recipe: { input_model: {}, passes: {}, engine: {}, systems: {} },
+  }));
+});
+
+afterEach(async () => {
+  try {
+    for (const id of trackedJobIds) {
+      const job = jobRegistry.get(id);
+      if (job && job.finishedAt == null) {
+        if (job.status !== "failed" && job.status !== "cancelled" && job.status !== "completed") {
+          job.status = "cancelled";
+        }
+        finalizeJob(job);
+      }
+    }
+  } finally {
+    trackedJobIds.clear();
+    jobRegistry.clear();
+    clearIdempotencyIndex();
+    delete process.env.OLIVE_JOB_SETUP_STUB;
+    delete process.env.OLIVE_JOB_SETUP_STUB_TIMEOUT_MS;
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  }
+});
+
+describe("OLIVE_JOB_SETUP_STUB timeout", () => {
+  it("falls back to 120s for non-positive OLIVE_JOB_SETUP_STUB_TIMEOUT_MS and fails the job", async () => {
+    process.env.OLIVE_JOB_SETUP_STUB_TIMEOUT_MS = "0";
+    const recipe = { input_model: {}, passes: {}, engine: {}, systems: {} } as never;
+
+    const admitted = await startOliveJob({ recipe, source: "mcp" });
+    expect(admitted.ok).toBe(true);
+    if (!admitted.ok) return;
+    trackedJobIds.add(admitted.jobId);
+
+    const job = jobRegistry.get(admitted.jobId);
+    expect(job).toBeDefined();
+    if (!job) return;
+    expect(job.status).toBe("setting_up");
+
+    await vi.advanceTimersByTimeAsync(119_999);
+    expect(job.status).toBe("setting_up");
+    expect(job.finishedAt).toBeNull();
+
+    await vi.advanceTimersByTimeAsync(200);
+    expect(job.status).toBe("failed");
+    expect(job.finishedAt).not.toBeNull();
+    expect(job.logs.some((line) => line.includes("Setup stub timed out after 120000ms"))).toBe(
+      true,
+    );
+  });
+
+  it("falls back to 120s for invalid OLIVE_JOB_SETUP_STUB_TIMEOUT_MS", async () => {
+    process.env.OLIVE_JOB_SETUP_STUB_TIMEOUT_MS = "nope";
+    const recipe = { input_model: {}, passes: {}, engine: {}, systems: {} } as never;
+
+    const admitted = await startOliveJob({ recipe, source: "mcp" });
+    expect(admitted.ok).toBe(true);
+    if (!admitted.ok) return;
+    trackedJobIds.add(admitted.jobId);
+    const job = jobRegistry.get(admitted.jobId);
+    expect(job).toBeDefined();
+    if (!job) return;
+
+    await vi.advanceTimersByTimeAsync(120_200);
+    expect(job.status).toBe("failed");
+    expect(job.finishedAt).not.toBeNull();
+    expect(job.logs.some((line) => line.includes("Setup stub timed out after 120000ms"))).toBe(
+      true,
+    );
+  });
+
+  it("honors a positive OLIVE_JOB_SETUP_STUB_TIMEOUT_MS override", async () => {
+    process.env.OLIVE_JOB_SETUP_STUB_TIMEOUT_MS = "500";
+    const recipe = { input_model: {}, passes: {}, engine: {}, systems: {} } as never;
+
+    const admitted = await startOliveJob({ recipe, source: "mcp" });
+    expect(admitted.ok).toBe(true);
+    if (!admitted.ok) return;
+    trackedJobIds.add(admitted.jobId);
+    const job = jobRegistry.get(admitted.jobId);
+    expect(job).toBeDefined();
+    if (!job) return;
+
+    await vi.advanceTimersByTimeAsync(499);
+    expect(job.status).toBe("setting_up");
+    await vi.advanceTimersByTimeAsync(200);
+    expect(job.status).toBe("failed");
+    expect(job.finishedAt).not.toBeNull();
+    expect(job.logs.some((line) => line.includes("Setup stub timed out after 500ms"))).toBe(true);
+  });
+});

--- a/src/server/services/olive/jobRunner.stubSetup.test.ts
+++ b/src/server/services/olive/jobRunner.stubSetup.test.ts
@@ -136,4 +136,21 @@ describe("OLIVE_JOB_SETUP_STUB timeout", () => {
     expect(job.finishedAt).not.toBeNull();
     expect(job.logs.some((line) => line.includes("Setup stub timed out after 500ms"))).toBe(true);
   });
+
+  it("returns ok:false with 504 when the UI path awaits a stub timeout", async () => {
+    process.env.OLIVE_JOB_SETUP_STUB_TIMEOUT_MS = "500";
+    const recipe = { input_model: {}, passes: {}, engine: {}, systems: {} } as never;
+
+    const pending = startOliveJob({ recipe, source: "ui" });
+    await vi.advanceTimersByTimeAsync(700);
+    const result = await pending;
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    if (result.jobId) trackedJobIds.add(result.jobId);
+    expect(result.httpStatus).toBe(504);
+    expect(result.error).toMatch(/timed out after 500ms/);
+    const job = result.jobId ? jobRegistry.get(result.jobId) : undefined;
+    expect(job?.status).toBe("failed");
+    expect(job?.finishedAt).not.toBeNull();
+  });
 });

--- a/src/server/services/olive/jobRunner.stubSetup.test.ts
+++ b/src/server/services/olive/jobRunner.stubSetup.test.ts
@@ -152,9 +152,14 @@ describe("OLIVE_JOB_SETUP_STUB timeout", () => {
     await vi.advanceTimersByTimeAsync(499);
     // Still inside the final shortened poll; UI promise has not settled.
     let settled = false;
-    void pending.then(() => {
-      settled = true;
-    });
+    void pending.then(
+      () => {
+        settled = true;
+      },
+      () => {
+        settled = true;
+      },
+    );
     await Promise.resolve();
     expect(settled).toBe(false);
 

--- a/src/server/services/olive/jobRunner.stubSetup.test.ts
+++ b/src/server/services/olive/jobRunner.stubSetup.test.ts
@@ -52,12 +52,17 @@ afterEach(async () => {
   try {
     for (const id of trackedJobIds) {
       const job = jobRegistry.get(id);
-      if (job && job.finishedAt == null) {
-        if (job.status !== "failed" && job.status !== "cancelled" && job.status !== "completed") {
-          job.status = "cancelled";
-        }
-        finalizeJob(job);
+      if (!job || job.finishedAt != null) continue;
+      if (job.status !== "failed" && job.status !== "cancelled" && job.status !== "completed") {
+        job.status = "cancelled";
       }
+    }
+    // Let stub / detached continueOliveJobSetup observe cancel on one poll tick.
+    await vi.advanceTimersByTimeAsync(200);
+    await Promise.resolve();
+    for (const id of trackedJobIds) {
+      const job = jobRegistry.get(id);
+      if (job && job.finishedAt == null) finalizeJob(job);
     }
   } finally {
     trackedJobIds.clear();
@@ -89,7 +94,7 @@ describe("OLIVE_JOB_SETUP_STUB timeout", () => {
     expect(job.status).toBe("setting_up");
     expect(job.finishedAt).toBeNull();
 
-    await vi.advanceTimersByTimeAsync(200);
+    await vi.advanceTimersByTimeAsync(1);
     expect(job.status).toBe("failed");
     expect(job.finishedAt).not.toBeNull();
     expect(job.logs.some((line) => line.includes("Setup stub timed out after 120000ms"))).toBe(
@@ -109,7 +114,7 @@ describe("OLIVE_JOB_SETUP_STUB timeout", () => {
     expect(job).toBeDefined();
     if (!job) return;
 
-    await vi.advanceTimersByTimeAsync(120_200);
+    await vi.advanceTimersByTimeAsync(120_000);
     expect(job.status).toBe("failed");
     expect(job.finishedAt).not.toBeNull();
     expect(job.logs.some((line) => line.includes("Setup stub timed out after 120000ms"))).toBe(
@@ -117,7 +122,7 @@ describe("OLIVE_JOB_SETUP_STUB timeout", () => {
     );
   });
 
-  it("honors a positive OLIVE_JOB_SETUP_STUB_TIMEOUT_MS override", async () => {
+  it("honors a 500ms timeout without overshooting the final poll", async () => {
     process.env.OLIVE_JOB_SETUP_STUB_TIMEOUT_MS = "500";
     const recipe = { input_model: {}, passes: {}, engine: {}, systems: {} } as never;
 
@@ -131,7 +136,9 @@ describe("OLIVE_JOB_SETUP_STUB timeout", () => {
 
     await vi.advanceTimersByTimeAsync(499);
     expect(job.status).toBe("setting_up");
-    await vi.advanceTimersByTimeAsync(200);
+    expect(job.finishedAt).toBeNull();
+
+    await vi.advanceTimersByTimeAsync(1);
     expect(job.status).toBe("failed");
     expect(job.finishedAt).not.toBeNull();
     expect(job.logs.some((line) => line.includes("Setup stub timed out after 500ms"))).toBe(true);
@@ -142,7 +149,16 @@ describe("OLIVE_JOB_SETUP_STUB timeout", () => {
     const recipe = { input_model: {}, passes: {}, engine: {}, systems: {} } as never;
 
     const pending = startOliveJob({ recipe, source: "ui" });
-    await vi.advanceTimersByTimeAsync(700);
+    await vi.advanceTimersByTimeAsync(499);
+    // Still inside the final shortened poll; UI promise has not settled.
+    let settled = false;
+    void pending.then(() => {
+      settled = true;
+    });
+    await Promise.resolve();
+    expect(settled).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(1);
     const result = await pending;
     expect(result.ok).toBe(false);
     if (result.ok) return;

--- a/src/server/services/olive/jobRunner.ts
+++ b/src/server/services/olive/jobRunner.ts
@@ -317,9 +317,11 @@ async function continueOliveJobSetup(
     const stubTimeoutMs =
       Number.isFinite(rawTimeout) && rawTimeout > 0 ? rawTimeout : 120_000;
     const deadline = Date.now() + stubTimeoutMs;
+    let timedOut = false;
     // Exit when cancelled, externally finalized, or the stub wait times out.
     while (job.status === "setting_up" && job.finishedAt == null) {
       if (Date.now() >= deadline) {
+        timedOut = true;
         job.status = "failed";
         pushLog(
           job,
@@ -331,6 +333,15 @@ async function continueOliveJobSetup(
     }
     cleanupJobArtifacts(job);
     if (job.finishedAt == null) finalizeJob(job);
+    if (timedOut) {
+      return {
+        ok: false,
+        error: `Setup stub timed out after ${stubTimeoutMs}ms waiting for cancel/finalize.`,
+        httpStatus: 504,
+        jobId,
+        fingerprint,
+      };
+    }
     return {
       ok: true,
       jobId,

--- a/src/server/services/olive/jobRunner.ts
+++ b/src/server/services/olive/jobRunner.ts
@@ -313,8 +313,20 @@ async function continueOliveJobSetup(
   );
   if (stubSetup) {
     pushLog(job, "[stub] Olive job setup stubbed; waiting for cancel.");
-    // Exit when cancelled or when another path finalizes the job without a status flip.
+    const rawTimeout = Number(process.env.OLIVE_JOB_SETUP_STUB_TIMEOUT_MS);
+    const stubTimeoutMs =
+      Number.isFinite(rawTimeout) && rawTimeout > 0 ? rawTimeout : 120_000;
+    const deadline = Date.now() + stubTimeoutMs;
+    // Exit when cancelled, externally finalized, or the stub wait times out.
     while (job.status === "setting_up" && job.finishedAt == null) {
+      if (Date.now() >= deadline) {
+        job.status = "failed";
+        pushLog(
+          job,
+          `[stub] Setup stub timed out after ${stubTimeoutMs}ms waiting for cancel/finalize.`,
+        );
+        break;
+      }
       await new Promise((r) => setTimeout(r, 200));
     }
     cleanupJobArtifacts(job);

--- a/src/server/services/olive/jobRunner.ts
+++ b/src/server/services/olive/jobRunner.ts
@@ -329,7 +329,9 @@ async function continueOliveJobSetup(
         );
         break;
       }
-      await new Promise((r) => setTimeout(r, 200));
+      const remainingMs = deadline - Date.now();
+      const sleepMs = Math.min(200, Math.max(0, remainingMs));
+      await new Promise((r) => setTimeout(r, sleepMs));
     }
     cleanupJobArtifacts(job);
     if (job.finishedAt == null) finalizeJob(job);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,7 +5,7 @@ import path from 'path';
 import { defineConfig, type Plugin } from 'vite';
 import { visualizer } from 'rollup-plugin-visualizer';
 import compression from 'vite-plugin-compression';
-import { ANY_DOT_VENV_DIR } from './src/server/shared/anyDotVenvDir';
+import { ANY_DOT_VENV_DIR } from './src/server/shared/anyDotVenvDir.ts';
 
 /**
  * onnxruntime-web's wasm binaries are never loaded from our own origin — every


### PR DESCRIPTION
## Summary
- Bound `OLIVE_JOB_SETUP_STUB` wait loops with a finite timeout (default 120s, overridable via `OLIVE_JOB_SETUP_STUB_TIMEOUT_MS`) and fail the job on expiration
- Reclaim empty/malformed Studio config smoke locks without busy-spinning on failed unlink; use `rmdirSync` for empty `.olive-studio` cleanup
- Map SIGHUP to exit code 129 in agent smoke; extend lock ownership and `resolvePython` preference tests
- Mock spawn/fs in idempotency tests, drain detached MCP setup, and assert hold-1/hold-2/fp-only registry reuse

## Skipped (still not valid)
- `state.test.ts` import reorder: vitest requires `vi.mock` before importing modules that load the mocked dependency; current order after `vi.hoisted`/`vi.mock` is correct

## Test plan
- [x] `pnpm exec vitest run src/lib/__tests__/resolvePython.test.ts src/lib/__tests__/studioConfigSmokeLock.test.ts src/lib/__tests__/studioConfigSnapshot.test.ts`
- [x] `pnpm exec vitest run src/server/services/olive/jobRunner.idempotency.test.ts --config vitest.server.config.ts`
- [ ] CI green on PR


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tonythethompson/Olive-Studio/pull/187?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

