### PR TITLE
fix(hardwareProbe): resolve PR #191 probe deadlock and add coverage

### DIFF
--- a/src/lib/__tests__/hardwareProbe.fetch.test.ts
+++ b/src/lib/__tests__/hardwareProbe.fetch.test.ts
@@ -5,28 +5,24 @@ import {
   type HardwareProbeResult,
 } from "@/lib/hardwareProbe";
 
-const baseProbe = (overrides?: Partial<HardwareProbeResult>): HardwareProbeResult => ({
-  probedAt: "2026-08-09T00:00:00.000Z",
-  platform: {
-    os: "Windows",
-    arch: "x64",
-    cpuModel: "test-cpu",
-    cpuCores: 8,
-    systemRamGb: 32,
-  },
-  detectedProviders: ["CPUExecutionProvider"],
-  recommendedProvider: "CPUExecutionProvider",
-  notes: [],
-  ...overrides,
-  platform: {
-    os: "Windows",
-    arch: "x64",
-    cpuModel: "test-cpu",
-    cpuCores: 8,
-    systemRamGb: 32,
-    ...overrides?.platform,
-  },
-});
+const baseProbe = (overrides?: Partial<HardwareProbeResult>): HardwareProbeResult => {
+  const { platform: platformOverride, ...rest } = overrides ?? {};
+  return {
+    probedAt: "2026-08-09T00:00:00.000Z",
+    detectedProviders: ["CPUExecutionProvider"],
+    recommendedProvider: "CPUExecutionProvider",
+    notes: [],
+    ...rest,
+    platform: {
+      os: "Windows",
+      arch: "x64",
+      cpuModel: "test-cpu",
+      cpuCores: 8,
+      systemRamGb: 32,
+      ...platformOverride,
+    },
+  };
+};
 
 const jsonResponse = (body: unknown, status = 200): Response =>
   new Response(JSON.stringify(body), {

--- a/src/lib/__tests__/hardwareProbe.fetch.test.ts
+++ b/src/lib/__tests__/hardwareProbe.fetch.test.ts
@@ -1,9 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import {
-  fetchHardwareProbe,
-  resetHardwareProbeFetchStateForTests,
-  type HardwareProbeResult,
-} from "@/lib/hardwareProbe";
+import type { HardwareProbeResult } from "@/lib/hardwareProbe";
+
+type FetchHardwareProbe = typeof import("@/lib/hardwareProbe").fetchHardwareProbe;
+
+let fetchHardwareProbe: FetchHardwareProbe;
 
 const baseProbe = (overrides?: Partial<HardwareProbeResult>): HardwareProbeResult => {
   const { platform: platformOverride, ...rest } = overrides ?? {};
@@ -31,13 +31,15 @@ const jsonResponse = (body: unknown, status = 200): Response =>
   });
 
 describe("fetchHardwareProbe", () => {
-  beforeEach(() => {
-    resetHardwareProbeFetchStateForTests();
+  beforeEach(async () => {
+    // Fresh module instance so cache/inflight state is not shared across tests
+    // without exporting a production reset helper.
+    vi.resetModules();
     vi.stubGlobal("fetch", vi.fn());
+    ({ fetchHardwareProbe } = await import("@/lib/hardwareProbe"));
   });
 
   afterEach(() => {
-    resetHardwareProbeFetchStateForTests();
     vi.unstubAllGlobals();
     vi.useRealTimers();
   });
@@ -131,16 +133,23 @@ describe("fetchHardwareProbe", () => {
         ),
       );
 
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
     const timeout = new Promise<never>((_, reject) => {
-      setTimeout(() => reject(new Error("fetchHardwareProbe hung (deadlock)")), 1000);
+      timeoutId = setTimeout(() => reject(new Error("fetchHardwareProbe hung (deadlock)")), 1000);
     });
 
-    const result = await Promise.race([fetchHardwareProbe(), timeout]);
+    try {
+      const result = await Promise.race([fetchHardwareProbe(), timeout]);
 
-    expect(result.platform.systemRamGb).toBe(16);
-    expect(fetch).toHaveBeenCalledTimes(2);
-    expect(vi.mocked(fetch).mock.calls[0]?.[0]).toBe("/api/system/hardware-probe");
-    expect(vi.mocked(fetch).mock.calls[1]?.[0]).toBe("/api/system/hardware-probe?refresh=1");
+      expect(result.platform.systemRamGb).toBe(16);
+      expect(fetch).toHaveBeenCalledTimes(2);
+      expect(vi.mocked(fetch).mock.calls[0]?.[0]).toBe("/api/system/hardware-probe");
+      expect(vi.mocked(fetch).mock.calls[1]?.[0]).toBe("/api/system/hardware-probe?refresh=1");
+    } finally {
+      if (timeoutId !== undefined) {
+        clearTimeout(timeoutId);
+      }
+    }
   });
 
   it("throws when the probe endpoint returns an error status", async () => {

--- a/src/lib/__tests__/hardwareProbe.fetch.test.ts
+++ b/src/lib/__tests__/hardwareProbe.fetch.test.ts
@@ -1,0 +1,155 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  fetchHardwareProbe,
+  resetHardwareProbeFetchStateForTests,
+  type HardwareProbeResult,
+} from "@/lib/hardwareProbe";
+
+const baseProbe = (overrides?: Partial<HardwareProbeResult>): HardwareProbeResult => ({
+  probedAt: "2026-08-09T00:00:00.000Z",
+  platform: {
+    os: "Windows",
+    arch: "x64",
+    cpuModel: "test-cpu",
+    cpuCores: 8,
+    systemRamGb: 32,
+  },
+  detectedProviders: ["CPUExecutionProvider"],
+  recommendedProvider: "CPUExecutionProvider",
+  notes: [],
+  ...overrides,
+  platform: {
+    os: "Windows",
+    arch: "x64",
+    cpuModel: "test-cpu",
+    cpuCores: 8,
+    systemRamGb: 32,
+    ...overrides?.platform,
+  },
+});
+
+const jsonResponse = (body: unknown, status = 200): Response =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+
+describe("fetchHardwareProbe", () => {
+  beforeEach(() => {
+    resetHardwareProbeFetchStateForTests();
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  afterEach(() => {
+    resetHardwareProbeFetchStateForTests();
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  it("shares one in-flight fetch across concurrent callers", async () => {
+    let resolveFetch!: (value: Response) => void;
+    const pending = new Promise<Response>((resolve) => {
+      resolveFetch = resolve;
+    });
+    vi.mocked(fetch).mockReturnValueOnce(pending);
+
+    const first = fetchHardwareProbe();
+    const second = fetchHardwareProbe();
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+
+    resolveFetch(jsonResponse(baseProbe()));
+    const [a, b] = await Promise.all([first, second]);
+
+    expect(a).toEqual(b);
+    expect(a.platform.systemRamGb).toBe(32);
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns cached result within TTL", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(jsonResponse(baseProbe()));
+
+    const first = await fetchHardwareProbe();
+    const second = await fetchHardwareProbe();
+
+    expect(first).toBe(second);
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("refetches after TTL expires", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-09T00:00:00.000Z"));
+
+    vi.mocked(fetch)
+      .mockResolvedValueOnce(jsonResponse(baseProbe({ probedAt: "t1" })))
+      .mockResolvedValueOnce(jsonResponse(baseProbe({ probedAt: "t2" })));
+
+    const first = await fetchHardwareProbe();
+    vi.setSystemTime(new Date("2026-08-09T00:00:31.000Z"));
+    const second = await fetchHardwareProbe();
+
+    expect(first.probedAt).toBe("t1");
+    expect(second.probedAt).toBe("t2");
+    expect(fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("bypasses cache when refresh=true", async () => {
+    vi.mocked(fetch)
+      .mockResolvedValueOnce(jsonResponse(baseProbe({ probedAt: "cached" })))
+      .mockResolvedValueOnce(jsonResponse(baseProbe({ probedAt: "refreshed" })));
+
+    await fetchHardwareProbe();
+    const refreshed = await fetchHardwareProbe(true);
+
+    expect(refreshed.probedAt).toBe("refreshed");
+    expect(fetch).toHaveBeenCalledTimes(2);
+    expect(vi.mocked(fetch).mock.calls[1]?.[0]).toBe("/api/system/hardware-probe?refresh=1");
+  });
+
+  it("retries with refresh when systemRamGb is missing without deadlocking", async () => {
+    vi.mocked(fetch)
+      .mockResolvedValueOnce(
+        jsonResponse(
+          baseProbe({
+            platform: {
+              os: "Windows",
+              arch: "x64",
+              cpuModel: "test-cpu",
+              cpuCores: 8,
+              systemRamGb: 0,
+            },
+          }),
+        ),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse(
+          baseProbe({
+            platform: {
+              os: "Windows",
+              arch: "x64",
+              cpuModel: "test-cpu",
+              cpuCores: 8,
+              systemRamGb: 16,
+            },
+          }),
+        ),
+      );
+
+    const timeout = new Promise<never>((_, reject) => {
+      setTimeout(() => reject(new Error("fetchHardwareProbe hung (deadlock)")), 1000);
+    });
+
+    const result = await Promise.race([fetchHardwareProbe(), timeout]);
+
+    expect(result.platform.systemRamGb).toBe(16);
+    expect(fetch).toHaveBeenCalledTimes(2);
+    expect(vi.mocked(fetch).mock.calls[0]?.[0]).toBe("/api/system/hardware-probe");
+    expect(vi.mocked(fetch).mock.calls[1]?.[0]).toBe("/api/system/hardware-probe?refresh=1");
+  });
+
+  it("throws when the probe endpoint returns an error status", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(jsonResponse({ error: "probe unavailable" }, 503));
+
+    await expect(fetchHardwareProbe()).rejects.toThrow("probe unavailable");
+  });
+});

--- a/src/lib/hardwareProbe.ts
+++ b/src/lib/hardwareProbe.ts
@@ -571,13 +571,6 @@ async function doFetchHardwareProbe(refresh: boolean): Promise<HardwareProbeResu
   return (await res.json()) as HardwareProbeResult;
 }
 
-/** Clears probe cache/inflight state. Exported for unit tests only. */
-export function resetHardwareProbeFetchStateForTests(): void {
-  _probeInflight = null;
-  _probeCache = null;
-  _probeCacheTime = 0;
-}
-
 export async function fetchHardwareProbe(refresh = false): Promise<HardwareProbeResult> {
   // Return cached result if fresh enough and not a forced refresh
   if (!refresh && _probeCache && Date.now() - _probeCacheTime < PROBE_CACHE_TTL_MS) {

--- a/src/lib/hardwareProbe.ts
+++ b/src/lib/hardwareProbe.ts
@@ -560,6 +560,24 @@ let _probeCache: HardwareProbeResult | null = null;
 const PROBE_CACHE_TTL_MS = 30_000; // 30s
 let _probeCacheTime = 0;
 
+/** Always issues a network request. Bypasses cache and in-flight dedup. */
+async function doFetchHardwareProbe(refresh: boolean): Promise<HardwareProbeResult> {
+  const url = refresh ? "/api/system/hardware-probe?refresh=1" : "/api/system/hardware-probe";
+  const res = await fetch(url);
+  if (!res.ok) {
+    const body = (await res.json().catch(() => ({}))) as { error?: string };
+    throw new Error(body.error ?? `Hardware probe failed (${res.status})`);
+  }
+  return (await res.json()) as HardwareProbeResult;
+}
+
+/** Clears probe cache/inflight state. Exported for unit tests only. */
+export function resetHardwareProbeFetchStateForTests(): void {
+  _probeInflight = null;
+  _probeCache = null;
+  _probeCacheTime = 0;
+}
+
 export async function fetchHardwareProbe(refresh = false): Promise<HardwareProbeResult> {
   // Return cached result if fresh enough and not a forced refresh
   if (!refresh && _probeCache && Date.now() - _probeCacheTime < PROBE_CACHE_TTL_MS) {
@@ -573,16 +591,12 @@ export async function fetchHardwareProbe(refresh = false): Promise<HardwareProbe
 
   _probeInflight = (async () => {
     try {
-      const url = refresh ? "/api/system/hardware-probe?refresh=1" : "/api/system/hardware-probe";
-      const res = await fetch(url);
-      if (!res.ok) {
-        const body = (await res.json().catch(() => ({}))) as { error?: string };
-        throw new Error(body.error ?? `Hardware probe failed (${res.status})`);
-      }
-      const result = (await res.json()) as HardwareProbeResult;
+      let result = await doFetchHardwareProbe(refresh);
 
+      // Retry once with refresh when RAM is missing/zero. Call doFetch directly
+      // so we do not re-enter the in-flight dedup guard (which would deadlock).
       if (!refresh && (result.platform.systemRamGb == null || result.platform.systemRamGb <= 0)) {
-        return fetchHardwareProbe(true);
+        result = await doFetchHardwareProbe(true);
       }
 
       _probeCache = result;


### PR DESCRIPTION
## Summary
- Follow-up to [#191](https://github.com/tonythethompson/Olive-Studio/pull/191) self-review findings on `fetchHardwareProbe`
- Fixes the recursive refresh deadlock: when `systemRamGb` is missing/zero, retry via `doFetchHardwareProbe(true)` instead of re-entering `fetchHardwareProbe(true)` while `_probeInflight` is still set
- Adds unit tests for concurrent dedup, TTL cache hit/miss, `refresh=true` bypass, zero-RAM retry, and error status

## Assessment of #191 tonythethompson comments
| Comment | Worth follow-up? | Action |
|---|---|---|
| Recursive retry deadlock | Yes (hang risk) | Fixed here |
| Missing cache/dedup tests | Yes | Added here |
| Undocumented functional change in #191 description | No (PR already merged) | N/A |
| Misleading `assertRunnableRecipe` test name | No (already renamed on main) | Already addressed in #191 |

## Test plan
- [x] `pnpm exec vitest run src/lib/__tests__/hardwareProbe.fetch.test.ts`
- [ ] Confirm hardware probe UI still loads when `/api/system/hardware-probe` returns `systemRamGb: 0` then a refreshed value


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tonythethompson/Olive-Studio/pull/195?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

