### PR TITLE
fix(mcp): guard stale transport close, close on failure, fix query sanitization

### DIFF
--- a/olive-mcp-server/olive_mcp_server/tools/docs_search.py
+++ b/olive-mcp-server/olive_mcp_server/tools/docs_search.py
@@ -563,8 +563,11 @@ def search_olive_documentation(
     if top_k < 0:
         raise ValueError(f"top_k must be >= 0, got {top_k}")
 
-    # Input sanitization: limit query length and strip control characters.
-    query = re.sub(r'[\x00-\x1f\x7f]', '', query[:2000]).strip()
+    # Input sanitization: limit length, normalize whitespace controls to spaces
+    # (preserving token boundaries), then strip non-whitespace control chars.
+    raw = query[:2000]
+    raw = re.sub(r'[\t\n\r\x0b\x0c]', ' ', raw)
+    query = re.sub(r'[\x00-\x08\x0e-\x1f\x7f]', '', raw).strip()
 
     mode_arg = mode if (mode or "").strip() else None
     resolved_mode = get_retrieval_mode(mode_arg)

--- a/olive-mcp-server/tests/test_docs_search_semantic.py
+++ b/olive-mcp-server/tests/test_docs_search_semantic.py
@@ -450,14 +450,20 @@ def test_search_query_sanitization(monkeypatch: pytest.MonkeyPatch):
     result = docs_search.search_olive_documentation(
         query="quant\x00ization", top_k=1, live=False, mode="keyword"
     )
-    assert result["count"] >= 0  # should not raise
+    assert result["query"] == "quantization"
 
-    # Very long query should be truncated (not crash)
+    # Whitespace controls should become spaces (preserve token boundaries)
+    result_ws = docs_search.search_olive_documentation(
+        query="quantization\ncalibration", top_k=1, live=False, mode="keyword"
+    )
+    assert result_ws["query"] == "quantization calibration"
+
+    # Very long query should be truncated to 2000 chars (not crash)
     long_query = "x" * 5000
     result2 = docs_search.search_olive_documentation(
         query=long_query, top_k=1, live=False, mode="keyword"
     )
-    assert result2["count"] >= 0
+    assert len(result2["query"]) == 2000
 
 
 def test_live_auto_budgets_even_when_model_is_warm(monkeypatch: pytest.MonkeyPatch):

--- a/olive-mcp-server/tests/test_docs_search_semantic.py
+++ b/olive-mcp-server/tests/test_docs_search_semantic.py
@@ -453,10 +453,14 @@ def test_search_query_sanitization(monkeypatch: pytest.MonkeyPatch):
     assert result["query"] == "quantization"
 
     # Whitespace controls should become spaces (preserve token boundaries)
-    result_ws = docs_search.search_olive_documentation(
-        query="quantization\ncalibration", top_k=1, live=False, mode="keyword"
-    )
-    assert result_ws["query"] == "quantization calibration"
+    for control in ("\n", "\t", "\r", "\x0b", "\x0c"):
+        result_ws = docs_search.search_olive_documentation(
+            query=f"quantization{control}calibration",
+            top_k=1,
+            live=False,
+            mode="keyword",
+        )
+        assert result_ws["query"] == "quantization calibration"
 
     # Very long query should be truncated to 2000 chars (not crash)
     long_query = "x" * 5000
@@ -464,6 +468,18 @@ def test_search_query_sanitization(monkeypatch: pytest.MonkeyPatch):
         query=long_query, top_k=1, live=False, mode="keyword"
     )
     assert len(result2["query"]) == 2000
+
+    # Truncation applies before control normalization ends; length stays <= 2000
+    long_with_controls = ("a\tb\nc\rd\x0be\x0cf") * 400
+    result3 = docs_search.search_olive_documentation(
+        query=long_with_controls, top_k=1, live=False, mode="keyword"
+    )
+    assert len(result3["query"]) == 2000
+    assert "\t" not in result3["query"]
+    assert "\n" not in result3["query"]
+    assert "\r" not in result3["query"]
+    assert "\x0b" not in result3["query"]
+    assert "\x0c" not in result3["query"]
 
 
 def test_live_auto_budgets_even_when_model_is_warm(monkeypatch: pytest.MonkeyPatch):

--- a/src/server/services/mcp/client.test.ts
+++ b/src/server/services/mcp/client.test.ts
@@ -11,6 +11,12 @@ const mocks = vi.hoisted(() => ({
   callTool: vi.fn(),
   connect: vi.fn(),
   close: vi.fn(),
+  transportInstances: [] as Array<{
+    stderr: null;
+    onclose: (() => void) | undefined;
+    onerror: ((error: Error) => void) | undefined;
+    close: ReturnType<typeof vi.fn>;
+  }>,
 }));
 
 vi.mock("@modelcontextprotocol/client", () => {
@@ -29,6 +35,12 @@ vi.mock("@modelcontextprotocol/client/stdio", () => {
       stderr = null;
       onclose: (() => void) | undefined = undefined;
       onerror: ((error: Error) => void) | undefined = undefined;
+      close = vi.fn(async () => {
+        this.onclose?.();
+      });
+      constructor() {
+        mocks.transportInstances.push(this);
+      }
     },
   };
 });
@@ -46,7 +58,11 @@ import {
   callOliveMcpTool,
   MCP_UNAVAILABLE_ERROR,
   resetPersistentClient,
+  getPersistentClientSnapshotForTests,
+  setPersistentClientSnapshotForTests,
 } from "./persistentClient.ts";
+import { Client } from "@modelcontextprotocol/client";
+import { StdioClientTransport } from "@modelcontextprotocol/client/stdio";
 import mcpBreaker, { resetMcpBreaker } from "./breaker.ts";
 
 /** Trip the breaker with 3 consecutive failures. */
@@ -62,6 +78,7 @@ describe("persistentClient circuit-breaker integration", () => {
   beforeEach(() => {
     resetMcpBreaker();
     resetPersistentClient();
+    mocks.transportInstances.length = 0;
     mocks.connect.mockReset().mockResolvedValue(undefined);
     mocks.callTool.mockReset();
     mocks.close.mockReset().mockResolvedValue(undefined);
@@ -215,5 +232,111 @@ describe("persistentClient circuit-breaker integration", () => {
     const out = await callOliveMcpTools([{ toolName: "x", args: {} }]);
 
     expect(out).toEqual([{ result: "just a plain string" }]);
+  });
+});
+
+describe("persistentClient transport lifecycle", () => {
+  beforeEach(() => {
+    resetMcpBreaker();
+    resetPersistentClient();
+    mocks.transportInstances.length = 0;
+    mocks.connect.mockReset().mockResolvedValue(undefined);
+    mocks.callTool.mockReset();
+    mocks.close.mockReset().mockResolvedValue(undefined);
+  });
+
+  it("active transport close marks crashed and clears client/transport refs", async () => {
+    mocks.callTool.mockResolvedValue({
+      content: [{ type: "text", text: '{"ok":true}' }],
+      isError: false,
+    });
+    await callOliveMcpTools([{ toolName: "x", args: {} }]);
+
+    const transportA = mocks.transportInstances[0];
+    expect(getPersistentClientSnapshotForTests().state).toBe("connected");
+
+    transportA.onclose?.();
+
+    expect(getPersistentClientSnapshotForTests()).toMatchObject({
+      state: "crashed",
+      client: null,
+      transport: null,
+    });
+  });
+
+  it("stale transport close leaves replacement client and transport unchanged", async () => {
+    mocks.callTool.mockResolvedValue({
+      content: [{ type: "text", text: '{"ok":true}' }],
+      isError: false,
+    });
+
+    await callOliveMcpTools([{ toolName: "a", args: {} }]);
+    const transportA = mocks.transportInstances[0];
+    transportA.onclose?.();
+
+    await callOliveMcpTools([{ toolName: "b", args: {} }]);
+    const transportB = mocks.transportInstances[1];
+    const replacement = getPersistentClientSnapshotForTests();
+    expect(replacement.state).toBe("connected");
+    expect(replacement.transport).toBe(transportB);
+    expect(mocks.transportInstances).toHaveLength(2);
+
+    transportA.onclose?.();
+
+    const afterStaleClose = getPersistentClientSnapshotForTests();
+    expect(afterStaleClose.state).toBe("connected");
+    expect(afterStaleClose.client).toBe(replacement.client);
+    expect(afterStaleClose.transport).toBe(transportB);
+  });
+
+  it("infra failure cleanup closes the owning transport", async () => {
+    mocks.callTool.mockRejectedValueOnce(new Error("Transport closed"));
+
+    await callOliveMcpTools([{ toolName: "x", args: {} }]);
+
+    const transportA = mocks.transportInstances[0];
+    expect(transportA.close).toHaveBeenCalledTimes(1);
+    expect(getPersistentClientSnapshotForTests()).toMatchObject({
+      state: "crashed",
+      client: null,
+      transport: null,
+    });
+  });
+
+  it("infra failure cleanup leaves a newer reconnect session untouched", async () => {
+    mocks.callTool.mockResolvedValueOnce({
+      content: [{ type: "text", text: '{"ok":true}' }],
+      isError: false,
+    });
+    await callOliveMcpTools([{ toolName: "warmup", args: {} }]);
+    const transportA = mocks.transportInstances[0];
+    expect(transportA.close).not.toHaveBeenCalled();
+
+    const replacementClient = new Client({ name: "replacement", version: "0.0.0" });
+    const replacementTransport = new StdioClientTransport({
+      command: "python",
+      args: ["-m", "olive_mcp_server"],
+    });
+    // Avoid recursive onclose from replacement mock close calls during assertions.
+    replacementTransport.onclose = undefined;
+
+    mocks.callTool.mockImplementationOnce(async () => {
+      setPersistentClientSnapshotForTests({
+        state: "connected",
+        client: replacementClient,
+        transport: replacementTransport,
+      });
+      throw new Error("Transport closed");
+    });
+
+    await callOliveMcpTools([{ toolName: "failing", args: {} }]);
+
+    expect(transportA.close).not.toHaveBeenCalled();
+    expect(replacementTransport.close).not.toHaveBeenCalled();
+    expect(getPersistentClientSnapshotForTests()).toMatchObject({
+      state: "connected",
+      client: replacementClient,
+      transport: replacementTransport,
+    });
   });
 });

--- a/src/server/services/mcp/persistentClient.ts
+++ b/src/server/services/mcp/persistentClient.ts
@@ -72,8 +72,11 @@ async function connect(): Promise<void> {
         });
       }
 
+      // Capture instance ref so a stale transport's close event doesn't
+      // null out a replacement connection established after a timeout.
+      const thisTransport = transport;
       transport.onclose = () => {
-        if (state === "connected") {
+        if (state === "connected" && transport === thisTransport) {
           state = "crashed";
           client = null;
           transport = null;
@@ -215,8 +218,11 @@ export async function callOliveMcpTools(requests: McpToolRequest[]): Promise<Mcp
   // ── Update breaker ──
   if (hadInfraFailure) {
     mcpBreaker.recordFailure(epoch);
-    // Mark connection as crashed for next attempt
+    // Close the abandoned transport to free the child process, then clear refs.
     state = "crashed";
+    if (transport) {
+      try { void transport.close().catch(() => undefined); } catch { /* best-effort */ }
+    }
     client = null;
     transport = null;
   } else {

--- a/src/server/services/mcp/persistentClient.ts
+++ b/src/server/services/mcp/persistentClient.ts
@@ -146,8 +146,10 @@ export async function callOliveMcpTools(requests: McpToolRequest[]): Promise<Mcp
     return requests.map(() => ({ error: MCP_UNAVAILABLE_ERROR, unavailable: true }));
   }
 
-  // Snapshot the client reference — onclose can null it between iterations.
+  // Snapshot the client/transport — onclose or a concurrent reconnect can
+  // replace them between iterations; failure cleanup must not tear down a newer session.
   const activeClient = client;
+  const activeTransport = transport;
 
   // ── Execute tool calls sequentially ──
   const results: McpToolCallResult[] = [];
@@ -218,13 +220,16 @@ export async function callOliveMcpTools(requests: McpToolRequest[]): Promise<Mcp
   // ── Update breaker ──
   if (hadInfraFailure) {
     mcpBreaker.recordFailure(epoch);
-    // Close the abandoned transport to free the child process, then clear refs.
-    state = "crashed";
-    if (transport) {
-      try { void transport.close().catch(() => undefined); } catch { /* best-effort */ }
+    // Only tear down if this call still owns the live session. A concurrent
+    // reconnect may have already installed a replacement client/transport.
+    if (client === activeClient && transport === activeTransport) {
+      state = "crashed";
+      if (activeTransport) {
+        try { void activeTransport.close().catch(() => undefined); } catch { /* best-effort */ }
+      }
+      client = null;
+      transport = null;
     }
-    client = null;
-    transport = null;
   } else {
     mcpBreaker.recordSuccess(epoch);
   }
@@ -310,4 +315,24 @@ export function resetPersistentClient(): void {
   transport = null;
   state = "idle";
   connectingPromise = null;
+}
+
+/** Test-only snapshot of module connection refs. */
+export function getPersistentClientSnapshotForTests(): {
+  state: ConnectionState;
+  client: Client | null;
+  transport: StdioClientTransport | null;
+} {
+  return { state, client, transport };
+}
+
+/** Test-only setter used to simulate concurrent reconnect races. */
+export function setPersistentClientSnapshotForTests(next: {
+  state: ConnectionState;
+  client: Client | null;
+  transport: StdioClientTransport | null;
+}): void {
+  state = next.state;
+  client = next.client;
+  transport = next.transport;
 }


### PR DESCRIPTION
Follow-up to #192 — addresses unresolved P1/P2 review comments:

- **persistentClient.ts**: onclose guards against superseded transports (Greptile P1, Codex P2)
- **persistentClient.ts**: infra failure path closes transport before clearing refs
- **docs_search.py**: whitespace controls → spaces instead of stripping (Codex P2)
- **test_docs_search_semantic.py**: assert sanitized query value, not just count >= 0 (CodeRabbit)

Fixes review comments from: #192 (comments 3743861930, 3743873634, 3743873643, 3743918042)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tonythethompson/Olive-Studio/pull/198?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

