### PR TITLE
fix: address PR #192 UI/lib review comments

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -361,7 +361,6 @@ function Dashboard() {
                                 onOpenAiAudit={handleOpenAiAudit}
                                 onRunStateChange={(running) => {
                                   setIsOliveRunning(running);
-                                  if (running) scrollToSection("execute");
                                 }}
                               />
                             </ErrorBoundary>

--- a/src/components/features/input/InputEnvironmentPanel.tsx
+++ b/src/components/features/input/InputEnvironmentPanel.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect, ChangeEvent } from "react";
+import { useState, useRef, useEffect, ChangeEvent, useTransition } from "react";
 import {
   Card,
   CardContent,
@@ -40,7 +40,6 @@ import { useHardwareProbe } from "@/lib/hooks/useHardwareProbe";
 import { navigatePipeline } from "@/lib/pipelineNavigation";
 import { estimateVramForCatalogPreset } from "@/lib/presetVramEstimate";
 import { presetDisplayName, useRecipeCatalog, type RecipeSortMode } from "@/components/features/input/useRecipeCatalog";
-import { useRecipeHub } from "@/components/features/input/useRecipeHub";
 import {
   getBaseName,
   formatFileSize,

--- a/src/components/features/input/InputEnvironmentPanel.tsx
+++ b/src/components/features/input/InputEnvironmentPanel.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect, ChangeEvent, useTransition } from "react";
+import { useState, useRef, useEffect, ChangeEvent } from "react";
 import {
   Card,
   CardContent,
@@ -40,6 +40,7 @@ import { useHardwareProbe } from "@/lib/hooks/useHardwareProbe";
 import { navigatePipeline } from "@/lib/pipelineNavigation";
 import { estimateVramForCatalogPreset } from "@/lib/presetVramEstimate";
 import { presetDisplayName, useRecipeCatalog, type RecipeSortMode } from "@/components/features/input/useRecipeCatalog";
+import { useRecipeHub } from "@/components/features/input/useRecipeHub";
 import {
   getBaseName,
   formatFileSize,
@@ -288,7 +289,6 @@ export function InputEnvironmentPanel({
   };
 
   const {
-    filteredRecipes,
     localMatchSummary,
     hardwareMatchSummary,
     curatedRecipesWithMatch,

--- a/src/components/features/input/localFileUtils.test.ts
+++ b/src/components/features/input/localFileUtils.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { getReconstructableGroups } from "./localFileUtils";
+
+function files(...names: string[]) {
+  return names.map((name) => ({ name, size: 1024 }));
+}
+
+describe("getReconstructableGroups", () => {
+  it("accepts a valid consecutive 001/002 pair", () => {
+    expect(getReconstructableGroups(files("model.bin.001", "model.bin.002"))).toEqual([
+      ["model.bin", [{ name: "model.bin.001", size: 1024 }, { name: "model.bin.002", size: 1024 }]],
+    ]);
+  });
+
+  it("rejects a single chunk", () => {
+    expect(getReconstructableGroups(files("model.bin.001"))).toEqual([]);
+  });
+
+  it("rejects sequences that start at 002", () => {
+    expect(getReconstructableGroups(files("model.bin.002", "model.bin.003"))).toEqual([]);
+  });
+
+  it("rejects gaps such as 001/003", () => {
+    expect(getReconstructableGroups(files("model.bin.001", "model.bin.003"))).toEqual([]);
+  });
+
+  it("rejects duplicate suffixes", () => {
+    expect(getReconstructableGroups(files("model.bin.001", "model.bin.001"))).toEqual([]);
+  });
+
+  it("rejects noncanonical suffix padding such as 0001/0002", () => {
+    expect(getReconstructableGroups(files("model.0001", "model.0002"))).toEqual([]);
+  });
+});

--- a/src/components/features/input/localFileUtils.ts
+++ b/src/components/features/input/localFileUtils.ts
@@ -111,7 +111,7 @@ export function getReconstructableGroups(
       })
       .filter((n) => n >= 0)
       .sort((a, b) => a - b);
-    if (indices.length < 2) return false;
+    if (indices.length < 2 || indices[0] !== 1) return false;
     for (let i = 1; i < indices.length; i++) {
       if (indices[i] !== indices[i - 1] + 1) return false;
     }

--- a/src/components/features/input/localFileUtils.ts
+++ b/src/components/features/input/localFileUtils.ts
@@ -101,5 +101,20 @@ export function getReconstructableGroups(
       groups[base].push(f);
     }
   }
-  return Object.entries(groups).filter(([, files]) => files.length > 0);
+  return Object.entries(groups).filter(([, files]) => {
+    if (files.length < 2) return false;
+    // Require consecutive numeric suffixes to prevent corrupted reconstruction
+    const indices = files
+      .map((f) => {
+        const m = f.name.match(/\.(\d{3,})$/);
+        return m ? parseInt(m[1], 10) : -1;
+      })
+      .filter((n) => n >= 0)
+      .sort((a, b) => a - b);
+    if (indices.length < 2) return false;
+    for (let i = 1; i < indices.length; i++) {
+      if (indices[i] !== indices[i - 1] + 1) return false;
+    }
+    return true;
+  });
 }

--- a/src/components/features/input/localFileUtils.ts
+++ b/src/components/features/input/localFileUtils.ts
@@ -103,17 +103,18 @@ export function getReconstructableGroups(
   }
   return Object.entries(groups).filter(([, files]) => {
     if (files.length < 2) return false;
-    // Require consecutive numeric suffixes to prevent corrupted reconstruction
-    const indices = files
+    // Require consecutive canonical suffixes (001, 002, ...) starting at 001
+    const suffixes = files
       .map((f) => {
         const m = f.name.match(/\.(\d{3,})$/);
-        return m ? parseInt(m[1], 10) : -1;
+        return m ? m[1] : null;
       })
-      .filter((n) => n >= 0)
-      .sort((a, b) => a - b);
-    if (indices.length < 2 || indices[0] !== 1) return false;
-    for (let i = 1; i < indices.length; i++) {
-      if (indices[i] !== indices[i - 1] + 1) return false;
+      .filter((s): s is string => s !== null)
+      .sort((a, b) => parseInt(a, 10) - parseInt(b, 10));
+    if (suffixes.length < 2 || suffixes[0] !== "001") return false;
+    for (let i = 1; i < suffixes.length; i++) {
+      const expected = String(i + 1).padStart(3, "0");
+      if (suffixes[i] !== expected) return false;
     }
     return true;
   });

--- a/src/lib/__tests__/usePresets.test.ts
+++ b/src/lib/__tests__/usePresets.test.ts
@@ -98,4 +98,62 @@ describe("useImportPresets", () => {
       mergedPresets: [{ name: "a" }],
     });
   });
+
+  it("clears stale confirmation when a later read fails", async () => {
+    const setError = vi.fn();
+    const parseImport = vi.fn().mockReturnValue({
+      ok: true as const,
+      presets: [{ name: "a" }],
+      importedPresets: [{ name: "a" }],
+      collisions: [],
+    });
+
+    const { result } = renderHook(() =>
+      useImportPresets<Preset>({
+        customPresets: [],
+        setError,
+        parseImport,
+      }),
+    );
+
+    const createElementSpy = vi.spyOn(document, "createElement");
+
+    await act(async () => {
+      result.current.handleImport();
+    });
+    const input1 = createElementSpy.mock.results.at(-1)?.value as HTMLInputElement;
+    Object.defineProperty(input1, "files", {
+      configurable: true,
+      value: [new File(['[{"name":"a"}]'], "good.json", { type: "application/json" })],
+    });
+    await act(async () => {
+      input1.onchange?.({ target: input1 } as unknown as Event);
+    });
+    await act(async () => {
+      const reader = fileReaders[0];
+      reader.result = '[{"name":"a"}]';
+      reader.onload?.({ target: reader } as ProgressEvent<FileReader>);
+    });
+    expect(result.current.importConfirm).not.toBeNull();
+
+    await act(async () => {
+      result.current.handleImport();
+    });
+    const input2 = createElementSpy.mock.results.at(-1)?.value as HTMLInputElement;
+    Object.defineProperty(input2, "files", {
+      configurable: true,
+      value: [new File(["x"], "unreadable.json", { type: "application/json" })],
+    });
+    await act(async () => {
+      input2.onchange?.({ target: input2 } as unknown as Event);
+    });
+    await act(async () => {
+      const reader = fileReaders[1];
+      reader.error = new DOMException("NotReadableError");
+      reader.onerror?.({ target: reader } as ProgressEvent<FileReader>);
+    });
+
+    expect(result.current.importConfirm).toBeNull();
+    expect(setError).toHaveBeenLastCalledWith("Failed to read file: NotReadableError");
+  });
 });

--- a/src/lib/__tests__/usePresets.test.ts
+++ b/src/lib/__tests__/usePresets.test.ts
@@ -156,4 +156,132 @@ describe("useImportPresets", () => {
     expect(result.current.importConfirm).toBeNull();
     expect(setError).toHaveBeenLastCalledWith("Failed to read file: NotReadableError");
   });
+
+  it("clears confirmation when a later parse fails after a successful import", async () => {
+    const setError = vi.fn();
+    const parseImport = vi
+      .fn()
+      .mockReturnValueOnce({
+        ok: true as const,
+        presets: [{ name: "a" }],
+        importedPresets: [{ name: "a" }],
+        collisions: [],
+      })
+      .mockReturnValueOnce({ ok: false as const, error: "bad json" });
+
+    const { result } = renderHook(() =>
+      useImportPresets<Preset>({
+        customPresets: [],
+        setError,
+        parseImport,
+      }),
+    );
+
+    const createElementSpy = vi.spyOn(document, "createElement");
+
+    await act(async () => {
+      result.current.handleImport();
+    });
+    const input1 = createElementSpy.mock.results.at(-1)?.value as HTMLInputElement;
+    Object.defineProperty(input1, "files", {
+      configurable: true,
+      value: [new File(['[{"name":"a"}]'], "good.json", { type: "application/json" })],
+    });
+    await act(async () => {
+      input1.onchange?.({ target: input1 } as unknown as Event);
+    });
+    await act(async () => {
+      const reader = fileReaders[0];
+      reader.result = '[{"name":"a"}]';
+      reader.onload?.({ target: reader } as ProgressEvent<FileReader>);
+    });
+    expect(result.current.importConfirm).not.toBeNull();
+
+    await act(async () => {
+      result.current.handleImport();
+    });
+    const input2 = createElementSpy.mock.results.at(-1)?.value as HTMLInputElement;
+    Object.defineProperty(input2, "files", {
+      configurable: true,
+      value: [new File(["{bad"], "bad.json", { type: "application/json" })],
+    });
+    await act(async () => {
+      input2.onchange?.({ target: input2 } as unknown as Event);
+    });
+    await act(async () => {
+      const reader = fileReaders[1];
+      reader.result = "{bad";
+      reader.onload?.({ target: reader } as ProgressEvent<FileReader>);
+    });
+
+    expect(result.current.importConfirm).toBeNull();
+    expect(setError).toHaveBeenLastCalledWith("bad json");
+  });
+
+  it("ignores an obsolete reader error after a newer import succeeds", async () => {
+    const setError = vi.fn();
+    const parseImport = vi.fn().mockReturnValue({
+      ok: true as const,
+      presets: [{ name: "newer" }],
+      importedPresets: [{ name: "newer" }],
+      collisions: [],
+    });
+
+    const { result } = renderHook(() =>
+      useImportPresets<Preset>({
+        customPresets: [],
+        setError,
+        parseImport,
+      }),
+    );
+
+    const createElementSpy = vi.spyOn(document, "createElement");
+
+    await act(async () => {
+      result.current.handleImport();
+    });
+    const input1 = createElementSpy.mock.results.at(-1)?.value as HTMLInputElement;
+    Object.defineProperty(input1, "files", {
+      configurable: true,
+      value: [new File(["old"], "old.json", { type: "application/json" })],
+    });
+    await act(async () => {
+      input1.onchange?.({ target: input1 } as unknown as Event);
+    });
+
+    await act(async () => {
+      result.current.handleImport();
+    });
+    const input2 = createElementSpy.mock.results.at(-1)?.value as HTMLInputElement;
+    Object.defineProperty(input2, "files", {
+      configurable: true,
+      value: [new File(['[{"name":"newer"}]'], "newer.json", { type: "application/json" })],
+    });
+    await act(async () => {
+      input2.onchange?.({ target: input2 } as unknown as Event);
+    });
+    await act(async () => {
+      const newer = fileReaders[1];
+      newer.result = '[{"name":"newer"}]';
+      newer.onload?.({ target: newer } as ProgressEvent<FileReader>);
+    });
+    expect(result.current.importConfirm).toEqual({
+      importedPresets: [{ name: "newer" }],
+      collisions: [],
+      mergedPresets: [{ name: "newer" }],
+    });
+
+    await act(async () => {
+      const older = fileReaders[0];
+      older.error = new DOMException("NotReadableError");
+      older.onerror?.({ target: older } as ProgressEvent<FileReader>);
+    });
+
+    expect(result.current.importConfirm).toEqual({
+      importedPresets: [{ name: "newer" }],
+      collisions: [],
+      mergedPresets: [{ name: "newer" }],
+    });
+    expect(setError).not.toHaveBeenCalledWith("Failed to read file: NotReadableError");
+  });
 });

--- a/src/lib/__tests__/usePresets.test.ts
+++ b/src/lib/__tests__/usePresets.test.ts
@@ -1,0 +1,101 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useImportPresets } from "@/lib/hooks/usePresets";
+
+type Preset = { name: string };
+
+describe("useImportPresets", () => {
+  let fileReaders: FakeFileReader[];
+
+  class FakeFileReader {
+    result: string | null = null;
+    error: DOMException | null = null;
+    onload: ((ev: ProgressEvent<FileReader>) => void) | null = null;
+    onerror: ((ev: ProgressEvent<FileReader>) => void) | null = null;
+
+    constructor() {
+      fileReaders.push(this);
+    }
+
+    readAsText(_file: Blob) {
+      // Tests drive onload/onerror explicitly.
+    }
+  }
+
+  beforeEach(() => {
+    fileReaders = [];
+    vi.stubGlobal("FileReader", FakeFileReader);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("clears a prior error when a later import succeeds", async () => {
+    const setError = vi.fn();
+    const parseImport = vi
+      .fn()
+      .mockReturnValueOnce({ ok: false as const, error: "bad json" })
+      .mockReturnValueOnce({
+        ok: true as const,
+        presets: [{ name: "a" }],
+        importedPresets: [{ name: "a" }],
+        collisions: [],
+      });
+
+    const { result } = renderHook(() =>
+      useImportPresets<Preset>({
+        customPresets: [],
+        setError,
+        parseImport,
+      }),
+    );
+
+    const createElementSpy = vi.spyOn(document, "createElement");
+
+    await act(async () => {
+      result.current.handleImport();
+    });
+    const input1 = createElementSpy.mock.results.at(-1)?.value as HTMLInputElement;
+    Object.defineProperty(input1, "files", {
+      configurable: true,
+      value: [new File(["{bad"], "bad.json", { type: "application/json" })],
+    });
+    await act(async () => {
+      input1.onchange?.({ target: input1 } as unknown as Event);
+    });
+    await act(async () => {
+      const reader = fileReaders[0];
+      reader.result = "{bad";
+      reader.onload?.({ target: reader } as ProgressEvent<FileReader>);
+    });
+    expect(setError).toHaveBeenCalledWith("bad json");
+    expect(result.current.importConfirm).toBeNull();
+
+    await act(async () => {
+      result.current.handleImport();
+    });
+    const input2 = createElementSpy.mock.results.at(-1)?.value as HTMLInputElement;
+    Object.defineProperty(input2, "files", {
+      configurable: true,
+      value: [new File(['[{"name":"a"}]'], "good.json", { type: "application/json" })],
+    });
+    await act(async () => {
+      input2.onchange?.({ target: input2 } as unknown as Event);
+    });
+    await act(async () => {
+      const reader = fileReaders[1];
+      reader.result = '[{"name":"a"}]';
+      reader.onload?.({ target: reader } as ProgressEvent<FileReader>);
+    });
+
+    expect(setError).toHaveBeenLastCalledWith("");
+    expect(result.current.importConfirm).toEqual({
+      importedPresets: [{ name: "a" }],
+      collisions: [],
+      mergedPresets: [{ name: "a" }],
+    });
+  });
+});

--- a/src/lib/hooks/useMcpDiagnostic.ts
+++ b/src/lib/hooks/useMcpDiagnostic.ts
@@ -50,6 +50,7 @@ export function useMcpDiagnostic(): UseMcpDiagnosticReturn {
 
     setIsDiagnosing(true);
     setError(null);
+    setDiagnostic(null);
     try {
       const { diagnostic: result, error: fetchError } = await requestMcpDiagnostic(logs, controller.signal);
       if (controller.signal.aborted) return null;

--- a/src/lib/hooks/usePresets.ts
+++ b/src/lib/hooks/usePresets.ts
@@ -1,7 +1,7 @@
 /**
  * Shared import/export preset hooks for inspector components.
  */
-import { useState, useCallback } from "react";
+import { useState, useCallback, useRef } from "react";
 
 // ─── Import Presets ─────────────────────────────────────────────
 
@@ -45,6 +45,7 @@ export function useImportPresets<T>(opts: {
 } {
   const { customPresets, setError, parseImport } = opts;
   const [importConfirm, setImportConfirm] = useState<ImportConfirmState<T> | null>(null);
+  const importGenerationRef = useRef(0);
 
   const handleImport = useCallback(() => {
     const input = document.createElement("input");
@@ -53,11 +54,14 @@ export function useImportPresets<T>(opts: {
     input.onchange = (e) => {
       const file = (e.target as HTMLInputElement).files?.[0];
       if (!file) return;
+      const generation = ++importGenerationRef.current;
       const reader = new FileReader();
       reader.onload = (ev) => {
+        if (generation !== importGenerationRef.current) return;
         const text = ev.target?.result as string;
         const result = parseImport(text, customPresets);
         if (result.ok === false) {
+          setImportConfirm(null);
           setError(result.error);
         } else {
           setError("");
@@ -69,6 +73,7 @@ export function useImportPresets<T>(opts: {
         }
       };
       reader.onerror = () => {
+        if (generation !== importGenerationRef.current) return;
         setImportConfirm(null);
         setError(`Failed to read file: ${reader.error?.message ?? "unknown error"}`);
       };

--- a/src/lib/hooks/usePresets.ts
+++ b/src/lib/hooks/usePresets.ts
@@ -67,6 +67,9 @@ export function useImportPresets<T>(opts: {
           });
         }
       };
+      reader.onerror = () => {
+        setError(`Failed to read file: ${reader.error?.message ?? "unknown error"}`);
+      };
       reader.readAsText(file);
     };
     input.click();

--- a/src/lib/hooks/usePresets.ts
+++ b/src/lib/hooks/usePresets.ts
@@ -69,6 +69,7 @@ export function useImportPresets<T>(opts: {
         }
       };
       reader.onerror = () => {
+        setImportConfirm(null);
         setError(`Failed to read file: ${reader.error?.message ?? "unknown error"}`);
       };
       reader.readAsText(file);

--- a/src/lib/hooks/usePresets.ts
+++ b/src/lib/hooks/usePresets.ts
@@ -60,6 +60,7 @@ export function useImportPresets<T>(opts: {
         if (result.ok === false) {
           setError(result.error);
         } else {
+          setError("");
           setImportConfirm({
             importedPresets: result.importedPresets,
             collisions: result.collisions,

--- a/src/lib/passAccessors.ts
+++ b/src/lib/passAccessors.ts
@@ -113,8 +113,12 @@ export function getQuantConfig(passes: Passes): QuantizationConfig | null {
       return { ...base, method: "spinquant" };
     case "quarot":
       return { ...base, method: "quarot" };
-    default:
+    case "ptq":
       return { ...base, method: "ptq" };
+    default: {
+      console.warn(`[passAccessors] Unknown quantMethod "${passes.quantMethod}", defaulting to PTQ`);
+      return { ...base, method: "ptq" };
+    }
   }
 }
 


### PR DESCRIPTION
Follow-up to #192 — addresses unresolved review comments:

- **passAccessors.ts**: explicit `case "ptq"` + warn on unknown quantMethod (Qodo P2)
- **useMcpDiagnostic.ts**: clear diagnostic before new request (CodeRabbit)
- **InputEnvironmentPanel.tsx**: remove unused `filteredRecipes` (CodeRabbit, ESLint)
- **localFileUtils.ts**: reject gapped chunk sequences before reconstruction (CodeRabbit Major)
- **usePresets.ts**: add `reader.onerror` handler (CodeRabbit)

Fixes review comments from: #192 (comments 3743875548, 3743918062, 3743918054, 3743918057, 3743918066)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tonythethompson/Olive-Studio/pull/199?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

