### PR TITLE
fix: docs/config quick wins from PR #192 review

### DIFF
--- a/.kiro/powers/olive-studio-dev/POWER.md
+++ b/.kiro/powers/olive-studio-dev/POWER.md
@@ -65,7 +65,7 @@ UIState (zustand) → commitUiStateUpdate (coercion) → buildOliveRecipe (memoi
 - Middleware: `bodyGuard.ts`, `rateLimit.ts`, `localOnly.ts`
 
 ### MCP Server
-- 26 tools registered via lazy `_TOOL_IMPORTS` dict
+- 27 tools registered via lazy `_TOOL_IMPORTS` dict
 - Knowledge base: `passes.json` (84+ passes), `hardware_profiles.json` (22 profiles), `compatibility_matrix.json`, `troubleshooting.json`
 - Transport: stdio (default) or SSE
 - Launcher: `olive-mcp-server/run.py` — finds project venv, sets PYTHONPATH

--- a/docs/v0.2-tech-debt-plan.md
+++ b/docs/v0.2-tech-debt-plan.md
@@ -190,7 +190,7 @@
 
 ## Execution Order
 
-```
+```text
 Parallel Track A (server/infra — no UI coupling):
   Task 1: Persistent MCP connection       ← THE v0.3 blocker
   Task 8: Security headers verification   ← already done, just verify

--- a/src/lib/mcpClient.ts
+++ b/src/lib/mcpClient.ts
@@ -15,6 +15,20 @@ import {
   parseFeedbackToolPayload,
 } from "@/lib/mcpPayload";
 
+/** Unwrap a `{ result }` envelope if present, otherwise return the raw record. */
+function unwrapToolPayload(data: unknown): Record<string, unknown> | null {
+  const record = data && typeof data === "object" ? (data as Record<string, unknown>) : null;
+  if (
+    record &&
+    record.result &&
+    typeof record.result === "object" &&
+    !Array.isArray(record.result)
+  ) {
+    return record.result as Record<string, unknown>;
+  }
+  return record;
+}
+
 /**
  * Retrieves a troubleshooting diagnostic for the provided logs.
  *
@@ -47,11 +61,7 @@ export async function requestMcpDiagnostic(
     if (signal?.aborted) return { diagnostic: null, error: null };
 
     const record = data && typeof data === "object" ? (data as Record<string, unknown>) : null;
-    // Prefer unwrapped tool payload when a legacy `{ result }` envelope is present.
-    const payload =
-      record && record.result && typeof record.result === "object" && !Array.isArray(record.result)
-        ? (record.result as Record<string, unknown>)
-        : record;
+    const payload = unwrapToolPayload(data);
 
     if (!resp.ok) {
       const msg =
@@ -143,10 +153,7 @@ function interpretFeedbackHttpResponse(
   data: unknown,
 ): McpTroubleshootFeedbackResult | McpTroubleshootFeedbackError {
   const record = data && typeof data === "object" ? (data as Record<string, unknown>) : null;
-  const payload =
-    record && record.result && typeof record.result === "object" && !Array.isArray(record.result)
-      ? (record.result as Record<string, unknown>)
-      : record;
+  const payload = unwrapToolPayload(data);
   if (!resp.ok) {
     const msg =
       (payload && typeof payload.error === "string" && payload.error) ||


### PR DESCRIPTION
Follow-up to #192 — addresses remaining review comments:

- **docs/v0.2-tech-debt-plan.md**: add `text` language to fenced block (markdownlint MD040)
- **POWER.md**: reconcile MCP tool count 26→27 (CodeRabbit)
- **mcpClient.ts**: extract `unwrapToolPayload()` helper to DRY envelope unwrap (CodeRabbit Trivial)

Fixes review comments from: #192 (comments 3743918035, 3743918038, 3743918072)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tonythethompson/Olive-Studio/pull/200?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

