### PR TITLE
Update roadmap with architecture themes and olive-ai upgrade

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -85,6 +85,7 @@ Manual vs Agent on Execute first; Assistant stays chat until the later bridge.
 
 - [ ] Export optimization report (PDF/Markdown)
 - [ ] Recipe catalog version pinning
+- [ ] MultiLoRA adapter support: target v0.4+; **blocked** on upstream Olive multi-adapter pass configuration (Olive >= 0.3.0). Schema `adapters[]` is forward-compatible today; builder still emits single `adapter_path` only. See `docs/multilora-design.md`. Not unblocked by the v0.3 `olive-ai` pin bump.
 
 ### Distribution
 
@@ -108,7 +109,6 @@ Converge Assistant and Execute Agent mode on one action path. Do not replace Exe
 
 ## Backlog
 
-- [ ] MultiLoRA adapter support (blocked on Olive ≥ 0.3.0 upstream)
 - [ ] Cloud sync for recipe presets
 - [ ] Collaborative recipe sharing (GitHub Gist export)
 - [ ] ONNX Runtime WebGPU inference preview

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -2,6 +2,21 @@
 
 ---
 
+## Architecture posture (agent / MCP)
+
+Decisions against the "start fresh" critique. Outcomes we want; rewrites we do not.
+
+| Theme | Disposition | Roadmap treatment |
+|-------|-------------|-------------------|
+| MCP as optimization agent (observe → reason → multi-step fix → retry) | **Modify** | Keep the loop. MCP stays Studio-mediated: tools call Studio's job API; MCP never launches Olive. Studio owns policy and execution. |
+| `UIState.passes` as a discriminated union | **Park** | Typed accessors (`passAccessors.ts`) stay the approach. Full union migration stays Tech Debt; not scheduled for v0.3-v0.4. Revisit only if flat-bag TypeScript pain dominates. |
+| Persistent MCP stdio (vs per-call spawn) | **Done** | Shipped in v0.2. No further roadmap item. |
+| Assistant sidebar as the sole agent UI | **Modify** | Ship Execute Agent mode first (v0.4). Later: shared proposed-actions / tool-approval path so Assistant and Agent mode use the same tools. Do not make chat the only agent shell. |
+
+Contract (unchanged): standalone MCP is advisory; MCP connected to Studio is an agent-facing control plane for Studio operations. See `docs/proposals/olive-mcp-agent-platform.md`.
+
+---
+
 ## v0.1.0 (shipped)
 
 - Recipe builder UI with pass catalog and pipeline graph
@@ -19,7 +34,7 @@
 ## v0.2 (shipped)
 
 - Persistent MCP stdio connection (<50ms warm tool calls, replaces subprocess spawn)
-- Typed pass accessors (`src/lib/passAccessors.ts`)
+- Typed pass accessors (`src/lib/passAccessors.ts`): deliberate alternative to a full `UIState.passes` union
 - Component splits: InputEnvironmentPanel (2200 → 241 lines), IHVIntegrationPanel (1000 → 563 lines)
 - Renamed GeminiSidebar → AssistantSidebar
 - Split hooks.ts into focused modules
@@ -34,13 +49,17 @@
 
 ### Agent autonomy tools (MCP)
 
-5 new tools that close the autonomous agent loop:
+Studio-mediated loop (not a second Olive executor). Five tools that close observe → plan → diagnose → retry:
 
-- [ ] `execute_and_observe` — submit job, poll until completion, return structured outcome
+- [ ] `execute_and_observe` — submit via Studio job API, poll until completion, return structured outcome
 - [ ] `plan_optimization` — intent + hardware probe → complete UIState patch with reasoning
 - [ ] `diagnose_and_fix` — error text + current recipe → diagnosis + fixed recipe for retry
 - [ ] `compare_results` — 2+ job results → structured comparison with recommendation
 - [ ] `get_model_info` — HuggingFace model ID → params, architecture, VRAM estimate (HF API with regex fallback)
+
+### Agent loop state
+
+- [ ] Attempt / session context for agent loops (last recipe, last failure, attempt history) owned by MCP session or Studio job metadata: enough for multi-step retry without turning MCP into the UI controller
 
 ### Minor quality
 
@@ -50,7 +69,9 @@
 
 ## v0.4 (next)
 
-### Agent UI
+### Agent UI (Execute panel)
+
+Manual vs Agent on Execute first; Assistant stays chat until the later bridge.
 
 - [ ] Agent mode toggle in Execute panel (Manual vs Agent)
 - [ ] Agent activity log (reasoning, attempts, decisions in real-time)
@@ -69,6 +90,18 @@
 
 ---
 
+## v0.5 (later)
+
+### Assistant ↔ agent bridge
+
+Converge Assistant and Execute Agent mode on one action path. Do not replace Execute Agent mode with chat-only.
+
+- [ ] Shared proposed-actions model (MCP tool call + user approve) used by Assistant and Agent mode
+- [ ] Assistant can invoke the same autonomy tools as Agent mode (`plan_optimization`, `diagnose_and_fix`, `execute_and_observe`, …)
+- [ ] Audit surfaces proactive agent findings on that path (not a permanent parallel “mode” forever inventing JSON patches)
+
+---
+
 ## Backlog
 
 - [ ] MultiLoRA adapter support (blocked on Olive ≥ 0.3.0 upstream)
@@ -77,6 +110,7 @@
 - [ ] ONNX Runtime WebGPU inference preview
 - [ ] Expand compatibility matrix with more models
 - [ ] Olive version tracking (support matrix for multiple Olive releases)
+- [ ] *(parked)* `UIState.passes` discriminated union: Tech Debt #11; accessors only unless DX pain forces migration
 
 ---
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -49,7 +49,7 @@ Contract (unchanged): standalone MCP is advisory; MCP connected to Studio is an 
 
 ### Olive runtime
 
-- [ ] Update `olive-ai` to 0.1.3 (venv pin / install path, docs, and compatibility notes)
+- [ ] Keep managed `olive-ai` pin, docs, and compatibility notes aligned with Olive **0.12.1** (current pass-catalog / CI baseline; venv already accepts `olive-ai>=0.9.0,<1`)
 
 ### Agent autonomy tools (MCP)
 
@@ -85,7 +85,7 @@ Manual vs Agent on Execute first; Assistant stays chat until the later bridge.
 
 - [ ] Export optimization report (PDF/Markdown)
 - [ ] Recipe catalog version pinning
-- [ ] MultiLoRA adapter support: target v0.4+; **blocked** on upstream Olive multi-adapter pass configuration (Olive >= 0.3.0). Schema `adapters[]` is forward-compatible today; builder still emits single `adapter_path` only. See `docs/multilora-design.md`. Not unblocked by the v0.3 `olive-ai` pin bump.
+- [ ] MultiLoRA adapter support: target v0.4+; **blocked** on upstream Olive multi-adapter pass configuration (Olive >= 0.3.0). Schema `adapters[]` is forward-compatible today; builder does not yet emit `adapter_path` or `adapters[]`. See `docs/multilora-design.md`. Not unblocked by the v0.3 `olive-ai` pin alignment.
 
 ### Distribution
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -47,6 +47,10 @@ Contract (unchanged): standalone MCP is advisory; MCP connected to Studio is an 
 
 ## v0.3 (in progress)
 
+### Olive runtime
+
+- [ ] Update `olive-ai` to 0.1.3 (venv pin / install path, docs, and compatibility notes)
+
 ### Agent autonomy tools (MCP)
 
 Studio-mediated loop (not a second Olive executor). Five tools that close observe → plan → diagnose → retry:

--- a/docs/multilora-design.md
+++ b/docs/multilora-design.md
@@ -51,14 +51,11 @@ critical for serving multiple fine-tuned variants of the same base model efficie
 to v0.2.0 single-adapter mode. The builder ignores unknown keys.
 
 **Current implementation status:** The recipe schema validator accepts the `adapters[]`
-field for forward-compatibility validation, but the current builder (`buildOliveRecipe`)
-does not consume it — only `passes.lora.config.adapter_path` (single-adapter mode) is
-emitted. When both `adapters[].path` and `passes.lora.config.adapter_path` are present,
-the validator does not reject this as a conflict; however, only the pass-level
-`adapter_path` will be used by the builder until multi-adapter builder support is
-implemented (requires Olive >= 0.3.0). For recipes using `adapters[]` today, the
-runtime adapter-loading artifacts will NOT be emitted until builder integration (Phase 4)
-is complete.
+field for forward-compatibility validation, but `buildPeftPass` does not emit
+`adapter_path` or `adapters[]` today (LoRA/QLoRA configs currently include fields such as
+`r` and `alpha`). Multi-adapter builder support still requires Olive >= 0.3.0 upstream
+pass configuration. For recipes that include `adapters[]` today, runtime adapter-loading
+artifacts will NOT be emitted until builder integration (Phase 4) is complete.
 
 ### TypeScript Interface
 


### PR DESCRIPTION
<h3>PR Summary by Qodo</h3>

Document architecture themes and roadmap updates (olive-ai 0.1.3, agent bridge)

<code>📝 Documentation</code> <code>🕐 10-20 Minutes</code>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<details>
<summary>AI Description</summary>

<dl>
<dd>
<br/>

><pre>
>• Add an explicit architecture posture table for agent/MCP themes (modify/park/done) to guide
>  roadmap decisions.
>• Update v0.3 roadmap with an <b><i>olive-ai</i></b> 0.1.3 upgrade and clarify Studio-mediated MCP tool
>  execution.
>• Refine upcoming work: agent loop state (v0.3), Execute-panel Agent UI focus (v0.4), and
>  Assistant↔agent bridge (v0.5).
></pre>

</dd>
</dl>

</details>

<details>
<summary>Diagram</summary>

<dl>
<dd>

<br/>

```mermaid
graph TD
  A["docs/ROADMAP.md"] --> B["Architecture posture"] --> C["v0.3: Olive + MCP tools"] --> D["v0.3: Loop state"] --> E["v0.4: Execute Agent UI"] --> F["v0.5: Assistant↔agent bridge"] --> G["Backlog/parked"]
```

</dd>
</dl>

</details>




<details>
<summary>High-Level Assessment</summary>

<dl>
<dd>

<br/>

>The following are alternative approaches to this PR:

<details>
<summary><b>1. Move posture content into an ADR and keep roadmap milestone-only</b></summary>

<dl>
<dd>

- ➕ Reduces roadmap verbosity; focuses it on deliverables/dates
- ➕ Keeps architectural rationale in a stable decision record (ADR)
- ➖ Less visible during planning; readers may miss the architectural constraints
- ➖ Requires cross-doc navigation to understand why items are parked/modified

</dd>
</dl>

</details>

<details>
<summary><b>2. Track theme dispositions as GitHub issues/labels instead of a table in ROADMAP</b></summary>

<dl>
<dd>

- ➕ Actionable ownership, status, and discussion history per theme
- ➕ Easier to keep current as plans change
- ➖ Harder to get a single-page narrative across versions
- ➖ Adds process/tooling overhead for contributors

</dd>
</dl>

</details>

>**Recommendation:** The PR’s approach (a concise posture table embedded in the roadmap, with links out to deeper docs) is a good balance for alignment: it makes &quot;non-goals&quot; and constraints visible where planning happens, while still pointing to a proposal doc for details. If this section grows further, consider extracting it into a short ADR and keeping a one-paragraph summary + link in the roadmap.

</dd>
</dl>

</details>

<details>
<summary> Files changed (1) <code> +43 / -5 </code> </summary>

<dl>
<dd>

<br/>

<details>
<summary>Documentation (1) <code> +43 / -5 </code></summary>

<dl>
<dd>

<details>
<summary>ROADMAP.md<code>Add architecture posture section and expand v0.3–v0.5 roadmap items</code> <code>+43/-5</code></summary>

<br/>

>Add architecture posture section and expand v0.3–v0.5 roadmap items
>
><pre>
>• Introduces an &quot;Architecture posture (agent / MCP)&quot; section clarifying dispositions for major themes (modify/park/done). Updates v0.3 with an &#x27;olive-ai&#x27; 0.1.3 upgrade task, refines MCP tool wording to emphasize Studio-mediated execution, and adds an agent loop state item. Adjusts v0.4 Agent UI framing, moves/clarifies MultiLoRA gating, adds a new v0.5 Assistant↔agent bridge section, and annotates parked backlog items.
></pre>
>
><a href='https://github.com/tonythethompson/Olive-Studio/pull/220/files#diff-0d96796e2b2a475d618f28659f8bca752e1513e54ae8741220ec7b800d3777c2'>docs/ROADMAP.md</a>

</details>

</dd>
</dl>

</details>

</dd>
</dl>

</details>