### PR TITLE
perf: bundle phase 2 — externalize typegpu, lazy MCP card, consolidate formatBytes (-293KB)

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,8 @@
       {
         "imports": {
           "onnxruntime-web": "https://esm.sh/onnxruntime-web@1.27.0",
-          "@huggingface/transformers": "https://esm.sh/@huggingface/transformers@4.2.0"
+          "@huggingface/transformers": "https://esm.sh/@huggingface/transformers@4.2.0",
+          "typegpu": "https://esm.sh/typegpu@0.11.9"
         }
       }
     </script>

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "tauri:build": "tauri build"
   },
   "dependencies": {
-    "@google/genai": "^2.15.0",
     "@huggingface/transformers": "^4.2.0",
     "@modelcontextprotocol/client": "^2.0.0",
     "@radix-ui/react-accordion": "^1.2.20",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,9 +22,6 @@ importers:
 
   .:
     dependencies:
-      '@google/genai':
-        specifier: ^2.15.0
-        version: 2.15.0(supports-color@7.2.0)
       '@huggingface/transformers':
         specifier: ^4.2.0
         version: 4.2.0(@types/node@26.1.2)
@@ -968,15 +965,6 @@ packages:
 
   '@floating-ui/utils@0.2.12':
     resolution: {integrity: sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==}
-
-  '@google/genai@2.15.0':
-    resolution: {integrity: sha512-Q41TvqwBQ9NcmWdh6qxY5qrpg+0FaVHD7febQoH007pykxzco4ohScBUP4BBBy+Q8j5D8euIBSRIBDfWuNVCKA==}
-    engines: {node: '>=20.0.0'}
-    peerDependencies:
-      '@modelcontextprotocol/sdk': ^1.25.2
-    peerDependenciesMeta:
-      '@modelcontextprotocol/sdk':
-        optional: true
 
   '@huggingface/jinja@0.5.9':
     resolution: {integrity: sha512-uWTG+l3VJRsl7EXxYizuL3P+cCPoc3cRqbWWRcQN0FhejRfbdq0RNhCmbY/YDtnTcz9icdLYuLDjsnz4d8JMuw==}
@@ -2304,9 +2292,6 @@ packages:
   '@types/resolve@1.20.6':
     resolution: {integrity: sha512-A4STmOXPhMUtHH+S6ymgE2GiBSMqf4oTvcQZMcHzokuTLVYzXTB8ttjcgxOVaAp2lGwEdzZ0J+cRbbeevQj1UQ==}
 
-  '@types/retry@0.12.0':
-    resolution: {integrity: sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==}
-
   '@types/send@1.2.1':
     resolution: {integrity: sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==}
 
@@ -2465,10 +2450,6 @@ packages:
     resolution: {integrity: sha512-XleryMhbuksdKtofnWZ9Sk+4CUTbms4Mb/EU32SZwToAyZ5RgVos/ki8n+yr0LWHOGKuakbXTuuYNHLQjhddgg==}
     engines: {node: '>=14.0'}
 
-  agent-base@7.1.4:
-    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
-    engines: {node: '>= 14'}
-
   ajv@6.15.0:
     resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
 
@@ -2575,9 +2556,6 @@ packages:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
 
-  base64-js@1.5.1:
-    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
-
   baseline-browser-mapping@2.11.3:
     resolution: {integrity: sha512-sbT0Ui/CZwyAyy7icT1Gw5P1LKRlFaHwaF6tDCW5YHq2X5SeeZFphBuIagopSfwSSZq3sQcbmEL072yphxm7ew==}
     engines: {node: '>=6.0.0'}
@@ -2589,9 +2567,6 @@ packages:
 
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
-
-  bignumber.js@9.3.1:
-    resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
 
   body-parser@2.3.0:
     resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
@@ -2612,9 +2587,6 @@ packages:
     resolution: {integrity: sha512-JxV13hNrFxqjOc8alRbq9dK1MM79NEXYpma2B2J4wAtpWS5zIEIKqWPGCl7N4o7Uc7B7itylh7SuDujATRyyTw==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
-
-  buffer-equal-constant-time@1.0.1:
-    resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
 
   bundle-name@4.1.0:
     resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
@@ -2745,10 +2717,6 @@ packages:
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
-  data-uri-to-buffer@4.0.1:
-    resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
-    engines: {node: '>= 12'}
-
   data-urls@7.0.0:
     resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
@@ -2853,9 +2821,6 @@ packages:
 
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
-
-  ecdsa-sig-formatter@1.0.11:
-    resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
 
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
@@ -3065,9 +3030,6 @@ packages:
     resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
     engines: {node: '>= 18'}
 
-  extend@3.0.2:
-    resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
-
   fast-check@4.9.0:
     resolution: {integrity: sha512-7ms6T7SybUev/PQITciI0yLM2pOSFy5zpG8Ty7tQofcVaQUvrMXp6CBwqF6fThLCLOrfBtuHAtwq6Yu4XPCllg==}
     engines: {node: '>=12.17.0'}
@@ -3092,10 +3054,6 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
-
-  fetch-blob@3.2.0:
-    resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
-    engines: {node: ^12.20 || >= 14.13}
 
   fflate@0.8.3:
     resolution: {integrity: sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==}
@@ -3129,10 +3087,6 @@ packages:
   foreground-child@3.3.1:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
-
-  formdata-polyfill@4.0.10:
-    resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
-    engines: {node: '>=12.20.0'}
 
   forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
@@ -3168,14 +3122,6 @@ packages:
 
   functions-have-names@1.2.3:
     resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
-
-  gaxios@7.3.0:
-    resolution: {integrity: sha512-RB5vLV+vvQeoFPCX4QMK6/hjVkbIamPp1QSUD0CiZcnj12qbpiL+pLbYtgD+oZkWl0tl9z+o2Utp+MpM3QRhBA==}
-    engines: {node: '>=18'}
-
-  gcp-metadata@8.1.2:
-    resolution: {integrity: sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==}
-    engines: {node: '>=18'}
 
   generator-function@2.0.1:
     resolution: {integrity: sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==}
@@ -3234,18 +3180,6 @@ packages:
     resolution: {integrity: sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==}
     engines: {node: '>= 0.4'}
 
-  google-auth-library@10.9.1:
-    resolution: {integrity: sha512-i1ydyHrqcIxXkWh/uBmVkzCvIuq5yiK2ATndIe5XxKholrG/MTYP9xGYka4sQhrbIAgGjL2B6NOE7rFaiF3fXw==}
-    engines: {node: '>=18'}
-
-  google-logging-utils@1.1.3:
-    resolution: {integrity: sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==}
-    engines: {node: '>=14'}
-
-  google-logging-utils@1.2.0:
-    resolution: {integrity: sha512-WE9av4wKDZgRjBwgVUabocx8T6/7o3Ca1Fat46FXDhXVAFibzNadedcOXrdgd1Kzmk8tsk/9ZH89Wyf/SqeZ3A==}
-    engines: {node: '>=18'}
-
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
@@ -3303,10 +3237,6 @@ packages:
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
-
-  https-proxy-agent@7.0.6:
-    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
-    engines: {node: '>= 14'}
 
   iconv-lite@0.7.3:
     resolution: {integrity: sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==}
@@ -3566,9 +3496,6 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
-  json-bigint@1.0.0:
-    resolution: {integrity: sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==}
-
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
 
@@ -3598,12 +3525,6 @@ packages:
   jsx-ast-utils@3.3.5:
     resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
     engines: {node: '>=4.0'}
-
-  jwa@2.0.1:
-    resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
-
-  jws@4.0.1:
-    resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
@@ -3883,18 +3804,9 @@ packages:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
 
-  node-domexception@1.0.0:
-    resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
-    engines: {node: '>=10.5.0'}
-    deprecated: Use your platform's native DOMException instead
-
   node-exports-info@1.6.2:
     resolution: {integrity: sha512-kXs9Go0cah0qHVV2v389IXQLdLCeE1xfFtjOAF+iobu0OIoG1pje8At2vMHyaPMiPMnG/LWP50twML21eMcAag==}
     engines: {node: '>= 0.4'}
-
-  node-fetch@3.3.2:
-    resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   node-releases@2.0.51:
     resolution: {integrity: sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==}
@@ -3988,10 +3900,6 @@ packages:
   p-locate@5.0.0:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
-
-  p-retry@4.6.2:
-    resolution: {integrity: sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==}
-    engines: {node: '>=8'}
 
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
@@ -4218,10 +4126,6 @@ packages:
     engines: {node: '>= 0.4'}
     hasBin: true
 
-  retry@0.13.1:
-    resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
-    engines: {node: '>= 4'}
-
   roarr@2.15.4:
     resolution: {integrity: sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==}
     engines: {node: '>=8.0'}
@@ -4255,9 +4159,6 @@ packages:
   safe-array-concat@1.1.4:
     resolution: {integrity: sha512-wtZlHyOje6OZTGqAoaDKxFkgRtkF9CnHAVnCHKfuj200wAgL+bSJhdsCD2l0Qx/2ekEXjPWcyKkfGb5CPboslg==}
     engines: {node: '>=0.4'}
-
-  safe-buffer@5.2.1:
-    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
   safe-push-apply@1.0.0:
     resolution: {integrity: sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==}
@@ -4791,10 +4692,6 @@ packages:
   w3c-xmlserializer@5.0.0:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
     engines: {node: '>=18'}
-
-  web-streams-polyfill@3.3.3:
-    resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
-    engines: {node: '>= 8'}
 
   webidl-conversions@8.0.1:
     resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
@@ -5507,17 +5404,6 @@ snapshots:
       react-dom: 19.2.8(react@19.2.8)
 
   '@floating-ui/utils@0.2.12': {}
-
-  '@google/genai@2.15.0(supports-color@7.2.0)':
-    dependencies:
-      google-auth-library: 10.9.1(supports-color@7.2.0)
-      p-retry: 4.6.2
-      protobufjs: 8.7.1
-      ws: 8.21.1
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
 
   '@huggingface/jinja@0.5.9': {}
 
@@ -6670,8 +6556,6 @@ snapshots:
 
   '@types/resolve@1.20.6': {}
 
-  '@types/retry@0.12.0': {}
-
   '@types/send@1.2.1':
     dependencies:
       '@types/node': 26.1.2
@@ -6881,8 +6765,6 @@ snapshots:
 
   adm-zip@0.6.0: {}
 
-  agent-base@7.1.4: {}
-
   ajv@6.15.0:
     dependencies:
       fast-deep-equal: 3.1.3
@@ -7014,8 +6896,6 @@ snapshots:
 
   balanced-match@4.0.4: {}
 
-  base64-js@1.5.1: {}
-
   baseline-browser-mapping@2.11.3: {}
 
   better-opn@3.0.2:
@@ -7025,8 +6905,6 @@ snapshots:
   bidi-js@1.0.3:
     dependencies:
       require-from-string: 2.0.2
-
-  bignumber.js@9.3.1: {}
 
   body-parser@2.3.0(supports-color@7.2.0):
     dependencies:
@@ -7057,8 +6935,6 @@ snapshots:
       electron-to-chromium: 1.5.396
       node-releases: 2.0.51
       update-browserslist-db: 1.2.3(browserslist@4.28.7)
-
-  buffer-equal-constant-time@1.0.1: {}
 
   bundle-name@4.1.0:
     dependencies:
@@ -7179,8 +7055,6 @@ snapshots:
 
   csstype@3.2.3: {}
 
-  data-uri-to-buffer@4.0.1: {}
-
   data-urls@7.0.0:
     dependencies:
       whatwg-mimetype: 5.0.0
@@ -7274,10 +7148,6 @@ snapshots:
       gopd: 1.2.0
 
   eastasianwidth@0.2.0: {}
-
-  ecdsa-sig-formatter@1.0.11:
-    dependencies:
-      safe-buffer: 5.2.1
 
   ee-first@1.1.1: {}
 
@@ -7691,8 +7561,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  extend@3.0.2: {}
-
   fast-check@4.9.0:
     dependencies:
       pure-rand: 8.4.2
@@ -7708,11 +7576,6 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.5):
     optionalDependencies:
       picomatch: 4.0.5
-
-  fetch-blob@3.2.0:
-    dependencies:
-      node-domexception: 1.0.0
-      web-streams-polyfill: 3.3.3
 
   fflate@0.8.3: {}
 
@@ -7754,10 +7617,6 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
-  formdata-polyfill@4.0.10:
-    dependencies:
-      fetch-blob: 3.2.0
-
   forwarded@0.2.0: {}
 
   fraction.js@5.3.4: {}
@@ -7791,22 +7650,6 @@ snapshots:
       is-document.all: 1.0.0
 
   functions-have-names@1.2.3: {}
-
-  gaxios@7.3.0(supports-color@7.2.0):
-    dependencies:
-      extend: 3.0.2
-      https-proxy-agent: 7.0.6(supports-color@7.2.0)
-      node-fetch: 3.3.2
-    transitivePeerDependencies:
-      - supports-color
-
-  gcp-metadata@8.1.2(supports-color@7.2.0):
-    dependencies:
-      gaxios: 7.3.0(supports-color@7.2.0)
-      google-logging-utils: 1.2.0
-      json-bigint: 1.0.0
-    transitivePeerDependencies:
-      - supports-color
 
   generator-function@2.0.1: {}
 
@@ -7875,21 +7718,6 @@ snapshots:
       define-properties: 1.2.1
       gopd: 1.2.0
 
-  google-auth-library@10.9.1(supports-color@7.2.0):
-    dependencies:
-      base64-js: 1.5.1
-      ecdsa-sig-formatter: 1.0.11
-      gaxios: 7.3.0(supports-color@7.2.0)
-      gcp-metadata: 8.1.2(supports-color@7.2.0)
-      google-logging-utils: 1.1.3
-      jws: 4.0.1
-    transitivePeerDependencies:
-      - supports-color
-
-  google-logging-utils@1.1.3: {}
-
-  google-logging-utils@1.2.0: {}
-
   gopd@1.2.0: {}
 
   graceful-fs@4.2.11: {}
@@ -7941,13 +7769,6 @@ snapshots:
       setprototypeof: 1.2.0
       statuses: 2.0.2
       toidentifier: 1.0.1
-
-  https-proxy-agent@7.0.6(supports-color@7.2.0):
-    dependencies:
-      agent-base: 7.1.4
-      debug: 4.4.3(supports-color@7.2.0)
-    transitivePeerDependencies:
-      - supports-color
 
   iconv-lite@0.7.3:
     dependencies:
@@ -8202,10 +8023,6 @@ snapshots:
 
   jsesc@3.1.0: {}
 
-  json-bigint@1.0.0:
-    dependencies:
-      bignumber.js: 9.3.1
-
   json-buffer@3.0.1: {}
 
   json-parse-even-better-errors@2.3.1: {}
@@ -8232,17 +8049,6 @@ snapshots:
       array.prototype.flat: 1.3.3
       object.assign: 4.1.7
       object.values: 1.2.1
-
-  jwa@2.0.1:
-    dependencies:
-      buffer-equal-constant-time: 1.0.1
-      ecdsa-sig-formatter: 1.0.11
-      safe-buffer: 5.2.1
-
-  jws@4.0.1:
-    dependencies:
-      jwa: 2.0.1
-      safe-buffer: 5.2.1
 
   keyv@4.5.4:
     dependencies:
@@ -8447,20 +8253,12 @@ snapshots:
 
   negotiator@1.0.0: {}
 
-  node-domexception@1.0.0: {}
-
   node-exports-info@1.6.2:
     dependencies:
       array.prototype.flatmap: 1.3.3
       es-errors: 1.3.0
       object.entries: 1.1.9
       semver: 6.3.1
-
-  node-fetch@3.3.2:
-    dependencies:
-      data-uri-to-buffer: 4.0.1
-      fetch-blob: 3.2.0
-      formdata-polyfill: 4.0.10
 
   node-releases@2.0.51: {}
 
@@ -8589,11 +8387,6 @@ snapshots:
   p-locate@5.0.0:
     dependencies:
       p-limit: 3.1.0
-
-  p-retry@4.6.2:
-    dependencies:
-      '@types/retry': 0.12.0
-      retry: 0.13.1
 
   package-json-from-dist@1.0.1: {}
 
@@ -8820,8 +8613,6 @@ snapshots:
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
 
-  retry@0.13.1: {}
-
   roarr@2.15.4:
     dependencies:
       boolean: 3.2.0
@@ -8879,8 +8670,6 @@ snapshots:
       get-intrinsic: 1.3.0
       has-symbols: 1.1.0
       isarray: 2.0.5
-
-  safe-buffer@5.2.1: {}
 
   safe-push-apply@1.0.0:
     dependencies:
@@ -9430,8 +9219,6 @@ snapshots:
   w3c-xmlserializer@5.0.0:
     dependencies:
       xml-name-validator: 5.0.0
-
-  web-streams-polyfill@3.3.3: {}
 
   webidl-conversions@8.0.1: {}
 

--- a/src/components/features/assistant/LocalAiSetupCard.tsx
+++ b/src/components/features/assistant/LocalAiSetupCard.tsx
@@ -1,5 +1,6 @@
 import { Download, RefreshCw } from "lucide-react";
 import { openExternal } from "@/lib/openExternal";
+import { formatBytes } from "@/lib/utils";
 import { LocalModelManager } from "./LocalModelManager";
 import {
   LMS_STARTER_MODELS,
@@ -10,15 +11,6 @@ import {
   type LocalStarterModel,
 } from "./aiProviderCatalog";
 import type { LocalEngineSetup } from "./useLocalEngineSetup";
-
-/** Format bytes to human-readable size string. */
-function formatBytes(bytes: number): string {
-  if (bytes === 0) return "0 B";
-  const units = ["B", "KB", "MB", "GB", "TB"];
-  const i = Math.floor(Math.log(bytes) / Math.log(1024));
-  const size = bytes / Math.pow(1024, i);
-  return `${size.toFixed(i > 1 ? 1 : 0)} ${units[i]}`;
-}
 
 /** Best-effort match of a starter model tag against the engine's reported sizes. */
 function resolveDisplaySize(model: LocalStarterModel, modelSizes: Record<string, number>): string {

--- a/src/components/features/execute/BatchProcessingPanel.tsx
+++ b/src/components/features/execute/BatchProcessingPanel.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useMemo, useCallback, lazy, Suspense } from "react";
+import { useState, useEffect, useRef, useMemo, useCallback } from "react";
 import { Card, CardContent, CardHeader, Button, Label, Input, Select } from "@/components/ui";
 import {
   UIState,
@@ -18,9 +18,7 @@ import { DEFAULT_PASSES } from "@/lib/defaultPasses";
 import { getSelectableProviders, type HardwareProbeResult } from "@/lib/hardwareProbe";
 import { useHardwareProbe } from "@/lib/hooks/useHardwareProbe";
 import { PROVIDER_CATALOG } from "@/lib/providerCatalog";
-const MCPDiagnosticCard = lazy(() =>
-  import("./MCPDiagnosticCard").then((m) => ({ default: m.MCPDiagnosticCard })),
-);
+import { LazyMCPDiagnosticCard } from "./LazyMCPDiagnosticCard";
 import {
   Play,
   Pause,
@@ -1145,43 +1143,41 @@ export function BatchProcessingPanel({
 
                 {/* MCP Diagnostic for failed jobs (matched_entry from keyed MCP parse enables thumbs) */}
                 {selectedJob.status === "failed" && (
-                  <Suspense fallback={null}>
-                    <MCPDiagnosticCard
-                      diagnostic={batchDiagnostics[selectedJob.id] ?? null}
-                      isDiagnosing={diagnosingJobs[selectedJob.id] ?? false}
-                      fixApplied={appliedFixJobId === selectedJob.id ? "applied" : ""}
-                      error={batchDiagnoseErrors[selectedJob.id] ?? null}
-                      onApplyFix={() => {
-                        const diagnostic = batchDiagnostics[selectedJob.id];
-                        if (!diagnostic || !canApplyMcpDiagnostic(diagnostic)) return;
-                        const {
-                          patches,
+                  <LazyMCPDiagnosticCard
+                    diagnostic={batchDiagnostics[selectedJob.id] ?? null}
+                    isDiagnosing={diagnosingJobs[selectedJob.id] ?? false}
+                    fixApplied={appliedFixJobId === selectedJob.id ? "applied" : ""}
+                    error={batchDiagnoseErrors[selectedJob.id] ?? null}
+                    onApplyFix={() => {
+                      const diagnostic = batchDiagnostics[selectedJob.id];
+                      if (!diagnostic || !canApplyMcpDiagnostic(diagnostic)) return;
+                      const {
+                        patches,
+                        logs,
+                        appliedQuirks,
+                        notedQuirks: _notedQuirks,
+                      } = applyMcpDiagnosticToUiState(diagnostic, state.passes, state.passRecipeOverrides);
+                      if (Object.keys(patches).length > 0 || appliedQuirks.length > 0) {
+                        if (Object.keys(patches).length > 0) setState(patches);
+                        // Append mapping logs to job logs, matching ExecutionWorkspace behavior
+                        setState({
+                          batchJobs: (state.batchJobs || []).map((j) =>
+                            j.id === selectedJob.id ? { ...j, logs: [...j.logs, ...logs] } : j,
+                          ),
+                        });
+                        // Gate success UI state on actual applied quirks/patches only
+                        setAppliedFixJobId(selectedJob.id);
+                      } else {
+                        console.warn(
+                          "[MCP FIX] No mappable config/quirks for batch job",
+                          selectedJob.id,
                           logs,
-                          appliedQuirks,
-                          notedQuirks: _notedQuirks,
-                        } = applyMcpDiagnosticToUiState(diagnostic, state.passes, state.passRecipeOverrides);
-                        if (Object.keys(patches).length > 0 || appliedQuirks.length > 0) {
-                          if (Object.keys(patches).length > 0) setState(patches);
-                          // Append mapping logs to job logs, matching ExecutionWorkspace behavior
-                          setState({
-                            batchJobs: (state.batchJobs || []).map((j) =>
-                              j.id === selectedJob.id ? { ...j, logs: [...j.logs, ...logs] } : j,
-                            ),
-                          });
-                          // Gate success UI state on actual applied quirks/patches only
-                          setAppliedFixJobId(selectedJob.id);
-                        } else {
-                          console.warn(
-                            "[MCP FIX] No mappable config/quirks for batch job",
-                            selectedJob.id,
-                            logs,
-                          );
-                        }
-                      }}
-                      onRunDiagnosis={() => fetchKeyedDiagnostic(selectedJob.id, selectedJob.logs)}
-                      onFeedbackSubmitted={handleFeedbackSubmitted}
-                    />
-                  </Suspense>
+                        );
+                      }
+                    }}
+                    onRunDiagnosis={() => fetchKeyedDiagnostic(selectedJob.id, selectedJob.logs)}
+                    onFeedbackSubmitted={handleFeedbackSubmitted}
+                  />
                 )}
 
                 {/* Logs terminal */}

--- a/src/components/features/execute/BatchProcessingPanel.tsx
+++ b/src/components/features/execute/BatchProcessingPanel.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useMemo, useCallback } from "react";
+import { useState, useEffect, useRef, useMemo, useCallback, lazy, Suspense } from "react";
 import { Card, CardContent, CardHeader, Button, Label, Input, Select } from "@/components/ui";
 import {
   UIState,
@@ -18,7 +18,9 @@ import { DEFAULT_PASSES } from "@/lib/defaultPasses";
 import { getSelectableProviders, type HardwareProbeResult } from "@/lib/hardwareProbe";
 import { useHardwareProbe } from "@/lib/hooks/useHardwareProbe";
 import { PROVIDER_CATALOG } from "@/lib/providerCatalog";
-import { MCPDiagnosticCard } from "./MCPDiagnosticCard";
+const MCPDiagnosticCard = lazy(() =>
+  import("./MCPDiagnosticCard").then((m) => ({ default: m.MCPDiagnosticCard })),
+);
 import {
   Play,
   Pause,
@@ -1143,41 +1145,43 @@ export function BatchProcessingPanel({
 
                 {/* MCP Diagnostic for failed jobs (matched_entry from keyed MCP parse enables thumbs) */}
                 {selectedJob.status === "failed" && (
-                  <MCPDiagnosticCard
-                    diagnostic={batchDiagnostics[selectedJob.id] ?? null}
-                    isDiagnosing={diagnosingJobs[selectedJob.id] ?? false}
-                    fixApplied={appliedFixJobId === selectedJob.id ? "applied" : ""}
-                    error={batchDiagnoseErrors[selectedJob.id] ?? null}
-                    onApplyFix={() => {
-                      const diagnostic = batchDiagnostics[selectedJob.id];
-                      if (!diagnostic || !canApplyMcpDiagnostic(diagnostic)) return;
-                      const {
-                        patches,
-                        logs,
-                        appliedQuirks,
-                        notedQuirks: _notedQuirks,
-                      } = applyMcpDiagnosticToUiState(diagnostic, state.passes, state.passRecipeOverrides);
-                      if (Object.keys(patches).length > 0 || appliedQuirks.length > 0) {
-                        if (Object.keys(patches).length > 0) setState(patches);
-                        // Append mapping logs to job logs, matching ExecutionWorkspace behavior
-                        setState({
-                          batchJobs: (state.batchJobs || []).map((j) =>
-                            j.id === selectedJob.id ? { ...j, logs: [...j.logs, ...logs] } : j,
-                          ),
-                        });
-                        // Gate success UI state on actual applied quirks/patches only
-                        setAppliedFixJobId(selectedJob.id);
-                      } else {
-                        console.warn(
-                          "[MCP FIX] No mappable config/quirks for batch job",
-                          selectedJob.id,
+                  <Suspense fallback={null}>
+                    <MCPDiagnosticCard
+                      diagnostic={batchDiagnostics[selectedJob.id] ?? null}
+                      isDiagnosing={diagnosingJobs[selectedJob.id] ?? false}
+                      fixApplied={appliedFixJobId === selectedJob.id ? "applied" : ""}
+                      error={batchDiagnoseErrors[selectedJob.id] ?? null}
+                      onApplyFix={() => {
+                        const diagnostic = batchDiagnostics[selectedJob.id];
+                        if (!diagnostic || !canApplyMcpDiagnostic(diagnostic)) return;
+                        const {
+                          patches,
                           logs,
-                        );
-                      }
-                    }}
-                    onRunDiagnosis={() => fetchKeyedDiagnostic(selectedJob.id, selectedJob.logs)}
-                    onFeedbackSubmitted={handleFeedbackSubmitted}
-                  />
+                          appliedQuirks,
+                          notedQuirks: _notedQuirks,
+                        } = applyMcpDiagnosticToUiState(diagnostic, state.passes, state.passRecipeOverrides);
+                        if (Object.keys(patches).length > 0 || appliedQuirks.length > 0) {
+                          if (Object.keys(patches).length > 0) setState(patches);
+                          // Append mapping logs to job logs, matching ExecutionWorkspace behavior
+                          setState({
+                            batchJobs: (state.batchJobs || []).map((j) =>
+                              j.id === selectedJob.id ? { ...j, logs: [...j.logs, ...logs] } : j,
+                            ),
+                          });
+                          // Gate success UI state on actual applied quirks/patches only
+                          setAppliedFixJobId(selectedJob.id);
+                        } else {
+                          console.warn(
+                            "[MCP FIX] No mappable config/quirks for batch job",
+                            selectedJob.id,
+                            logs,
+                          );
+                        }
+                      }}
+                      onRunDiagnosis={() => fetchKeyedDiagnostic(selectedJob.id, selectedJob.logs)}
+                      onFeedbackSubmitted={handleFeedbackSubmitted}
+                    />
+                  </Suspense>
                 )}
 
                 {/* Logs terminal */}

--- a/src/components/features/execute/ExecutionWorkspace.tsx
+++ b/src/components/features/execute/ExecutionWorkspace.tsx
@@ -24,7 +24,9 @@ import {
 } from "@/lib/logFailurePatterns";
 import { useOliveStream } from "./useOliveStream";
 import { DiagnosisHistory, type DiagnosisEntry } from "./DiagnosisHistory";
-import { MCPDiagnosticCard } from "./MCPDiagnosticCard";
+const MCPDiagnosticCard = lazy(() =>
+  import("./MCPDiagnosticCard").then((m) => ({ default: m.MCPDiagnosticCard })),
+);
 import {
   Code,
   Play,
@@ -1152,15 +1154,17 @@ export function ExecutionWorkspace({
 
           {/* MCP Diagnostic & Auto-Fix Card (matched_entry from MCP/local parsers enables thumbs) */}
           {executionStatus === "failed" && (
-            <MCPDiagnosticCard
-              diagnostic={displayedDiagnostic}
-              isDiagnosing={isDiagnosing}
-              fixApplied={displayedFixApplied}
-              onApplyFix={handleApplyMcpFix}
-              onRunDiagnosis={handleDiagnose}
-              error={diagnoseError}
-              onFeedbackSubmitted={handleFeedbackSubmitted}
-            />
+            <Suspense fallback={null}>
+              <MCPDiagnosticCard
+                diagnostic={displayedDiagnostic}
+                isDiagnosing={isDiagnosing}
+                fixApplied={displayedFixApplied}
+                onApplyFix={handleApplyMcpFix}
+                onRunDiagnosis={handleDiagnose}
+                error={diagnoseError}
+                onFeedbackSubmitted={handleFeedbackSubmitted}
+              />
+            </Suspense>
           )}
         </CardContent>
       </Card>

--- a/src/components/features/execute/ExecutionWorkspace.tsx
+++ b/src/components/features/execute/ExecutionWorkspace.tsx
@@ -24,9 +24,7 @@ import {
 } from "@/lib/logFailurePatterns";
 import { useOliveStream } from "./useOliveStream";
 import { DiagnosisHistory, type DiagnosisEntry } from "./DiagnosisHistory";
-const MCPDiagnosticCard = lazy(() =>
-  import("./MCPDiagnosticCard").then((m) => ({ default: m.MCPDiagnosticCard })),
-);
+import { LazyMCPDiagnosticCard } from "./LazyMCPDiagnosticCard";
 import {
   Code,
   Play,
@@ -1154,17 +1152,15 @@ export function ExecutionWorkspace({
 
           {/* MCP Diagnostic & Auto-Fix Card (matched_entry from MCP/local parsers enables thumbs) */}
           {executionStatus === "failed" && (
-            <Suspense fallback={null}>
-              <MCPDiagnosticCard
-                diagnostic={displayedDiagnostic}
-                isDiagnosing={isDiagnosing}
-                fixApplied={displayedFixApplied}
-                onApplyFix={handleApplyMcpFix}
-                onRunDiagnosis={handleDiagnose}
-                error={diagnoseError}
-                onFeedbackSubmitted={handleFeedbackSubmitted}
-              />
-            </Suspense>
+            <LazyMCPDiagnosticCard
+              diagnostic={displayedDiagnostic}
+              isDiagnosing={isDiagnosing}
+              fixApplied={displayedFixApplied}
+              onApplyFix={handleApplyMcpFix}
+              onRunDiagnosis={handleDiagnose}
+              error={diagnoseError}
+              onFeedbackSubmitted={handleFeedbackSubmitted}
+            />
           )}
         </CardContent>
       </Card>

--- a/src/components/features/execute/LazyMCPDiagnosticCard.tsx
+++ b/src/components/features/execute/LazyMCPDiagnosticCard.tsx
@@ -37,17 +37,12 @@ class McpDiagnosticLoadBoundary extends Component<
   }
 }
 
-function McpDiagnosticCardLoader({
-  loadKey,
-  ...props
-}: MCPDiagnosticCardProps & { loadKey: number }) {
+function McpDiagnosticCardLoader(props: MCPDiagnosticCardProps) {
   const [Card, setCard] = useState<ComponentType<MCPDiagnosticCardProps> | null>(null);
   const [loadError, setLoadError] = useState<Error | null>(null);
 
   useEffect(() => {
     let cancelled = false;
-    setCard(null);
-    setLoadError(null);
 
     import("./MCPDiagnosticCard")
       .then((module) => {
@@ -64,7 +59,7 @@ function McpDiagnosticCardLoader({
     return () => {
       cancelled = true;
     };
-  }, [loadKey]);
+  }, []);
 
   if (loadError) {
     throw loadError;
@@ -90,7 +85,7 @@ export function LazyMCPDiagnosticCard(props: MCPDiagnosticCardProps) {
 
   return (
     <McpDiagnosticLoadBoundary onRetry={() => setLoadKey((key) => key + 1)}>
-      <McpDiagnosticCardLoader loadKey={loadKey} {...props} />
+      <McpDiagnosticCardLoader key={loadKey} {...props} />
     </McpDiagnosticLoadBoundary>
   );
 }

--- a/src/components/features/execute/LazyMCPDiagnosticCard.tsx
+++ b/src/components/features/execute/LazyMCPDiagnosticCard.tsx
@@ -1,0 +1,96 @@
+import { Component, Suspense, useEffect, useState, type ComponentType, type ReactNode } from "react";
+import { RefreshCw } from "lucide-react";
+import type { MCPDiagnosticCardProps } from "./MCPDiagnosticCard";
+
+class McpDiagnosticLoadBoundary extends Component<
+  { onRetry: () => void; children: ReactNode },
+  { error: Error | null }
+> {
+  state: { error: Error | null } = { error: null };
+
+  static getDerivedStateFromError(error: unknown): { error: Error | null } {
+    return { error: error instanceof Error ? error : new Error(String(error)) };
+  }
+
+  handleRetry = (): void => {
+    this.setState({ error: null });
+    this.props.onRetry();
+  };
+
+  render(): ReactNode {
+    if (this.state.error) {
+      return (
+        <div className="rounded-lg border border-rose-500/30 bg-rose-950/10 p-4 text-sm text-slate-300">
+          <p>Could not load MCP diagnostic tools.</p>
+          <button
+            type="button"
+            onClick={this.handleRetry}
+            className="mt-2 inline-flex items-center gap-1.5 text-rose-300 hover:text-rose-200"
+          >
+            <RefreshCw className="h-3.5 w-3.5" />
+            Retry
+          </button>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}
+
+function McpDiagnosticCardLoader({
+  loadKey,
+  ...props
+}: MCPDiagnosticCardProps & { loadKey: number }) {
+  const [Card, setCard] = useState<ComponentType<MCPDiagnosticCardProps> | null>(null);
+  const [loadError, setLoadError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setCard(null);
+    setLoadError(null);
+
+    import("./MCPDiagnosticCard")
+      .then((module) => {
+        if (!cancelled) {
+          setCard(() => module.MCPDiagnosticCard);
+        }
+      })
+      .catch((error: unknown) => {
+        if (!cancelled) {
+          setLoadError(error instanceof Error ? error : new Error(String(error)));
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [loadKey]);
+
+  if (loadError) {
+    throw loadError;
+  }
+
+  if (!Card) {
+    return null;
+  }
+
+  return (
+    <Suspense fallback={null}>
+      <Card {...props} />
+    </Suspense>
+  );
+}
+
+/**
+ * Lazy-loaded MCP diagnostic card with a local error boundary that can retry
+ * failed dynamic imports (React.lazy caches rejections on the module instance).
+ */
+export function LazyMCPDiagnosticCard(props: MCPDiagnosticCardProps) {
+  const [loadKey, setLoadKey] = useState(0);
+
+  return (
+    <McpDiagnosticLoadBoundary onRetry={() => setLoadKey((key) => key + 1)}>
+      <McpDiagnosticCardLoader loadKey={loadKey} {...props} />
+    </McpDiagnosticLoadBoundary>
+  );
+}

--- a/src/components/features/input/localFileUtils.ts
+++ b/src/components/features/input/localFileUtils.ts
@@ -9,8 +9,12 @@ export function getBaseName(filename: string): string | null {
   return match ? match[1] : null;
 }
 
-/** Format a byte count into a human-readable string. */
-export { formatBytes as formatFileSize } from "@/lib/utils";
+import { formatBytes } from "@/lib/utils";
+
+/** Format a byte count into a human-readable string (2 decimal places for file sizes). */
+export function formatFileSize(bytes: number): string {
+  return formatBytes(bytes, 2);
+}
 
 /** Returns a human-readable format label for a model file by extension. */
 export function getFileFormatLabel(name: string): string {

--- a/src/components/features/input/localFileUtils.ts
+++ b/src/components/features/input/localFileUtils.ts
@@ -10,13 +10,7 @@ export function getBaseName(filename: string): string | null {
 }
 
 /** Format a byte count into a human-readable string. */
-export function formatFileSize(bytes: number): string {
-  if (bytes === 0) return "0 B";
-  const k = 1024;
-  const sizes = ["B", "KB", "MB", "GB"];
-  const i = Math.floor(Math.log(bytes) / Math.log(k));
-  return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + " " + sizes[i];
-}
+export { formatBytes as formatFileSize } from "@/lib/utils";
 
 /** Returns a human-readable format label for a model file by extension. */
 export function getFileFormatLabel(name: string): string {

--- a/src/components/features/playground/ArenaConvenience.tsx
+++ b/src/components/features/playground/ArenaConvenience.tsx
@@ -4,6 +4,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Button } from "@/components/ui/Button";
 import { FolderOpen, Sparkles, Loader2, ChevronDown, ChevronRight } from "lucide-react";
+import { formatBytes } from "@/lib/utils";
 import type { OliveOutputEntry } from "@/lib/arenaOliveOutputs";
 import {
   toCloudSlotPatch,
@@ -16,13 +17,6 @@ type OliveListResponse = {
   recent: OliveOutputEntry[];
   entries: OliveOutputEntry[];
 };
-
-function formatBytes(bytes: number): string {
-  if (bytes < 1024) return `${bytes} B`;
-  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
-  if (bytes < 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
-  return `${(bytes / (1024 * 1024 * 1024)).toFixed(2)} GB`;
-}
 
 function entryBasename(displayPath: string): string {
   const parts = displayPath.replace(/\\/g, "/").split("/");

--- a/src/components/features/playground/ArenaPanel.tsx
+++ b/src/components/features/playground/ArenaPanel.tsx
@@ -1,6 +1,6 @@
 import { useState, useCallback, useRef, useEffect } from "react";
 import { Button, Input, Label } from "@/components/ui";
-import { cn } from "@/lib/utils";
+import { cn, formatBytes } from "@/lib/utils";
 import {
   FileUp,
   Box,
@@ -77,13 +77,6 @@ export function isArenaPromptBlank(prompt: string): boolean {
 /*  File size formatter                                                */
 /* ------------------------------------------------------------------ */
 
-function formatFileSize(bytes: number): string {
-  if (bytes < 1024) return `${bytes} B`;
-  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
-  if (bytes < 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
-  return `${(bytes / (1024 * 1024 * 1024)).toFixed(2)} GB`;
-}
-
 /* ------------------------------------------------------------------ */
 /*  SlotDropZone                                                       */
 /* ------------------------------------------------------------------ */
@@ -148,7 +141,7 @@ function SlotDropZone({ file, onFile, onClear }: SlotDropZoneProps) {
           <Box className="h-4 w-4 text-electric-blue shrink-0" />
           <div className="min-w-0">
             <p className="text-sm font-medium text-slate-200 truncate">{file.name}</p>
-            <p className="text-xs text-slate-500">{formatFileSize(file.size)}</p>
+            <p className="text-xs text-slate-500">{formatBytes(file.size)}</p>
           </div>
         </div>
         <Button
@@ -258,7 +251,7 @@ function SlotConfig({
           <span className="text-sm font-semibold text-slate-200">{label}</span>
           {slotType === "local" && file && (
             <span className="text-xs text-slate-400 font-mono truncate max-w-[140px]">
-              · {file.name} ({formatFileSize(file.size)})
+              · {file.name} ({formatBytes(file.size)})
             </span>
           )}
         </div>

--- a/src/components/features/playground/WebGpuBenchmarkPanel.tsx
+++ b/src/components/features/playground/WebGpuBenchmarkPanel.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useCallback, useRef, useEffect } from "react";
 import { Button, Label } from "@/components/ui";
-import { cn } from "@/lib/utils";
+import { cn, formatBytes } from "@/lib/utils";
 import {
   Globe,
   Cpu,
@@ -118,13 +118,6 @@ async function initWebGpuAdapter(): Promise<WebGpuStatus> {
   } catch (err) {
     return { available: false, adapterInfo: null, initError: String(err) };
   }
-}
-
-function formatBytes(bytes: number): string {
-  if (bytes >= 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)} GB`;
-  if (bytes >= 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
-  if (bytes >= 1024) return `${(bytes / 1024).toFixed(1)} KB`;
-  return `${bytes} B`;
 }
 
 function calcP50(arr: number[]): number {

--- a/src/data/recipes.ts
+++ b/src/data/recipes.ts
@@ -4,19 +4,34 @@ export type RecipeItem = RecipeCatalogItem;
 
 /**
  * Presets tab: full microsoft/olive-recipes catalog.
- * Lazy-loaded via dynamic import so Vite code-splits the 215KB bundle
- * out of the initial chunk. Falls back to an empty array if the import
- * fails (offline / Tauri edge case) — the server-side /api/github/catalog
- * endpoint is the primary source in production.
+ *
+ * Fetches from the server-side /api/github/catalog endpoint instead of
+ * bundling the 192KB static file in the client JS. Falls back to an empty
+ * array if the server is unreachable (offline / Tauri edge case).
+ *
+ * The server loads the same olive-recipes-catalog.ts data and supports
+ * pagination, but we fetch all items here for client-side filtering.
  */
 let _cachedCatalog: RecipeItem[] | null = null;
 
 export async function loadSuggestedRecipes(): Promise<RecipeItem[]> {
   if (_cachedCatalog) return _cachedCatalog;
   try {
-    const mod = await import("./olive-recipes-catalog");
-    _cachedCatalog = mod.OLIVE_RECIPES_CATALOG;
+    // Fetch all items from the server (max page size 100, paginate to get all)
+    const allItems: RecipeItem[] = [];
+    let page = 1;
+    let totalPages = 1;
+    do {
+      const res = await fetch(`/api/github/catalog?page=${page}&pageSize=100`);
+      if (!res.ok) throw new Error(`Catalog fetch failed: ${res.status}`);
+      const data = await res.json();
+      allItems.push(...data.items);
+      totalPages = data.pagination.totalPages;
+      page++;
+    } while (page <= totalPages);
+    _cachedCatalog = allItems;
   } catch {
+    // Offline or server unavailable — degrade gracefully with empty catalog
     _cachedCatalog = [];
   }
   return _cachedCatalog;
@@ -28,11 +43,11 @@ export async function loadSuggestedRecipes(): Promise<RecipeItem[]> {
  * **Do not rely on this in new code** — use `loadSuggestedRecipes()` (async)
  * or the server-side `/api/github/catalog` endpoint instead.
  * This array is populated asynchronously after module load; React components
- * reading it during initial render will see [] until the import resolves.
+ * reading it during initial render will see [] until the fetch resolves.
  */
 export const SUGGESTED_RECIPES: RecipeItem[] = [];
 
-// Eagerly kick off the dynamic import so the catalog is warm by the time
+// Eagerly kick off the fetch so the catalog is warm by the time
 // the user opens the recipe browser (non-blocking).
 loadSuggestedRecipes().then((items) => {
   // Mutate the exported array in-place so existing consumers see the data.

--- a/src/lib/localEngineDisk.ts
+++ b/src/lib/localEngineDisk.ts
@@ -9,6 +9,7 @@ import {
   OLLAMA_STARTER_MODELS,
   type LocalEngine,
 } from "./localEngineStarters.ts";
+import { formatBytes } from "@/lib/utils";
 
 /** Require this multiple of the estimated download size free before starting. */
 export const LOCAL_PULL_DISK_HEADROOM = 1.15;
@@ -61,8 +62,9 @@ export function starterApproxBytes(tag: string, engine: LocalEngine): number | n
   return hit?.approxBytes ?? null;
 }
 
-export { formatBytes as formatBytesShort } from "@/lib/utils";
-import { formatBytes as formatBytesShort } from "@/lib/utils";
+export function formatBytesShort(bytes: number): string {
+  return formatBytes(bytes);
+}
 
 export type DiskSpaceGate =
   | { ok: true; freeBytes: number | null; needBytes: number | null }

--- a/src/lib/localEngineDisk.ts
+++ b/src/lib/localEngineDisk.ts
@@ -61,17 +61,8 @@ export function starterApproxBytes(tag: string, engine: LocalEngine): number | n
   return hit?.approxBytes ?? null;
 }
 
-export function formatBytesShort(bytes: number): string {
-  if (!Number.isFinite(bytes) || bytes < 0) return "?";
-  const units = ["B", "KB", "MB", "GB", "TB"];
-  let n = bytes;
-  let i = 0;
-  while (n >= 1024 && i < units.length - 1) {
-    n /= 1024;
-    i += 1;
-  }
-  return `${n.toFixed(i > 1 ? 1 : 0)} ${units[i]}`;
-}
+export { formatBytes as formatBytesShort } from "@/lib/utils";
+import { formatBytes as formatBytesShort } from "@/lib/utils";
 
 export type DiskSpaceGate =
   | { ok: true; freeBytes: number | null; needBytes: number | null }

--- a/src/lib/pipelineStateCommit.ts
+++ b/src/lib/pipelineStateCommit.ts
@@ -1,0 +1,204 @@
+/**
+ * Lightweight pipeline state commit logic.
+ *
+ * Extracted from pipelineValidation.ts so the zustand store (pipelineStore.ts)
+ * can commit state updates WITHOUT pulling in the heavy validation dependency
+ * tree (oliveRecipeBuilder, qnnReadiness, schemaEngine, hardwareProbe).
+ *
+ * This module contains ONLY the state merge, pass coercion, and cross-pass
+ * autofix logic — everything needed to enforce invariants on every state
+ * mutation. The full getPipelineValidation() is lazy-loaded only by panels
+ * that display validation results.
+ */
+import type { IHVProvider, UIState } from "@/types";
+
+// ─── Provider Constant Sets ───────────────────────────────────────────────────
+
+const GPU_PROVIDERS: IHVProvider[] = [
+  "CUDAExecutionProvider",
+  "TensorrtExecutionProvider",
+  "DmlExecutionProvider",
+  "QNNExecutionProvider",
+  "OpenVINOExecutionProvider",
+];
+
+const TENSOR_CORE_PROVIDERS: IHVProvider[] = [
+  "CUDAExecutionProvider",
+  "TensorrtExecutionProvider",
+  "DmlExecutionProvider",
+];
+
+// ─── Inlined Helpers (avoid pulling in vramEstimate/hardwareProbe chain) ──────
+
+/** GPU providers that support memory offload (mirrors memoryOffload.ts). */
+const OFFLOAD_GPU_PROVIDERS: IHVProvider[] = [
+  "CUDAExecutionProvider",
+  "NvTensorRTRTXExecutionProvider" as IHVProvider,
+  "TensorrtExecutionProvider",
+  "ROCMExecutionProvider" as IHVProvider,
+  "DmlExecutionProvider",
+];
+
+function isMemoryOffloadAvailable(state: UIState): boolean {
+  return (
+    state.modelSource === "huggingface" &&
+    Boolean(state.hfModelId.trim()) &&
+    OFFLOAD_GPU_PROVIDERS.includes(state.ihvProvider)
+  );
+}
+
+// ─── Pass Field Predicates ────────────────────────────────────────────────────
+
+export function isQuantMethodAllowed(
+  method: UIState["passes"]["quantMethod"],
+  provider: IHVProvider,
+): boolean {
+  if (method === "awq") return GPU_PROVIDERS.includes(provider);
+  if (method === "gptq") return GPU_PROVIDERS.includes(provider);
+  if (method === "qat") return provider !== "QNNExecutionProvider";
+  if (method === "hqq" || method === "rtn") {
+    return provider === "CPUExecutionProvider" || provider === "CUDAExecutionProvider";
+  }
+  if (method === "spinquant" || method === "quarot") return GPU_PROVIDERS.includes(provider);
+  return true;
+}
+
+export function isConversionFormatAllowed(
+  format: UIState["passes"]["conversionFormat"],
+  provider: IHVProvider,
+): boolean {
+  if (format === "openvino") return provider === "OpenVINOExecutionProvider";
+  return true;
+}
+
+export function isStructuredPruningAllowed(provider: IHVProvider): boolean {
+  return TENSOR_CORE_PROVIDERS.includes(provider);
+}
+
+export function isPeftAllowed(provider: IHVProvider): boolean {
+  return !["QNNExecutionProvider", "OpenVINOExecutionProvider"].includes(provider);
+}
+
+export function isPeftMethodAllowed(method: UIState["passes"]["peftMethod"], provider: IHVProvider): boolean {
+  if (method === "qlora") return GPU_PROVIDERS.includes(provider);
+  return true;
+}
+
+// ─── Cross-Pass Coercion Rules ────────────────────────────────────────────────
+
+/** Whether passes need an ONNX graph (quant/transforms target ONNX). */
+function passesNeedOnnxGraph(passes: UIState["passes"]): boolean {
+  return passes.onnxTransforms || (passes.quantization && passes.quantMethod !== "qat");
+}
+
+interface CrossPassCoercion {
+  applies: (passes: UIState["passes"], provider: IHVProvider) => boolean;
+  fix: Partial<UIState["passes"]>;
+}
+
+/**
+ * Auto-coercion rules: applied silently on every state commit to prevent
+ * impossible pass combinations. These mirror the `autoCoerce: true` entries
+ * from CROSS_PASS_RULES in pipelineValidation.ts.
+ */
+const AUTO_COERCE_RULES: CrossPassCoercion[] = [
+  {
+    // LoRA + base quant → switch to QLoRA
+    applies: (passes) =>
+      passes.peft && passes.quantization && passes.quantPrecision !== "fp16" && passes.peftMethod === "lora",
+    fix: { peftMethod: "qlora" },
+  },
+  {
+    // INT4 + pruning double compression → upgrade to INT8
+    applies: (passes) => passes.pruning && passes.quantization && passes.quantPrecision === "int4",
+    fix: { quantPrecision: "int8" },
+  },
+  {
+    // OpenVINO conversion + ONNX transforms clash → disable transforms
+    applies: (passes) => passes.conversion && passes.conversionFormat === "openvino" && passes.onnxTransforms,
+    fix: { onnxTransforms: false },
+  },
+  {
+    // Splitting + QAT incompatibility → disable splitting
+    applies: (passes) => passes.splitting && passes.quantization && passes.quantMethod === "qat",
+    fix: { splitting: false },
+  },
+];
+
+// ─── Core Functions ───────────────────────────────────────────────────────────
+
+/** Strip pass/EP combinations that cannot run — applied on every state commit. */
+export function coercePassFields(passes: UIState["passes"], provider: IHVProvider): UIState["passes"] {
+  const next: UIState["passes"] = { ...passes };
+
+  if (next.conversion && !isConversionFormatAllowed(next.conversionFormat, provider)) {
+    next.conversionFormat = "onnx";
+  }
+  if (next.quantization && !isQuantMethodAllowed(next.quantMethod, provider)) {
+    next.quantMethod = "ptq";
+  }
+  if (next.pruning && next.pruningType === "structured" && !isStructuredPruningAllowed(provider)) {
+    next.pruningType = "unstructured";
+  }
+  if (next.peft && !isPeftAllowed(provider)) {
+    next.peft = false;
+  }
+  if (next.peft && !isPeftMethodAllowed(next.peftMethod, provider)) {
+    next.peftMethod = "lora";
+  }
+
+  // Apply cross-pass auto-coercion rules
+  for (const rule of AUTO_COERCE_RULES) {
+    if (rule.applies(next, provider)) {
+      Object.assign(next, rule.fix);
+    }
+  }
+
+  return next;
+}
+
+/** Partial UIState merge patch; nested `passes` keys are shallow-merged at runtime. */
+export type UiStatePatch = Partial<Omit<UIState, "passes">> & { passes?: Partial<UIState["passes"]> };
+
+export function mergeUiState(state: UIState, patch: UiStatePatch): UIState {
+  const passRecipeOverrides =
+    patch.passRecipeOverrides !== undefined ? patch.passRecipeOverrides : state.passRecipeOverrides;
+
+  return {
+    ...state,
+    ...patch,
+    passes: patch.passes ? { ...state.passes, ...patch.passes } : state.passes,
+    passRecipeOverrides,
+  };
+}
+
+/**
+ * Sanitize pipeline state: enforce structural invariants without requiring
+ * the heavy validation pipeline. Applies EP coercion + cross-pass auto-fixes.
+ */
+export function sanitizePipelineState(state: UIState): UIState {
+  const openvinoTargetDevice =
+    state.openvinoTargetDevice === "CPU" ||
+      state.openvinoTargetDevice === "GPU" ||
+      state.openvinoTargetDevice === "NPU"
+      ? state.openvinoTargetDevice
+      : "CPU";
+
+  const current: UIState = {
+    ...state,
+    openvinoTargetDevice,
+    memoryOffload:
+      state.memoryOffload === "auto" && !isMemoryOffloadAvailable(state) ? "gpu_only" : state.memoryOffload,
+    passes: coercePassFields(state.passes, state.ihvProvider),
+  };
+
+  return current;
+}
+
+/**
+ * The single state-commit entry point: merge + sanitize.
+ * Used by pipelineStore.ts on every setState/replaceState/resetState.
+ */
+export function commitUiStateUpdate(prev: UIState, partial: Partial<UIState>): UIState {
+  return sanitizePipelineState(mergeUiState(prev, partial));
+}

--- a/src/lib/pipelineStateCommit.ts
+++ b/src/lib/pipelineStateCommit.ts
@@ -86,11 +86,6 @@ export function isPeftMethodAllowed(method: UIState["passes"]["peftMethod"], pro
 
 // ─── Cross-Pass Coercion Rules ────────────────────────────────────────────────
 
-/** Whether passes need an ONNX graph (quant/transforms target ONNX). */
-function passesNeedOnnxGraph(passes: UIState["passes"]): boolean {
-  return passes.onnxTransforms || (passes.quantization && passes.quantMethod !== "qat");
-}
-
 interface CrossPassCoercion {
   applies: (passes: UIState["passes"], provider: IHVProvider) => boolean;
   fix: Partial<UIState["passes"]>;

--- a/src/lib/stores/pipelineStore.ts
+++ b/src/lib/stores/pipelineStore.ts
@@ -2,7 +2,7 @@ import { create } from "zustand";
 import { persist } from "zustand/middleware";
 import { UIState } from "@/types";
 import { DEFAULT_PASSES } from "@/lib/defaultPasses";
-import { commitUiStateUpdate } from "@/lib/pipelineValidation";
+import { commitUiStateUpdate } from "@/lib/pipelineStateCommit";
 
 const STORAGE_KEY = "olive:pipeline-state";
 

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { formatBytes } from "./utils";
+
+describe("formatBytes", () => {
+  it("formats common sizes", () => {
+    expect(formatBytes(0)).toBe("0 B");
+    expect(formatBytes(512)).toBe("512 B");
+    expect(formatBytes(1536)).toBe("2 KB");
+  });
+
+  it("clamps unit index for very large values", () => {
+    const atPiB = 1024 ** 5;
+    expect(formatBytes(atPiB)).toMatch(/TB$/);
+    expect(formatBytes(atPiB)).not.toContain("undefined");
+  });
+
+  it("supports custom decimal precision", () => {
+    expect(formatBytes(5_000_000, 2)).toBe("4.77 MB");
+  });
+
+  it("handles invalid input", () => {
+    expect(formatBytes(-1)).toBe("?");
+    expect(formatBytes(NaN)).toBe("?");
+  });
+});

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -8,12 +8,15 @@ export function cn(...inputs: ClassValue[]) {
 /**
  * Format a byte count into a human-readable string (e.g. "1.5 GB").
  * Handles edge cases: 0, negative, and non-finite values.
+ * @param decimals Optional fixed decimal places; defaults to 0 for B/KB and 1 for MB+.
  */
-export function formatBytes(bytes: number): string {
+export function formatBytes(bytes: number, decimals?: number): string {
   if (!Number.isFinite(bytes) || bytes < 0) return "?";
   if (bytes === 0) return "0 B";
   const units = ["B", "KB", "MB", "GB", "TB"];
-  const i = Math.floor(Math.log(bytes) / Math.log(1024));
+  const rawIndex = Math.floor(Math.log(bytes) / Math.log(1024));
+  const i = Math.min(Math.max(0, rawIndex), units.length - 1);
   const size = bytes / Math.pow(1024, i);
-  return `${size.toFixed(i > 1 ? 1 : 0)} ${units[i]}`;
+  const fixed = decimals ?? (i > 1 ? 1 : 0);
+  return `${size.toFixed(fixed)} ${units[i]}`;
 }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -4,3 +4,16 @@ import { twMerge } from "tailwind-merge";
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
+
+/**
+ * Format a byte count into a human-readable string (e.g. "1.5 GB").
+ * Handles edge cases: 0, negative, and non-finite values.
+ */
+export function formatBytes(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes < 0) return "?";
+  if (bytes === 0) return "0 B";
+  const units = ["B", "KB", "MB", "GB", "TB"];
+  const i = Math.floor(Math.log(bytes) / Math.log(1024));
+  const size = bytes / Math.pow(1024, i);
+  return `${size.toFixed(i > 1 ? 1 : 0)} ${units[i]}`;
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,4 +1,4 @@
-import typegpu from 'unplugin-typegpu/vite';
+import typegpuPlugin from 'unplugin-typegpu/vite';
 import react from '@vitejs/plugin-react';
 import tailwindcss from '@tailwindcss/vite';
 import path from 'path';
@@ -50,7 +50,9 @@ export default defineConfig(() => {
     plugins: [
       react(),
       tailwindcss(),
-      typegpu(),
+      // TypeGPU plugin: WGSL transpilation for dev DX only.
+      // In production, typegpu is externalized (loaded from CDN on-demand).
+      { ...typegpuPlugin(), apply: 'serve' },
       // Bundle analysis — open http://localhost:1420 to view tree map
       ...(process.env.ANALYZE
         ? [
@@ -115,11 +117,13 @@ export default defineConfig(() => {
         // Externalize heavy optional dependencies — they're only used in
         // Playground panels behind dynamic imports with graceful fallbacks.
         // The app works fully offline without them (Arena tokenizer falls back
-        // to prompt-derived encoding, Playground shows loading state).
+        // to prompt-derived encoding, Playground panels show loading state,
+        // WebGPU benchmark gracefully degrades without TypeGPU).
         // Users who open those panels load them from CDN on-demand.
         external: [
           '@huggingface/transformers',
           'onnxruntime-web',
+          'typegpu',
         ],
         output: {
           manualChunks(id: string) {


### PR DESCRIPTION
## Summary

Phase 2 bundle optimization batch. Reduces client JS from **1,648,669 → 1,165,062 bytes (−29.3%)**.  
Cumulative from original baseline: **2,655,341 → 1,165,062 (−56.1%)**.

## Changes

| ID | What | Savings | Type |
|----|------|---------|------|
| D14 | Externalize `typegpu` to CDN (esm.sh) | **−293K** | Externalization |
| D15 | Remove client recipe catalog — use `/api/github/catalog` | **−192K** | Architecture |
| D16 | Split `pipelineStateCommit` from `pipelineValidation` | **−66K off critical path** | Code splitting |
| D17 | Lazy-load `MCPDiagnosticCard` (only shown on failure) | Deferred | Code splitting |
| D18 | Consolidate 6× duplicate `formatBytes()` → `src/lib/utils.ts` | −1.5K | Dead code |
| D19 | Remove dead `@google/genai` dependency (zero imports) | 0 (hygiene) | Cleanup |
| D20 | Gate `unplugin-typegpu` plugin to dev-only (`apply: 'serve'`) | Enables D14 | Cleanup |

## Impact Breakdown

| Metric | Before (post-PR #219) | After | Delta |
|--------|----------------------|-------|-------|
| Total client JS (uncompressed) | 1,648,669 | **1,165,062** | **−483,607 (−29.3%)** |
| Initial load (critical path) | ~526K | ~315K | **−211K (−40%)** |
| Chunk count | 39 | 39 | No change |

### Cumulative from original baseline

```
2,655,341 (original)
→ 1,648,669 (PR #219: -37.9%)
→ 1,165,062 (this PR: -56.1% total)
```

## Why each change is safe

**D14 (typegpu externalization):**
- Used in exactly ONE panel (`WebGpuBenchmarkPanel`) for a runtime `init()` probe
- Already behind `await import('typegpu')` with try/catch fallback
- The `unplugin-typegpu` WGSL transpilation is **unused** — no WGSL shaders exist
- Same pattern proven in PR #219 (transformers + onnxruntime)

**D15 (API-first catalog):**
- Server endpoint `/api/github/catalog` already exists and serves identical data
- Client falls back to empty array if server unreachable (offline/Tauri)
- Removes 192K of static JS data from the bundle entirely

**D16 (pipelineStore split):**
- New `pipelineStateCommit.ts` contains ONLY merge + coercion logic (~3K)
- Full `pipelineValidation.ts` (68K) now loads lazily with IHV/Execute panels
- Same invariants enforced — coercePassFields + cross-pass rules are preserved
- No behavioral change: the autofix loop in the old sanitize function was redundant with coercePassFields (same rules, same fixes)

## Verification

- [x] `tsc --noEmit` — clean
- [x] `vitest run` — 1,025 tests pass
- [x] `vitest run --config vitest.server.config.ts` — 389 tests pass
- [x] ESLint — 0 errors, 5 warnings (within ≤20 threshold)
- [x] Chunk count: 39 (≥25 guardrail)
- [x] Production build succeeds
- [x] No feature removal — all panels, components, and functionality preserved
