### PR TITLE
feat: add light mode theme with settings menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,7 +30,10 @@
               if (pref === "light" || pref === "dark") return pref;
             }
           } catch (e) { /* corrupted or unavailable — fall through */ }
-          return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+          if (typeof window.matchMedia === "function") {
+            return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+          }
+          return "light";
         }
 
         var theme = getResolved();

--- a/index.html
+++ b/index.html
@@ -15,6 +15,29 @@
         }
       }
     </script>
+    <!-- Synchronous theme init — prevents flash of wrong theme before React mounts -->
+    <script>
+      (function () {
+        var STORAGE_KEY = "olive:preferences";
+        var ATTR = "data-theme";
+
+        function getResolved() {
+          try {
+            var raw = localStorage.getItem(STORAGE_KEY);
+            if (raw) {
+              var parsed = JSON.parse(raw);
+              var pref = parsed && parsed.state && parsed.state.themePreference;
+              if (pref === "light" || pref === "dark") return pref;
+            }
+          } catch (e) { /* corrupted or unavailable — fall through */ }
+          return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+        }
+
+        var theme = getResolved();
+        document.documentElement.setAttribute(ATTR, theme);
+        document.documentElement.style.colorScheme = theme;
+      })();
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/index.html
+++ b/index.html
@@ -15,7 +15,8 @@
         }
       }
     </script>
-    <!-- Synchronous theme init — prevents flash of wrong theme before React mounts -->
+    <!-- Synchronous theme init — prevents flash of wrong theme before React mounts.
+         STORAGE_KEY must match STORAGE_KEY in src/lib/stores/preferencesStore.ts -->
     <script>
       (function () {
         var STORAGE_KEY = "olive:preferences";

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -123,6 +123,19 @@ function Dashboard() {
   const [headerCompact, setHeaderCompact] = useState(false);
   const HEADER_CLUSTER_FULL_WIDTH = 520;
 
+  const [isOliveRunning, setIsOliveRunning] = useState(false);
+  const [isAiSidebarOpen, setIsAiSidebarOpen] = useState(false);
+  const [triggerAiAudit, setTriggerAiAudit] = useState(false);
+  const [pendingChatQuery, setPendingChatQuery] = useState<AskAiChatDetail | null>(null);
+  const [licenseOpen, setLicenseOpen] = useState(false);
+  const [isReportOpen, setIsReportOpen] = useState(false);
+  const [reportData, setReportData] = useState<{
+    error: Error;
+    label?: string;
+    componentStack?: string;
+    frequencyInfo?: import("@/lib/errorFrequency").ErrorFrequencyInfo | null;
+  } | null>(null);
+
   useEffect(() => {
     const leftEl = headerLeftRef.current;
     const rightEl = headerRightRef.current;
@@ -143,18 +156,6 @@ function Dashboard() {
       window.removeEventListener("resize", measure);
     };
   }, [isAiSidebarOpen]);
-  const [isOliveRunning, setIsOliveRunning] = useState(false);
-  const [isAiSidebarOpen, setIsAiSidebarOpen] = useState(false);
-  const [triggerAiAudit, setTriggerAiAudit] = useState(false);
-  const [pendingChatQuery, setPendingChatQuery] = useState<AskAiChatDetail | null>(null);
-  const [licenseOpen, setLicenseOpen] = useState(false);
-  const [isReportOpen, setIsReportOpen] = useState(false);
-  const [reportData, setReportData] = useState<{
-    error: Error;
-    label?: string;
-    componentStack?: string;
-    frequencyInfo?: import("@/lib/errorFrequency").ErrorFrequencyInfo | null;
-  } | null>(null);
 
   const handleReportError = useCallback(
     (details: {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,8 @@
 import { lazy, Suspense, useCallback, useEffect, useRef, useState } from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { BrainCircuit, Cpu, Terminal, Bot, RefreshCw, FlaskConical } from "lucide-react";
+import { BrainCircuit, Cpu, Terminal, Bot, RefreshCw, FlaskConical, Settings } from "lucide-react";
+import { useThemeEffect } from "@/lib/hooks/useThemeEffect";
+import { SettingsMenu } from "@/components/SettingsMenu";
 import { InputEnvironmentPanel } from "@/components/features/input/InputEnvironmentPanel";
 import { LicenseNotice } from "@/components/LicenseNotice";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
@@ -103,6 +105,8 @@ const SECTIONS: { id: ActiveView; step: string; label: string; desc: string; ico
  * Renders the Olive Studio recipe builder dashboard with navigable model, hardware, and execution sections.
  */
 function Dashboard() {
+  useThemeEffect();
+
   const { state: pipelineState } = usePipelineState();
   const [activeView, setActiveView] = useState<ActiveView>("input");
   const [isOliveRunning, setIsOliveRunning] = useState(false);
@@ -315,7 +319,10 @@ function Dashboard() {
                   identical, which keeps the center cluster visually centered
                   instead of drifting toward the empty side.
                 */}
-                <div className="justify-self-start" aria-hidden="true">
+                <div className="justify-self-start flex items-center gap-2" aria-hidden="true">
+                  <span className="invisible p-1.5">
+                    <Settings className="h-4 w-4" />
+                  </span>
                   <span
                     className={cn(
                       "invisible px-2.5 wide:px-3 py-1.5 border text-[clamp(0.75rem,0.65rem+0.3vw,0.875rem)] flex items-center gap-1.5",
@@ -332,7 +339,8 @@ function Dashboard() {
                   <span className="hidden sm:block w-px h-4 bg-slate-700/80 shrink-0" aria-hidden />
                   <AgentAccessControls />
                 </div>
-                <div className="justify-self-end">
+                <div className="justify-self-end flex items-center gap-2">
+                  <SettingsMenu />
                   <button
                     type="button"
                     onClick={() => setIsAiSidebarOpen((open) => !open)}
@@ -454,20 +462,20 @@ function Dashboard() {
           <ErrorBoundary label="Report issue" onReportError={() => setIsReportOpen(false)}>
             <Suspense fallback={null}>
               <ReportIssueModal
-          open={isReportOpen}
-          onClose={() => {
-            setIsReportOpen(false);
-            setReportData(null);
-          }}
-          state={pipelineState}
-          defaultArea={labelToArea(reportData?.label)}
-          defaultDescription={
-            reportData
-              ? `Error in ${reportData.label ?? "unknown section"}:\n\n${reportData.error.message}\n\n${reportData.componentStack ? `Component stack:\n${reportData.componentStack}` : ""}`
-              : undefined
-          }
-          frequencyInfo={reportData?.frequencyInfo}
-        />
+                open={isReportOpen}
+                onClose={() => {
+                  setIsReportOpen(false);
+                  setReportData(null);
+                }}
+                state={pipelineState}
+                defaultArea={labelToArea(reportData?.label)}
+                defaultDescription={
+                  reportData
+                    ? `Error in ${reportData.label ?? "unknown section"}:\n\n${reportData.error.message}\n\n${reportData.componentStack ? `Component stack:\n${reportData.componentStack}` : ""}`
+                    : undefined
+                }
+                frequencyInfo={reportData?.frequencyInfo}
+              />
             </Suspense>
           </ErrorBoundary>
         )}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -110,6 +110,38 @@ function Dashboard() {
   const { state: pipelineState } = usePipelineState();
   const [activeView, setActiveView] = useState<ActiveView>("input");
   const [visitedSections, setVisitedSections] = useState<ReadonlySet<ActiveView>>(() => new Set(["input"]));
+
+  // Header center cluster (KB sync / runtime / agent access) must never wrap
+  // onto a second line. Measure the actual gap between the fixed left and
+  // right header columns and collapse the cluster to icon-only once the
+  // full-label layout wouldn't fit — driven by real available space rather
+  // than a viewport breakpoint, since the sidebar and header columns already
+  // resize independently at their own breakpoints.
+  const headerLeftRef = useRef<HTMLDivElement>(null);
+  const headerRightRef = useRef<HTMLDivElement>(null);
+  const [headerCompact, setHeaderCompact] = useState(false);
+  const HEADER_CLUSTER_FULL_WIDTH = 520;
+
+  useEffect(() => {
+    const leftEl = headerLeftRef.current;
+    const rightEl = headerRightRef.current;
+    if (!leftEl || !rightEl) return;
+
+    const measure = () => {
+      const available = rightEl.getBoundingClientRect().left - leftEl.getBoundingClientRect().right;
+      setHeaderCompact(available < HEADER_CLUSTER_FULL_WIDTH);
+    };
+
+    measure();
+    const ro = new ResizeObserver(measure);
+    ro.observe(leftEl);
+    ro.observe(rightEl);
+    window.addEventListener("resize", measure);
+    return () => {
+      ro.disconnect();
+      window.removeEventListener("resize", measure);
+    };
+  }, []);
   const [isOliveRunning, setIsOliveRunning] = useState(false);
   const [isAiSidebarOpen, setIsAiSidebarOpen] = useState(false);
   const [triggerAiAudit, setTriggerAiAudit] = useState(false);
@@ -322,7 +354,7 @@ function Dashboard() {
                   identical, which keeps the center cluster visually centered
                   instead of drifting toward the empty side.
                 */}
-                <div className="justify-self-start flex items-center gap-2" aria-hidden="true">
+                <div ref={headerLeftRef} className="justify-self-start flex items-center gap-2" aria-hidden="true">
                   <span className="invisible p-1.5">
                     <Settings className="h-4 w-4" />
                   </span>
@@ -335,14 +367,14 @@ function Dashboard() {
                     <span className="hidden wide:inline">Assistant</span>
                   </span>
                 </div>
-                <div className="justify-self-center flex items-center flex-wrap justify-center gap-x-3 gap-y-1 min-w-0 overflow-hidden">
-                  <KbSyncIndicator />
-                  <span className="hidden sm:block w-px h-4 bg-slate-700/80 shrink-0" aria-hidden />
-                  <RuntimeEnvControls />
-                  <span className="hidden sm:block w-px h-4 bg-slate-700/80 shrink-0" aria-hidden />
-                  <AgentAccessControls />
+                <div className="justify-self-center flex items-center flex-nowrap justify-center gap-x-3 min-w-0 overflow-hidden">
+                  <KbSyncIndicator compact={headerCompact} />
+                  {!headerCompact && <span className="block w-px h-4 bg-slate-700/80 shrink-0" aria-hidden />}
+                  <RuntimeEnvControls compact={headerCompact} />
+                  {!headerCompact && <span className="block w-px h-4 bg-slate-700/80 shrink-0" aria-hidden />}
+                  <AgentAccessControls compact={headerCompact} />
                 </div>
-                <div className="justify-self-end flex items-center gap-2">
+                <div ref={headerRightRef} className="justify-self-end flex items-center gap-2">
                   <SettingsMenu />
                   <button
                     type="button"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -142,7 +142,7 @@ function Dashboard() {
       ro.disconnect();
       window.removeEventListener("resize", measure);
     };
-  }, []);
+  }, [isAiSidebarOpen]);
   const [isOliveRunning, setIsOliveRunning] = useState(false);
   const [isAiSidebarOpen, setIsAiSidebarOpen] = useState(false);
   const [triggerAiAudit, setTriggerAiAudit] = useState(false);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -109,6 +109,7 @@ function Dashboard() {
 
   const { state: pipelineState } = usePipelineState();
   const [activeView, setActiveView] = useState<ActiveView>("input");
+  const [visitedSections, setVisitedSections] = useState<ReadonlySet<ActiveView>>(() => new Set(["input"]));
   const [isOliveRunning, setIsOliveRunning] = useState(false);
   const [isAiSidebarOpen, setIsAiSidebarOpen] = useState(false);
   const [triggerAiAudit, setTriggerAiAudit] = useState(false);
@@ -157,6 +158,7 @@ function Dashboard() {
     (id: ActiveView) => {
       if (isOliveRunning && id !== "execute" && id !== "playground") return;
       setActiveView(id);
+      setVisitedSections((prev) => (prev.has(id) ? prev : new Set(prev).add(id)));
       scrollingToRef.current = id;
       const main = mainRef.current;
       const target = document.getElementById(id);
@@ -199,6 +201,7 @@ function Dashboard() {
         if (el.getBoundingClientRect().top - mainTop <= 96) current = id;
       }
       setActiveView((prev) => (prev === current ? prev : current));
+      setVisitedSections((prev) => (prev.has(current) ? prev : new Set(prev).add(current)));
     };
 
     main.addEventListener("scroll", syncActiveFromScroll, { passive: true });
@@ -242,7 +245,7 @@ function Dashboard() {
                 {SECTIONS.map(({ id, step, label, icon: Icon }) => {
                   const isActive = activeView === id;
                   const modelSelected = hasSelectedModel(pipelineState);
-                  const isIncomplete = !modelSelected && id !== "input";
+                  const isIncomplete = !modelSelected && id !== "input" && !visitedSections.has(id);
                   return (
                     <button
                       key={id}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,6 +17,7 @@ import { TitleBar } from "@/components/TitleBar";
 import { DesktopMinimumViewport } from "@/components/DesktopMinimumViewport";
 import { cn } from "@/lib/utils";
 import { OLIVE_PIPELINE_NAVIGATE, isPipelineViewId, type PipelineViewId } from "@/lib/pipelineNavigation";
+import { OLIVE_ASK_AI_CHAT, type AskAiChatDetail } from "@/lib/aiChatBridge";
 
 const BatchProcessingPanel = lazy(() =>
   import("@/components/features/execute/BatchProcessingPanel").then((m) => ({ default: m.BatchProcessingPanel })),
@@ -145,6 +146,7 @@ function Dashboard() {
   const [isOliveRunning, setIsOliveRunning] = useState(false);
   const [isAiSidebarOpen, setIsAiSidebarOpen] = useState(false);
   const [triggerAiAudit, setTriggerAiAudit] = useState(false);
+  const [pendingChatQuery, setPendingChatQuery] = useState<AskAiChatDetail | null>(null);
   const [licenseOpen, setLicenseOpen] = useState(false);
   const [isReportOpen, setIsReportOpen] = useState(false);
   const [reportData, setReportData] = useState<{
@@ -218,6 +220,17 @@ function Dashboard() {
     window.addEventListener(OLIVE_PIPELINE_NAVIGATE, onNavigate);
     return () => window.removeEventListener(OLIVE_PIPELINE_NAVIGATE, onNavigate);
   }, [scrollToSection]);
+
+  useEffect(() => {
+    const onAskAiChat = (event: Event) => {
+      const detail = (event as CustomEvent<AskAiChatDetail>).detail;
+      if (!detail?.query) return;
+      setIsAiSidebarOpen(true);
+      setPendingChatQuery(detail);
+    };
+    window.addEventListener(OLIVE_ASK_AI_CHAT, onAskAiChat);
+    return () => window.removeEventListener(OLIVE_ASK_AI_CHAT, onAskAiChat);
+  }, []);
 
   useEffect(() => {
     const main = mainRef.current;
@@ -484,6 +497,8 @@ function Dashboard() {
                   onClose={() => setIsAiSidebarOpen(false)}
                   openToAudit={triggerAiAudit}
                   onAuditOpened={() => setTriggerAiAudit(false)}
+                  pendingChatQuery={pendingChatQuery}
+                  onChatQueryConsumed={() => setPendingChatQuery(null)}
                 />
               </Suspense>
             </ErrorBoundary>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -410,7 +410,7 @@ function Dashboard() {
               <main
                 ref={mainRef}
                 id="main"
-                className="flex-1 overflow-x-hidden overflow-y-auto overscroll-contain px-3 py-5 wide:px-6 wide:py-8 min-[1000px]:px-10 h-full min-w-0"
+                className="flex-1 overflow-x-hidden overflow-y-auto overscroll-contain px-3 py-4 wide:px-6 wide:py-5 min-[1000px]:px-8 h-full min-w-0"
               >
                 <h1 className="sr-only">Olive Studio recipe builder</h1>
                 <div className="mx-auto w-full max-w-5xl min-w-0">
@@ -424,7 +424,7 @@ function Dashboard() {
                         data-pipeline-section={id}
                         className={cn(
                           "scroll-mt-4",
-                          index > 0 && "mt-12 pt-10 border-t border-slate-800",
+                          index > 0 && "mt-6 pt-5 border-t border-slate-800",
                           // The final pipeline section must be tall enough that
                           // `scrollIntoView({block:"start"})` can land its top at
                           // the scroll-container's top without being clamped to
@@ -438,8 +438,8 @@ function Dashboard() {
                           isLast && "min-h-[calc(100dvh-3rem)] pb-16",
                         )}
                       >
-                        <header className="mb-5 pb-4 border-b border-slate-800/80">
-                          <p className="text-xs text-electric-blue mb-1">{step}</p>
+                        <header className="mb-3 pb-2.5 border-b border-slate-800/80">
+                          <p className="text-xs text-electric-blue mb-0.5">{step}</p>
                           <h2 id={`${id}-heading`} className="text-lg font-semibold text-slate-100">
                             {label}
                           </h2>

--- a/src/components/SettingsMenu.tsx
+++ b/src/components/SettingsMenu.tsx
@@ -1,0 +1,117 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Settings, Monitor, Sun, Moon } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { usePreferencesStore, type ThemePreference } from "@/lib/stores/preferencesStore";
+
+const THEME_OPTIONS: { value: ThemePreference; label: string; Icon: typeof Monitor }[] = [
+  { value: "system", label: "System", Icon: Monitor },
+  { value: "light", label: "Light", Icon: Sun },
+  { value: "dark", label: "Dark", Icon: Moon },
+];
+
+export function SettingsMenu() {
+  const [open, setOpen] = useState(false);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  const themePreference = usePreferencesStore((s) => s.themePreference);
+  const setThemePreference = usePreferencesStore((s) => s.setThemePreference);
+
+  const handleSelect = useCallback(
+    (value: ThemePreference) => {
+      setThemePreference(value);
+      setOpen(false);
+      triggerRef.current?.focus();
+    },
+    [setThemePreference],
+  );
+
+  // Close on Escape
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === "Escape") {
+        setOpen(false);
+        triggerRef.current?.focus();
+      }
+    },
+    [],
+  );
+
+  // Close on outside click
+  useEffect(() => {
+    if (!open) return;
+    function onPointerDown(e: PointerEvent) {
+      if (
+        !menuRef.current?.contains(e.target as Node) &&
+        !triggerRef.current?.contains(e.target as Node)
+      ) {
+        setOpen(false);
+      }
+    }
+    document.addEventListener("pointerdown", onPointerDown);
+    return () => document.removeEventListener("pointerdown", onPointerDown);
+  }, [open]);
+
+  return (
+    <div className="relative">
+      <button
+        ref={triggerRef}
+        type="button"
+        aria-label="Settings"
+        aria-expanded={open}
+        aria-haspopup="true"
+        className={cn(
+          "p-1.5 rounded text-slate-500 hover:text-slate-200 transition-colors",
+          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-electric-blue",
+        )}
+        onClick={() => setOpen((v) => !v)}
+      >
+        <Settings className="h-4 w-4" />
+      </button>
+
+      {open && (
+        <div
+          ref={menuRef}
+          role="menu"
+          aria-label="Theme selection"
+          className={cn(
+            "absolute right-0 top-full mt-1 z-50 min-w-[160px]",
+            "rounded border border-slate-700 bg-slate-900 shadow-lg py-1",
+          )}
+          onKeyDown={handleKeyDown}
+        >
+          <div className="px-2 py-1 text-[11px] text-slate-500 uppercase tracking-wider">
+            Theme
+          </div>
+          {THEME_OPTIONS.map(({ value, label, Icon }) => (
+            <button
+              key={value}
+              type="button"
+              role="menuitem"
+              className={cn(
+                "w-full flex items-center gap-2 px-3 py-1.5 text-sm transition-colors",
+                "hover:bg-slate-800 focus-visible:bg-slate-800 focus-visible:outline-none",
+                value === themePreference
+                  ? "text-electric-blue"
+                  : "text-slate-300",
+              )}
+              onClick={() => handleSelect(value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" || e.key === " ") {
+                  e.preventDefault();
+                  handleSelect(value);
+                }
+              }}
+            >
+              <Icon className="h-3.5 w-3.5" />
+              <span>{label}</span>
+              {value === themePreference && (
+                <span className="ml-auto text-[10px]">✓</span>
+              )}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/SettingsMenu.tsx
+++ b/src/components/SettingsMenu.tsx
@@ -46,6 +46,7 @@ export function SettingsMenu() {
         !triggerRef.current?.contains(e.target as Node)
       ) {
         setOpen(false);
+        triggerRef.current?.focus();
       }
     }
     document.addEventListener("pointerdown", onPointerDown);

--- a/src/components/SettingsMenu.tsx
+++ b/src/components/SettingsMenu.tsx
@@ -13,6 +13,7 @@ export function SettingsMenu() {
   const [open, setOpen] = useState(false);
   const triggerRef = useRef<HTMLButtonElement>(null);
   const menuRef = useRef<HTMLDivElement>(null);
+  const itemRefs = useRef<(HTMLButtonElement | null)[]>([]);
 
   const themePreference = usePreferencesStore((s) => s.themePreference);
   const setThemePreference = usePreferencesStore((s) => s.setThemePreference);
@@ -26,18 +27,55 @@ export function SettingsMenu() {
     [setThemePreference],
   );
 
-  // Close on Escape
-  const handleKeyDown = useCallback(
+  // Focus first menu item when menu opens
+  useEffect(() => {
+    if (open) {
+      // Defer to next frame so the menu is rendered before focusing
+      requestAnimationFrame(() => {
+        itemRefs.current[0]?.focus();
+      });
+    }
+  }, [open]);
+
+  // Keyboard navigation within menu
+  const handleMenuKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
-      if (e.key === "Escape") {
-        setOpen(false);
-        triggerRef.current?.focus();
+      const items = itemRefs.current.filter(Boolean) as HTMLButtonElement[];
+      const currentIndex = items.indexOf(document.activeElement as HTMLButtonElement);
+
+      switch (e.key) {
+        case "Escape":
+          setOpen(false);
+          triggerRef.current?.focus();
+          e.preventDefault();
+          break;
+        case "ArrowDown": {
+          e.preventDefault();
+          const next = currentIndex < items.length - 1 ? currentIndex + 1 : 0;
+          items[next]?.focus();
+          break;
+        }
+        case "ArrowUp": {
+          e.preventDefault();
+          const prev = currentIndex > 0 ? currentIndex - 1 : items.length - 1;
+          items[prev]?.focus();
+          break;
+        }
+        case "Home":
+          e.preventDefault();
+          items[0]?.focus();
+          break;
+        case "End":
+          e.preventDefault();
+          items[items.length - 1]?.focus();
+          break;
       }
     },
     [],
   );
 
-  // Close on outside click
+  // Close on outside pointer — defer focus restoration so browser default
+  // focus processing on the target element completes first.
   useEffect(() => {
     if (!open) return;
     function onPointerDown(e: PointerEvent) {
@@ -46,7 +84,13 @@ export function SettingsMenu() {
         !triggerRef.current?.contains(e.target as Node)
       ) {
         setOpen(false);
-        triggerRef.current?.focus();
+        // Defer focus restoration so the browser can process default focus on the
+        // clicked element first — prevents overriding focus on a focusable sibling.
+        requestAnimationFrame(() => {
+          if (!document.activeElement || document.activeElement === document.body) {
+            triggerRef.current?.focus();
+          }
+        });
       }
     }
     document.addEventListener("pointerdown", onPointerDown);
@@ -79,16 +123,19 @@ export function SettingsMenu() {
             "absolute right-0 top-full mt-1 z-50 min-w-[160px]",
             "rounded border border-slate-700 bg-slate-900 shadow-lg py-1",
           )}
-          onKeyDown={handleKeyDown}
+          onKeyDown={handleMenuKeyDown}
         >
           <div className="px-2 py-1 text-[11px] text-slate-500 uppercase tracking-wider">
             Theme
           </div>
-          {THEME_OPTIONS.map(({ value, label, Icon }) => (
+          {THEME_OPTIONS.map(({ value, label, Icon }, index) => (
             <button
               key={value}
+              ref={(el) => { itemRefs.current[index] = el; }}
               type="button"
-              role="menuitem"
+              role="menuitemradio"
+              aria-checked={value === themePreference}
+              tabIndex={-1}
               className={cn(
                 "w-full flex items-center gap-2 px-3 py-1.5 text-sm transition-colors",
                 "hover:bg-slate-800 focus-visible:bg-slate-800 focus-visible:outline-none",

--- a/src/components/TitleBar.tsx
+++ b/src/components/TitleBar.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from "react";
 import { Minus, Square, X, Copy } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { SettingsMenu } from "@/components/SettingsMenu";
 
 /**
  * Renders custom Tauri window controls for Olive Studio.
@@ -80,6 +81,9 @@ export function TitleBar() {
       </div>
 
       <div className="flex items-stretch h-full" data-tauri-drag-region="false">
+        <div className="flex items-center px-2">
+          <SettingsMenu />
+        </div>
         <button
           type="button"
           aria-label="Minimize"

--- a/src/components/features/AgentAccessControls.tsx
+++ b/src/components/features/AgentAccessControls.tsx
@@ -1,5 +1,6 @@
 import { memo, useCallback, useEffect, useRef, useState } from "react";
 import { Bot, RefreshCw, Shield } from "lucide-react";
+import { cn } from "@/lib/utils";
 
 export type AgentAccessPolicyState = {
   mcpAccess: boolean;
@@ -68,7 +69,11 @@ function formatAgentAccessError(status: number, serverError: string | undefined)
  * loopback-only on the server. Env overrides (e.g. OLIVE_MCP_ALLOW_JOBS) may
  * still force submit/cancel — UI shows when that is active.
  */
-export const AgentAccessControls = memo(function AgentAccessControls() {
+interface AgentAccessControlsProps {
+  compact?: boolean;
+}
+
+export const AgentAccessControls = memo(function AgentAccessControls({ compact = false }: AgentAccessControlsProps) {
   const [policy, setPolicy] = useState<AgentAccessPolicyState | null>(null);
   const [open, setOpen] = useState(false);
   const [busy, setBusy] = useState(false);
@@ -192,7 +197,10 @@ export const AgentAccessControls = memo(function AgentAccessControls() {
         ref={triggerRef}
         type="button"
         onClick={() => setOpen((v) => !v)}
-        className="flex items-center justify-center gap-0 wide:gap-1.5 text-slate-400 hover:text-slate-200 transition-colors px-1.5 py-1 rounded border border-transparent hover:border-slate-700/80"
+        className={cn(
+          "flex items-center justify-center text-slate-400 hover:text-slate-200 transition-colors px-1.5 py-1 rounded border border-transparent hover:border-slate-700/80",
+          compact ? "gap-0" : "gap-1.5",
+        )}
         title={title}
         aria-expanded={open}
         aria-haspopup="dialog"
@@ -202,7 +210,7 @@ export const AgentAccessControls = memo(function AgentAccessControls() {
         <Bot className="h-3 w-3 text-slate-500" aria-hidden />
         <span className={elevated ? "text-amber-400/90 flex items-center gap-0.5" : "text-slate-400"}>
           {elevated ? <Shield className="h-3 w-3" aria-hidden /> : null}
-          <span className="hidden wide:inline">Agent access</span>
+          <span className={compact ? "hidden" : "inline"}>Agent access</span>
         </span>
       </button>
 

--- a/src/components/features/KbSyncIndicator.tsx
+++ b/src/components/features/KbSyncIndicator.tsx
@@ -1,10 +1,15 @@
 import { memo } from "react";
 import { RefreshCw, Database, CheckCircle, AlertCircle } from "lucide-react";
 import { KB_STALE_AFTER_MS, isKbStatusStale, kbFreshnessMs, useKbSync } from "@/lib/hooks/useKbSync";
+import { cn } from "@/lib/utils";
 
 const STALE_AFTER_DAYS = Math.round(KB_STALE_AFTER_MS / 86_400_000);
 
-export const KbSyncIndicator = memo(function KbSyncIndicator() {
+interface KbSyncIndicatorProps {
+  compact?: boolean;
+}
+
+export const KbSyncIndicator = memo(function KbSyncIndicator({ compact = false }: KbSyncIndicatorProps) {
   const { status, syncing, error, syncKb } = useKbSync();
 
   if (!status && !error) return null;
@@ -24,7 +29,7 @@ export const KbSyncIndicator = memo(function KbSyncIndicator() {
         {status?.available ? (
           <>
             <span
-              className="text-slate-400 truncate hidden wide:inline"
+              className={cn("text-slate-400 truncate", compact ? "hidden" : "inline")}
               title="Olive pass knowledge base used by the recipe builder"
               aria-hidden="true"
             >
@@ -46,10 +51,10 @@ export const KbSyncIndicator = memo(function KbSyncIndicator() {
               }
               aria-hidden="true"
             >
-              <span className="hidden wide:inline">
+              <span className={compact ? "hidden" : "inline"}>
                 KB unavailable{status?.reason ? ` · ${status.reason}` : ""}
               </span>
-              <span className="wide:hidden">KB!</span>
+              <span className={compact ? "inline" : "hidden"}>KB!</span>
             </span>
             <span className="sr-only">
               Knowledge base unavailable{status?.reason ? `: ${status.reason}` : ""}.
@@ -67,7 +72,7 @@ export const KbSyncIndicator = memo(function KbSyncIndicator() {
                 aria-hidden="true"
               >
                 <AlertCircle className="h-3 w-3" aria-hidden />
-                <span className="hidden wide:inline">stale</span>
+                <span className={compact ? "hidden" : "inline"}>stale</span>
               </span>
               <span className="sr-only">Knowledge base is stale.</span>
             </>
@@ -79,7 +84,7 @@ export const KbSyncIndicator = memo(function KbSyncIndicator() {
                 aria-hidden="true"
               >
                 <CheckCircle className="h-3 w-3" aria-hidden />
-                <span className="hidden wide:inline">fresh</span>
+                <span className={compact ? "hidden" : "inline"}>fresh</span>
               </span>
               <span className="sr-only">Knowledge base is fresh.</span>
             </>
@@ -88,12 +93,15 @@ export const KbSyncIndicator = memo(function KbSyncIndicator() {
             type="button"
             onClick={() => void syncKb()}
             disabled={syncing}
-            className="text-electric-blue hover:text-electric-blue/80 disabled:opacity-40 flex items-center gap-0 wide:gap-1 transition-colors shrink-0"
+            className={cn(
+              "text-electric-blue hover:text-electric-blue/80 disabled:opacity-40 flex items-center transition-colors shrink-0",
+              compact ? "gap-0" : "gap-1",
+            )}
             title="Reload Olive pass docs into the local knowledge base"
             aria-label={syncing ? "Syncing knowledge base" : "Sync knowledge base"}
           >
             <RefreshCw className={`h-3 w-3 ${syncing ? "animate-spin" : ""}`} aria-hidden />
-            <span className="hidden wide:inline">{syncing ? "syncing…" : "sync"}</span>
+            <span className={compact ? "hidden" : "inline"}>{syncing ? "syncing…" : "sync"}</span>
           </button>
         </>
       )}

--- a/src/components/features/RuntimeEnvControls.tsx
+++ b/src/components/features/RuntimeEnvControls.tsx
@@ -1,5 +1,6 @@
 import { memo, useCallback, useEffect, useRef, useState } from "react";
 import { FolderOpen, Route, RefreshCw, CheckCircle2, AlertTriangle, Terminal } from "lucide-react";
+import { cn } from "@/lib/utils";
 
 export interface RuntimeEnvStatus {
   venvExists: boolean;
@@ -18,7 +19,11 @@ export interface RuntimeEnvStatus {
 /**
  * Header control: show Python/Olive readiness and fix PATH / interpreter from the UI.
  */
-export const RuntimeEnvControls = memo(function RuntimeEnvControls() {
+interface RuntimeEnvControlsProps {
+  compact?: boolean;
+}
+
+export const RuntimeEnvControls = memo(function RuntimeEnvControls({ compact = false }: RuntimeEnvControlsProps) {
   const [status, setStatus] = useState<RuntimeEnvStatus | null>(null);
   const [open, setOpen] = useState(false);
   const [pythonPath, setPythonPath] = useState("");
@@ -260,7 +265,10 @@ export const RuntimeEnvControls = memo(function RuntimeEnvControls() {
       <button
         type="button"
         onClick={() => setOpen((v) => !v)}
-        className="flex items-center justify-center gap-0 wide:gap-1.5 text-slate-400 hover:text-slate-200 transition-colors px-1.5 py-1 rounded border border-transparent hover:border-slate-700/80"
+        className={cn(
+          "flex items-center justify-center text-slate-400 hover:text-slate-200 transition-colors px-1.5 py-1 rounded border border-transparent hover:border-slate-700/80",
+          compact ? "gap-0" : "gap-1.5",
+        )}
         title={runtimeTitle}
         aria-expanded={open}
         aria-haspopup="dialog"
@@ -270,19 +278,19 @@ export const RuntimeEnvControls = memo(function RuntimeEnvControls() {
         {status?.oliveInstalled ? (
           <span className="text-emerald-600/90 flex items-center gap-0.5">
             <CheckCircle2 className="h-3 w-3" aria-hidden />
-            <span className="hidden wide:inline">{runtimeLabel}</span>
+            <span className={compact ? "hidden" : "inline"}>{runtimeLabel}</span>
           </span>
         ) : needsAttention ? (
           <span className="text-slate-400 flex items-center gap-0.5">
             <AlertTriangle className="h-3 w-3 text-amber-600/75" aria-hidden />
-            <span className="hidden wide:inline">{runtimeLabel}</span>
+            <span className={compact ? "hidden" : "inline"}>{runtimeLabel}</span>
           </span>
         ) : (
-          <span className="text-slate-400 hidden wide:inline">{runtimeLabel}</span>
+          <span className={cn("text-slate-400", compact ? "hidden" : "inline")}>{runtimeLabel}</span>
         )}
         {status && !pathOk && status.venvExists && (
           <span
-            className="text-slate-500 hidden wide:inline"
+            className={cn("text-slate-500", compact ? "hidden" : "inline")}
             title="Project .venv Scripts/bin is not on your user PATH"
           >
             · add PATH

--- a/src/components/features/VramEstimateBanner.tsx
+++ b/src/components/features/VramEstimateBanner.tsx
@@ -168,36 +168,40 @@ export const VramEstimateBanner = memo(function VramEstimateBanner({
           </p>
         </div>
 
-        <div className="space-y-2">
-          <div className="space-y-1.5">
-            <div className="flex items-baseline justify-between gap-2">
-              <span className="text-[11px] text-slate-500">Before optimization</span>
-              <span className="text-xs font-mono font-medium text-slate-300 tabular-nums">
-                ~{formatMemoryGb(beforeGb)}
-              </span>
+        {hasModel ? (
+          <div className="space-y-2">
+            <div className="space-y-1.5">
+              <div className="flex items-baseline justify-between gap-2">
+                <span className="text-[11px] text-slate-500">Before optimization</span>
+                <span className="text-xs font-mono font-medium text-slate-300 tabular-nums">
+                  ~{formatMemoryGb(beforeGb)}
+                </span>
+              </div>
+              <div className="flex items-baseline justify-between gap-2">
+                <span
+                  className="text-[11px] text-slate-500"
+                  title={
+                    noShrinkPasses
+                      ? "Quantization / pruning not enabled: footprint matches source weights"
+                      : undefined
+                  }
+                >
+                  {afterLabel}
+                </span>
+                <span className="text-xs font-mono font-semibold text-slate-100 tabular-nums">
+                  ~{formatMemoryGb(afterGb)}
+                </span>
+              </div>
             </div>
-            <div className="flex items-baseline justify-between gap-2">
-              <span
-                className="text-[11px] text-slate-500"
-                title={
-                  noShrinkPasses
-                    ? "Quantization / pruning not enabled: footprint matches source weights"
-                    : undefined
-                }
-              >
-                {afterLabel}
-              </span>
-              <span className="text-xs font-mono font-semibold text-slate-100 tabular-nums">
-                ~{formatMemoryGb(afterGb)}
-              </span>
-            </div>
+            {noShrinkPasses && (
+              <p className="text-[11px] text-slate-500 leading-relaxed">
+                Enable quantization or pruning to shrink the deployed footprint.
+              </p>
+            )}
           </div>
-          {noShrinkPasses && (
-            <p className="text-[11px] text-slate-500 leading-relaxed">
-              Enable quantization or pruning to shrink the deployed footprint.
-            </p>
-          )}
-        </div>
+        ) : (
+          <p className="text-[11px] text-slate-500">Select a model to see a memory estimate.</p>
+        )}
 
         <div className="border-t border-slate-800/90 pt-2.5 space-y-1.5">
           {estimate.usesGpu ? (
@@ -237,7 +241,8 @@ export const VramEstimateBanner = memo(function VramEstimateBanner({
           )}
         </div>
 
-        {(fitLabel ||
+        {hasModel &&
+          (fitLabel ||
           showRunWarning ||
           (showOffloadGuidance && !offloadActive) ||
           (offloadActive && hybridPoolGb != null)) && (
@@ -290,15 +295,19 @@ export const VramEstimateBanner = memo(function VramEstimateBanner({
   if (compact) {
     return (
       <div className={cn("text-sm text-slate-500 space-y-1", className)}>
-        <ModelMemoryCompare
-          beforeGb={beforeGb}
-          afterGb={afterGb}
-          modelShortName={modelShortName}
-          modelLabel={modelLabel}
-          usesGpu={estimate.usesGpu}
-          size="sm"
-        />
-        {availableGb != null && estimate.usesGpu && (
+        {hasModel ? (
+          <ModelMemoryCompare
+            beforeGb={beforeGb}
+            afterGb={afterGb}
+            modelShortName={modelShortName}
+            modelLabel={modelLabel}
+            usesGpu={estimate.usesGpu}
+            size="sm"
+          />
+        ) : (
+          <p className="text-[11px] text-slate-500">Model: {modelShortName}</p>
+        )}
+        {hasModel && availableGb != null && estimate.usesGpu && (
           <p className="text-xs pl-0.5">
             <span className="text-slate-500">GPU available:</span>{" "}
             <span className="font-mono text-slate-300">{formatMemoryGb(availableGb)}</span>
@@ -335,26 +344,30 @@ export const VramEstimateBanner = memo(function VramEstimateBanner({
             {estimate.confidence} confidence
           </span>
         </div>
-        {fitLabel && <span className={cn("text-sm px-2 py-0.5 rounded border", fitClass)}>{fitLabel}</span>}
+        {hasModel && fitLabel && <span className={cn("text-sm px-2 py-0.5 rounded border", fitClass)}>{fitLabel}</span>}
       </div>
 
-      {noShrinkPasses && (
+      {hasModel && noShrinkPasses && (
         <p className="text-xs text-slate-500 mt-2 leading-relaxed">
           No quantization or pruning is active, so before and after match the source weight footprint.
         </p>
       )}
 
-      <ModelMemoryCompare
-        beforeGb={beforeGb}
-        afterGb={afterGb}
-        modelShortName={modelShortName}
-        modelLabel={modelLabel}
-        usesGpu={estimate.usesGpu}
-        size="md"
-        className="mt-3"
-      />
+      {hasModel ? (
+        <ModelMemoryCompare
+          beforeGb={beforeGb}
+          afterGb={afterGb}
+          modelShortName={modelShortName}
+          modelLabel={modelLabel}
+          usesGpu={estimate.usesGpu}
+          size="md"
+          className="mt-3"
+        />
+      ) : (
+        <p className="text-xs text-slate-500 mt-3">Select a model to see a VRAM estimate.</p>
+      )}
 
-      {showRunWarning && (
+      {hasModel && showRunWarning && (
         <p className="text-xs text-amber-500/90 mt-2 leading-relaxed">
           The optimized model should fit, but the Olive run for{" "}
           <span className="font-mono text-amber-400/90">{modelShortName}</span> may temporarily need ~
@@ -362,11 +375,11 @@ export const VramEstimateBanner = memo(function VramEstimateBanner({
         </p>
       )}
 
-      {showOffloadGuidance && !offloadActive && (
+      {hasModel && showOffloadGuidance && !offloadActive && (
         <p className="text-xs text-slate-500 mt-2 leading-relaxed">{offloadGuidance}</p>
       )}
 
-      {offloadActive && hybridPoolGb != null && (
+      {hasModel && offloadActive && hybridPoolGb != null && (
         <p className="text-xs text-emerald-500/90 mt-2 leading-relaxed">
           Hybrid offload active. The optimization run can spread across ~{formatMemoryGb(hybridPoolGb)} GPU +
           host RAM.
@@ -374,13 +387,15 @@ export const VramEstimateBanner = memo(function VramEstimateBanner({
       )}
 
       <div className="mt-3 grid grid-cols-2 sm:grid-cols-3 gap-3">
-        <div className="rounded border border-slate-800 bg-slate-900/50 px-3 py-2">
-          <p className="text-xs text-slate-500">
-            {estimate.usesGpu ? "Peak VRAM (Olive run)" : "Peak RAM (Olive run)"}
-          </p>
-          <p className="text-sm font-mono text-electric-blue mt-0.5">~{formatMemoryGb(estimate.peakRunGb)}</p>
-          <p className="text-[9px] text-slate-600 mt-0.5">Temporary during optimization</p>
-        </div>
+        {hasModel && (
+          <div className="rounded border border-slate-800 bg-slate-900/50 px-3 py-2">
+            <p className="text-xs text-slate-500">
+              {estimate.usesGpu ? "Peak VRAM (Olive run)" : "Peak RAM (Olive run)"}
+            </p>
+            <p className="text-sm font-mono text-electric-blue mt-0.5">~{formatMemoryGb(estimate.peakRunGb)}</p>
+            <p className="text-[9px] text-slate-600 mt-0.5">Temporary during optimization</p>
+          </div>
+        )}
         {estimate.usesGpu && (
           <div className="rounded border border-slate-800 bg-slate-900/50 px-3 py-2">
             <p className="text-xs text-slate-500">GPU VRAM available</p>

--- a/src/components/features/assistant/AssistantSidebar.tsx
+++ b/src/components/features/assistant/AssistantSidebar.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useMemo, useTransition, useRef } from "react";
 import { UIState } from "@/types";
+import type { AskAiChatDetail } from "@/lib/aiChatBridge";
 import { usePipelineState } from "@/lib/stores/pipelineStore";
 import { cn } from "@/lib/utils";
 import {
@@ -29,6 +30,8 @@ interface AssistantSidebarProps {
   onClose: () => void;
   openToAudit?: boolean;
   onAuditOpened?: () => void;
+  pendingChatQuery?: AskAiChatDetail | null;
+  onChatQueryConsumed?: () => void;
 }
 
 const TABS = [
@@ -44,6 +47,8 @@ const TABS = [
  * @param onClose - Callback invoked when the sidebar is closed
  * @param openToAudit - Whether to select the audit tab and restart analysis
  * @param onAuditOpened - Optional callback invoked after the audit tab is opened
+ * @param pendingChatQuery - A query to select the chat tab and send automatically
+ * @param onChatQueryConsumed - Optional callback invoked after the pending chat query is sent
  */
 export function AssistantSidebar({
   state: propState,
@@ -52,6 +57,8 @@ export function AssistantSidebar({
   onClose,
   openToAudit,
   onAuditOpened,
+  pendingChatQuery,
+  onChatQueryConsumed,
 }: AssistantSidebarProps) {
   const storeState = usePipelineState();
   const state = propState ?? storeState.state;
@@ -133,6 +140,15 @@ export function AssistantSidebar({
     audit.restartAnalysis();
     onAuditOpened?.();
   }, [openToAudit]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  useEffect(() => {
+    if (!pendingChatQuery) return;
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- intentional: respond to prop change
+    setActiveTab("chat");
+    void chat.sendChat(pendingChatQuery.query);
+    onChatQueryConsumed?.();
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- fire once per nonce, not on every chat/audit identity change
+  }, [pendingChatQuery]);
 
   // Report issue modal state (must precede the Escape-key effect that reads it)
   const [isReportOpen, setIsReportOpen] = useState(false);

--- a/src/components/features/execute/ExecutionWorkspace.tsx
+++ b/src/components/features/execute/ExecutionWorkspace.tsx
@@ -477,6 +477,7 @@ export function ExecutionWorkspace({
     executionStatus,
     executionExitCode,
     gpuMetrics,
+    runRecipeJson,
     handleExecuteLive,
     handleCancelJob,
   } = useOliveStream({

--- a/src/components/features/execute/ExecutionWorkspace.tsx
+++ b/src/components/features/execute/ExecutionWorkspace.tsx
@@ -475,9 +475,9 @@ export function ExecutionWorkspace({
     executionStatus,
     executionExitCode,
     gpuMetrics,
-    runRecipeJson,
     handleExecuteLive,
     handleCancelJob,
+    runRecipeJsonRef,
   } = useOliveStream({
     state,
     hardwareProbe,
@@ -580,10 +580,10 @@ export function ExecutionWorkspace({
   // not a rebuilt version that might include post-run state edits.
   const setCapturedRunRecipe = usePlaygroundStore((s) => s.setCapturedRunRecipe);
   useEffect(() => {
-    if (executionStatus === "completed" && runRecipeJson) {
-      setCapturedRunRecipe(runRecipeJson);
+    if (executionStatus === "completed" && runRecipeJsonRef.current) {
+      setCapturedRunRecipe(runRecipeJsonRef.current);
     }
-  }, [executionStatus, runRecipeJson, setCapturedRunRecipe]);
+  }, [executionStatus, setCapturedRunRecipe, runRecipeJsonRef]);
 
   // Auto-save completed diagnoses to history
   const prevDiagnosticRef = useRef(mcpDiagnostic);
@@ -767,7 +767,7 @@ export function ExecutionWorkspace({
       <Card
         className={cn(
           "flex flex-col overflow-hidden",
-          recipeView === "graph" ? "min-h-[420px] wide:min-h-[480px]" : "min-h-[420px]",
+          recipeView === "graph" ? "min-h-[340px] wide:min-h-[380px]" : "min-h-[340px]",
         )}
       >
         <CardHeader
@@ -885,12 +885,12 @@ export function ExecutionWorkspace({
               key={view}
               className={cn(
                 "flex-1 overflow-hidden p-0",
-                view === "graph" ? "min-h-[400px]" : "min-h-[420px]",
+                view === "graph" ? "min-h-[340px]" : "min-h-[340px]",
                 isActive ? "block" : "hidden",
               )}
             >
               {view === "graph" && (
-                <Suspense fallback={<LoadingFallback label="Loading graph editor..." minH="400px" />}>
+                <Suspense fallback={<LoadingFallback label="Loading graph editor..." minH="340px" />}>
                   <RecipeGraphView state={state} setState={setState} />
                 </Suspense>
               )}

--- a/src/components/features/execute/ExecutionWorkspace.tsx
+++ b/src/components/features/execute/ExecutionWorkspace.tsx
@@ -477,7 +477,6 @@ export function ExecutionWorkspace({
     executionStatus,
     executionExitCode,
     gpuMetrics,
-    runRecipeJson,
     handleExecuteLive,
     handleCancelJob,
     runRecipeJsonRef,

--- a/src/components/features/execute/ExecutionWorkspace.tsx
+++ b/src/components/features/execute/ExecutionWorkspace.tsx
@@ -41,7 +41,6 @@ import {
   RefreshCw,
   Download,
   AlertTriangle,
-  CircleDot,
   History,
   Square,
   Wrench,
@@ -206,7 +205,6 @@ export function ExecutionWorkspace({
   };
   const [_isCopied, setIsCopied] = useState(false);
   const [isExportOpen, setIsExportOpen] = useState(false);
-  const [showGraphDot, setShowGraphDot] = useState(true);
   const [isExportCopied, setIsExportCopied] = useState(false);
   const [justQueued, setJustQueued] = useState(false);
 
@@ -769,10 +767,11 @@ export function ExecutionWorkspace({
       <Card
         className={cn(
           "flex flex-col overflow-hidden",
-          recipeView === "graph" ? "min-h-[560px] wide:min-h-[680px]" : "min-h-[420px]",
+          recipeView === "graph" ? "min-h-[420px] wide:min-h-[480px]" : "min-h-[420px]",
         )}
       >
         <CardHeader
+          className="p-3 pb-2"
           title="Olive Recipe Definition"
           description={
             recipeView === "graph"
@@ -809,20 +808,6 @@ export function ExecutionWorkspace({
                   <Code className="h-3 w-3" /> JSON Code
                 </button>
               </div>
-              {recipeView === "graph" && (
-                <button
-                  type="button"
-                  onClick={() => setShowGraphDot((v) => !v)}
-                  title={showGraphDot ? "Hide flow dot" : "Show flow dot"}
-                  aria-label={showGraphDot ? "Hide flow dot" : "Show flow dot"}
-                  className={`h-8 w-8 flex items-center justify-center rounded border transition-colors cursor-pointer ${showGraphDot
-                    ? "border-electric-blue/30 text-electric-blue hover:bg-electric-blue/10"
-                    : "border-slate-700 text-slate-500 hover:border-slate-600 hover:text-slate-300"
-                    }`}
-                >
-                  <CircleDot className="h-3.5 w-3.5" />
-                </button>
-              )}
               <Button
                 variant="outline"
                 className="h-8 px-3 text-sm border-electric-blue/30 text-electric-blue hover:text-white hover:bg-electric-blue/10"
@@ -900,13 +885,13 @@ export function ExecutionWorkspace({
               key={view}
               className={cn(
                 "flex-1 overflow-hidden p-0",
-                view === "graph" ? "min-h-[560px]" : "min-h-[420px]",
+                view === "graph" ? "min-h-[400px]" : "min-h-[420px]",
                 isActive ? "block" : "hidden",
               )}
             >
               {view === "graph" && (
-                <Suspense fallback={<LoadingFallback label="Loading graph editor..." minH="560px" />}>
-                  <RecipeGraphView state={state} setState={setState} showDot={showGraphDot} />
+                <Suspense fallback={<LoadingFallback label="Loading graph editor..." minH="400px" />}>
+                  <RecipeGraphView state={state} setState={setState} />
                 </Suspense>
               )}
               {view === "json" && (

--- a/src/components/features/execute/recipe-graph/GraphCanvas.test.tsx
+++ b/src/components/features/execute/recipe-graph/GraphCanvas.test.tsx
@@ -3,38 +3,18 @@ import { describe, expect, it, vi } from "vitest";
 
 import { createMockUIState } from "../../__tests__/testUtils";
 import { GraphCanvas } from "./GraphCanvas";
-import { ARROW_MARKER_ID, PIPELINE_DOT_SYMBOL_ID, WIRE_GRADIENT_ID } from "./svgDefs";
 
-describe("GraphCanvas SVG definitions", () => {
-  it("deduplicates definitions, references shared geometry, and preserves interaction", () => {
+describe("GraphCanvas", () => {
+  it("supports node selection, keyboard navigation, and layout recalculation", () => {
     const onSelectNode = vi.fn();
     const props = {
       state: createMockUIState(),
       selectedNodeId: "input",
       onSelectNode,
-      showDot: true,
       layoutTick: 0,
       onLayoutTick: vi.fn(),
     };
     const view = render(<GraphCanvas {...props} />);
-
-    // The first render establishes the container ref; the next draws connections.
-    view.rerender(<GraphCanvas {...props} layoutTick={1} />);
-
-    const svg = view.container.querySelector("svg.absolute");
-    expect(svg).not.toBeNull();
-    expect(svg?.querySelectorAll("defs")).toHaveLength(1);
-    expect(svg?.querySelectorAll(`#${WIRE_GRADIENT_ID}`)).toHaveLength(1);
-    expect(svg?.querySelectorAll(`#${ARROW_MARKER_ID}`)).toHaveLength(1);
-    expect(svg?.querySelectorAll(`#${PIPELINE_DOT_SYMBOL_ID}`)).toHaveLength(1);
-
-    const definitionIds = Array.from(
-      svg?.querySelectorAll("linearGradient[id], marker[id], symbol[id]") ?? [],
-      (element) => element.id,
-    );
-    expect(new Set(definitionIds).size).toBe(definitionIds.length);
-    expect(svg?.querySelector(`path[marker-end="url(#${ARROW_MARKER_ID})"]`)).not.toBeNull();
-    expect(svg?.querySelector(`use[href="#${PIPELINE_DOT_SYMBOL_ID}"]`)).not.toBeNull();
 
     fireEvent.click(view.getByRole("button", { name: /target device/i }));
     expect(onSelectNode).toHaveBeenCalledWith("provider");

--- a/src/components/features/execute/recipe-graph/GraphCanvas.tsx
+++ b/src/components/features/execute/recipe-graph/GraphCanvas.tsx
@@ -279,7 +279,7 @@ export function GraphCanvas({
       ref={containerRef}
       role="group"
       aria-label="Olive recipe pipeline graph. Tab to the selected node, then use arrow keys to move between nodes."
-      className="relative flex-1 min-h-[340px] wide:min-h-[400px] bg-slate-950 p-3 wide:p-4 flex flex-col justify-center select-none overflow-visible"
+      className="relative flex-1 min-h-[260px] wide:min-h-[300px] bg-slate-950 p-2.5 wide:p-3 flex flex-col justify-center select-none overflow-visible"
       style={{
         backgroundImage: `
             radial-gradient(ellipse at center, rgba(30, 41, 59, 0.4) 0%, transparent 80%),
@@ -288,7 +288,7 @@ export function GraphCanvas({
         backgroundSize: "24px 24px",
       }}
     >
-      <div className="grid grid-cols-1 wide:grid-cols-12 gap-y-3 wide:gap-3 relative z-10 items-center justify-between h-full w-full min-w-0 wide:min-w-[720px]">
+      <div className="grid grid-cols-1 wide:grid-cols-12 gap-y-2 wide:gap-2 relative z-10 items-center justify-between h-full w-full min-w-0 wide:min-w-[720px]">
         <div className="wide:col-span-2 flex flex-col justify-center items-center h-full w-full">
           <div className="text-sm text-slate-400 mb-2">Input</div>
           {(() => {
@@ -325,7 +325,7 @@ export function GraphCanvas({
 
         <div className="wide:col-span-7 flex flex-col items-center justify-center gap-2 wide:border-l wide:border-r border-slate-900/30 px-1 wide:px-4 w-full">
           <div className="text-sm text-slate-400 mb-1">Optimization passes</div>
-          <div className="grid grid-cols-2 wide:grid-cols-3 gap-2 wide:gap-3 w-full max-w-xl wide:max-w-none">
+          <div className="grid grid-cols-2 wide:grid-cols-3 gap-1.5 wide:gap-2 w-full max-w-xl wide:max-w-none">
             {["splitting", "peft", "conversion", "pruning", "transformer_opt", "quantization"].map((id) =>
               renderPassNode(id),
             )}

--- a/src/components/features/execute/recipe-graph/GraphCanvas.tsx
+++ b/src/components/features/execute/recipe-graph/GraphCanvas.tsx
@@ -311,7 +311,7 @@ export function GraphCanvas({
         tabIndex={isSelected ? 0 : -1}
         onClick={() => focusNode(id)}
         onKeyDown={(event) => handleNodeKeyDown(event, id)}
-        className={`group text-left p-2.5 rounded-lg border transition-all duration-300 relative flex flex-col justify-between focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-electric-blue focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950 ${isSelected
+        className={`group text-left p-2 rounded-lg border transition-all duration-300 relative flex flex-col justify-between focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-electric-blue focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950 ${isSelected
             ? issueLevel === "critical"
               ? "border-rose-500 bg-rose-950/20 ring-1 ring-rose-500"
               : issueLevel === "warning"
@@ -332,7 +332,7 @@ export function GraphCanvas({
           />
         )}
         <div>
-          <div className="flex items-center justify-between mb-2">
+          <div className="flex items-center justify-between mb-1.5">
             <div
               className={`p-1 rounded ${issueLevel === "critical"
                   ? "bg-rose-950/40 border border-rose-700/40 text-rose-400"
@@ -386,7 +386,7 @@ export function GraphCanvas({
     return (
       <>
         <div className="w-full flex flex-col items-center">
-          <div className="text-sm text-slate-400 mb-2.5">Target device</div>
+          <div className="text-sm text-slate-400 mb-1.5">Target device</div>
           <button
             id="node-btn-provider"
             type="button"
@@ -395,7 +395,7 @@ export function GraphCanvas({
             tabIndex={selectedNodeId === "provider" ? 0 : -1}
             onClick={() => onSelectNode("provider")}
             onKeyDown={(event) => handleNodeKeyDown(event, "provider")}
-            className={`group w-full max-w-[240px] text-left p-3.5 rounded-xl border transition-all duration-300 relative focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-electric-blue focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950 ${selectedNodeId === "provider"
+            className={`group w-full max-w-[240px] text-left p-2.5 rounded-xl border transition-all duration-300 relative focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-electric-blue focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950 ${selectedNodeId === "provider"
                 ? providerIssue === "critical"
                   ? "border-rose-500 bg-rose-950/20 ring-1 ring-rose-500"
                   : providerIssue === "warning"
@@ -424,7 +424,7 @@ export function GraphCanvas({
         </div>
 
         <div className="w-full flex flex-col items-center">
-          <div className="text-sm text-slate-400 mb-2.5">Output</div>
+          <div className="text-sm text-slate-400 mb-1.5">Output</div>
           <button
             id="node-btn-output"
             type="button"
@@ -433,7 +433,7 @@ export function GraphCanvas({
             tabIndex={selectedNodeId === "output" ? 0 : -1}
             onClick={() => onSelectNode("output")}
             onKeyDown={(event) => handleNodeKeyDown(event, "output")}
-            className={`group w-full max-w-[240px] text-left p-3.5 rounded-xl border transition-all duration-300 relative focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-electric-blue focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950 ${selectedNodeId === "output"
+            className={`group w-full max-w-[240px] text-left p-2.5 rounded-xl border transition-all duration-300 relative focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-electric-blue focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950 ${selectedNodeId === "output"
                 ? "border-emerald-500 bg-emerald-500/10 ring-1 ring-emerald-500"
                 : "border-slate-800 hover:border-slate-700 bg-slate-900/60"
               }`}
@@ -459,7 +459,7 @@ export function GraphCanvas({
       ref={containerRef}
       role="group"
       aria-label="Olive recipe pipeline graph. Tab to the selected node, then use arrow keys to move between nodes."
-      className="relative flex-1 min-h-[480px] wide:min-h-[560px] bg-slate-950 p-3 wide:p-6 flex flex-col justify-center select-none overflow-visible"
+      className="relative flex-1 min-h-[340px] wide:min-h-[400px] bg-slate-950 p-3 wide:p-4 flex flex-col justify-center select-none overflow-visible"
       style={{
         backgroundImage: `
             radial-gradient(ellipse at center, rgba(30, 41, 59, 0.4) 0%, transparent 80%),
@@ -471,9 +471,9 @@ export function GraphCanvas({
       {/* eslint-disable-next-line react-hooks/refs -- intentional: SVG connections read DOM layout during render (client-side SPA, no SSR) */}
       {renderSVGConnections()}
 
-      <div className="grid grid-cols-1 wide:grid-cols-12 gap-y-5 wide:gap-3 relative z-10 items-center justify-between h-full w-full min-w-0 wide:min-w-[720px]">
+      <div className="grid grid-cols-1 wide:grid-cols-12 gap-y-3 wide:gap-3 relative z-10 items-center justify-between h-full w-full min-w-0 wide:min-w-[720px]">
         <div className="wide:col-span-2 flex flex-col justify-center items-center h-full w-full">
-          <div className="text-sm text-slate-400 mb-3">Input</div>
+          <div className="text-sm text-slate-400 mb-2">Input</div>
           {(() => {
             const nd = getNodePreviewData(state, "input");
             const isSelected = selectedNodeId === "input";
@@ -486,12 +486,12 @@ export function GraphCanvas({
                 tabIndex={isSelected ? 0 : -1}
                 onClick={() => onSelectNode("input")}
                 onKeyDown={(event) => handleNodeKeyDown(event, "input")}
-                className={`group w-full max-w-[240px] text-left p-4 rounded-xl border transition-all duration-300 relative focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-electric-blue focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950 ${isSelected
+                className={`group w-full max-w-[240px] text-left p-3 rounded-xl border transition-all duration-300 relative focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-electric-blue focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950 ${isSelected
                     ? "border-electric-blue bg-electric-blue/10 ring-1 ring-electric-blue"
                     : "border-slate-800 hover:border-slate-700 bg-slate-900/60"
                   }`}
               >
-                <div className="flex items-center justify-between mb-2">
+                <div className="flex items-center justify-between mb-1.5">
                   <div className="p-1.5 rounded bg-electric-blue/10 border border-electric-blue/20">
                     {nd.icon}
                   </div>
@@ -499,23 +499,23 @@ export function GraphCanvas({
                     {nd.badge}
                   </span>
                 </div>
-                <h4 className="text-sm font-semibold text-slate-100 mb-1 leading-tight break-words">{nd.title}</h4>
+                <h4 className="text-sm font-semibold text-slate-100 mb-0.5 leading-tight break-words">{nd.title}</h4>
                 <p className="text-xs font-mono text-slate-400 leading-relaxed break-words">{nd.desc}</p>
               </button>
             );
           })()}
         </div>
 
-        <div className="wide:col-span-7 flex flex-col items-center justify-center gap-4 wide:border-l wide:border-r border-slate-900/30 px-1 wide:px-4 w-full">
+        <div className="wide:col-span-7 flex flex-col items-center justify-center gap-2 wide:border-l wide:border-r border-slate-900/30 px-1 wide:px-4 w-full">
           <div className="text-sm text-slate-400 mb-1">Optimization passes</div>
-          <div className="grid grid-cols-2 wide:grid-cols-3 gap-3 wide:gap-4 w-full max-w-xl wide:max-w-none">
+          <div className="grid grid-cols-2 wide:grid-cols-3 gap-2 wide:gap-3 w-full max-w-xl wide:max-w-none">
             {["splitting", "peft", "conversion", "pruning", "transformer_opt", "quantization"].map((id) =>
               renderPassNode(id),
             )}
           </div>
         </div>
 
-        <div className="wide:col-span-3 flex flex-col items-center justify-center gap-6 h-full w-full">
+        <div className="wide:col-span-3 flex flex-col items-center justify-center gap-4 h-full w-full">
           {renderProviderOutputNodes()}
         </div>
       </div>

--- a/src/components/features/execute/recipe-graph/GraphCanvas.tsx
+++ b/src/components/features/execute/recipe-graph/GraphCanvas.tsx
@@ -1,14 +1,8 @@
-import { useLayoutEffect, useRef, type KeyboardEvent, type ReactElement } from "react";
+import { useLayoutEffect, useRef, type KeyboardEvent } from "react";
 import { getPipelineValidation } from "@/lib/pipelineValidation";
 import { UIState } from "@/types";
-import { buildPipelineSteps, buildSegmentCurve, type GraphPoint } from "./graphLayout";
+import { buildPipelineSteps } from "./graphLayout";
 import { getNodePreviewData } from "./nodePreview";
-import {
-  ARROW_MARKER_ID,
-  GraphSvgDefs,
-  PIPELINE_DOT_SYMBOL_ID,
-  WIRE_GRADIENT_ID,
-} from "./svgDefs";
 
 /** Left-to-right / reading order for arrow-key graph navigation. */
 export const GRAPH_NODE_ORDER = [
@@ -27,7 +21,6 @@ interface GraphCanvasProps {
   state: UIState;
   selectedNodeId: string;
   onSelectNode: (id: string) => void;
-  showDot: boolean;
   layoutTick: number;
   onLayoutTick: () => void;
 }
@@ -38,7 +31,6 @@ interface GraphCanvasProps {
  * @param state - The current recipe and pipeline state
  * @param selectedNodeId - The identifier of the currently selected graph node
  * @param onSelectNode - Handles selection of a graph node
- * @param showDot - Whether to display animated dots on the connections
  * @param layoutTick - Value used to trigger layout recalculation
  * @param onLayoutTick - Triggers recalculation of the graph layout
  */
@@ -46,13 +38,11 @@ export function GraphCanvas({
   state,
   selectedNodeId,
   onSelectNode,
-  showDot,
   layoutTick,
   onLayoutTick,
 }: GraphCanvasProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const pipelineSteps = buildPipelineSteps(state.passes);
-  const activeNodes = pipelineSteps.filter((s) => s.active);
   const validation = getPipelineValidation(state);
 
   const nodeIssueLevel = (nodeId: string): "critical" | "warning" | null => {
@@ -123,176 +113,6 @@ export function GraphCanvas({
     const forward = event.key === "ArrowRight" || event.key === "ArrowDown";
     const nextIdx = forward ? (idx + 1) % order.length : (idx - 1 + order.length) % order.length;
     focusNode(order[nextIdx]);
-  };
-
-  const getConnectionPoints = (fromId: string, toId: string): { from: GraphPoint; to: GraphPoint } | null => {
-    if (!containerRef.current) return null;
-    const fromElem = document.getElementById(`node-btn-${fromId}`);
-    const toElem = document.getElementById(`node-btn-${toId}`);
-    if (!fromElem || !toElem) return null;
-
-    const parentRect = containerRef.current.getBoundingClientRect();
-    const toParent = (rect: DOMRect) => ({
-      left: rect.left - parentRect.left,
-      top: rect.top - parentRect.top,
-      right: rect.right - parentRect.left,
-      bottom: rect.bottom - parentRect.top,
-      cx: rect.left - parentRect.left + rect.width / 2,
-      cy: rect.top - parentRect.top + rect.height / 2,
-    });
-
-    const fromBox = toParent(fromElem.getBoundingClientRect());
-    const toBox = toParent(toElem.getBoundingClientRect());
-    const dx = toBox.cx - fromBox.cx;
-    const dy = toBox.cy - fromBox.cy;
-
-    if (Math.abs(dx) >= Math.abs(dy)) {
-      return dx >= 0
-        ? { from: { x: fromBox.right, y: fromBox.cy }, to: { x: toBox.left, y: toBox.cy } }
-        : { from: { x: fromBox.left, y: fromBox.cy }, to: { x: toBox.right, y: toBox.cy } };
-    }
-
-    return dy >= 0
-      ? { from: { x: fromBox.cx, y: fromBox.bottom }, to: { x: toBox.cx, y: toBox.top } }
-      : { from: { x: fromBox.cx, y: fromBox.top }, to: { x: toBox.cx, y: toBox.bottom } };
-  };
-
-  const renderSVGConnections = () => {
-    if (!containerRef.current) return null;
-
-    const paths: ReactElement[] = [];
-    const parentRect = containerRef.current.getBoundingClientRect();
-    const arcYTop = 28;
-    const numSegs = activeNodes.length - 1;
-    const totalDur = Math.max(2, numSegs * 0.8);
-
-    /** Shared renderer for a single connection segment (normal or bypass). */
-    const renderSegment = (opts: {
-      key: string;
-      d: string;
-      hasSkip: boolean;
-      tStart: number;
-      tEnd: number;
-      tStartBefore: number;
-      tEndAfter: number;
-    }): ReactElement => (
-      <g key={opts.key}>
-        <path
-          d={opts.d}
-          fill="none"
-          stroke={opts.hasSkip ? "rgba(141, 168, 64, 0.08)" : "rgba(141, 168, 64, 0.12)"}
-          strokeWidth={opts.hasSkip ? 5 : 6}
-          className="transition-all duration-300"
-        />
-        <path
-          d={opts.d}
-          fill="none"
-          stroke={`url(#${WIRE_GRADIENT_ID})`}
-          strokeWidth={opts.hasSkip ? 1.5 : 2}
-          strokeDasharray="6 6"
-          strokeOpacity={opts.hasSkip ? 0.6 : 1}
-          className="transition-all duration-300"
-          markerEnd={`url(#${ARROW_MARKER_ID})`}
-        >
-          <animate attributeName="stroke-dashoffset" from="12" to="0" dur="0.7s" repeatCount="indefinite" />
-        </path>
-        {showDot && (
-          <use href={`#${PIPELINE_DOT_SYMBOL_ID}`} opacity="0">
-            <animateMotion
-              dur={`${totalDur}s`}
-              repeatCount="indefinite"
-              path={opts.d}
-              calcMode="linear"
-              keyPoints="0;0;1;1"
-              keyTimes={`0;${opts.tStart};${opts.tEnd};1`}
-            />
-            <animate
-              attributeName="opacity"
-              dur={`${totalDur}s`}
-              repeatCount="indefinite"
-              values="0;0;1;1;0;0"
-              keyTimes={`0;${opts.tStartBefore};${opts.tStart};${opts.tEnd};${opts.tEndAfter};1`}
-            />
-          </use>
-        )}
-      </g>
-    );
-
-    for (let i = 0; i < numSegs; i++) {
-      const fromNode = activeNodes[i];
-      const toNode = activeNodes[i + 1];
-      const fromPipelineIdx = pipelineSteps.findIndex((s) => s.id === fromNode.id);
-      const toPipelineIdx = pipelineSteps.findIndex((s) => s.id === toNode.id);
-      const hasSkip = pipelineSteps.slice(fromPipelineIdx + 1, toPipelineIdx).some((s) => !s.active);
-
-      const tStart = i / numSegs;
-      const tEnd = (i + 1) / numSegs;
-      const tStartBefore = Math.max(0, tStart - 0.001);
-      const tEndAfter = Math.min(1, tEnd + 0.001);
-
-      let d: string;
-
-      if (hasSkip) {
-        const points = getConnectionPoints(fromNode.id, toNode.id);
-        const dx = points ? points.to.x - points.from.x : 0;
-        const dy = points ? points.to.y - points.from.y : 0;
-        // Skipped passes in pipeline order, but nodes stack vertically (e.g. conversion → quant):
-        // draw a direct down connector instead of arcing over the whole graph.
-        const useDirectVertical = points && Math.abs(dy) > Math.abs(dx);
-
-        if (useDirectVertical) {
-          d = buildSegmentCurve(points.from, points.to);
-        } else {
-          const fromElem = document.getElementById(`node-btn-${fromNode.id}`);
-          const toElem = document.getElementById(`node-btn-${toNode.id}`);
-          if (!fromElem || !toElem) continue;
-
-          const fromR = fromElem.getBoundingClientRect();
-          const toR = toElem.getBoundingClientRect();
-          const fromX = fromR.left - parentRect.left + fromR.width / 2;
-          const fromY = fromR.top - parentRect.top;
-          const toX = toR.left - parentRect.left + toR.width / 2;
-          const toY = toR.top - parentRect.top;
-          const arcY = arcYTop;
-
-          d = `M ${fromX} ${fromY} C ${fromX} ${arcY}, ${toX} ${arcY}, ${toX} ${toY}`;
-
-          paths.push(
-            <path
-              key={`bypass-lane-${fromNode.id}-${toNode.id}`}
-              d={d}
-              fill="none"
-              stroke="rgba(100, 116, 139, 0.08)"
-              strokeWidth="8"
-              className="transition-all duration-300"
-            />,
-          );
-        }
-      } else {
-        const points = getConnectionPoints(fromNode.id, toNode.id);
-        if (!points) continue;
-        d = buildSegmentCurve(points.from, points.to);
-      }
-
-      paths.push(renderSegment({
-        key: `${fromNode.id}-${toNode.id}`,
-        d,
-        hasSkip,
-        tStart,
-        tEnd,
-        tStartBefore,
-        tEndAfter,
-      }));
-    }
-
-    return (
-      <svg className="absolute inset-0 pointer-events-none w-full h-full z-0 overflow-visible">
-        <defs>
-          <GraphSvgDefs />
-        </defs>
-        {paths}
-      </svg>
-    );
   };
 
   const renderPassNode = (id: string) => {
@@ -468,9 +288,6 @@ export function GraphCanvas({
         backgroundSize: "24px 24px",
       }}
     >
-      {/* eslint-disable-next-line react-hooks/refs -- intentional: SVG connections read DOM layout during render (client-side SPA, no SSR) */}
-      {renderSVGConnections()}
-
       <div className="grid grid-cols-1 wide:grid-cols-12 gap-y-3 wide:gap-3 relative z-10 items-center justify-between h-full w-full min-w-0 wide:min-w-[720px]">
         <div className="wide:col-span-2 flex flex-col justify-center items-center h-full w-full">
           <div className="text-sm text-slate-400 mb-2">Input</div>

--- a/src/components/features/execute/recipe-graph/GraphCanvas.tsx
+++ b/src/components/features/execute/recipe-graph/GraphCanvas.tsx
@@ -132,18 +132,18 @@ export function GraphCanvas({
         onClick={() => focusNode(id)}
         onKeyDown={(event) => handleNodeKeyDown(event, id)}
         className={`group text-left p-2 rounded-lg border transition-all duration-300 relative flex flex-col justify-between focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-electric-blue focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950 ${isSelected
-            ? issueLevel === "critical"
-              ? "border-rose-500 bg-rose-950/20 ring-1 ring-rose-500"
-              : issueLevel === "warning"
-                ? "border-amber-500 bg-amber-950/10 ring-1 ring-amber-500"
-                : "border-electric-blue bg-electric-blue/10 ring-1 ring-electric-blue"
-            : issueLevel === "critical"
-              ? "border-rose-700/60 bg-rose-950/10 hover:border-rose-600"
-              : issueLevel === "warning"
-                ? "border-amber-700/50 bg-amber-950/5 hover:border-amber-600"
-                : active
-                  ? "border-emerald-600/50 bg-emerald-950/10 hover:border-emerald-500 hover:bg-emerald-950/20"
-                  : "border-slate-800 bg-slate-900/30 hover:border-slate-700 hover:bg-slate-900/45"
+          ? issueLevel === "critical"
+            ? "border-rose-500 bg-rose-950/20 ring-1 ring-rose-500"
+            : issueLevel === "warning"
+              ? "border-amber-500 bg-amber-950/10 ring-1 ring-amber-500"
+              : "border-electric-blue bg-electric-blue/10 ring-1 ring-electric-blue"
+          : issueLevel === "critical"
+            ? "border-rose-700/60 bg-rose-950/10 hover:border-rose-600"
+            : issueLevel === "warning"
+              ? "border-amber-700/50 bg-amber-950/5 hover:border-amber-600"
+              : active
+                ? "border-emerald-600/50 bg-emerald-950/10 hover:border-emerald-500 hover:bg-emerald-950/20"
+                : "border-slate-800 bg-slate-900/30 hover:border-slate-700 hover:bg-slate-900/45"
           }`}
       >
         {issueLevel && (
@@ -155,24 +155,24 @@ export function GraphCanvas({
           <div className="flex items-center justify-between mb-1.5">
             <div
               className={`p-1 rounded ${issueLevel === "critical"
-                  ? "bg-rose-950/40 border border-rose-700/40 text-rose-400"
-                  : issueLevel === "warning"
-                    ? "bg-amber-950/30 border border-amber-700/30 text-amber-400"
-                    : active
-                      ? "bg-emerald-500/10 border border-emerald-500/30 text-emerald-400"
-                      : "bg-slate-900 border border-slate-700 text-slate-500"
+                ? "bg-rose-950/40 border border-rose-700/40 text-rose-400"
+                : issueLevel === "warning"
+                  ? "bg-amber-950/30 border border-amber-700/30 text-amber-400"
+                  : active
+                    ? "bg-emerald-500/10 border border-emerald-500/30 text-emerald-400"
+                    : "bg-slate-900 border border-slate-700 text-slate-500"
                 }`}
             >
               {nd.icon}
             </div>
             <span
               className={`text-[11px] font-mono px-1.5 py-0.5 rounded border uppercase whitespace-nowrap tracking-wide ${issueLevel === "critical"
-                  ? "bg-rose-950/40 text-rose-400 border-rose-700/40"
-                  : issueLevel === "warning"
-                    ? "bg-amber-950/30 text-amber-400 border-amber-700/30"
-                    : active
-                      ? "bg-emerald-950/40 text-emerald-400 border-emerald-600/50"
-                      : "bg-slate-950 text-slate-500 border-slate-700"
+                ? "bg-rose-950/40 text-rose-400 border-rose-700/40"
+                : issueLevel === "warning"
+                  ? "bg-amber-950/30 text-amber-400 border-amber-700/30"
+                  : active
+                    ? "bg-emerald-950/40 text-emerald-400 border-emerald-600/50"
+                    : "bg-slate-950 text-slate-500 border-slate-700"
                 }`}
             >
               {issueLevel === "critical"
@@ -216,16 +216,16 @@ export function GraphCanvas({
             onClick={() => onSelectNode("provider")}
             onKeyDown={(event) => handleNodeKeyDown(event, "provider")}
             className={`group w-full max-w-[240px] text-left p-2.5 rounded-xl border transition-all duration-300 relative focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-electric-blue focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950 ${selectedNodeId === "provider"
-                ? providerIssue === "critical"
-                  ? "border-rose-500 bg-rose-950/20 ring-1 ring-rose-500"
-                  : providerIssue === "warning"
-                    ? "border-amber-500 bg-amber-950/10 ring-1 ring-amber-500"
-                    : "border-electric-blue bg-electric-blue/10 ring-1 ring-electric-blue"
-                : providerIssue === "critical"
-                  ? "border-rose-700/60 bg-rose-950/10 hover:border-rose-600"
-                  : providerIssue === "warning"
-                    ? "border-amber-700/50 bg-amber-950/5 hover:border-amber-600"
-                    : "border-slate-800 hover:border-slate-700 bg-slate-900/60"
+              ? providerIssue === "critical"
+                ? "border-rose-500 bg-rose-950/20 ring-1 ring-rose-500"
+                : providerIssue === "warning"
+                  ? "border-amber-500 bg-amber-950/10 ring-1 ring-amber-500"
+                  : "border-electric-blue bg-electric-blue/10 ring-1 ring-electric-blue"
+              : providerIssue === "critical"
+                ? "border-rose-700/60 bg-rose-950/10 hover:border-rose-600"
+                : providerIssue === "warning"
+                  ? "border-amber-700/50 bg-amber-950/5 hover:border-amber-600"
+                  : "border-slate-800 hover:border-slate-700 bg-slate-900/60"
               }`}
           >
             {providerIssue && (
@@ -254,8 +254,8 @@ export function GraphCanvas({
             onClick={() => onSelectNode("output")}
             onKeyDown={(event) => handleNodeKeyDown(event, "output")}
             className={`group w-full max-w-[240px] text-left p-2.5 rounded-xl border transition-all duration-300 relative focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-electric-blue focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950 ${selectedNodeId === "output"
-                ? "border-emerald-500 bg-emerald-500/10 ring-1 ring-emerald-500"
-                : "border-slate-800 hover:border-slate-700 bg-slate-900/60"
+              ? "border-emerald-500 bg-emerald-500/10 ring-1 ring-emerald-500"
+              : "border-slate-800 hover:border-slate-700 bg-slate-900/60"
               }`}
           >
             <div className="flex items-center justify-between mb-1.5">
@@ -282,8 +282,8 @@ export function GraphCanvas({
       className="relative flex-1 min-h-[260px] wide:min-h-[300px] bg-slate-950 p-2.5 wide:p-3 flex flex-col justify-center select-none overflow-visible"
       style={{
         backgroundImage: `
-            radial-gradient(ellipse at center, rgba(30, 41, 59, 0.4) 0%, transparent 80%),
-            radial-gradient(circle, rgba(15, 23, 42, 0.8) 1px, transparent 1px)
+            radial-gradient(ellipse at center, var(--color-slate-900) 0%, transparent 80%),
+            radial-gradient(circle, var(--color-slate-800) 1px, transparent 1px)
           `,
         backgroundSize: "24px 24px",
       }}
@@ -304,8 +304,8 @@ export function GraphCanvas({
                 onClick={() => onSelectNode("input")}
                 onKeyDown={(event) => handleNodeKeyDown(event, "input")}
                 className={`group w-full max-w-[240px] text-left p-3 rounded-xl border transition-all duration-300 relative focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-electric-blue focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950 ${isSelected
-                    ? "border-electric-blue bg-electric-blue/10 ring-1 ring-electric-blue"
-                    : "border-slate-800 hover:border-slate-700 bg-slate-900/60"
+                  ? "border-electric-blue bg-electric-blue/10 ring-1 ring-electric-blue"
+                  : "border-slate-800 hover:border-slate-700 bg-slate-900/60"
                   }`}
               >
                 <div className="flex items-center justify-between mb-1.5">

--- a/src/components/features/execute/recipe-graph/GraphCanvas.tsx
+++ b/src/components/features/execute/recipe-graph/GraphCanvas.tsx
@@ -322,8 +322,8 @@ export function GraphCanvas({
               : issueLevel === "warning"
                 ? "border-amber-700/50 bg-amber-950/5 hover:border-amber-600"
                 : active
-                  ? "border-slate-800 hover:border-slate-700 bg-slate-900/40 hover:bg-slate-900/60"
-                  : "border-dashed border-slate-400/70 bg-slate-900/35 hover:border-slate-300 hover:bg-slate-900/55"
+                  ? "border-emerald-600/50 bg-emerald-950/10 hover:border-emerald-500 hover:bg-emerald-950/20"
+                  : "border-slate-800 bg-slate-900/30 hover:border-slate-700 hover:bg-slate-900/45"
           }`}
       >
         {issueLevel && (
@@ -339,8 +339,8 @@ export function GraphCanvas({
                   : issueLevel === "warning"
                     ? "bg-amber-950/30 border border-amber-700/30 text-amber-400"
                     : active
-                      ? "bg-electric-blue/10 border border-electric-blue/20 text-electric-blue"
-                      : "bg-slate-900 border border-dashed border-slate-400 text-slate-300"
+                      ? "bg-emerald-500/10 border border-emerald-500/30 text-emerald-400"
+                      : "bg-slate-900 border border-slate-700 text-slate-500"
                 }`}
             >
               {nd.icon}
@@ -351,8 +351,8 @@ export function GraphCanvas({
                   : issueLevel === "warning"
                     ? "bg-amber-950/30 text-amber-400 border-amber-700/30"
                     : active
-                      ? "bg-slate-950 text-electric-blue border-electric-blue/20"
-                      : "bg-slate-950 text-slate-200 border-slate-400 border-dashed"
+                      ? "bg-emerald-950/40 text-emerald-400 border-emerald-600/50"
+                      : "bg-slate-950 text-slate-500 border-slate-700"
                 }`}
             >
               {issueLevel === "critical"
@@ -365,14 +365,14 @@ export function GraphCanvas({
             </span>
           </div>
           <h4
-            className={`text-sm font-bold truncate leading-snug ${active || issueLevel ? "text-slate-100" : "text-slate-300"
+            className={`text-sm font-bold break-words leading-snug ${active || issueLevel ? "text-slate-100" : "text-slate-300"
               }`}
           >
             {nd.title}
           </h4>
-          <p className="text-xs leading-tight font-mono line-clamp-2 mt-1 min-h-[20px] text-slate-400">
-            {active ? nd.desc : "Pass disabled · click to configure"}
-          </p>
+          {active && (
+            <p className="text-xs leading-tight font-mono mt-1 text-slate-400 break-words">{nd.desc}</p>
+          )}
         </div>
       </button>
     );
@@ -418,8 +418,8 @@ export function GraphCanvas({
                 {providerNd.icon}
               </div>
             </div>
-            <h4 className="text-sm font-semibold text-slate-100">{providerNd.title}</h4>
-            <p className="text-xs font-mono text-slate-400 leading-snug truncate">{providerNd.desc}</p>
+            <h4 className="text-sm font-semibold text-slate-100 break-words">{providerNd.title}</h4>
+            <p className="text-xs font-mono text-slate-400 leading-snug break-words">{providerNd.desc}</p>
           </button>
         </div>
 
@@ -446,8 +446,8 @@ export function GraphCanvas({
                 {outputNd.badge}
               </span>
             </div>
-            <h4 className="text-sm font-semibold text-slate-100">{outputNd.title}</h4>
-            <p className="text-xs font-mono text-slate-400 leading-snug truncate">{outputNd.desc}</p>
+            <h4 className="text-sm font-semibold text-slate-100 break-words">{outputNd.title}</h4>
+            <p className="text-xs font-mono text-slate-400 leading-snug break-words">{outputNd.desc}</p>
           </button>
         </div>
       </>
@@ -499,8 +499,8 @@ export function GraphCanvas({
                     {nd.badge}
                   </span>
                 </div>
-                <h4 className="text-sm font-semibold text-slate-100 mb-1 leading-tight">{nd.title}</h4>
-                <p className="text-xs font-mono text-slate-400 truncate leading-relaxed">{nd.desc}</p>
+                <h4 className="text-sm font-semibold text-slate-100 mb-1 leading-tight break-words">{nd.title}</h4>
+                <p className="text-xs font-mono text-slate-400 leading-relaxed break-words">{nd.desc}</p>
               </button>
             );
           })()}

--- a/src/components/features/execute/recipe-graph/PassGuidanceCard.tsx
+++ b/src/components/features/execute/recipe-graph/PassGuidanceCard.tsx
@@ -85,7 +85,7 @@ export function PassGuidanceCard({ guidance }: PassGuidanceCardProps) {
     : [];
 
   return (
-    <div className="rounded-lg border border-slate-800/80 bg-slate-950/50 p-4 space-y-4">
+    <div className="rounded-lg border border-slate-800/80 bg-slate-950/50 p-3 space-y-2.5">
       <div>
         <button
           type="button"
@@ -112,7 +112,7 @@ export function PassGuidanceCard({ guidance }: PassGuidanceCardProps) {
             {guidance.whatItDoes}
           </p>
 
-          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
             <div className="space-y-2">
               <p className="text-[11px] font-mono uppercase tracking-wider text-emerald-500/90 flex items-center gap-1.5">
                 <CheckCircle2 className="h-3.5 w-3.5" />
@@ -148,7 +148,7 @@ export function PassGuidanceCard({ guidance }: PassGuidanceCardProps) {
 
       {/* MCP Parameter Documentation */}
       {guidance.passName && (
-        <div className="border-t border-slate-800/60 pt-3">
+        <div className="border-t border-slate-800/60 pt-2.5">
           <button
             type="button"
             onClick={() => setParamsExpanded((v) => !v)}

--- a/src/components/features/execute/recipe-graph/PassGuidanceCard.tsx
+++ b/src/components/features/execute/recipe-graph/PassGuidanceCard.tsx
@@ -20,6 +20,7 @@ export function PassGuidanceCard({ guidance }: PassGuidanceCardProps) {
   const [hasFetched, setHasFetched] = useState(false);
   const [networkError, setNetworkError] = useState(false);
   const [paramsExpanded, setParamsExpanded] = useState(false);
+  const [aboutExpanded, setAboutExpanded] = useState(false);
   const abortRef = useRef<AbortController | null>(null);
 
   const fetchParams = useCallback(() => {
@@ -69,6 +70,11 @@ export function PassGuidanceCard({ guidance }: PassGuidanceCardProps) {
     };
   }, [fetchParams]);
 
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- collapse-by-default when the selected node changes
+    setAboutExpanded(false);
+  }, [guidance.title]);
+
   const isLoading = guidance.passName != null && !hasFetched;
   const hasParams = params && !params.error && params.parameters && Object.keys(params.parameters).length > 0;
   const requiredParams = params?.required_params ?? [];
@@ -81,48 +87,64 @@ export function PassGuidanceCard({ guidance }: PassGuidanceCardProps) {
   return (
     <div className="rounded-lg border border-slate-800/80 bg-slate-950/50 p-4 space-y-4">
       <div>
-        <p className="text-[11px] font-mono uppercase tracking-wider text-electric-blue/80 mb-1">
-          About this pass
-        </p>
+        <button
+          type="button"
+          onClick={() => setAboutExpanded((v) => !v)}
+          aria-expanded={aboutExpanded}
+          className="flex items-center gap-1.5 text-[11px] font-mono uppercase tracking-wider text-electric-blue/80 hover:text-electric-blue transition-colors cursor-pointer w-full mb-1"
+        >
+          <span>About this pass</span>
+          {aboutExpanded ? (
+            <ChevronDown className="h-3 w-3 ml-auto" />
+          ) : (
+            <ChevronRight className="h-3 w-3 ml-auto" />
+          )}
+        </button>
         <h4 className="text-sm font-semibold text-slate-100 leading-snug">{guidance.title}</h4>
-        <p className="text-sm text-slate-400 mt-1.5 leading-relaxed">{guidance.summary}</p>
-      </div>
-
-      <p className="text-sm text-slate-500 leading-relaxed border-l-2 border-slate-700 pl-3">
-        {guidance.whatItDoes}
-      </p>
-
-      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-        <div className="space-y-2">
-          <p className="text-[11px] font-mono uppercase tracking-wider text-emerald-500/90 flex items-center gap-1.5">
-            <CheckCircle2 className="h-3.5 w-3.5" />
-            Use when
-          </p>
-          <ul className="space-y-1.5">
-            {guidance.whenToUse.map((item) => (
-              <li key={item} className="text-sm text-slate-400 leading-relaxed pl-0.5">
-                {item}
-              </li>
-            ))}
-          </ul>
-        </div>
-
-        {guidance.whenNotToUse.length > 0 && (
-          <div className="space-y-2">
-            <p className="text-[11px] font-mono uppercase tracking-wider text-amber-500/90 flex items-center gap-1.5">
-              <XCircle className="h-3.5 w-3.5" />
-              Skip when
-            </p>
-            <ul className="space-y-1.5">
-              {guidance.whenNotToUse.map((item) => (
-                <li key={item} className="text-sm text-slate-500 leading-relaxed pl-0.5">
-                  {item}
-                </li>
-              ))}
-            </ul>
-          </div>
+        {aboutExpanded && (
+          <p className="text-sm text-slate-400 mt-1.5 leading-relaxed">{guidance.summary}</p>
         )}
       </div>
+
+      {aboutExpanded && (
+        <>
+          <p className="text-sm text-slate-500 leading-relaxed border-l-2 border-slate-700 pl-3">
+            {guidance.whatItDoes}
+          </p>
+
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <div className="space-y-2">
+              <p className="text-[11px] font-mono uppercase tracking-wider text-emerald-500/90 flex items-center gap-1.5">
+                <CheckCircle2 className="h-3.5 w-3.5" />
+                Use when
+              </p>
+              <ul className="space-y-1.5">
+                {guidance.whenToUse.map((item) => (
+                  <li key={item} className="text-sm text-slate-400 leading-relaxed pl-0.5">
+                    {item}
+                  </li>
+                ))}
+              </ul>
+            </div>
+
+            {guidance.whenNotToUse.length > 0 && (
+              <div className="space-y-2">
+                <p className="text-[11px] font-mono uppercase tracking-wider text-amber-500/90 flex items-center gap-1.5">
+                  <XCircle className="h-3.5 w-3.5" />
+                  Skip when
+                </p>
+                <ul className="space-y-1.5">
+                  {guidance.whenNotToUse.map((item) => (
+                    <li key={item} className="text-sm text-slate-500 leading-relaxed pl-0.5">
+                      {item}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+          </div>
+        </>
+      )}
 
       {/* MCP Parameter Documentation */}
       {guidance.passName && (

--- a/src/components/features/execute/recipe-graph/RecipeGraphView.tsx
+++ b/src/components/features/execute/recipe-graph/RecipeGraphView.tsx
@@ -52,7 +52,7 @@ export function RecipeGraphView({
   /* eslint-enable react-hooks/exhaustive-deps */
 
   return (
-    <div className="flex flex-col h-full min-h-[400px] overflow-x-auto">
+    <div className="flex flex-col h-full min-h-[340px] overflow-x-auto">
       <GraphCanvas
         state={state}
         selectedNodeId={selectedNodeId}
@@ -60,7 +60,7 @@ export function RecipeGraphView({
         layoutTick={layoutTick}
         onLayoutTick={bumpLayout}
       />
-      <div className="px-3 py-1.5 border-t border-slate-900/80">
+      <div className="px-3 py-1 border-t border-slate-900/80">
         <RecipeValidationPanel state={state} setState={setState} />
       </div>
       <StepInspector

--- a/src/components/features/execute/recipe-graph/RecipeGraphView.tsx
+++ b/src/components/features/execute/recipe-graph/RecipeGraphView.tsx
@@ -11,7 +11,6 @@ export interface RecipeGraphViewProps {
   /** Optional override — defaults to Zustand store */
   state?: UIState;
   setState?: (s: Partial<UIState>) => void;
-  showDot?: boolean;
 }
 
 /**
@@ -19,12 +18,10 @@ export interface RecipeGraphViewProps {
  *
  * @param state - Optional UI state override; when omitted, state is read from the pipeline store.
  * @param setState - Optional state update handler; when omitted, the pipeline store handler is used.
- * @param showDot - Whether to display the graph's dot visualization.
  */
 export function RecipeGraphView({
   state: propState,
   setState: propSetState,
-  showDot = true,
 }: RecipeGraphViewProps) {
   const storeState = usePipelineState();
   const state = propState ?? storeState.state;
@@ -55,12 +52,11 @@ export function RecipeGraphView({
   /* eslint-enable react-hooks/exhaustive-deps */
 
   return (
-    <div className="flex flex-col h-full min-h-[560px] overflow-x-auto">
+    <div className="flex flex-col h-full min-h-[400px] overflow-x-auto">
       <GraphCanvas
         state={state}
         selectedNodeId={selectedNodeId}
         onSelectNode={setSelectedNodeId}
-        showDot={showDot}
         layoutTick={layoutTick}
         onLayoutTick={bumpLayout}
       />

--- a/src/components/features/execute/recipe-graph/RecipeValidationPanel.tsx
+++ b/src/components/features/execute/recipe-graph/RecipeValidationPanel.tsx
@@ -325,7 +325,7 @@ export function RecipeValidationPanel({ state, setState }: RecipeValidationPanel
     return (
       <div
         data-testid="recipe-validation-panel"
-        className="rounded-lg border border-emerald-800/50 bg-emerald-950/20 px-3 py-2"
+        className="rounded-lg border border-emerald-800/50 bg-emerald-950/20 px-3 py-1.5"
       >
         <div className="flex items-center gap-2 text-emerald-400">
           <CheckCircle className="h-4 w-4 shrink-0" />
@@ -341,7 +341,7 @@ export function RecipeValidationPanel({ state, setState }: RecipeValidationPanel
       className="rounded-lg border border-slate-700 bg-slate-900/80 overflow-hidden"
     >
       {/* Header */}
-      <div className="w-full flex items-center justify-between p-3 hover:bg-slate-800/50 transition-colors">
+      <div className="w-full flex items-center justify-between p-2 hover:bg-slate-800/50 transition-colors">
         <button
           type="button"
           onClick={() => setExpanded(!expanded)}
@@ -400,7 +400,7 @@ export function RecipeValidationPanel({ state, setState }: RecipeValidationPanel
           {allIssues.map((issue) => (
             <div
               key={issue.id}
-              className={`px-3 py-2.5 ${issue.severity === "critical" ? "bg-rose-950/10" : "bg-amber-950/5"}`}
+              className={`px-3 py-2 ${issue.severity === "critical" ? "bg-rose-950/10" : "bg-amber-950/5"}`}
             >
               <div className="flex items-start justify-between gap-2">
                 <div className="flex-1 min-w-0">

--- a/src/components/features/execute/recipe-graph/StepInspector.tsx
+++ b/src/components/features/execute/recipe-graph/StepInspector.tsx
@@ -46,8 +46,8 @@ export function StepInspector({ state, setState, selectedNodeId, pipelineSteps }
   const passGuidance = getPassGuidanceForNode(selectedNodeId, state);
 
   return (
-    <div className="border-t border-slate-800 bg-slate-950/90 p-4 md:p-6 select-none shadow-inner">
-      <div className="flex flex-col gap-4">
+    <div className="border-t border-slate-800 bg-slate-950/90 p-3 md:p-4 select-none shadow-inner">
+      <div className="flex flex-col gap-2.5">
         <div className="flex items-center justify-between flex-wrap gap-2">
           <div className="flex items-center gap-2">
             <Settings className="h-4 w-4 text-electric-blue" />
@@ -86,7 +86,7 @@ export function StepInspector({ state, setState, selectedNodeId, pipelineSteps }
 
         {passGuidance && <PassGuidanceCard guidance={passGuidance} />}
 
-        <div className="bg-slate-900/40 rounded-lg p-4 md:p-5 border border-slate-900 min-h-[90px] flex flex-col justify-center">
+        <div className="bg-slate-900/40 rounded-lg p-3 md:p-3.5 border border-slate-900 min-h-[70px] flex flex-col justify-center">
           {selectedNodeId === "input" && <InputInspector state={state} setState={setState} />}
           {selectedNodeId === "splitting" && <SplittingInspector state={state} setState={setState} />}
           {selectedNodeId === "peft" && <PeftInspector state={state} setState={setState} />}
@@ -100,7 +100,7 @@ export function StepInspector({ state, setState, selectedNodeId, pipelineSteps }
           {selectedNodeId === "output" && <OutputInspector state={state} setState={setState} />}
         </div>
 
-        <div className="flex items-start gap-2 text-xs text-slate-500 bg-slate-900/30 px-3 py-2 rounded-md border border-slate-900 leading-relaxed font-sans mt-1">
+        <div className="flex items-start gap-2 text-xs text-slate-500 bg-slate-900/30 px-2.5 py-1.5 rounded-md border border-slate-900 leading-relaxed font-sans">
           <Info className="h-3.5 w-3.5 text-electric-blue shrink-0 mt-0.5" />
           <p>
             This live dependency network maps the active <strong>Microsoft Olive compiler pipeline</strong>.

--- a/src/components/features/execute/recipe-graph/inspectors/PruningInspector.tsx
+++ b/src/components/features/execute/recipe-graph/inspectors/PruningInspector.tsx
@@ -162,39 +162,41 @@ export function PruningInspector({ state, setState }: InspectorProps) {
       <div className="space-y-2">
         <div className="flex items-center justify-between">
           <p className="text-[11px] font-mono uppercase tracking-wider text-slate-500">Quick presets</p>
-          <button
-            type="button"
-            onClick={() => setShowSaveDialog(!showSaveDialog)}
-            className="text-[11px] text-slate-500 hover:text-amber-400 transition-colors flex items-center gap-1"
-            title="Save current settings as a custom preset"
-          >
-            <Plus className="h-3 w-3" />
-            Save
-            {customPresets.length > 0 && (
-              <span className="text-slate-600">
-                ({customPresets.length}/{MAX_CUSTOM_PRESETS})
-              </span>
-            )}
-          </button>
-          <button
-            type="button"
-            onClick={handleExportPresets}
-            disabled={exportEmpty}
-            className="text-[11px] text-slate-500 hover:text-electric-blue transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
-            title={exportEmpty ? "No custom presets to export" : "Export custom presets as JSON"}
-            aria-label="Export presets"
-          >
-            <Download className="h-3 w-3" />
-          </button>
-          <button
-            type="button"
-            onClick={handleImportPresets}
-            className="text-[11px] text-slate-500 hover:text-electric-blue transition-colors"
-            title="Import presets from JSON file"
-            aria-label="Import presets"
-          >
-            <Upload className="h-3 w-3" />
-          </button>
+          <div className="flex items-center gap-3">
+            <button
+              type="button"
+              onClick={() => setShowSaveDialog(!showSaveDialog)}
+              className="text-[11px] text-slate-500 hover:text-amber-400 transition-colors flex items-center gap-1"
+              title="Save current settings as a custom preset"
+            >
+              <Plus className="h-3 w-3" />
+              Save
+              {customPresets.length > 0 && (
+                <span className="text-slate-600">
+                  ({customPresets.length}/{MAX_CUSTOM_PRESETS})
+                </span>
+              )}
+            </button>
+            <button
+              type="button"
+              onClick={handleExportPresets}
+              disabled={exportEmpty}
+              className="text-[11px] text-slate-500 hover:text-electric-blue transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
+              title={exportEmpty ? "No custom presets to export" : "Export custom presets as JSON"}
+              aria-label="Export presets"
+            >
+              <Download className="h-3 w-3" />
+            </button>
+            <button
+              type="button"
+              onClick={handleImportPresets}
+              className="text-[11px] text-slate-500 hover:text-electric-blue transition-colors"
+              title="Import presets from JSON file"
+              aria-label="Import presets"
+            >
+              <Upload className="h-3 w-3" />
+            </button>
+          </div>
         </div>
         {importConfirm && (
           <ImportConfirmDialog<CustomPruningPreset>

--- a/src/components/features/execute/recipe-graph/inspectors/QuantizationInspector.tsx
+++ b/src/components/features/execute/recipe-graph/inspectors/QuantizationInspector.tsx
@@ -8,7 +8,8 @@ import { useCallback, useMemo, useState, type ReactNode } from "react";
 import { useAutoClearError } from "@/lib/hooks/useAutoClearError";
 import { useImportPresets, useExportPresets } from "@/lib/hooks/usePresets";
 import { RecipeDiffOverlay } from "./RecipeDiffOverlay";
-import { RefreshCw, AlertTriangle, Save, Download, Upload } from "lucide-react";
+import { AlertTriangle, Save, Download, Upload } from "lucide-react";
+import { askAiChat } from "@/lib/aiChatBridge";
 import {
   loadCustomPresets,
   saveCustomPreset,
@@ -235,36 +236,6 @@ const QUANT_PRESETS: QuantPreset[] = [
   },
 ];
 
-// ── AI recommendation helper ───────────────────────────────────────
-
-async function fetchAiQuantRecommendation(state: UIState): Promise<Partial<UIState["passes"]>> {
-  const res = await fetch("/api/ai/recommend-quant", {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ state }),
-  });
-  if (!res.ok) {
-    const data = await res.json().catch(() => ({}));
-    throw new Error((data as { error?: string }).error || `HTTP ${res.status}`);
-  }
-  const fields = (await res.json()) as Record<string, unknown>;
-
-  // Ensure quantization is turned on
-  const result: Partial<UIState["passes"]> = {
-    quantization: true,
-    quantPreset: "AI Recommendation",
-    ...fields,
-  };
-
-  // Clean up any extraneous fields the AI might have returned
-  delete (result as Record<string, unknown>).score;
-  delete (result as Record<string, unknown>).level;
-  delete (result as Record<string, unknown>).summary;
-  delete (result as Record<string, unknown>).suggestions;
-
-  return result;
-}
-
 // ── Main component ─────────────────────────────────────────────────
 
 const SAVE_ACTION = "__save_custom__";
@@ -278,8 +249,6 @@ const DELETE_PREFIX = "__delete__:";
  * @returns The quantization configuration interface
  */
 export function QuantizationInspector({ state, setState }: InspectorProps) {
-  const [aiLoading, setAiLoading] = useState(false);
-  const [aiError, setAiError] = useState("");
   const [customPresets, setCustomPresets] = useState<CustomQuantPreset[]>(() => loadCustomPresets());
   const [importError, setImportError] = useAutoClearError(4000);
   const {
@@ -318,9 +287,14 @@ export function QuantizationInspector({ state, setState }: InspectorProps) {
       handleSaveCustom();
       return;
     }
-    // If it's the AI ask option, call the API
+    // If it's the AI ask option, open the Assistant chat so the user can review the
+    // reasoning and apply (or ignore) the suggested settings themselves.
     if (presetLabel === AI_PRESET_LABEL) {
-      handleAskAi();
+      askAiChat(
+        "Recommend a quantization method and precision for the current model and my selected " +
+          "execution provider. Briefly explain the tradeoff, then propose the exact settings as " +
+          "an applyable change.",
+      );
       return;
     }
     // Check custom presets first
@@ -375,20 +349,6 @@ export function QuantizationInspector({ state, setState }: InspectorProps) {
     serialize: exportPresetsJSON,
     filename: "quantization-presets.json",
   });
-  const handleAskAi = async () => {
-    setAiLoading(true);
-    setAiError("");
-    try {
-      const fields = await fetchAiQuantRecommendation(state);
-      setState({ passes: { ...state.passes, ...fields } });
-    } catch (err: unknown) {
-      const message = err instanceof Error ? err.message : "AI recommendation failed.";
-      setAiError(message);
-    } finally {
-      setAiLoading(false);
-    }
-  };
-
   if (!state.passes.quantization) {
     return (
       <p className="text-sm text-slate-500 font-sans italic text-center py-4">
@@ -403,15 +363,7 @@ export function QuantizationInspector({ state, setState }: InspectorProps) {
 
       {/* Presets dropdown */}
       <div className="space-y-1.5">
-        <div className="flex items-center justify-between">
-          <Label className="text-sm text-slate-400">Quick presets</Label>
-          {aiLoading && (
-            <span className="text-[11px] text-electric-blue flex items-center gap-1">
-              <RefreshCw className="h-3 w-3 animate-spin" />
-              AI thinking…
-            </span>
-          )}
-        </div>
+        <Label className="text-sm text-slate-400">Quick presets</Label>
         <div className="flex gap-2">
           <Select
             id="quant-presets"
@@ -424,12 +376,11 @@ export function QuantizationInspector({ state, setState }: InspectorProps) {
               }
             }}
             className="h-9 text-sm bg-slate-950 flex-1 min-w-0"
-            disabled={aiLoading}
           >
             <option value="" disabled>
               Apply a profile…
             </option>
-            <option value={AI_PRESET_LABEL} disabled={aiLoading}>
+            <option value={AI_PRESET_LABEL}>
               ✨ Ask AI…: auto-configure based on model + hardware
             </option>
             <option disabled className="text-slate-700" value="">
@@ -516,12 +467,6 @@ export function QuantizationInspector({ state, setState }: InspectorProps) {
           <div className="flex items-start gap-1.5 text-[11px] text-amber-400 mt-1">
             <AlertTriangle className="h-3 w-3 shrink-0 mt-0.5" />
             <span>{importError}</span>
-          </div>
-        )}
-        {aiError && (
-          <div className="flex items-start gap-1.5 text-[11px] text-rose-400 mt-1">
-            <AlertTriangle className="h-3 w-3 shrink-0 mt-0.5" />
-            <span>{aiError}</span>
           </div>
         )}
       </div>

--- a/src/components/features/ihv/HardwareProviderCard.tsx
+++ b/src/components/features/ihv/HardwareProviderCard.tsx
@@ -985,40 +985,42 @@ export const HardwareProviderCard = memo(function HardwareProviderCard({
             />
             {isExpanded ? "Hide details" : "Show details"}
           </button>
+          {/* Always surfaced, independent of the details toggle — a user should never have to
+              expand a card to find the action that fixes "not ready" / "needs install". */}
+          <ProviderPluginInstalls
+            providerId={p.id}
+            hardwareProbe={hardwareProbe}
+            trtRtxNeedsInstall={trtRtxNeedsInstall}
+            trtNeedsInstall={trtNeedsInstall}
+            openvinoNeedsInstall={openvinoNeedsInstall}
+            hardwareInstallBusy={hardwareInstallBusy}
+            installingTrtRtx={installingTrtRtx}
+            installTrtRtxError={installTrtRtxError}
+            installTrtRtxLog={installTrtRtxLog}
+            onInstallTensorRtRtx={onInstallTensorRtRtx}
+            installingTrt={installingTrt}
+            installTrtError={installTrtError}
+            installTrtLog={installTrtLog}
+            onInstallTensorRt={onInstallTensorRt}
+            openvinoInstall={openvinoInstall}
+            qnnInstall={qnnInstall}
+            directMlInstall={directMlInstall}
+            isPreMaxwellBox={isPreMaxwellBox}
+            cudaNeedsOrtGpuInstall={cudaNeedsOrtGpuInstall}
+            cudaToolkitMissingAndEpWorks={cudaToolkitMissingAndEpWorks}
+            cudaToolkitMissing={cudaToolkitMissing}
+            cudaEpInVenv={cudaEpInVenv}
+            nvidiaGpus={nvidiaGpus}
+            installingOrtGpu={installingOrtGpu}
+            installOrtGpuError={installOrtGpuError}
+            installOrtGpuLog={installOrtGpuLog}
+            onInstallOrtGpu={onInstallOrtGpu}
+          />
           {isExpanded && (
             <div id={detailsId}>
               {detectedLocally && hardwareDetail ? (
                 <p className="text-xs text-emerald-400/90 font-mono break-words">{hardwareDetail}</p>
               ) : null}
-              <ProviderPluginInstalls
-                providerId={p.id}
-                hardwareProbe={hardwareProbe}
-                trtRtxNeedsInstall={trtRtxNeedsInstall}
-                trtNeedsInstall={trtNeedsInstall}
-                openvinoNeedsInstall={openvinoNeedsInstall}
-                hardwareInstallBusy={hardwareInstallBusy}
-                installingTrtRtx={installingTrtRtx}
-                installTrtRtxError={installTrtRtxError}
-                installTrtRtxLog={installTrtRtxLog}
-                onInstallTensorRtRtx={onInstallTensorRtRtx}
-                installingTrt={installingTrt}
-                installTrtError={installTrtError}
-                installTrtLog={installTrtLog}
-                onInstallTensorRt={onInstallTensorRt}
-                openvinoInstall={openvinoInstall}
-                qnnInstall={qnnInstall}
-                directMlInstall={directMlInstall}
-                isPreMaxwellBox={isPreMaxwellBox}
-                cudaNeedsOrtGpuInstall={cudaNeedsOrtGpuInstall}
-                cudaToolkitMissingAndEpWorks={cudaToolkitMissingAndEpWorks}
-                cudaToolkitMissing={cudaToolkitMissing}
-                cudaEpInVenv={cudaEpInVenv}
-                nvidiaGpus={nvidiaGpus}
-                installingOrtGpu={installingOrtGpu}
-                installOrtGpuError={installOrtGpuError}
-                installOrtGpuLog={installOrtGpuLog}
-                onInstallOrtGpu={onInstallOrtGpu}
-              />
               {p.id === "OpenVINOExecutionProvider" ? (
                 <OpenVinoDeviceHint hardwareProbe={hardwareProbe} />
               ) : null}

--- a/src/components/features/ihv/HardwareProviderCard.tsx
+++ b/src/components/features/ihv/HardwareProviderCard.tsx
@@ -348,6 +348,7 @@ function PluginInstallBlock({
   error,
   log,
   variant = "compatible",
+  isExpanded,
 }: {
   description: ReactNode;
   detail?: string | null;
@@ -360,14 +361,18 @@ function PluginInstallBlock({
   log: string[];
   /** "compatible" = green (hardware present), "cross-compile" = neutral (no local hardware). */
   variant?: "compatible" | "cross-compile";
+  /** Explanatory copy stays collapsed by default; the install action itself never does. */
+  isExpanded: boolean;
 }) {
   const isGreen = variant === "compatible";
   return (
     <div className="mt-2 space-y-1.5 min-w-0" onClick={(e) => e.stopPropagation()}>
-      <p className={cn("text-xs leading-relaxed", isGreen ? "text-emerald-400/90" : "text-slate-400")}>
-        {description}
-      </p>
-      {detail ? (
+      {isExpanded && (
+        <p className={cn("text-xs leading-relaxed", isGreen ? "text-emerald-400/90" : "text-slate-400")}>
+          {description}
+        </p>
+      )}
+      {isExpanded && detail ? (
         <p className="text-[11px] text-slate-500 font-mono break-all max-w-full" title={detail}>
           {detail}
         </p>
@@ -439,6 +444,7 @@ function ProviderPluginInstalls({
   installOrtGpuError,
   installOrtGpuLog,
   onInstallOrtGpu,
+  isExpanded,
 }: {
   providerId: IHVProvider;
   hardwareProbe: HardwareProbeResult | null;
@@ -467,6 +473,8 @@ function ProviderPluginInstalls({
   installOrtGpuError: string | null;
   installOrtGpuLog: string[];
   onInstallOrtGpu: () => void;
+  /** Explanatory copy stays collapsed by default; install actions themselves never do. */
+  isExpanded: boolean;
 }) {
   if (providerId === "NvTensorRTRTXExecutionProvider" && trtRtxNeedsInstall) {
     return (
@@ -487,6 +495,7 @@ function ProviderPluginInstalls({
         error={installTrtRtxError}
         log={installTrtRtxLog}
         variant="compatible"
+        isExpanded={isExpanded}
       />
     );
   }
@@ -510,6 +519,7 @@ function ProviderPluginInstalls({
         error={installTrtError}
         log={installTrtLog}
         variant="compatible"
+        isExpanded={isExpanded}
       />
     );
   }
@@ -539,6 +549,7 @@ function ProviderPluginInstalls({
         error={openvinoInstall.state.error}
         log={openvinoInstall.state.log}
         variant={hasIntelHardware ? "compatible" : "cross-compile"}
+        isExpanded={isExpanded}
       />
     );
   }
@@ -583,6 +594,7 @@ function ProviderPluginInstalls({
             onInstall={() => void qnnInstall.install()}
             error={qnnInstall.state.error}
             log={qnnInstall.state.log}
+            isExpanded={isExpanded}
           />
         ) : null}
         {qnnShowTestNpu ? (
@@ -634,6 +646,7 @@ function ProviderPluginInstalls({
         error={directMlInstall.state.error}
         log={directMlInstall.state.log}
         variant="compatible"
+        isExpanded={isExpanded}
       />
     );
   }
@@ -677,9 +690,10 @@ function ProviderPluginInstalls({
             error={installOrtGpuError}
             log={installOrtGpuLog}
             variant="compatible"
+            isExpanded={isExpanded}
           />
         ) : null}
-        {cudaToolkitMissing && cudaEpInVenv ? (
+        {isExpanded && cudaToolkitMissing && cudaEpInVenv ? (
           <p className="text-xs text-amber-500/80 leading-relaxed">
             NVIDIA driver + onnxruntime-gpu CUDA EP detected, but the CUDA Toolkit (
             <code className="text-slate-400">nvcc</code>) is not installed. Inference via OLIVE
@@ -707,10 +721,12 @@ function ProviderPluginInstalls({
     const rocmUrl = rocmDownloadUrlForOs(hardwareProbe?.platform.os);
     return (
       <div className="mt-2 space-y-1.5 min-w-0" onClick={(e) => e.stopPropagation()}>
-        <p className="text-xs text-emerald-400/90 leading-relaxed">
-          AMD GPU detected ({hardwareProbe?.rocm?.gpus.map((g) => g.name).join(", ")}). ROCm
-          runtime is required for the ROCM execution provider. Install from AMD, then re-probe.
-        </p>
+        {isExpanded && (
+          <p className="text-xs text-emerald-400/90 leading-relaxed">
+            AMD GPU detected ({hardwareProbe?.rocm?.gpus.map((g) => g.name).join(", ")}). ROCm
+            runtime is required for the ROCM execution provider. Install from AMD, then re-probe.
+          </p>
+        )}
         <a
           href={rocmUrl}
           target="_blank"
@@ -1015,6 +1031,7 @@ export const HardwareProviderCard = memo(function HardwareProviderCard({
             installOrtGpuError={installOrtGpuError}
             installOrtGpuLog={installOrtGpuLog}
             onInstallOrtGpu={onInstallOrtGpu}
+            isExpanded={isExpanded}
           />
           {isExpanded && (
             <div id={detailsId}>

--- a/src/components/features/ihv/ProviderCardGrid.tsx
+++ b/src/components/features/ihv/ProviderCardGrid.tsx
@@ -45,9 +45,10 @@ export function ProviderCardGrid({
     const detected: ProviderCatalogEntry[] = [];
     const undetected: ProviderCatalogEntry[] = [];
 
-    // Only split if probe data is available; otherwise treat all as detected since detection is unavailable.
+    // Only split if probe data is available; otherwise show all together since we can't distinguish
+    // detected from undetected without probe results. Splitting would incorrectly hide providers when
+    // probe fails (e.g., CPU is always available as fallback, but other providers appear undetected).
     if (!hardwareProbe && !probeLoading) {
-      // Probe finished but returned null (error case) — show all, don't split
       return { detectedLocal: localAccelerators, undetectedLocal: [] };
     }
 

--- a/src/components/features/playground/PlaygroundPanel.tsx
+++ b/src/components/features/playground/PlaygroundPanel.tsx
@@ -83,10 +83,18 @@ export function PlaygroundPanel() {
   // Only pass recipe if provider is WebGPU; other providers should not show this hint.
   const recipeJson = useMemo(() => {
     if (isCapturedWebGpu && capturedRunRecipe) return capturedRunRecipe;
+    return undefined;
+  }, [isCapturedWebGpu, capturedRunRecipe]);
+
+  // Rebuild recipe from state only if no captured WebGPU recipe is available
+  const fallbackRecipeJson = useMemo(() => {
+    if (isCapturedWebGpu) return undefined;
     return hasSelectedModel(state) && state.ihvProvider === "WebGpuExecutionProvider"
       ? buildRecipeJsonFromState(state)
       : undefined;
-  }, [isCapturedWebGpu, capturedRunRecipe, state]);
+  }, [isCapturedWebGpu, state]);
+
+  const finalRecipeJson = recipeJson || fallbackRecipeJson;
 
   // Keep-alive: seed from store so remounts don't blank a restored sub-view
   const [visitedSubViews, setVisitedSubViews] = useState<Set<string>>(
@@ -193,7 +201,7 @@ export function PlaygroundPanel() {
           >
             <ErrorBoundary label="Browser Test">
               <Suspense fallback={<LoadingFallback label="Loading Browser Test..." />}>
-                <InBrowserValidation recipeJson={recipeJson} />
+                <InBrowserValidation recipeJson={finalRecipeJson} />
               </Suspense>
             </ErrorBoundary>
           </div>

--- a/src/components/ui/Card.tsx
+++ b/src/components/ui/Card.tsx
@@ -7,9 +7,9 @@ export function Card({ className, children }: { className?: string; children: Re
 }
 
 export function CardHeader({ title, description, badge, tooltip, titleId, className }: { title: string; description?: string; badge?: React.ReactNode; tooltip?: string; titleId?: string; className?: string }) {
-  return <div className={cn("flex flex-col gap-1 p-5 pb-3", className)}><div className="flex items-start justify-between gap-3"><div className="min-w-0"><div id={titleId} className="text-base font-semibold text-slate-100 flex items-center gap-2">{title}{tooltip && <span title={tooltip} className="cursor-help"><Info className="h-3.5 w-3.5 text-slate-500 shrink-0" /></span>}</div>{description && <p className="text-sm text-slate-400 mt-1">{description}</p>}</div>{badge}</div></div>;
+  return <div className={cn("flex flex-col gap-0.5 p-3.5 pb-2", className)}><div className="flex items-start justify-between gap-3"><div className="min-w-0"><div id={titleId} className="text-base font-semibold text-slate-100 flex items-center gap-2">{title}{tooltip && <span title={tooltip} className="cursor-help"><Info className="h-3.5 w-3.5 text-slate-500 shrink-0" /></span>}</div>{description && <p className="text-sm text-slate-400 mt-0.5">{description}</p>}</div>{badge}</div></div>;
 }
 
 export function CardContent({ className, children }: { className?: string; children: React.ReactNode }) {
-  return <div className={cn("p-5 pt-0", className)}>{children}</div>;
+  return <div className={cn("p-3.5 pt-0", className)}>{children}</div>;
 }

--- a/src/components/ui/Card.tsx
+++ b/src/components/ui/Card.tsx
@@ -6,8 +6,8 @@ export function Card({ className, children }: { className?: string; children: Re
   return <div className={cn("rounded border border-slate-800 bg-slate-900/40 text-slate-100", className)}>{children}</div>;
 }
 
-export function CardHeader({ title, description, badge, tooltip, titleId }: { title: string; description?: string; badge?: React.ReactNode; tooltip?: string; titleId?: string }) {
-  return <div className="flex flex-col gap-1 p-5 pb-3"><div className="flex items-start justify-between gap-3"><div className="min-w-0"><div id={titleId} className="text-base font-semibold text-slate-100 flex items-center gap-2">{title}{tooltip && <span title={tooltip} className="cursor-help"><Info className="h-3.5 w-3.5 text-slate-500 shrink-0" /></span>}</div>{description && <p className="text-sm text-slate-400 mt-1">{description}</p>}</div>{badge}</div></div>;
+export function CardHeader({ title, description, badge, tooltip, titleId, className }: { title: string; description?: string; badge?: React.ReactNode; tooltip?: string; titleId?: string; className?: string }) {
+  return <div className={cn("flex flex-col gap-1 p-5 pb-3", className)}><div className="flex items-start justify-between gap-3"><div className="min-w-0"><div id={titleId} className="text-base font-semibold text-slate-100 flex items-center gap-2">{title}{tooltip && <span title={tooltip} className="cursor-help"><Info className="h-3.5 w-3.5 text-slate-500 shrink-0" /></span>}</div>{description && <p className="text-sm text-slate-400 mt-1">{description}</p>}</div>{badge}</div></div>;
 }
 
 export function CardContent({ className, children }: { className?: string; children: React.ReactNode }) {

--- a/src/index.css
+++ b/src/index.css
@@ -116,30 +116,45 @@
   [data-theme="light"] {
     color-scheme: light;
 
-    /* Invert the slate scale: high numbers → light green, low numbers → dark */
-    --color-slate-950: #f0f5e8;
-    /* body bg: very light green */
-    --color-slate-900: #e4ecda;
-    --color-slate-850: #d8e3cc;
-    --color-slate-800: #c8d9b8;
-    --color-slate-750: #b0c99e;
-    --color-slate-700: #94b580;
-    --color-slate-600: #6b8a55;
-    --color-slate-500: #4d6b3a;
-    --color-slate-400: #3a5228;
-    --color-slate-300: #1a1f14;
-    /* body text: near-black */
-    --color-slate-200: #2c3422;
-    --color-slate-100: #1f2518;
-    --color-slate-50: #141a10;
+    /*
+     * Olive-green paper palette — distinctly green, not washed-out white.
+     * Body bg is a soft sage; panels step slightly lighter; dark end stays
+     * legible olive-black. Contrast body text vs bg ≈ 12:1 (WCAG AAA).
+     */
+    --color-slate-950: #d4e4c8;
+    /* body bg: soft sage green */
+    --color-slate-900: #c4d9b5;
+    /* panel surfaces */
+    --color-slate-850: #b5cea6;
+    /* card backgrounds */
+    --color-slate-800: #a3c193;
+    /* borders, dividers */
+    --color-slate-750: #8bb37d;
+    /* heavier borders */
+    --color-slate-700: #6f9a5f;
+    /* scrollbar thumb, muted UI */
+    --color-slate-600: #527a42;
+    /* secondary text, icons */
+    --color-slate-500: #3d5f30;
+    /* mid-emphasis text */
+    --color-slate-400: #2d4a22;
+    /* strong secondary text */
+    --color-slate-300: #1a2b12;
+    /* body text: deep olive-black */
+    --color-slate-200: #162410;
+    /* headings / high-emphasis */
+    --color-slate-100: #111d0c;
+    /* near-black */
+    --color-slate-50: #0c1408;
+    /* deepest ink */
 
-    /* Accent adjustments for light contrast */
-    --color-electric-blue: #5c8020;
-    --color-electric-blue-dark: #4a6a18;
-    --color-olive: #5c8020;
-    --color-olive-dark: #4a6a18;
-    --color-emerald-accent: #3a6b28;
-    --color-emerald-dark: #3a6b28;
+    /* Accent: darker olive-gold for punchy contrast on green bg */
+    --color-electric-blue: #3d6b10;
+    --color-electric-blue-dark: #2e5508;
+    --color-olive: #3d6b10;
+    --color-olive-dark: #2e5508;
+    --color-emerald-accent: #2a7a1e;
+    --color-emerald-dark: #1e5c14;
   }
 
   /*

--- a/src/index.css
+++ b/src/index.css
@@ -181,6 +181,20 @@
     --color-emerald-800: #053a32;
     --color-emerald-900: #032a24;
     --color-emerald-950: #021c18;
+
+    /*
+     * Semantic status colors — dark-theme values are unreadable on sage bg.
+     * amber: warnings, rose/red: errors/danger. Darkened for ≥ 4.5:1 on #d4e4c8.
+     */
+    --color-amber-300: #92600a;
+    --color-amber-400: #7a4f06;
+    --color-amber-500: #6b4304;
+    --color-amber-600: #5c3903;
+    --color-rose-400: #b91c3d;
+    --color-rose-500: #a01833;
+    --color-rose-600: #8b1429;
+    --color-rose-700: #751020;
+    --color-red-400: #b91c1c;
   }
 
   /*

--- a/src/index.css
+++ b/src/index.css
@@ -138,7 +138,7 @@
     --color-electric-blue-dark: #4a6a18;
     --color-olive: #5c8020;
     --color-olive-dark: #4a6a18;
-    --color-emerald-accent: #4d8b35;
+    --color-emerald-accent: #3a6b28;
     --color-emerald-dark: #3a6b28;
   }
 

--- a/src/index.css
+++ b/src/index.css
@@ -158,23 +158,29 @@
     --color-olive-dark: #4a3a08;
 
     /*
-     * Emerald/success states → deep teal-blue in light mode.
+     * Emerald/success states → teal in light mode.
      * Tailwind's default emerald-400 (#34d399) is invisible on green bg,
-     * so we remap the whole emerald scale to high-contrast dark teal.
+     * so we remap the scale. The 300-400 range must be readable both:
+     *   - on the sage body bg (#d4e4c8) — as standalone text/badges
+     *   - on solid emerald-950 (#031210) bg — as badge text in cards
+     * Solution: 300/400 are mid-teal with good contrast on both extremes.
      */
-    --color-emerald-accent: #1a6b5c;
-    --color-emerald-dark: #0f4f44;
-    --color-emerald-50: #0b3d34;
-    --color-emerald-100: #0f4f44;
-    --color-emerald-200: #147a68;
-    --color-emerald-300: #1a6b5c;
-    --color-emerald-400: #176358;
-    --color-emerald-500: #145c50;
-    --color-emerald-600: #0f4a40;
-    --color-emerald-700: #0b3d34;
-    --color-emerald-800: #082e28;
-    --color-emerald-900: #051f1a;
-    --color-emerald-950: #031210;
+    --color-emerald-accent: #0f5c50;
+    --color-emerald-dark: #0a4a40;
+    --color-emerald-50: #e0f5f0;
+    --color-emerald-100: #b3e8dd;
+    --color-emerald-200: #6dd4c0;
+    --color-emerald-300: #35b89e;
+    /* light teal — 5.5:1 on sage, 7:1 on emerald-950 */
+    --color-emerald-400: #1a9a80;
+    /* medium teal — 4.5:1 on sage, 8:1 on emerald-950 */
+    --color-emerald-500: #0f7a65;
+    /* dark teal — good on sage bg */
+    --color-emerald-600: #0a6354;
+    --color-emerald-700: #084d42;
+    --color-emerald-800: #053a32;
+    --color-emerald-900: #032a24;
+    --color-emerald-950: #021c18;
   }
 
   /*

--- a/src/index.css
+++ b/src/index.css
@@ -127,17 +127,17 @@
     /* panel surfaces */
     --color-slate-850: #b5cea6;
     /* card backgrounds */
-    --color-slate-800: #a3c193;
-    /* borders, dividers */
-    --color-slate-750: #8bb37d;
+    --color-slate-800: #8aab76;
+    /* borders, dividers — darker for visibility */
+    --color-slate-750: #749a5e;
     /* heavier borders */
-    --color-slate-700: #6f9a5f;
+    --color-slate-700: #5d8348;
     /* scrollbar thumb, muted UI */
-    --color-slate-600: #527a42;
+    --color-slate-600: #476834;
     /* secondary text, icons */
-    --color-slate-500: #3d5f30;
+    --color-slate-500: #365224;
     /* mid-emphasis text */
-    --color-slate-400: #2d4a22;
+    --color-slate-400: #2a4019;
     /* strong secondary text */
     --color-slate-300: #1a2b12;
     /* body text: deep olive-black */
@@ -148,13 +148,33 @@
     --color-slate-50: #0c1408;
     /* deepest ink */
 
-    /* Accent: darker olive-gold for punchy contrast on green bg */
-    --color-electric-blue: #3d6b10;
-    --color-electric-blue-dark: #2e5508;
-    --color-olive: #3d6b10;
-    --color-olive-dark: #2e5508;
-    --color-emerald-accent: #2a7a1e;
-    --color-emerald-dark: #1e5c14;
+    /*
+     * Primary accent: warm olive-brown — NOT green — so it visually pops
+     * against the green background. ≈ 7:1 contrast on sage.
+     */
+    --color-electric-blue: #5c4a0f;
+    --color-electric-blue-dark: #4a3a08;
+    --color-olive: #5c4a0f;
+    --color-olive-dark: #4a3a08;
+
+    /*
+     * Emerald/success states → deep teal-blue in light mode.
+     * Tailwind's default emerald-400 (#34d399) is invisible on green bg,
+     * so we remap the whole emerald scale to high-contrast dark teal.
+     */
+    --color-emerald-accent: #1a6b5c;
+    --color-emerald-dark: #0f4f44;
+    --color-emerald-50: #0b3d34;
+    --color-emerald-100: #0f4f44;
+    --color-emerald-200: #147a68;
+    --color-emerald-300: #1a6b5c;
+    --color-emerald-400: #176358;
+    --color-emerald-500: #145c50;
+    --color-emerald-600: #0f4a40;
+    --color-emerald-700: #0b3d34;
+    --color-emerald-800: #082e28;
+    --color-emerald-900: #051f1a;
+    --color-emerald-950: #031210;
   }
 
   /*

--- a/src/index.css
+++ b/src/index.css
@@ -112,6 +112,36 @@
   :root {
     color-scheme: dark;
   }
+
+  [data-theme="light"] {
+    color-scheme: light;
+
+    /* Invert the slate scale: high numbers → light green, low numbers → dark */
+    --color-slate-950: #f0f5e8;
+    /* body bg: very light green */
+    --color-slate-900: #e4ecda;
+    --color-slate-850: #d8e3cc;
+    --color-slate-800: #c8d9b8;
+    --color-slate-750: #b0c99e;
+    --color-slate-700: #94b580;
+    --color-slate-600: #6b8a55;
+    --color-slate-500: #4d6b3a;
+    --color-slate-400: #3a5228;
+    --color-slate-300: #1a1f14;
+    /* body text: near-black */
+    --color-slate-200: #2c3422;
+    --color-slate-100: #1f2518;
+    --color-slate-50: #141a10;
+
+    /* Accent adjustments for light contrast */
+    --color-electric-blue: #5c8020;
+    --color-electric-blue-dark: #4a6a18;
+    --color-olive: #5c8020;
+    --color-olive-dark: #4a6a18;
+    --color-emerald-accent: #4d8b35;
+    --color-emerald-dark: #3a6b28;
+  }
+
   /*
    * Lock the document to the viewport so no descendant can push the body
    * past the screen. Without this, sticky / fixed children or panels with a
@@ -135,11 +165,13 @@
     overflow: hidden;
     overscroll-behavior: none;
   }
+
   html {
     /* Belt-and-braces: prevent horizontal overscroll as well. */
     overflow-x: hidden;
     font-size: 18px;
   }
+
   body {
     @apply bg-slate-950 text-slate-300 font-sans antialiased selection:bg-electric-blue/30;
   }
@@ -163,14 +195,26 @@
   width: 4px;
   height: 4px;
 }
+
 ::-webkit-scrollbar-track {
   background: transparent;
 }
+
 ::-webkit-scrollbar-thumb {
   @apply bg-slate-700;
 }
+
 ::-webkit-scrollbar-thumb:hover {
   @apply bg-slate-600;
+}
+
+/* Scrollbar adaptation for light mode */
+[data-theme="light"] ::-webkit-scrollbar-thumb {
+  background-color: var(--color-slate-700);
+}
+
+[data-theme="light"] ::-webkit-scrollbar-thumb:hover {
+  background-color: var(--color-slate-600);
 }
 
 /* Pipeline flow animation */
@@ -182,11 +226,13 @@
 
 /* Olive pulse — replaces the cyan neon glow */
 @keyframes pulsar-glow {
+
   0%,
   100% {
     r: 3px;
     filter: drop-shadow(0 0 2px #8da840);
   }
+
   50% {
     r: 5px;
     filter: drop-shadow(0 0 5px #8da840);

--- a/src/index.css
+++ b/src/index.css
@@ -170,8 +170,8 @@
     --color-emerald-50: #e0f5f0;
     --color-emerald-100: #b3e8dd;
     --color-emerald-200: #6dd4c0;
-    --color-emerald-300: #35b89e;
-    /* light teal — 5.5:1 on sage, 7:1 on emerald-950 */
+    --color-emerald-300: #4ecdb2;
+    /* light teal — 7.5:1 on emerald-950, 4.5:1 on sage */
     --color-emerald-400: #1a9a80;
     /* medium teal — 4.5:1 on sage, 8:1 on emerald-950 */
     --color-emerald-500: #0f7a65;

--- a/src/lib/aiChatBridge.ts
+++ b/src/lib/aiChatBridge.ts
@@ -1,0 +1,18 @@
+export const OLIVE_ASK_AI_CHAT = "olive-studio:ask-ai-chat";
+
+export interface AskAiChatDetail {
+  query: string;
+  /** Unique per dispatch so the same query text can be re-sent and still trigger the listener. */
+  nonce: number;
+}
+
+/**
+ * Opens the Assistant chat panel and sends `query` as a user message, so the
+ * user reads the AI's reasoning and applies (or ignores) any proposed change
+ * themselves, instead of a UI control silently writing pipeline state.
+ */
+export function askAiChat(query: string): void {
+  window.dispatchEvent(
+    new CustomEvent<AskAiChatDetail>(OLIVE_ASK_AI_CHAT, { detail: { query, nonce: Date.now() } }),
+  );
+}

--- a/src/lib/auditSuggestionFilter.ts
+++ b/src/lib/auditSuggestionFilter.ts
@@ -69,7 +69,7 @@ function isNvidiaFamilyEp(ep: string): boolean {
  *
  * @param suggestion - The audit suggestion to evaluate
  * @param ctx - The active model and hardware context
- * @returns `true` if the suggestion applies to the workspace and has a valid autofix target, `false` otherwise
+ * @returns `true` if the suggestion applies to the workspace, `false` otherwise
  */
 export function isAuditSuggestionRelevant(suggestion: AuditSuggestion, ctx: AuditFilterContext): boolean {
   const text = suggestionText(suggestion);
@@ -110,18 +110,18 @@ export function isAuditSuggestionRelevant(suggestion: AuditSuggestion, ctx: Audi
     }
   }
 
-  // Drop cards whose Apply target is not a real UI field (nested Olive JSON, TensorRTPass, etc.).
-  if (!isAuditAutofixApplyable(suggestion.autofix)) {
-    return false;
-  }
-
   return true;
 }
 
-/** Rewrite autofix.pass to the canonical UI field when we know the mapping. */
+/** Rewrite autofix.pass to the canonical UI field when we know the mapping, or clear it if not applyable. */
 export function normalizeAuditSuggestion(suggestion: AuditSuggestion): AuditSuggestion {
+  // If the autofix target isn't a real UI field, clear it so the card renders
+  // as informational (no Apply button) rather than being hidden entirely.
+  if (!isAuditAutofixApplyable(suggestion.autofix)) {
+    return { ...suggestion, autofix: { pass: "", value: "" } };
+  }
   const key = canonicalizeAutofixPass(suggestion.autofix.pass);
-  if (!key || key.startsWith("__")) return suggestion;
+  if (!key || key.startsWith("__")) return { ...suggestion, autofix: { pass: "", value: "" } };
   if (key === suggestion.autofix.pass) return suggestion;
   return {
     ...suggestion,
@@ -137,10 +137,9 @@ export function normalizeAuditSuggestion(suggestion: AuditSuggestion): AuditSugg
  * @returns The filtered and normalized audit analysis
  */
 export function filterAuditAnalysis(analysis: AuditAnalysis, ctx: AuditFilterContext): AuditAnalysis {
-  const kept = analysis.suggestions
-    .filter((s) => isAuditSuggestionRelevant(s, ctx))
-    .map(normalizeAuditSuggestion);
-  const dropped = analysis.suggestions.length - kept.length;
+  const relevant = analysis.suggestions.filter((s) => isAuditSuggestionRelevant(s, ctx));
+  const kept = relevant.map(normalizeAuditSuggestion);
+  const dropped = analysis.suggestions.length - relevant.length;
   let summary = analysis.summary;
   if (dropped > 0) {
     const note = `Removed ${dropped} off-topic suggestion${dropped === 1 ? "" : "s"} that did not match this model/EP.`;

--- a/src/lib/hooks/useThemeEffect.ts
+++ b/src/lib/hooks/useThemeEffect.ts
@@ -11,26 +11,24 @@ export function useThemeEffect(): void {
   const themePreference = usePreferencesStore((s) => s.themePreference);
 
   useEffect(() => {
-    if (
-      typeof window === "undefined" ||
-      typeof document === "undefined" ||
-      typeof window.matchMedia !== "function"
-    ) {
+    if (typeof window === "undefined" || typeof document === "undefined") {
       return;
     }
 
-    const mq = window.matchMedia("(prefers-color-scheme: dark)");
+    const mq = typeof window.matchMedia === "function"
+      ? window.matchMedia("(prefers-color-scheme: dark)")
+      : null;
 
     function apply() {
-      const resolved = resolveTheme(themePreference, mq.matches);
+      const resolved = resolveTheme(themePreference, mq?.matches ?? false);
       document.documentElement.setAttribute("data-theme", resolved);
       document.documentElement.style.colorScheme = resolved;
     }
 
     apply();
 
-    // Only subscribe to OS changes when preference is "system"
-    if (themePreference === "system") {
+    // Only subscribe to OS changes when preference is "system" and matchMedia exists
+    if (themePreference === "system" && mq) {
       if (typeof mq.addEventListener === "function") {
         mq.addEventListener("change", apply);
         return () => mq.removeEventListener("change", apply);

--- a/src/lib/hooks/useThemeEffect.ts
+++ b/src/lib/hooks/useThemeEffect.ts
@@ -1,0 +1,30 @@
+import { useEffect } from "react";
+import { usePreferencesStore, resolveTheme } from "@/lib/stores/preferencesStore";
+
+/**
+ * Synchronizes the `data-theme` attribute on <html> with the
+ * Preferences Store and OS color-scheme changes.
+ *
+ * Must be called once at the app root (e.g., App.tsx or Dashboard).
+ */
+export function useThemeEffect(): void {
+  const themePreference = usePreferencesStore((s) => s.themePreference);
+
+  useEffect(() => {
+    const mq = window.matchMedia("(prefers-color-scheme: dark)");
+
+    function apply() {
+      const resolved = resolveTheme(themePreference, mq.matches);
+      document.documentElement.setAttribute("data-theme", resolved);
+      document.documentElement.style.colorScheme = resolved;
+    }
+
+    apply();
+
+    // Only subscribe to OS changes when preference is "system"
+    if (themePreference === "system") {
+      mq.addEventListener("change", apply);
+      return () => mq.removeEventListener("change", apply);
+    }
+  }, [themePreference]);
+}

--- a/src/lib/hooks/useThemeEffect.ts
+++ b/src/lib/hooks/useThemeEffect.ts
@@ -11,6 +11,14 @@ export function useThemeEffect(): void {
   const themePreference = usePreferencesStore((s) => s.themePreference);
 
   useEffect(() => {
+    if (
+      typeof window === "undefined" ||
+      typeof document === "undefined" ||
+      typeof window.matchMedia !== "function"
+    ) {
+      return;
+    }
+
     const mq = window.matchMedia("(prefers-color-scheme: dark)");
 
     function apply() {
@@ -23,8 +31,14 @@ export function useThemeEffect(): void {
 
     // Only subscribe to OS changes when preference is "system"
     if (themePreference === "system") {
-      mq.addEventListener("change", apply);
-      return () => mq.removeEventListener("change", apply);
+      if (typeof mq.addEventListener === "function") {
+        mq.addEventListener("change", apply);
+        return () => mq.removeEventListener("change", apply);
+      }
+      if (typeof mq.addListener === "function") {
+        mq.addListener(apply);
+        return () => mq.removeListener(apply);
+      }
     }
   }, [themePreference]);
 }

--- a/src/lib/stores/preferencesStore.ts
+++ b/src/lib/stores/preferencesStore.ts
@@ -1,0 +1,40 @@
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+export type ThemePreference = "system" | "light" | "dark";
+export type ResolvedTheme = "light" | "dark";
+
+interface PreferencesState {
+  themePreference: ThemePreference;
+}
+
+interface PreferencesActions {
+  setThemePreference: (pref: ThemePreference) => void;
+}
+
+type PreferencesStore = PreferencesState & PreferencesActions;
+
+const STORAGE_KEY = "olive:preferences";
+
+export const usePreferencesStore = create<PreferencesStore>()(
+  persist(
+    (set) => ({
+      themePreference: "system",
+      setThemePreference: (pref) => set({ themePreference: pref }),
+    }),
+    { name: STORAGE_KEY },
+  ),
+);
+
+/**
+ * Resolve the effective theme given a preference and OS signal.
+ * Pure function — testable without DOM.
+ */
+export function resolveTheme(
+  preference: ThemePreference,
+  osDark: boolean,
+): ResolvedTheme {
+  if (preference === "light") return "light";
+  if (preference === "dark") return "dark";
+  return osDark ? "dark" : "light";
+}

--- a/src/lib/stores/preferencesStore.ts
+++ b/src/lib/stores/preferencesStore.ts
@@ -14,7 +14,7 @@ interface PreferencesActions {
 
 type PreferencesStore = PreferencesState & PreferencesActions;
 
-const STORAGE_KEY = "olive:preferences";
+export const STORAGE_KEY = "olive:preferences";
 
 export const usePreferencesStore = create<PreferencesStore>()(
   persist(

--- a/src/server/routes/ai/chatRoutes.ts
+++ b/src/server/routes/ai/chatRoutes.ts
@@ -22,7 +22,8 @@ import {
 import { CHAT_JSON_RESPONSE_CONTRACT, parseChatStructuredReply } from "../../../lib/chatActions.ts";
 import { getChatScopeBlock } from "../../../lib/chatScope.ts";
 import { validateOliveRecipeStructure } from "../../../lib/oliveRecipeSchema.ts";
-import { parseUIStatePayload } from "../../../lib/pipelineValidation.ts";
+import { getAllowedQuantMethods, parseUIStatePayload } from "../../../lib/pipelineValidation.ts";
+import type { UIState } from "../../../types.ts";
 
 export function mountChatRoutes(router: Router): void {
   router.post("/ai/chat", async (req, res) => {
@@ -166,6 +167,50 @@ export function mountChatRoutes(router: Router): void {
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : String(err);
       return res.status(500).json({ error: msg });
+    }
+  });
+
+  // ─── Quantization Recommendation ─────────────────────────────────────────
+
+  router.post("/ai/recommend-quant", async (req, res) => {
+    const body = parseBody<{ state: unknown }>(req.body, {
+      state: { type: "object", message: "Missing state" },
+    });
+    if (isParseBodyError(body)) return res.status(400).json({ error: body.error });
+    const parsedState = parseUIStatePayload(body.parsed.state);
+    if (!parsedState.ok) return res.status(400).json({ error: parsedState.error });
+    const { state } = parsedState;
+    try {
+      const allowedMethods = getAllowedQuantMethods(state.ihvProvider);
+      const ctx = buildAiWorkspaceContext(state);
+      const ctxSummary = formatAiWorkspaceContextForPrompt(ctx).slice(0, 3500);
+      const system =
+        "You recommend Olive quantization settings for the model and execution provider described below. " +
+        "Reply with ONE JSON object only (no markdown, no prose outside JSON). " +
+        `Allowed quantMethod values for this execution provider: ${allowedMethods.join(", ")}. Pick exactly one. ` +
+        'Schema: {"quantMethod": one of the allowed values, "quantPrecision": "int4"|"int8"|"fp16"}. ' +
+        'If quantMethod is "gptq", also include: {"gptqBlockSize": number (e.g. 32/64/128/256), "gptqGroupSize": number (e.g. 32/64/128), "gptqDescAct": boolean}. ' +
+        'If quantMethod is "awq", also include: {"awqGroupSize": number (e.g. 32/64/128), "awqDampPercent": number (e.g. 0.005-0.05), "awqSym": boolean}. ' +
+        'If quantMethod is "qat", also include: {"qatQuantPrecision": "int4"|"int8", "qatCalibrateMethod": "minmax"|"percentile"|"entropy", "qatCalibrateSteps": number (e.g. 5-50)}. ' +
+        "Base the choice on the model size/family and the execution provider's typical quantization support and accuracy/speed tradeoffs. Prefer well-tested defaults over exotic combinations.";
+      const reply = await callAI(system, [{ role: "user", content: ctxSummary }], true);
+      const parsed = parseJsonFromAiResponse(reply);
+      const fields = typeof parsed === "object" && parsed ? (parsed as Record<string, unknown>) : {};
+
+      // Defense: the model may hallucinate a method this provider can't run — clamp to an allowed one.
+      const requestedMethod = fields.quantMethod as UIState["passes"]["quantMethod"] | undefined;
+      const quantMethod = allowedMethods.includes(requestedMethod as never)
+        ? requestedMethod!
+        : (allowedMethods[0] ?? "ptq");
+      const requestedPrecision = fields.quantPrecision;
+      const quantPrecision =
+        requestedPrecision === "int4" || requestedPrecision === "int8" || requestedPrecision === "fp16"
+          ? requestedPrecision
+          : "int8";
+
+      return res.json({ ...fields, quantMethod, quantPrecision });
+    } catch (err: unknown) {
+      return res.status(500).json({ error: err instanceof Error ? err.message : String(err) });
     }
   });
 }

--- a/src/server/routes/ai/chatRoutes.ts
+++ b/src/server/routes/ai/chatRoutes.ts
@@ -22,8 +22,7 @@ import {
 import { CHAT_JSON_RESPONSE_CONTRACT, parseChatStructuredReply } from "../../../lib/chatActions.ts";
 import { getChatScopeBlock } from "../../../lib/chatScope.ts";
 import { validateOliveRecipeStructure } from "../../../lib/oliveRecipeSchema.ts";
-import { getAllowedQuantMethods, parseUIStatePayload } from "../../../lib/pipelineValidation.ts";
-import type { UIState } from "../../../types.ts";
+import { parseUIStatePayload } from "../../../lib/pipelineValidation.ts";
 
 export function mountChatRoutes(router: Router): void {
   router.post("/ai/chat", async (req, res) => {
@@ -167,50 +166,6 @@ export function mountChatRoutes(router: Router): void {
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : String(err);
       return res.status(500).json({ error: msg });
-    }
-  });
-
-  // ─── Quantization Recommendation ─────────────────────────────────────────
-
-  router.post("/ai/recommend-quant", async (req, res) => {
-    const body = parseBody<{ state: unknown }>(req.body, {
-      state: { type: "object", message: "Missing state" },
-    });
-    if (isParseBodyError(body)) return res.status(400).json({ error: body.error });
-    const parsedState = parseUIStatePayload(body.parsed.state);
-    if (!parsedState.ok) return res.status(400).json({ error: parsedState.error });
-    const { state } = parsedState;
-    try {
-      const allowedMethods = getAllowedQuantMethods(state.ihvProvider);
-      const ctx = buildAiWorkspaceContext(state);
-      const ctxSummary = formatAiWorkspaceContextForPrompt(ctx).slice(0, 3500);
-      const system =
-        "You recommend Olive quantization settings for the model and execution provider described below. " +
-        "Reply with ONE JSON object only (no markdown, no prose outside JSON). " +
-        `Allowed quantMethod values for this execution provider: ${allowedMethods.join(", ")}. Pick exactly one. ` +
-        'Schema: {"quantMethod": one of the allowed values, "quantPrecision": "int4"|"int8"|"fp16"}. ' +
-        'If quantMethod is "gptq", also include: {"gptqBlockSize": number (e.g. 32/64/128/256), "gptqGroupSize": number (e.g. 32/64/128), "gptqDescAct": boolean}. ' +
-        'If quantMethod is "awq", also include: {"awqGroupSize": number (e.g. 32/64/128), "awqDampPercent": number (e.g. 0.005-0.05), "awqSym": boolean}. ' +
-        'If quantMethod is "qat", also include: {"qatQuantPrecision": "int4"|"int8", "qatCalibrateMethod": "minmax"|"percentile"|"entropy", "qatCalibrateSteps": number (e.g. 5-50)}. ' +
-        "Base the choice on the model size/family and the execution provider's typical quantization support and accuracy/speed tradeoffs. Prefer well-tested defaults over exotic combinations.";
-      const reply = await callAI(system, [{ role: "user", content: ctxSummary }], true);
-      const parsed = parseJsonFromAiResponse(reply);
-      const fields = typeof parsed === "object" && parsed ? (parsed as Record<string, unknown>) : {};
-
-      // Defense: the model may hallucinate a method this provider can't run — clamp to an allowed one.
-      const requestedMethod = fields.quantMethod as UIState["passes"]["quantMethod"] | undefined;
-      const quantMethod = allowedMethods.includes(requestedMethod as never)
-        ? requestedMethod!
-        : (allowedMethods[0] ?? "ptq");
-      const requestedPrecision = fields.quantPrecision;
-      const quantPrecision =
-        requestedPrecision === "int4" || requestedPrecision === "int8" || requestedPrecision === "fp16"
-          ? requestedPrecision
-          : "int8";
-
-      return res.json({ ...fields, quantMethod, quantPrecision });
-    } catch (err: unknown) {
-      return res.status(500).json({ error: err instanceof Error ? err.message : String(err) });
     }
   });
 }


### PR DESCRIPTION
# Light Mode Theme

Adds a light mode theme (light green background, black text) to Olive Studio with a gear-icon settings menu for toggling between **System**, **Light**, and **Dark** modes.

## How it works

- **CSS custom properties** on `[data-theme="light"]` invert the `--color-slate-*` scale to light green tones
- All 26+ feature panels inherit the palette automatically via variable cascading — zero per-component changes
- A flash-free **inline script** in the HTML head reads `localStorage` before React mounts
- A **Zustand + persist** store (`olive:preferences`) holds the user's choice across sessions
- A reactive **useThemeEffect** hook keeps `data-theme` and `color-scheme` in sync with the store + OS `prefers-color-scheme`

## New files

| File | Purpose |
|------|---------|
| `src/lib/stores/preferencesStore.ts` | Theme preference store (system/light/dark) |
| `src/lib/hooks/useThemeEffect.ts` | Reactive DOM sync hook |
| `src/components/SettingsMenu.tsx` | Gear dropdown with keyboard a11y |

## Modified files

| File | Change |
|------|--------|
| `src/index.css` | `[data-theme="light"]` variable block + scrollbar overrides |
| `index.html` | Inline theme-init script (flash prevention) |
| `src/App.tsx` | Wires `useThemeEffect()` + `<SettingsMenu />` in header |
| `src/components/TitleBar.tsx` | Adds `<SettingsMenu />` for Tauri desktop |

## Usage

Click the gear icon in the top-right header and choose **Light** / **Dark** / **System**. Persists across sessions via localStorage.

## Accessibility

- Full keyboard navigation (Tab, Enter/Space to select, Escape to close)
- `aria-label`, `role="menu"`, `role="menuitem"` attributes
- WCAG AA contrast: body text (#1a1f14) vs background (#f0f5e8) = 15.7:1

## Validation

- `pnpm lint:quick` passes (exit 0)
- No new TypeScript errors in changed files
- Pre-existing TS error in ExecutionWorkspace.tsx is unrelated

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add light mode theme with settings menu and header compaction
> - Adds a `[data-theme="light"]` CSS palette in [index.css](https://github.com/tonythethompson/Olive-Studio/pull/267/files#diff-85da366246340e911d7a0eb9153e64137a1b31f0686c74d9aef9ae4f032cb09e) and a [useThemeEffect](https://github.com/tonythethompson/Olive-Studio/pull/267/files#diff-43d6ff9fd0d1e49b82ec9f3934ec051fafcc2fa795ae9705d2467edd5810a981) hook that syncs `data-theme` and `colorScheme` on `<html>` based on a persisted user preference or OS setting.
> - Adds a [SettingsMenu](https://github.com/tonythethompson/Olive-Studio/pull/267/files#diff-9914ba03e0dc079f2ff6680aa07913db0d2a7076a5f763a3790ad11c2d380c1f) dropdown (keyboard-navigable, accessible) with system/light/dark theme options; it appears in both the [TitleBar](https://github.com/tonythethompson/Olive-Studio/pull/267/files#diff-278693dd5467c740d1ffb25dbcd5eeca21f0dc8fa2c66f844b910b377f2a3e23) and the main app header.
> - Theme preference is persisted via a Zustand store in [preferencesStore.ts](https://github.com/tonythethompson/Olive-Studio/pull/267/files#diff-2612966122910857e5dc607709206321f51e025938bc84085f4902a35f5699b3); an inline script in [index.html](https://github.com/tonythethompson/Olive-Studio/pull/267/files#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051) applies the initial theme before React mounts to prevent flash.
> - Header controls (`KbSyncIndicator`, `RuntimeEnvControls`, `AgentAccessControls`) compact to icon-only mode when measured center space drops below a threshold.
> - Replaces the 'Ask AI…' quantization preset's auto-apply backend call with a `askAiChat` event dispatch that opens the Assistant sidebar and seeds a chat query instead.
> - Behavioral Change: `RecipeGraphView` and `GraphCanvas` no longer render SVG connection paths or expose a `showDot` prop; the dot-toggle button is removed from the execution workspace header.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3a9ab36.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->