### PR TITLE
Improve issue reporting and AI diagnostics

### DIFF
--- a/src/components/ReportIssueModal.tsx
+++ b/src/components/ReportIssueModal.tsx
@@ -18,6 +18,7 @@ import {
   type ReportArea,
   type TelemetryOptionId,
   type IssueReport,
+  categoryHasSeverity,
   collectTelemetry,
   buildReport,
 } from "@/lib/issueReport";
@@ -28,6 +29,7 @@ interface ReportIssueModalProps {
   state?: UIState;
   hardwareProbe?: HardwareProbeResult | null;
   executionLogs?: string[];
+  chatLog?: string[];
   mcpDiagnostic?: unknown;
   /** Pre-fill the area dropdown (e.g., from execution context). */
   defaultArea?: ReportArea;
@@ -43,6 +45,7 @@ export function ReportIssueModal({
   state,
   hardwareProbe,
   executionLogs,
+  chatLog,
   mcpDiagnostic: _mcpDiagnostic,
   defaultArea,
   defaultDescription,
@@ -78,6 +81,16 @@ export function ReportIssueModal({
     // eslint-disable-next-line react-hooks/exhaustive-deps -- intentionally only depend on open
   }, [open]);
 
+  // Lock severity to N/A whenever the category isn't "bug" — severity only
+  // describes bug impact and has no meaning for feature requests etc.
+  useEffect(() => {
+    if (!categoryHasSeverity(category)) {
+      setSeverity("n-a");
+    } else {
+      setSeverity((prev) => (prev === "n-a" ? "annoying" : prev));
+    }
+  }, [category]);
+
   const toggleTelemetry = useCallback((id: TelemetryOptionId) => {
     setSelectedTelemetry((prev) => {
       const next = new Set(prev);
@@ -97,6 +110,7 @@ export function ReportIssueModal({
         state,
         hardwareProbe,
         executionLogs,
+        chatLog,
       }),
       frequencyInfo: frequencyInfo
         ? {
@@ -107,12 +121,12 @@ export function ReportIssueModal({
           }
         : null,
     }),
-    [category, severity, area, description, selectedTelemetry, state, hardwareProbe, executionLogs, frequencyInfo],
+    [category, severity, area, description, selectedTelemetry, state, hardwareProbe, executionLogs, chatLog, frequencyInfo],
   );
 
   const { url, fullText, urlExceededBudget } = useMemo(
-    () => buildReport(report, { state, hardwareProbe, executionLogs }),
-    [report, state, hardwareProbe, executionLogs],
+    () => buildReport(report, { state, hardwareProbe, executionLogs, chatLog }),
+    [report, state, hardwareProbe, executionLogs, chatLog],
   );
 
   const dialogRef = useRef<HTMLDivElement>(null);
@@ -283,8 +297,9 @@ export function ReportIssueModal({
               <select
                 id="report-severity"
                 value={severity}
+                disabled={!categoryHasSeverity(category)}
                 onChange={(e) => setSeverity(e.target.value as ReportSeverity)}
-                className="w-full appearance-none bg-slate-950 border border-slate-800 rounded-md px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-2 focus:ring-electric-blue cursor-pointer"
+                className="w-full appearance-none bg-slate-950 border border-slate-800 rounded-md px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-2 focus:ring-electric-blue cursor-pointer disabled:cursor-not-allowed disabled:opacity-50"
               >
                 {REPORT_SEVERITIES.map((s) => (
                   <option key={s.id} value={s.id}>
@@ -378,7 +393,7 @@ export function ReportIssueModal({
               {showPreview && (
                 <div className="bg-slate-950 border border-slate-800 rounded-md p-3 text-sm font-mono text-slate-400 max-h-40 overflow-y-auto">
                   {Array.from(selectedTelemetry).map((key) => {
-                    const telemetry = collectTelemetry([key], { state, hardwareProbe, executionLogs });
+                    const telemetry = collectTelemetry([key], { state, hardwareProbe, executionLogs, chatLog });
                     const value = telemetry[key] ?? "N/A";
                     const label = TELEMETRY_OPTIONS.find((o) => o.id === key)?.label ?? key;
                     return (

--- a/src/components/ReportIssueModal.tsx
+++ b/src/components/ReportIssueModal.tsx
@@ -301,7 +301,9 @@ export function ReportIssueModal({
                 onChange={(e) => setSeverity(e.target.value as ReportSeverity)}
                 className="w-full appearance-none bg-slate-950 border border-slate-800 rounded-md px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-2 focus:ring-electric-blue cursor-pointer disabled:cursor-not-allowed disabled:opacity-50"
               >
-                {REPORT_SEVERITIES.map((s) => (
+                {REPORT_SEVERITIES.filter((s) =>
+                  categoryHasSeverity(category) ? s.id !== "n-a" : s.id === "n-a",
+                ).map((s) => (
                   <option key={s.id} value={s.id}>
                     {s.label}
                   </option>

--- a/src/components/features/assistant/AssistantSidebar.flows.test.tsx
+++ b/src/components/features/assistant/AssistantSidebar.flows.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeAll, afterEach } from "vitest";
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
-import { createMockUIState } from "../__tests__/testUtils";
+import { screen, fireEvent, waitFor } from "@testing-library/react";
+import { createMockUIState, renderWithProviders as render } from "../__tests__/testUtils";
 
 const mockSetState = vi.fn();
 vi.mock("@/lib/stores/pipelineStore", () => ({

--- a/src/components/features/assistant/AssistantSidebar.test.tsx
+++ b/src/components/features/assistant/AssistantSidebar.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeAll } from "vitest";
-import { render, screen, fireEvent, act } from "@testing-library/react";
-import { createMockUIState, useFetchRoutesMock } from "../__tests__/testUtils";
+import { screen, fireEvent, act } from "@testing-library/react";
+import { createMockUIState, renderWithProviders as render, useFetchRoutesMock } from "../__tests__/testUtils";
 
 // Mock the pipeline store
 const mockSetState = vi.fn();

--- a/src/components/features/assistant/AssistantSidebar.tsx
+++ b/src/components/features/assistant/AssistantSidebar.tsx
@@ -10,6 +10,7 @@ import {
 } from "@/lib/aiWorkspaceContext";
 import { chatPatchToUiState, sanitizeChatActionPatch, type ChatAction } from "@/lib/chatActions";
 import { Bot, X, Lightbulb, MessageSquareCode, Settings2, Bug } from "lucide-react";
+import { useHardwareProbe } from "@/lib/hooks/useHardwareProbe";
 import { AuditPanel } from "./AuditPanel";
 import { ReportIssueModal } from "@/components/ReportIssueModal";
 import { PROVIDER_OPTIONS, normalizeUiProviderId } from "./aiProviderCatalog";
@@ -65,6 +66,7 @@ export function AssistantSidebar({
   const setState = propSetState ?? storeState.setState;
   const [activeTab, setActiveTab] = useState<SidebarTab>("audit");
   const [, startTabTransition] = useTransition();
+  const { data: hardwareProbe = null } = useHardwareProbe();
 
   const handleTabChange = (tab: SidebarTab) => {
     startTabTransition(() => {
@@ -79,6 +81,10 @@ export function AssistantSidebar({
   const audit = useAiAudit({ state, setState });
   const chat = useAiChat(workspaceContext);
   const chatActionAuditTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const chatLogForReport = useMemo(
+    () => chat.chatMessages.map((m) => `${m.sender}: ${m.text}`),
+    [chat.chatMessages],
+  );
 
   useEffect(() => {
     return () => {
@@ -328,6 +334,9 @@ export function AssistantSidebar({
             open={isReportOpen}
             onClose={() => setIsReportOpen(false)}
             state={state}
+            hardwareProbe={hardwareProbe}
+            chatLog={chatLogForReport}
+            defaultArea="assistant-ai"
           />
         </div>
       </aside>

--- a/src/components/features/assistant/AssistantSidebar.tsx
+++ b/src/components/features/assistant/AssistantSidebar.tsx
@@ -66,7 +66,7 @@ export function AssistantSidebar({
   const setState = propSetState ?? storeState.setState;
   const [activeTab, setActiveTab] = useState<SidebarTab>("audit");
   const [, startTabTransition] = useTransition();
-  const { data: hardwareProbe = null } = useHardwareProbe();
+  const { data: hardwareProbe = null } = useHardwareProbe({ enabled: isOpen });
 
   const handleTabChange = (tab: SidebarTab) => {
     startTabTransition(() => {
@@ -123,9 +123,9 @@ export function AssistantSidebar({
 
   const local = useLocalEngineSetup({
     isOpen,
-    onModelActivated: async (modelTag, source) => {
-      const ok = await providers.enableLocalAiProvider(source, modelTag);
-      if (!ok) return;
+    onModelActivated: async (modelTag, source, signal) => {
+      const ok = await providers.enableLocalAiProvider(source, modelTag, signal);
+      if (!ok || signal?.aborted) return;
       audit.resetAnalysis();
     },
   });

--- a/src/components/features/assistant/useAiProviderSettings.ts
+++ b/src/components/features/assistant/useAiProviderSettings.ts
@@ -255,9 +255,10 @@ export function useAiProviderSettings({
     }
   };
 
-  const fetchProviderStatus = async (): Promise<ProviderStatus> => {
+  const fetchProviderStatus = async (signal?: AbortSignal): Promise<ProviderStatus> => {
     try {
-      const r = await fetch("/api/ai/provider");
+      const r = signal ? await fetch("/api/ai/provider", { signal }) : await fetch("/api/ai/provider");
+      if (signal?.aborted) return { source: "none" };
       const contentType = r.headers.get("content-type") ?? "";
       if (!r.ok || !contentType.includes("application/json")) {
         const fallback: ProviderStatus = { source: "none" };
@@ -265,6 +266,7 @@ export function useAiProviderSettings({
         return fallback;
       }
       const d = (await r.json()) as ProviderStatus;
+      if (signal?.aborted) return { source: "none" };
       setProviderStatus(d);
       if (d.provider) {
         const uiProvider = normalizeUiProviderId(d.provider);
@@ -279,6 +281,7 @@ export function useAiProviderSettings({
       setSettingsBaseUrl(hydratedSettingsBaseUrl(d.baseUrl));
       return d;
     } catch {
+      if (signal?.aborted) return { source: "none" };
       const fallback: ProviderStatus = { source: "none" };
       setProviderStatus(fallback);
       return fallback;
@@ -582,7 +585,11 @@ export function useAiProviderSettings({
   };
 
   /** Activate LM Studio / Ollama as openai-compat local provider. Returns true on success. */
-  const enableLocalAiProvider = async (source: "lms" | "ollama", modelTag: string): Promise<boolean> => {
+  const enableLocalAiProvider = async (
+    source: "lms" | "ollama",
+    modelTag: string,
+    signal?: AbortSignal,
+  ): Promise<boolean> => {
     const baseUrl = source === "ollama" ? "http://127.0.0.1:11434/v1" : "http://127.0.0.1:1234/v1";
     setIsSavingProvider(true);
     setProviderSaveError("");
@@ -596,18 +603,22 @@ export function useAiProviderSettings({
           model: modelTag,
           baseUrl,
         }),
+        signal,
       });
       const data = (await r.json().catch(() => ({}))) as { error?: string };
       if (!r.ok) throw new Error(data.error || `HTTP ${r.status}`);
+      if (signal?.aborted) return false;
       setSettingsProvider("openai-compat");
       userModelOverrideRef.current = true;
       setSettingsModel(modelTag);
       setCustomModel(modelTag);
       setSettingsBaseUrl(baseUrl);
-      await fetchProviderStatus();
+      await fetchProviderStatus(signal);
+      if (signal?.aborted) return false;
       // Stay on Settings after local enable (do not jump to Audit).
       return true;
     } catch (err: unknown) {
+      if (signal?.aborted) return false;
       setProviderSaveError(err instanceof Error ? err.message : "Failed to enable local provider.");
       return false;
     } finally {

--- a/src/components/features/assistant/useLocalEngineSetup.ts
+++ b/src/components/features/assistant/useLocalEngineSetup.ts
@@ -165,6 +165,8 @@ export function useLocalEngineSetup({ isOpen, onModelActivated }: UseLocalEngine
   const [installingEngine, setInstallingEngine] = useState<LocalEngine | null>(null);
   const [preferredEngine, setPreferredEngine] = useState<LocalEngine>(readStoredEngine);
   const pullAbortRef = useRef<AbortController | null>(null);
+  const pullCompletionRef = useRef<Promise<void> | null>(null);
+  const resolvePullCompletionRef = useRef<(() => void) | null>(null);
   const pullUserCancelledRef = useRef(false);
 
   const selectPreferredEngine = (engine: LocalEngine) => {
@@ -442,12 +444,9 @@ export function useLocalEngineSetup({ isOpen, onModelActivated }: UseLocalEngine
   const cancelLocalPull = () => {
     pullUserCancelledRef.current = true;
     pullAbortRef.current?.abort();
-    // Free the busy guard immediately rather than waiting for the aborted
-    // fetch/stream to finish unwinding — that teardown can lag (or, on some
-    // platforms, never resolve if the underlying connection is already
-    // stuck), which otherwise leaves "another download is in progress"
-    // blocking every retry until the stale request eventually settles.
-    pullAbortRef.current = null;
+    // Keep the controller until the aborted request has fully unwound. A retry
+    // requested during that window waits for server-side process teardown, so
+    // it cannot be rejected by the LM Studio busy gate or overlap the old pull.
     setPullingModel(null);
     setLocalPullPercent(null);
     setLocalInstallInfo(null);
@@ -456,12 +455,20 @@ export function useLocalEngineSetup({ isOpen, onModelActivated }: UseLocalEngine
 
   const pullLocalModel = async (modelTag: string, source: LocalEngine = "lms") => {
     if (pullAbortRef.current) {
+      if (pullUserCancelledRef.current && pullCompletionRef.current) {
+        await pullCompletionRef.current;
+        if (!pullAbortRef.current) return pullLocalModel(modelTag, source);
+      }
       setLocalPullError("A download is already in progress. Cancel it first, or wait for it to finish.");
       return;
     }
 
     const controller = new AbortController();
     pullAbortRef.current = controller;
+    const completion = new Promise<void>((resolve) => {
+      resolvePullCompletionRef.current = resolve;
+    });
+    pullCompletionRef.current = completion;
 
     setPullingModel(modelTag);
     setLocalPullError("");
@@ -543,9 +550,14 @@ export function useLocalEngineSetup({ isOpen, onModelActivated }: UseLocalEngine
     } finally {
       if (pullAbortRef.current === controller) {
         pullAbortRef.current = null;
+        pullCompletionRef.current = null;
+        pullUserCancelledRef.current = false;
         setPullingModel(null);
       }
-      if (pullAbortRef.current === controller) pullUserCancelledRef.current = false;
+      if (resolvePullCompletionRef.current) {
+        resolvePullCompletionRef.current();
+        resolvePullCompletionRef.current = null;
+      }
     }
   };
 

--- a/src/components/features/assistant/useLocalEngineSetup.ts
+++ b/src/components/features/assistant/useLocalEngineSetup.ts
@@ -34,6 +34,40 @@ type PullStreamEvent = {
   verified?: boolean;
 };
 
+type PullState = {
+  gotDone: boolean;
+  finalMessage: string;
+  modelId?: string;
+  verified?: boolean;
+};
+
+type PullMeta = Pick<PullState, "modelId" | "verified">;
+
+function applyLegacyPullBody(
+  body: string,
+  response: Response,
+  state: PullState,
+  onDownloadPhase?: () => void,
+): void {
+  if (!state.gotDone && response.headers.get("content-type")?.includes("application/json") && body.trim()) {
+    const data = JSON.parse(body) as {
+      ok?: boolean;
+      error?: string;
+      message?: string;
+      modelId?: string;
+      verified?: boolean;
+    };
+    if (data.error) throw new Error(data.error);
+    if (data.ok) {
+      state.gotDone = true;
+      state.finalMessage = data.message || "Model ready.";
+      if (data.modelId) state.modelId = data.modelId;
+      if (typeof data.verified === "boolean") state.verified = data.verified;
+      onDownloadPhase?.();
+    }
+  }
+}
+
 function readStoredEngine(): LocalEngine {
   try {
     const stored = localStorage.getItem("localEngine");
@@ -297,7 +331,7 @@ export function useLocalEngineSetup({ isOpen, onModelActivated }: UseLocalEngine
 
   const handlePullStreamEvent = (
     evt: PullStreamEvent,
-    state: { gotDone: boolean; finalMessage: string; modelId?: string; verified?: boolean },
+    state: PullState,
     onDownloadPhase?: () => void,
     controller?: AbortController,
   ) => {
@@ -335,14 +369,14 @@ export function useLocalEngineSetup({ isOpen, onModelActivated }: UseLocalEngine
     r: Response,
     controller: AbortController,
     onDownloadPhase?: () => void,
-  ): Promise<{ modelId?: string; verified?: boolean }> => {
+  ): Promise<PullMeta> => {
     if (!r.ok && !r.body) {
       const data = (await r.json().catch(() => ({}))) as { error?: string; hint?: string };
       throw new Error(joinErrorParts(data.error || `HTTP ${r.status}`, data.hint));
     }
     if (!r.body) throw new Error(`Empty response (HTTP ${r.status})`);
 
-    const state: { gotDone: boolean; finalMessage: string; modelId?: string; verified?: boolean } = {
+    const state: PullState = {
       gotDone: false,
       finalMessage: "",
     };
@@ -355,24 +389,8 @@ export function useLocalEngineSetup({ isOpen, onModelActivated }: UseLocalEngine
       }
     });
 
-    // Legacy JSON body (non-stream) if server ever falls back
-    if (!state.gotDone && r.headers.get("content-type")?.includes("application/json") && buf.trim()) {
-      const data = JSON.parse(buf) as {
-        ok?: boolean;
-        error?: string;
-        message?: string;
-        modelId?: string;
-        verified?: boolean;
-      };
-      if (data.error) throw new Error(data.error);
-      if (data.ok) {
-        state.gotDone = true;
-        state.finalMessage = data.message || "Model ready.";
-        if (data.modelId) state.modelId = data.modelId;
-        if (typeof data.verified === "boolean") state.verified = data.verified;
-        onDownloadPhase?.();
-      }
-    }
+    // Legacy JSON body (non-stream) if server ever falls back.
+    applyLegacyPullBody(buf, r, state, onDownloadPhase);
     if (!state.gotDone && !r.ok) {
       throw new Error(`Pull failed (HTTP ${r.status})`);
     }
@@ -380,6 +398,45 @@ export function useLocalEngineSetup({ isOpen, onModelActivated }: UseLocalEngine
     if (controller.signal.aborted || pullAbortRef.current !== controller) return {};
     setLocalInstallInfo(state.finalMessage || "Model ready.");
     return { modelId: state.modelId, verified: state.verified };
+  };
+
+  const runModelPull = async (
+    modelTag: string,
+    source: LocalEngine,
+    controller: AbortController,
+  ): Promise<PullMeta> => {
+    const endpoint = source === "ollama" ? "/api/ai/ollama-pull" : "/api/ai/local-pull";
+    // Align the 20m abort with the server's lms get / ollama pull timer (starts after ensure*).
+    const DOWNLOAD_MAX_MS = 20 * 60 * 1000;
+    // Cap hung ensure/install so a stuck startup cannot stream forever.
+    const ENSURE_PHASE_MAX_MS = 15 * 60 * 1000;
+    let downloadTimer: ReturnType<typeof setTimeout> | undefined;
+    const ensureTimer = setTimeout(() => {
+      if (!downloadTimer) controller.abort();
+    }, ENSURE_PHASE_MAX_MS);
+    const armDownloadTimeout = () => {
+      if (downloadTimer) return;
+      clearTimeout(ensureTimer);
+      downloadTimer = setTimeout(() => controller.abort(), DOWNLOAD_MAX_MS);
+    };
+
+    try {
+      if (controller.signal.aborted) return {};
+      const r = await fetch(endpoint, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Accept: "application/x-ndjson, application/json",
+        },
+        body: JSON.stringify({ modelTag }),
+        signal: controller.signal,
+      });
+      if (controller.signal.aborted) return {};
+      return await consumePullStream(r, controller, armDownloadTimeout);
+    } finally {
+      clearTimeout(ensureTimer);
+      if (downloadTimer) clearTimeout(downloadTimer);
+    }
   };
 
   const cancelLocalPull = () => {
@@ -441,39 +498,7 @@ export function useLocalEngineSetup({ isOpen, onModelActivated }: UseLocalEngine
           : "Starting: ensure LM Studio → serve → download…",
       );
 
-      const endpoint = source === "ollama" ? "/api/ai/ollama-pull" : "/api/ai/local-pull";
-      // Align the 20m abort with the server's lms get / ollama pull timer (starts after ensure*).
-      const DOWNLOAD_MAX_MS = 20 * 60 * 1000;
-      // Cap hung ensure/install so a stuck startup cannot stream forever.
-      const ENSURE_PHASE_MAX_MS = 15 * 60 * 1000;
-      let downloadTimer: ReturnType<typeof setTimeout> | undefined;
-      const ensureTimer = setTimeout(() => {
-        if (!downloadTimer) controller.abort();
-      }, ENSURE_PHASE_MAX_MS);
-      const armDownloadTimeout = () => {
-        if (downloadTimer) return;
-        clearTimeout(ensureTimer);
-        downloadTimer = setTimeout(() => controller.abort(), DOWNLOAD_MAX_MS);
-      };
-      let pullMeta: { modelId?: string; verified?: boolean } = {};
-      try {
-        if (controller.signal.aborted) return;
-        const r = await fetch(endpoint, {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            Accept: "application/x-ndjson, application/json",
-          },
-          body: JSON.stringify({ modelTag }),
-          signal: controller.signal,
-        });
-        if (controller.signal.aborted) return;
-        pullMeta = await consumePullStream(r, controller, armDownloadTimeout);
-      } finally {
-        clearTimeout(ensureTimer);
-        if (downloadTimer) clearTimeout(downloadTimer);
-      }
-
+      const pullMeta = await runModelPull(modelTag, source, controller);
       if (controller.signal.aborted) return;
       markEngineReady(source);
       const after = await refreshInstalledModels(source);

--- a/src/components/features/assistant/useLocalEngineSetup.ts
+++ b/src/components/features/assistant/useLocalEngineSetup.ts
@@ -43,6 +43,32 @@ type PullState = {
 
 type PullMeta = Pick<PullState, "modelId" | "verified">;
 
+function isPullDownloadPhaseEvent(evt: PullStreamEvent): boolean {
+  return (
+    evt.type === "progress" ||
+    evt.type === "log" ||
+    (evt.type === "step" && /download|pulling/i.test(evt.message ?? ""))
+  );
+}
+
+function isPullLogEvent(evt: PullStreamEvent): boolean {
+  return evt.type === "log" || evt.type === "step" || evt.type === "progress";
+}
+
+function isCurrentPullController(
+  controller: AbortController,
+  activeController: AbortController | null,
+): boolean {
+  return !controller.signal.aborted && activeController === controller;
+}
+
+function applyPullCompletion(evt: PullStreamEvent, state: PullState): void {
+  state.gotDone = true;
+  state.finalMessage = evt.message || "Model ready.";
+  if (typeof evt.modelId === "string" && evt.modelId.trim()) state.modelId = evt.modelId.trim();
+  if (typeof evt.verified === "boolean") state.verified = evt.verified;
+}
+
 function applyLegacyPullBody(
   body: string,
   response: Response,
@@ -337,32 +363,21 @@ export function useLocalEngineSetup({ isOpen, onModelActivated }: UseLocalEngine
     onDownloadPhase?: () => void,
     controller?: AbortController,
   ) => {
-    if (controller && (controller.signal.aborted || pullAbortRef.current !== controller)) return;
+    if (controller && !isCurrentPullController(controller, pullAbortRef.current)) return;
     // Server only starts its 20m lms get / ollama timer after ensure*; arm ours then too.
-    if (
-      evt.type === "progress" ||
-      evt.type === "log" ||
-      (evt.type === "step" && /download|pulling/i.test(evt.message ?? ""))
-    ) {
-      onDownloadPhase?.();
-    }
+    if (isPullDownloadPhaseEvent(evt)) onDownloadPhase?.();
     if (typeof evt.percent === "number" && Number.isFinite(evt.percent)) {
       setLocalPullPercent(clampPercent(evt.percent));
     }
     if (evt.message) {
       setLocalInstallInfo(evt.message);
-      if (evt.type === "log" || evt.type === "step" || evt.type === "progress") {
-        appendPullLog(evt.message);
-      }
+      if (isPullLogEvent(evt)) appendPullLog(evt.message);
     }
     if (evt.type === "error") {
       throw new Error(joinErrorParts(evt.error || "Pull failed", evt.hint));
     }
     if (evt.type === "done") {
-      state.gotDone = true;
-      state.finalMessage = evt.message || "Model ready.";
-      if (typeof evt.modelId === "string" && evt.modelId.trim()) state.modelId = evt.modelId.trim();
-      if (typeof evt.verified === "boolean") state.verified = evt.verified;
+      applyPullCompletion(evt, state);
       setLocalPullPercent(100);
     }
   };
@@ -453,15 +468,31 @@ export function useLocalEngineSetup({ isOpen, onModelActivated }: UseLocalEngine
     setLocalPullError("Download cancelled.");
   };
 
-  const pullLocalModel = async (modelTag: string, source: LocalEngine = "lms") => {
-    if (pullAbortRef.current) {
-      if (pullUserCancelledRef.current && pullCompletionRef.current) {
-        await pullCompletionRef.current;
-        if (!pullAbortRef.current) return pullLocalModel(modelTag, source);
-      }
-      setLocalPullError("A download is already in progress. Cancel it first, or wait for it to finish.");
-      return;
+  const waitForPullSlot = async (): Promise<boolean> => {
+    if (!pullAbortRef.current) return true;
+    if (pullUserCancelledRef.current && pullCompletionRef.current) {
+      await pullCompletionRef.current;
+      return !pullAbortRef.current;
     }
+    setLocalPullError("A download is already in progress. Cancel it first, or wait for it to finish.");
+    return false;
+  };
+
+  const activateExistingPull = async (
+    modelId: string,
+    source: LocalEngine,
+    controller: AbortController,
+  ): Promise<void> => {
+    if (!isCurrentPullController(controller, pullAbortRef.current)) return;
+    setLocalPullPercent(100);
+    setLocalInstallInfo(`Already installed — enabling ${modelId}…`);
+    await onModelActivated(modelId, source, controller.signal);
+    if (!isCurrentPullController(controller, pullAbortRef.current)) return;
+    setLocalInstallInfo(`Ready: ${modelId}`);
+  };
+
+  const pullLocalModel = async (modelTag: string, source: LocalEngine = "lms") => {
+    if (!(await waitForPullSlot())) return;
 
     const controller = new AbortController();
     pullAbortRef.current = controller;
@@ -489,12 +520,7 @@ export function useLocalEngineSetup({ isOpen, onModelActivated }: UseLocalEngine
         installed,
       );
       if (existing) {
-        if (controller.signal.aborted || pullAbortRef.current !== controller) return;
-        setLocalPullPercent(100);
-        setLocalInstallInfo(`Already installed — enabling ${existing}…`);
-        await onModelActivated(existing, source, controller.signal);
-        if (controller.signal.aborted || pullAbortRef.current !== controller) return;
-        setLocalInstallInfo(`Ready: ${existing}`);
+        await activateExistingPull(existing, source, controller);
         return;
       }
 

--- a/src/components/features/assistant/useLocalEngineSetup.ts
+++ b/src/components/features/assistant/useLocalEngineSetup.ts
@@ -381,7 +381,16 @@ export function useLocalEngineSetup({ isOpen, onModelActivated }: UseLocalEngine
   const cancelLocalPull = () => {
     pullUserCancelledRef.current = true;
     pullAbortRef.current?.abort();
-    setLocalInstallInfo("Cancelling download…");
+    // Free the busy guard immediately rather than waiting for the aborted
+    // fetch/stream to finish unwinding — that teardown can lag (or, on some
+    // platforms, never resolve if the underlying connection is already
+    // stuck), which otherwise leaves "another download is in progress"
+    // blocking every retry until the stale request eventually settles.
+    pullAbortRef.current = null;
+    setPullingModel(null);
+    setLocalPullPercent(null);
+    setLocalInstallInfo(null);
+    setLocalPullError("Download cancelled.");
   };
 
   const pullLocalModel = async (modelTag: string, source: LocalEngine = "lms") => {
@@ -493,14 +502,19 @@ export function useLocalEngineSetup({ isOpen, onModelActivated }: UseLocalEngine
       if (controller.signal.aborted) return;
       setLocalInstallInfo(`Ready: ${enableId}`);
     } catch (err: unknown) {
+      // A cancelled pull already reset all this state synchronously and may have
+      // let the user start a new pull — don't let this stale rejection stomp it.
+      if (pullAbortRef.current !== controller) return;
       setLocalPullError(
         describePullFetchError(err, { userCancelled: pullUserCancelledRef.current }),
       );
       setLocalInstallInfo(null);
     } finally {
-      pullAbortRef.current = null;
+      if (pullAbortRef.current === controller) {
+        pullAbortRef.current = null;
+        setPullingModel(null);
+      }
       pullUserCancelledRef.current = false;
-      setPullingModel(null);
     }
   };
 

--- a/src/components/features/assistant/useLocalEngineSetup.ts
+++ b/src/components/features/assistant/useLocalEngineSetup.ts
@@ -491,6 +491,79 @@ export function useLocalEngineSetup({ isOpen, onModelActivated }: UseLocalEngine
     setLocalInstallInfo(`Ready: ${modelId}`);
   };
 
+  const activateDownloadedPull = async (
+    modelTag: string,
+    source: LocalEngine,
+    starter: ReturnType<typeof starterForTag>,
+    pullMeta: PullMeta,
+    controller: AbortController,
+  ): Promise<void> => {
+    if (controller.signal.aborted) return;
+    markEngineReady(source);
+    const after = await refreshInstalledModels(source);
+    if (controller.signal.aborted) return;
+    const found = findInstalledStarterId(
+      {
+        tag: modelTag,
+        enableTag: starter?.enableTag ?? preferredEnableTag(modelTag, source) ?? modelTag,
+        match: starter?.match ?? starter?.enableTag ?? modelTag,
+      },
+      after,
+    );
+    const enableId =
+      found ??
+      (pullMeta.modelId && after.includes(pullMeta.modelId) ? pullMeta.modelId : undefined) ??
+      (pullMeta.verified && pullMeta.modelId ? pullMeta.modelId : undefined);
+    if (!enableId) {
+      const expected =
+        pullMeta.modelId ||
+        preferredEnableTag(modelTag, source) ||
+        resolveLocalEnableModelId(modelTag, preferredEnableTag(modelTag, source), after);
+      throw new Error(
+        joinErrorParts(
+          `Download finished but the model did not appear in ${source === "ollama" ? "Ollama" : "LM Studio"}`,
+          `Expected something like "${expected}". Click Refresh under Installed models, then Enable.`,
+        ),
+      );
+    }
+    setLocalInstallInfo(`Enabling ${enableId}…`);
+    if (!isCurrentPullController(controller, pullAbortRef.current)) return;
+    await onModelActivated(enableId, source, controller.signal);
+    if (!isCurrentPullController(controller, pullAbortRef.current)) return;
+    setLocalInstallInfo(`Ready: ${enableId}`);
+  };
+
+  const executePullLocalModel = async (
+    modelTag: string,
+    source: LocalEngine,
+    controller: AbortController,
+  ): Promise<void> => {
+    const starter = starterForTag(modelTag, source);
+    const installed = await refreshInstalledModels(source);
+    if (controller.signal.aborted) return;
+    const existing = findInstalledStarterId(
+      {
+        tag: modelTag,
+        enableTag: starter?.enableTag ?? preferredEnableTag(modelTag, source) ?? modelTag,
+        match: starter?.match ?? starter?.enableTag ?? modelTag,
+      },
+      installed,
+    );
+    if (existing) {
+      await activateExistingPull(existing, source, controller);
+      return;
+    }
+
+    setLocalPullPercent(0);
+    setLocalInstallInfo(
+      source === "ollama"
+        ? "Starting: ensure Ollama → serve → download…"
+        : "Starting: ensure LM Studio → serve → download…",
+    );
+    const pullMeta = await runModelPull(modelTag, source, controller);
+    await activateDownloadedPull(modelTag, source, starter, pullMeta, controller);
+  };
+
   const pullLocalModel = async (modelTag: string, source: LocalEngine = "lms") => {
     if (!(await waitForPullSlot())) return;
 
@@ -508,63 +581,7 @@ export function useLocalEngineSetup({ isOpen, onModelActivated }: UseLocalEngine
     pullUserCancelledRef.current = false;
 
     try {
-      const starter = starterForTag(modelTag, source);
-      const installed = await refreshInstalledModels(source);
-      if (controller.signal.aborted) return;
-      const existing = findInstalledStarterId(
-        {
-          tag: modelTag,
-          enableTag: starter?.enableTag ?? preferredEnableTag(modelTag, source) ?? modelTag,
-          match: starter?.match ?? starter?.enableTag ?? modelTag,
-        },
-        installed,
-      );
-      if (existing) {
-        await activateExistingPull(existing, source, controller);
-        return;
-      }
-
-      setLocalPullPercent(0);
-      setLocalInstallInfo(
-        source === "ollama"
-          ? "Starting: ensure Ollama → serve → download…"
-          : "Starting: ensure LM Studio → serve → download…",
-      );
-
-      const pullMeta = await runModelPull(modelTag, source, controller);
-      if (controller.signal.aborted) return;
-      markEngineReady(source);
-      const after = await refreshInstalledModels(source);
-      if (controller.signal.aborted) return;
-      const found = findInstalledStarterId(
-        {
-          tag: modelTag,
-          enableTag: starter?.enableTag ?? preferredEnableTag(modelTag, source) ?? modelTag,
-          match: starter?.match ?? starter?.enableTag ?? modelTag,
-        },
-        after,
-      );
-      const enableId =
-        found ??
-        (pullMeta.modelId && after.includes(pullMeta.modelId) ? pullMeta.modelId : undefined) ??
-        (pullMeta.verified && pullMeta.modelId ? pullMeta.modelId : undefined);
-      if (!enableId) {
-        const expected =
-          pullMeta.modelId ||
-          preferredEnableTag(modelTag, source) ||
-          resolveLocalEnableModelId(modelTag, preferredEnableTag(modelTag, source), after);
-        throw new Error(
-          joinErrorParts(
-            `Download finished but the model did not appear in ${source === "ollama" ? "Ollama" : "LM Studio"}`,
-            `Expected something like "${expected}". Click Refresh under Installed models, then Enable.`,
-          ),
-        );
-      }
-      setLocalInstallInfo(`Enabling ${enableId}…`);
-      if (controller.signal.aborted || pullAbortRef.current !== controller) return;
-      await onModelActivated(enableId, source, controller.signal);
-      if (controller.signal.aborted || pullAbortRef.current !== controller) return;
-      setLocalInstallInfo(`Ready: ${enableId}`);
+      await executePullLocalModel(modelTag, source, controller);
     } catch (err: unknown) {
       // A cancelled pull already reset all this state synchronously and may have
       // let the user start a new pull — don't let this stale rejection stomp it.

--- a/src/components/features/assistant/useLocalEngineSetup.ts
+++ b/src/components/features/assistant/useLocalEngineSetup.ts
@@ -11,7 +11,7 @@ import {
 interface UseLocalEngineSetupOptions {
   isOpen: boolean;
   /** Called after a 1-click pull finishes so the provider status / audit can refresh. */
-  onModelActivated: (modelTag: string, source: LocalEngine) => void | Promise<void>;
+  onModelActivated: (modelTag: string, source: LocalEngine, signal?: AbortSignal) => void | Promise<void>;
 }
 
 type InstallStreamEvent = {
@@ -299,7 +299,9 @@ export function useLocalEngineSetup({ isOpen, onModelActivated }: UseLocalEngine
     evt: PullStreamEvent,
     state: { gotDone: boolean; finalMessage: string; modelId?: string; verified?: boolean },
     onDownloadPhase?: () => void,
+    controller?: AbortController,
   ) => {
+    if (controller && (controller.signal.aborted || pullAbortRef.current !== controller)) return;
     // Server only starts its 20m lms get / ollama timer after ensure*; arm ours then too.
     if (
       evt.type === "progress" ||
@@ -331,6 +333,7 @@ export function useLocalEngineSetup({ isOpen, onModelActivated }: UseLocalEngine
 
   const consumePullStream = async (
     r: Response,
+    controller: AbortController,
     onDownloadPhase?: () => void,
   ): Promise<{ modelId?: string; verified?: boolean }> => {
     if (!r.ok && !r.body) {
@@ -345,7 +348,7 @@ export function useLocalEngineSetup({ isOpen, onModelActivated }: UseLocalEngine
     };
     const buf = await readNdjsonLines(r.body, (line) => {
       try {
-        handlePullStreamEvent(JSON.parse(line) as PullStreamEvent, state, onDownloadPhase);
+        handlePullStreamEvent(JSON.parse(line) as PullStreamEvent, state, onDownloadPhase, controller);
       } catch (e) {
         if (e instanceof SyntaxError) return;
         throw e;
@@ -374,6 +377,7 @@ export function useLocalEngineSetup({ isOpen, onModelActivated }: UseLocalEngine
       throw new Error(`Pull failed (HTTP ${r.status})`);
     }
 
+    if (controller.signal.aborted || pullAbortRef.current !== controller) return {};
     setLocalInstallInfo(state.finalMessage || "Model ready.");
     return { modelId: state.modelId, verified: state.verified };
   };
@@ -421,10 +425,11 @@ export function useLocalEngineSetup({ isOpen, onModelActivated }: UseLocalEngine
         installed,
       );
       if (existing) {
+        if (controller.signal.aborted || pullAbortRef.current !== controller) return;
         setLocalPullPercent(100);
         setLocalInstallInfo(`Already installed — enabling ${existing}…`);
-        await onModelActivated(existing, source);
-        if (controller.signal.aborted) return;
+        await onModelActivated(existing, source, controller.signal);
+        if (controller.signal.aborted || pullAbortRef.current !== controller) return;
         setLocalInstallInfo(`Ready: ${existing}`);
         return;
       }
@@ -463,7 +468,7 @@ export function useLocalEngineSetup({ isOpen, onModelActivated }: UseLocalEngine
           signal: controller.signal,
         });
         if (controller.signal.aborted) return;
-        pullMeta = await consumePullStream(r, armDownloadTimeout);
+        pullMeta = await consumePullStream(r, controller, armDownloadTimeout);
       } finally {
         clearTimeout(ensureTimer);
         if (downloadTimer) clearTimeout(downloadTimer);
@@ -498,8 +503,9 @@ export function useLocalEngineSetup({ isOpen, onModelActivated }: UseLocalEngine
         );
       }
       setLocalInstallInfo(`Enabling ${enableId}…`);
-      await onModelActivated(enableId, source);
-      if (controller.signal.aborted) return;
+      if (controller.signal.aborted || pullAbortRef.current !== controller) return;
+      await onModelActivated(enableId, source, controller.signal);
+      if (controller.signal.aborted || pullAbortRef.current !== controller) return;
       setLocalInstallInfo(`Ready: ${enableId}`);
     } catch (err: unknown) {
       // A cancelled pull already reset all this state synchronously and may have
@@ -514,7 +520,7 @@ export function useLocalEngineSetup({ isOpen, onModelActivated }: UseLocalEngine
         pullAbortRef.current = null;
         setPullingModel(null);
       }
-      pullUserCancelledRef.current = false;
+      if (pullAbortRef.current === controller) pullUserCancelledRef.current = false;
     }
   };
 

--- a/src/index.css
+++ b/src/index.css
@@ -224,7 +224,7 @@
   html {
     /* Belt-and-braces: prevent horizontal overscroll as well. */
     overflow-x: hidden;
-    font-size: 18px;
+    font-size: 16px;
   }
 
   body {

--- a/src/lib/issueReport.test.ts
+++ b/src/lib/issueReport.test.ts
@@ -37,11 +37,15 @@ describe("redactSecrets", () => {
 
   it("redacts standalone JWTs and PEM private keys", () => {
     const jwt = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.signaturevalue123";
+    const compactJwt = "a.e30.-";
+    const emptySignatureJwt = "a.e30.";
     const pem = "-----BEGIN PRIVATE KEY-----\nsecret-material\n-----END PRIVATE KEY-----";
-    const redacted = redactSecrets(`jwt=${jwt}\nkey=${pem}`);
+    const redacted = redactSecrets(`jwt=${jwt}\ncompact=${compactJwt}\nempty=${emptySignatureJwt}\nkey=${pem}`);
     expect(redacted).not.toContain(jwt);
+    expect(redacted).not.toContain(compactJwt);
+    expect(redacted).not.toContain(emptySignatureJwt);
     expect(redacted).not.toContain("secret-material");
-    expect(redacted.match(/\[REDACTED\]/g)?.length).toBe(2);
+    expect(redacted.match(/\[REDACTED\]/g)?.length).toBe(4);
   });
 
   it("redacts Windows user paths", () => {

--- a/src/lib/issueReport.test.ts
+++ b/src/lib/issueReport.test.ts
@@ -6,6 +6,7 @@ import {
   buildIssueTitle,
   buildGitHubIssueUrl,
   buildReport,
+  categoryHasSeverity,
   type IssueReport,
   type BuildReportOptions,
 } from "./issueReport";
@@ -154,6 +155,18 @@ describe("buildIssueBody", () => {
     const report = { ...baseReport, telemetry: {} };
     const body = buildIssueBody(report);
     expect(body).not.toContain("### Telemetry");
+  });
+
+  it("normalizes N/A away from bug reports", () => {
+    const body = buildIssueBody({ ...baseReport, severity: "n-a" });
+    expect(body).toContain("**Severity:** Annoying");
+    expect(body).not.toContain("**Severity:** N/A");
+  });
+
+  it("uses N/A for non-bug categories", () => {
+    expect(categoryHasSeverity("feature")).toBe(false);
+    const body = buildIssueBody({ ...baseReport, category: "feature", severity: "blocking" });
+    expect(body).toContain("**Severity:** N/A");
   });
 });
 

--- a/src/lib/issueReport.test.ts
+++ b/src/lib/issueReport.test.ts
@@ -35,6 +35,15 @@ describe("redactSecrets", () => {
     expect(redactSecrets('api_key="sk-1234567890abcdef1234567890"')).toContain("[REDACTED]");
   });
 
+  it("redacts standalone JWTs and PEM private keys", () => {
+    const jwt = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.signaturevalue123";
+    const pem = "-----BEGIN PRIVATE KEY-----\nsecret-material\n-----END PRIVATE KEY-----";
+    const redacted = redactSecrets(`jwt=${jwt}\nkey=${pem}`);
+    expect(redacted).not.toContain(jwt);
+    expect(redacted).not.toContain("secret-material");
+    expect(redacted.match(/\[REDACTED\]/g)?.length).toBe(2);
+  });
+
   it("redacts Windows user paths", () => {
     expect(redactSecrets("C:\\Users\\JohnDoe\\Documents")).toContain("[REDACTED]");
     expect(redactSecrets("C:\\Users\\JohnDoe\\Documents")).not.toContain("JohnDoe");

--- a/src/lib/issueReport.ts
+++ b/src/lib/issueReport.ts
@@ -66,8 +66,8 @@ const SECRET_PATTERNS: RegExp[] = [
   /(?:AKIA|ASIA)[A-Z0-9]{16}/g,
   // Bearer tokens (Authorization header)
   /Bearer\s+[A-Za-z0-9\-._~+/]+=*/g,
-  // JSON Web Tokens (three base64url-encoded segments)
-  /\b[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\b/g,
+  // JSON Web Tokens (three base64url-encoded segments; payload/signature may be empty)
+  /(?<![A-Za-z0-9_-])[A-Za-z0-9_-]+\.[A-Za-z0-9_-]*\.[A-Za-z0-9_-]*(?![A-Za-z0-9_-])/g,
   // PEM private-key blocks
   /-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z0-9 ]*PRIVATE KEY-----/gi,
   // Generic long hex strings that look like secrets (32+ hex chars)

--- a/src/lib/issueReport.ts
+++ b/src/lib/issueReport.ts
@@ -13,11 +13,17 @@ export const REPORT_CATEGORIES = [
 export type ReportCategory = (typeof REPORT_CATEGORIES)[number]["id"];
 
 export const REPORT_SEVERITIES = [
+  { id: "n-a", label: "N/A" },
   { id: "annoying", label: "Annoying" },
   { id: "blocking", label: "Blocking" },
   { id: "crash", label: "Crash" },
   { id: "silent", label: "Silent data loss" },
 ] as const;
+
+/** Severity only describes bug impact; other categories have nothing to rate. */
+export function categoryHasSeverity(category: ReportCategory): boolean {
+  return category === "bug";
+}
 
 export type ReportSeverity = (typeof REPORT_SEVERITIES)[number]["id"];
 
@@ -41,6 +47,7 @@ export const TELEMETRY_OPTIONS = [
   { id: "olive-version", label: "Olive & ORT versions", description: "ONNX Runtime and Olive engine versions" },
   { id: "recipe", label: "Current recipe", description: "The active recipe JSON (redacted)" },
   { id: "logs", label: "Execution logs", description: "Recent log lines from the last run" },
+  { id: "chat-logs", label: "Assistant chat log", description: "Recent messages from this chat session (redacted)" },
 ] as const;
 
 export type TelemetryOptionId = (typeof TELEMETRY_OPTIONS)[number]["id"];
@@ -113,6 +120,8 @@ export interface BuildReportOptions {
   state?: UIState;
   hardwareProbe?: HardwareProbeResult | null;
   executionLogs?: string[];
+  /** Recent assistant chat transcript, formatted as one "sender: text" line per turn. */
+  chatLog?: string[];
   mcpDiagnostic?: unknown;
 }
 
@@ -180,6 +189,11 @@ function collectLogs(logs: string[] | undefined, maxLines = 50): string {
   return recent.join("\n");
 }
 
+function collectChatLog(chatLog: string[] | undefined, maxLines = 20): string {
+  if (!chatLog || chatLog.length === 0) return "No chat history available";
+  return chatLog.slice(-maxLines).join("\n");
+}
+
 // ── Builder ──────────────────────────────────────────────────────────────────
 
 /**
@@ -207,6 +221,9 @@ export function collectTelemetry(
         break;
       case "logs":
         telemetry.logs = redactSecrets(collectLogs(buildOptions.executionLogs));
+        break;
+      case "chat-logs":
+        telemetry["chat-logs"] = redactSecrets(collectChatLog(buildOptions.chatLog));
         break;
     }
   }

--- a/src/lib/issueReport.ts
+++ b/src/lib/issueReport.ts
@@ -66,6 +66,10 @@ const SECRET_PATTERNS: RegExp[] = [
   /(?:AKIA|ASIA)[A-Z0-9]{16}/g,
   // Bearer tokens (Authorization header)
   /Bearer\s+[A-Za-z0-9\-._~+/]+=*/g,
+  // JSON Web Tokens (three base64url-encoded segments)
+  /\b[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\b/g,
+  // PEM private-key blocks
+  /-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z0-9 ]*PRIVATE KEY-----/gi,
   // Generic long hex strings that look like secrets (32+ hex chars)
   /(?:["'\s:=]|^)[0-9a-f]{32,}(?:["'\s]|$)/gi,
   // Paths containing user home directories (privacy)

--- a/src/lib/issueReport.ts
+++ b/src/lib/issueReport.ts
@@ -4,10 +4,10 @@ import type { UIState } from "@/types";
 // ── Report categories ────────────────────────────────────────────────────────
 
 export const REPORT_CATEGORIES = [
-  { id: "bug", label: "Bug report" },
-  { id: "feature", label: "Feature request" },
-  { id: "docs", label: "Documentation" },
-  { id: "other", label: "Other" },
+  { id: "bug", label: "Bug report", hasSeverity: true },
+  { id: "feature", label: "Feature request", hasSeverity: false },
+  { id: "docs", label: "Documentation", hasSeverity: false },
+  { id: "other", label: "Other", hasSeverity: false },
 ] as const;
 
 export type ReportCategory = (typeof REPORT_CATEGORIES)[number]["id"];
@@ -22,7 +22,7 @@ export const REPORT_SEVERITIES = [
 
 /** Severity only describes bug impact; other categories have nothing to rate. */
 export function categoryHasSeverity(category: ReportCategory): boolean {
-  return category === "bug";
+  return REPORT_CATEGORIES.find((candidate) => candidate.id === category)?.hasSeverity ?? false;
 }
 
 export type ReportSeverity = (typeof REPORT_SEVERITIES)[number]["id"];
@@ -236,6 +236,8 @@ export function collectTelemetry(
  */
 export function buildIssueBody(report: IssueReport): string {
   const lines: string[] = [];
+  const hasSeverity = categoryHasSeverity(report.category);
+  const severity = hasSeverity ? (report.severity === "n-a" ? "annoying" : report.severity) : "n-a";
 
   // Header
   lines.push("## Issue Report");
@@ -243,7 +245,7 @@ export function buildIssueBody(report: IssueReport): string {
 
   // Metadata
   lines.push(`**Category:** ${REPORT_CATEGORIES.find((c) => c.id === report.category)?.label ?? report.category}`);
-  lines.push(`**Severity:** ${REPORT_SEVERITIES.find((s) => s.id === report.severity)?.label ?? report.severity}`);
+  lines.push(`**Severity:** ${REPORT_SEVERITIES.find((s) => s.id === severity)?.label ?? severity}`);
   lines.push(`**Area:** ${REPORT_AREAS.find((a) => a.id === report.area)?.label ?? report.area}`);
   
   // Frequency info for repeated errors

--- a/src/server/routes/ai/lmStudioRoutes.ts
+++ b/src/server/routes/ai/lmStudioRoutes.ts
@@ -139,10 +139,22 @@ export function mountLmStudioRoutes(router: Router): void {
     };
     const tag = String(modelTag);
     let ownsBusy = false;
+    let resolveTeardown: (() => void) | null = null;
+    const teardown = new Promise<void>((resolve) => {
+      resolveTeardown = resolve;
+    });
     const releaseBusy = () => {
       if (ownsBusy && localEngineRuntime.lmsPullBusyTag === tag) {
         localEngineRuntime.lmsPullBusyTag = null;
         ownsBusy = false;
+      }
+    };
+    const finalizeBusy = () => {
+      releaseBusy();
+      if (localEngineRuntime.lmsPullTeardown === teardown) {
+        localEngineRuntime.lmsPullTeardown = null;
+        resolveTeardown?.();
+        resolveTeardown = null;
       }
     };
     try {
@@ -152,13 +164,24 @@ export function mountLmStudioRoutes(router: Router): void {
         return;
       }
       if (localEngineRuntime.lmsPullBusyTag) {
-        send({
-          type: "error",
-          error: "Another LM Studio download is already in progress.",
-          hint: `Wait for "${localEngineRuntime.lmsPullBusyTag}" to finish, or cancel that download, then retry.`,
-        });
-        guard.endOnce();
-        return;
+        const cancelledPull =
+          localEngineRuntime.lmsPullBusyTag === tag ? localEngineRuntime.lmsPullTeardown : null;
+        if (cancelledPull) {
+          await cancelledPull;
+          if (guard.disconnected()) {
+            guard.endOnce();
+            return;
+          }
+        }
+        if (localEngineRuntime.lmsPullBusyTag) {
+          send({
+            type: "error",
+            error: "Another LM Studio download is already in progress.",
+            hint: `Wait for "${localEngineRuntime.lmsPullBusyTag}" to finish, or cancel that download, then retry.`,
+          });
+          guard.endOnce();
+          return;
+        }
       }
       const disk = gateLocalPullDiskSpace("lms", tag);
       if (!disk.ok) {
@@ -169,10 +192,16 @@ export function mountLmStudioRoutes(router: Router): void {
 
       localEngineRuntime.lmsPullBusyTag = tag;
       ownsBusy = true;
+      const markCancelled = () => {
+        if (ownsBusy && localEngineRuntime.lmsPullBusyTag === tag) {
+          localEngineRuntime.lmsPullTeardown = teardown;
+        }
+      };
+      guard.signal.addEventListener("abort", markCancelled, { once: true });
       // Waiter-based abort: shared ensure continues while other clients wait.
       const ready = await ensureLmsReady((evt) => send(evt), guard.signal);
       if (guard.disconnected()) {
-        releaseBusy();
+        finalizeBusy();
         guard.endOnce();
         return;
       }
@@ -182,7 +211,7 @@ export function mountLmStudioRoutes(router: Router): void {
           error: ready.error || "LM Studio is not ready",
           openedUrl: ready.openedUrl ?? "https://lmstudio.ai",
         });
-        releaseBusy();
+        finalizeBusy();
         guard.endOnce();
         return;
       }
@@ -193,7 +222,7 @@ export function mountLmStudioRoutes(router: Router): void {
           error: "LM Studio CLI (lms) not found. Install LM Studio from https://lmstudio.ai",
           openedUrl: "https://lmstudio.ai",
         });
-        releaseBusy();
+        finalizeBusy();
         guard.endOnce();
         return;
       }
@@ -326,7 +355,7 @@ export function mountLmStudioRoutes(router: Router): void {
               }
             }
           } finally {
-            releaseBusy();
+            finalizeBusy();
             guard.endOnce();
           }
         })();
@@ -336,11 +365,11 @@ export function mountLmStudioRoutes(router: Router): void {
         clearKillEscalate();
         clearStallTimer();
         if (!guard.disconnected()) send({ type: "error", error: err.message });
-        releaseBusy();
+        finalizeBusy();
         guard.endOnce();
       });
     } catch (err: unknown) {
-      releaseBusy();
+      finalizeBusy();
       if (!guard.disconnected()) {
         send({ type: "error", error: err instanceof Error ? err.message : String(err) });
       }

--- a/src/server/routes/ai/lmStudioRoutes.ts
+++ b/src/server/routes/ai/lmStudioRoutes.ts
@@ -253,12 +253,12 @@ export function mountLmStudioRoutes(router: Router): void {
 
       const logBuf: string[] = [];
       const pushCliChunk = (d: Buffer) => {
-        armStallTimer();
         for (const line of splitCliLines(d.toString())) {
           logBuf.push(line);
           if (logBuf.length > 80) logBuf.splice(0, logBuf.length - 80);
           const cliPct = parseLmsGetPercent(line);
           if (cliPct !== null) {
+            armStallTimer();
             send({
               type: "progress",
               message: line.replace(/\s+/g, " ").slice(0, 160),

--- a/src/server/routes/ai/lmStudioRoutes.ts
+++ b/src/server/routes/ai/lmStudioRoutes.ts
@@ -157,32 +157,33 @@ export function mountLmStudioRoutes(router: Router): void {
         resolveTeardown = null;
       }
     };
+    const waitForPullSlot = async (): Promise<boolean> => {
+      if (!localEngineRuntime.lmsPullBusyTag) return true;
+      const cancelledPull =
+        localEngineRuntime.lmsPullBusyTag === tag ? localEngineRuntime.lmsPullTeardown : null;
+      if (cancelledPull) {
+        await cancelledPull;
+        if (guard.disconnected()) {
+          guard.endOnce();
+          return false;
+        }
+      }
+      if (!localEngineRuntime.lmsPullBusyTag) return true;
+      send({
+        type: "error",
+        error: "Another LM Studio download is already in progress.",
+        hint: `Wait for "${localEngineRuntime.lmsPullBusyTag}" to finish, or cancel that download, then retry.`,
+      });
+      guard.endOnce();
+      return false;
+    };
     try {
       if (!isValidLocalModelTag(tag)) {
         send({ type: "error", error: "Invalid modelTag." });
         guard.endOnce();
         return;
       }
-      if (localEngineRuntime.lmsPullBusyTag) {
-        const cancelledPull =
-          localEngineRuntime.lmsPullBusyTag === tag ? localEngineRuntime.lmsPullTeardown : null;
-        if (cancelledPull) {
-          await cancelledPull;
-          if (guard.disconnected()) {
-            guard.endOnce();
-            return;
-          }
-        }
-        if (localEngineRuntime.lmsPullBusyTag) {
-          send({
-            type: "error",
-            error: "Another LM Studio download is already in progress.",
-            hint: `Wait for "${localEngineRuntime.lmsPullBusyTag}" to finish, or cancel that download, then retry.`,
-          });
-          guard.endOnce();
-          return;
-        }
-      }
+      if (!(await waitForPullSlot())) return;
       const disk = gateLocalPullDiskSpace("lms", tag);
       if (!disk.ok) {
         send({ type: "error", error: disk.error, hint: disk.hint });

--- a/src/server/routes/ai/lmStudioRoutes.ts
+++ b/src/server/routes/ai/lmStudioRoutes.ts
@@ -252,13 +252,17 @@ export function mountLmStudioRoutes(router: Router): void {
       armStallTimer();
 
       const logBuf: string[] = [];
+      let lastProgressPercent: number | null = null;
       const pushCliChunk = (d: Buffer) => {
         for (const line of splitCliLines(d.toString())) {
           logBuf.push(line);
           if (logBuf.length > 80) logBuf.splice(0, logBuf.length - 80);
           const cliPct = parseLmsGetPercent(line);
           if (cliPct !== null) {
-            armStallTimer();
+            if (lastProgressPercent === null || cliPct > lastProgressPercent) {
+              lastProgressPercent = cliPct;
+              armStallTimer();
+            }
             send({
               type: "progress",
               message: line.replace(/\s+/g, " ").slice(0, 160),

--- a/src/server/routes/ai/lmStudioRoutes.ts
+++ b/src/server/routes/ai/lmStudioRoutes.ts
@@ -228,8 +228,32 @@ export function mountLmStudioRoutes(router: Router): void {
       }, LMS_GET_MAX_MS);
       guard.signal.addEventListener("abort", killProc, { once: true });
 
+      // `lms get` can go silent for long stretches on a stalled connection well
+      // before the 20-minute hard timeout. Surface that instead of leaving the
+      // user staring at a frozen percentage with no idea whether it's still working.
+      const STALL_WARN_MS = 45_000;
+      let stallTimer: ReturnType<typeof setTimeout> | undefined;
+      const armStallTimer = () => {
+        if (stallTimer) clearTimeout(stallTimer);
+        stallTimer = setTimeout(() => {
+          send({
+            type: "log",
+            message: `No progress for ${Math.round(STALL_WARN_MS / 1000)}s — the download may be stuck. You can cancel and retry.`,
+          });
+        }, STALL_WARN_MS);
+        if (typeof stallTimer.unref === "function") stallTimer.unref();
+      };
+      const clearStallTimer = () => {
+        if (stallTimer) {
+          clearTimeout(stallTimer);
+          stallTimer = undefined;
+        }
+      };
+      armStallTimer();
+
       const logBuf: string[] = [];
       const pushCliChunk = (d: Buffer) => {
+        armStallTimer();
         for (const line of splitCliLines(d.toString())) {
           logBuf.push(line);
           if (logBuf.length > 80) logBuf.splice(0, logBuf.length - 80);
@@ -250,6 +274,7 @@ export function mountLmStudioRoutes(router: Router): void {
       proc.on("close", (code) => {
         clearTimeout(maxTimer);
         clearKillEscalate();
+        clearStallTimer();
         void (async () => {
           try {
             if (!guard.disconnected()) {
@@ -300,6 +325,7 @@ export function mountLmStudioRoutes(router: Router): void {
       proc.on("error", (err) => {
         clearTimeout(maxTimer);
         clearKillEscalate();
+        clearStallTimer();
         if (!guard.disconnected()) send({ type: "error", error: err.message });
         releaseBusy();
         guard.endOnce();

--- a/src/server/routes/ai/lmStudioRoutes.ts
+++ b/src/server/routes/ai/lmStudioRoutes.ts
@@ -138,8 +138,12 @@ export function mountLmStudioRoutes(router: Router): void {
       rawSend(evt);
     };
     const tag = String(modelTag);
+    let ownsBusy = false;
     const releaseBusy = () => {
-      if (localEngineRuntime.lmsPullBusyTag === tag) localEngineRuntime.lmsPullBusyTag = null;
+      if (ownsBusy && localEngineRuntime.lmsPullBusyTag === tag) {
+        localEngineRuntime.lmsPullBusyTag = null;
+        ownsBusy = false;
+      }
     };
     try {
       if (!isValidLocalModelTag(tag)) {
@@ -164,6 +168,7 @@ export function mountLmStudioRoutes(router: Router): void {
       }
 
       localEngineRuntime.lmsPullBusyTag = tag;
+      ownsBusy = true;
       // Waiter-based abort: shared ensure continues while other clients wait.
       const ready = await ensureLmsReady((evt) => send(evt), guard.signal);
       if (guard.disconnected()) {

--- a/src/server/routes/ai/lmStudioRoutes.ts
+++ b/src/server/routes/ai/lmStudioRoutes.ts
@@ -158,24 +158,29 @@ export function mountLmStudioRoutes(router: Router): void {
       }
     };
     const waitForPullSlot = async (): Promise<boolean> => {
-      if (!localEngineRuntime.lmsPullBusyTag) return true;
-      const cancelledPull =
-        localEngineRuntime.lmsPullBusyTag === tag ? localEngineRuntime.lmsPullTeardown : null;
-      if (cancelledPull) {
-        await cancelledPull;
-        if (guard.disconnected()) {
+      if (localEngineRuntime.lmsPullBusyTag) {
+        const cancelledPull =
+          localEngineRuntime.lmsPullBusyTag === tag ? localEngineRuntime.lmsPullTeardown : null;
+        if (cancelledPull) {
+          await cancelledPull;
+          if (guard.disconnected()) {
+            guard.endOnce();
+            return false;
+          }
+        }
+        if (localEngineRuntime.lmsPullBusyTag) {
+          send({
+            type: "error",
+            error: "Another LM Studio download is already in progress.",
+            hint: `Wait for "${localEngineRuntime.lmsPullBusyTag}" to finish, or cancel that download, then retry.`,
+          });
           guard.endOnce();
           return false;
         }
       }
-      if (!localEngineRuntime.lmsPullBusyTag) return true;
-      send({
-        type: "error",
-        error: "Another LM Studio download is already in progress.",
-        hint: `Wait for "${localEngineRuntime.lmsPullBusyTag}" to finish, or cancel that download, then retry.`,
-      });
-      guard.endOnce();
-      return false;
+      localEngineRuntime.lmsPullBusyTag = tag;
+      ownsBusy = true;
+      return true;
     };
     try {
       if (!isValidLocalModelTag(tag)) {
@@ -187,12 +192,11 @@ export function mountLmStudioRoutes(router: Router): void {
       const disk = gateLocalPullDiskSpace("lms", tag);
       if (!disk.ok) {
         send({ type: "error", error: disk.error, hint: disk.hint });
+        finalizeBusy();
         guard.endOnce();
         return;
       }
 
-      localEngineRuntime.lmsPullBusyTag = tag;
-      ownsBusy = true;
       const markCancelled = () => {
         if (ownsBusy && localEngineRuntime.lmsPullBusyTag === tag) {
           localEngineRuntime.lmsPullTeardown = teardown;

--- a/src/server/services/ai/localEngineState.ts
+++ b/src/server/services/ai/localEngineState.ts
@@ -17,6 +17,8 @@ export interface LocalEngineRuntime {
   lastOllamaStartAt: number;
   /** One active `lms get` at a time (server-side single-flight). */
   lmsPullBusyTag: string | null;
+  /** Resolves after a cancelled LM Studio pull has fully torn down. */
+  lmsPullTeardown: Promise<void> | null;
   /** One active Ollama pull at a time (server-side single-flight). */
   ollamaPullBusyTag: string | null;
   ollamaProgressSubscribers: Set<(evt: EnsureProgressEvt) => void>;
@@ -36,6 +38,7 @@ function createLocalEngineRuntime(): LocalEngineRuntime {
     lmsEnsureInFlight: null,
     lastOllamaStartAt: 0,
     lmsPullBusyTag: null,
+    lmsPullTeardown: null,
     ollamaPullBusyTag: null,
     ollamaProgressSubscribers: new Set(),
     lmsProgressSubscribers: new Set(),

--- a/src/server/services/ai/oliveMcpKnowledge.ts
+++ b/src/server/services/ai/oliveMcpKnowledge.ts
@@ -476,6 +476,7 @@ export function buildOliveAssistantSystemPrompt(opts: {
     "- On refusal: briefly redirect to Olive Studio / model optimization (or ask for professional language), invite a pipeline-related question, and set actions to []. Never provide the off-topic, hateful/sexual, or harmful content.",
     "- Stay professional and technical in your own replies. Do not use childish euphemisms or role-play outside the Olive domain.",
     "Use the Olive MCP knowledge block as your primary source. Workspace context describes the user's current recipe UI state, detected hardware, and built recipe JSON.",
+    "The only model in scope is the workspace context's `Model:` line (the target model being optimized). You (the assistant) may be running on a different, unrelated local or hosted LLM to power this chat — never confuse that chat LLM with the target model, and never assume the user is asking about you when they say 'the model' or 'my model'. If the workspace `Model:` line says \"(not set)\", say no model is selected yet instead of guessing.",
     "When you suggest a concrete change the user can make in Olive Studio, include an Apply action with a valid patch so they can click Apply.",
     "",
     opts.mcpBlock,


### PR DESCRIPTION
The issue report modal now locks severity to N/A for non-bug categories and includes assistant chat logs in telemetry/report previews. This also wires the assistant sidebar to send hardware and chat context, improves local model pull cancellation resets, adds LM Studio stall warnings, and clarifies the MCP system prompt to distinguish the target workspace model from the chat LLM.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tonythethompson/Olive-Studio/pull/268?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Improve issue reporting with chat logs, severity normalization, and single-flight model downloads
> - Adds an optional assistant chat log to issue reports: the `ReportIssueModal` accepts a `chatLog` prop and a new `'chat-logs'` telemetry option collects redacted transcript lines via `collectTelemetry` in [issueReport.ts](https://github.com/tonythethompson/Olive-Studio/pull/268/files#diff-f0dfcdeeb10722fbc772ebf6cce3d19c8ff3dc55288e7a2bd44b73b0c5cc97ac)
> - Normalizes severity in generated issue bodies: non-bug categories show `N/A`, and bug reports with `N/A` severity fall back to `Annoying`
> - `AssistantSidebar` now passes hardware probe data and the current chat log into `ReportIssueModal` for richer diagnostics
> - Serializes LM Studio model downloads so a new pull waits for a cancelled pull's teardown before starting; a stall warning is emitted if no download progress is observed for 45s
> - Abort signal support is threaded through `enableLocalAiProvider`, `fetchProviderStatus`, and `useLocalEngineSetup` to prevent stale operations from updating UI state
> - Behavioral Change: base HTML font size is reduced from 18px to 16px in [index.css](https://github.com/tonythethompson/Olive-Studio/pull/268/files#diff-85da366246340e911d7a0eb9153e64137a1b31f0686c74d9aef9ae4f032cb09e)
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fc90f7d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->