### PR TITLE
Fix issues 273-276: EP recommendation nag, silent audit-apply, unbounded olive/run wait

### DIFF
--- a/src/components/features/assistant/useAiAudit.ts
+++ b/src/components/features/assistant/useAiAudit.ts
@@ -79,7 +79,11 @@ export function useAiAudit({ state, setState }: UseAiAuditOptions) {
     if (!autofix?.pass) return;
     const current = stateRef.current;
     const patch = resolveAuditAutofix(autofix, current);
-    if (!patch) return;
+    if (!patch) {
+      setAnalysisError("Couldn't apply this suggestion automatically — please make the change manually.");
+      return;
+    }
+    setAnalysisError("");
     const prior = analysis?.score ?? null;
     const next: UIState = {
       ...current,

--- a/src/components/features/ihv/HardwareProbeDisplay.tsx
+++ b/src/components/features/ihv/HardwareProbeDisplay.tsx
@@ -40,104 +40,7 @@ export function HardwareProbeDisplay({
           {probeError ? (
             <p className="text-sm text-rose-400 break-all">{probeError}</p>
           ) : hardwareProbe ? (
-            <div className="space-y-1.5 text-sm text-slate-400">
-              <p>
-                <span className="text-slate-500">CPU:</span>{" "}
-                <span className="text-slate-200">{hardwareProbe.platform.cpuModel}</span>
-                <span className="text-slate-600">
-                  {" "}
-                  · {hardwareProbe.platform.cpuCores} cores · {hardwareProbe.platform.os} (
-                  {hardwareProbe.platform.arch})
-                </span>
-              </p>
-              <p>
-                <span className="text-slate-500">System RAM:</span>{" "}
-                <span className="text-slate-200 font-mono">
-                  {hardwareProbe.platform.systemRamGb != null
-                    ? formatMemoryGb(hardwareProbe.platform.systemRamGb)
-                    : "Unknown"}
-                </span>
-              </p>
-              {hardwareProbe.nvidia?.gpus.length ? (
-                <p>
-                  <span className="text-slate-500">NVIDIA:</span>{" "}
-                  <span className="text-slate-200">
-                    {hardwareProbe.nvidia.gpus
-                      .map((g) =>
-                        g.vramMb ? `${g.name} (${formatMemoryGb(g.vramMb / 1024)})` : g.name,
-                      )
-                      .join(", ")}
-                  </span>
-                  {hardwareProbe.nvidia.cudaVersion && (
-                    <span className="text-slate-600">
-                      {" "}
-                      · driver CUDA {hardwareProbe.nvidia.cudaVersion}
-                      {hardwareProbe.nvidia.cudaTag ? ` → ${hardwareProbe.nvidia.cudaTag}` : ""}
-                    </span>
-                  )}
-                </p>
-              ) : (
-                <p>
-                  <span className="text-slate-500">NVIDIA:</span>{" "}
-                  <span className="text-slate-600">not detected</span>
-                </p>
-              )}
-              {hardwareProbe.rocm?.gpus.length ? (
-                <p>
-                  <span className="text-slate-500">AMD ROCm:</span>{" "}
-                  <span className="text-slate-200">
-                    {hardwareProbe.rocm.gpus
-                      .map((g) =>
-                        g.vramMb ? `${g.name} (${formatMemoryGb(g.vramMb / 1024)})` : g.name,
-                      )
-                      .join(", ")}
-                  </span>
-                </p>
-              ) : null}
-              {hardwareProbe.openvino?.loadable ? (
-                <p>
-                  <span className="text-slate-500">OpenVINO:</span>{" "}
-                  <span className="text-slate-200">
-                    Python package v{hardwareProbe.openvino.version ?? "unknown"}
-                  </span>
-                </p>
-              ) : null}
-              {hardwareProbe.onnxRuntimeProviders?.length ? (
-                <p>
-                  <span className="text-slate-500">ONNX Runtime EPs:</span>{" "}
-                  <span className="font-mono text-xs text-emerald-400">
-                    {hardwareProbe.onnxRuntimeProviders.join(", ")}
-                  </span>
-                </p>
-              ) : null}
-              {!hardwareProbe.detectedProviders?.includes(state.ihvProvider) && (
-                <p className="text-xs text-slate-500 pt-1">
-                  Recommended target:{" "}
-                  <span className="text-electric-blue font-semibold">
-                    {providers.find((p) => p.id === hardwareProbe.recommendedProvider)?.name ??
-                      hardwareProbe.recommendedProvider}
-                  </span>
-                  {state.ihvProvider !== hardwareProbe.recommendedProvider && (
-                    <button
-                      type="button"
-                      onClick={() =>
-                      {
-                        const patch = prepareProviderChange(
-                          state,
-                          hardwareProbe.recommendedProvider,
-                          hardwareProbe,
-                        );
-                        if (patch) setState(patch);
-                      }
-                      }
-                      className="ml-2 text-sm text-electric-blue hover:text-white cursor-pointer"
-                    >
-                      Apply
-                    </button>
-                  )}
-                </p>
-              )}
-            </div>
+            <HardwareProbeDetails state={state} setState={setState} hardwareProbe={hardwareProbe} />
           ) : !probeLoading ? (
             <p className="text-sm text-slate-500">No hardware data yet.</p>
           ) : null}
@@ -152,6 +55,109 @@ export function HardwareProbeDisplay({
           Re-scan hardware
         </button>
       </div>
+    </div>
+  );
+}
+
+interface HardwareProbeDetailsProps {
+  state: UIState;
+  setState: (s: Partial<UIState>) => void;
+  hardwareProbe: HardwareProbeResult;
+}
+
+/** Detected CPU/GPU/runtime rows plus the recommended-EP nudge. Split out of
+ * HardwareProbeDisplay to keep that component's branch count low. */
+function HardwareProbeDetails({ state, setState, hardwareProbe }: HardwareProbeDetailsProps) {
+  const showRecommendation = !hardwareProbe.detectedProviders?.includes(state.ihvProvider);
+
+  return (
+    <div className="space-y-1.5 text-sm text-slate-400">
+      <p>
+        <span className="text-slate-500">CPU:</span>{" "}
+        <span className="text-slate-200">{hardwareProbe.platform.cpuModel}</span>
+        <span className="text-slate-600">
+          {" "}
+          · {hardwareProbe.platform.cpuCores} cores · {hardwareProbe.platform.os} (
+          {hardwareProbe.platform.arch})
+        </span>
+      </p>
+      <p>
+        <span className="text-slate-500">System RAM:</span>{" "}
+        <span className="text-slate-200 font-mono">
+          {hardwareProbe.platform.systemRamGb != null
+            ? formatMemoryGb(hardwareProbe.platform.systemRamGb)
+            : "Unknown"}
+        </span>
+      </p>
+      {hardwareProbe.nvidia?.gpus.length ? (
+        <p>
+          <span className="text-slate-500">NVIDIA:</span>{" "}
+          <span className="text-slate-200">
+            {hardwareProbe.nvidia.gpus
+              .map((g) => (g.vramMb ? `${g.name} (${formatMemoryGb(g.vramMb / 1024)})` : g.name))
+              .join(", ")}
+          </span>
+          {hardwareProbe.nvidia.cudaVersion && (
+            <span className="text-slate-600">
+              {" "}
+              · driver CUDA {hardwareProbe.nvidia.cudaVersion}
+              {hardwareProbe.nvidia.cudaTag ? ` → ${hardwareProbe.nvidia.cudaTag}` : ""}
+            </span>
+          )}
+        </p>
+      ) : (
+        <p>
+          <span className="text-slate-500">NVIDIA:</span>{" "}
+          <span className="text-slate-600">not detected</span>
+        </p>
+      )}
+      {hardwareProbe.rocm?.gpus.length ? (
+        <p>
+          <span className="text-slate-500">AMD ROCm:</span>{" "}
+          <span className="text-slate-200">
+            {hardwareProbe.rocm.gpus
+              .map((g) => (g.vramMb ? `${g.name} (${formatMemoryGb(g.vramMb / 1024)})` : g.name))
+              .join(", ")}
+          </span>
+        </p>
+      ) : null}
+      {hardwareProbe.openvino?.loadable ? (
+        <p>
+          <span className="text-slate-500">OpenVINO:</span>{" "}
+          <span className="text-slate-200">
+            Python package v{hardwareProbe.openvino.version ?? "unknown"}
+          </span>
+        </p>
+      ) : null}
+      {hardwareProbe.onnxRuntimeProviders?.length ? (
+        <p>
+          <span className="text-slate-500">ONNX Runtime EPs:</span>{" "}
+          <span className="font-mono text-xs text-emerald-400">
+            {hardwareProbe.onnxRuntimeProviders.join(", ")}
+          </span>
+        </p>
+      ) : null}
+      {showRecommendation && (
+        <p className="text-xs text-slate-500 pt-1">
+          Recommended target:{" "}
+          <span className="text-electric-blue font-semibold">
+            {providers.find((p) => p.id === hardwareProbe.recommendedProvider)?.name ??
+              hardwareProbe.recommendedProvider}
+          </span>
+          {state.ihvProvider !== hardwareProbe.recommendedProvider && (
+            <button
+              type="button"
+              onClick={() => {
+                const patch = prepareProviderChange(state, hardwareProbe.recommendedProvider, hardwareProbe);
+                if (patch) setState(patch);
+              }}
+              className="ml-2 text-sm text-electric-blue hover:text-white cursor-pointer"
+            >
+              Apply
+            </button>
+          )}
+        </p>
+      )}
     </div>
   );
 }

--- a/src/components/features/ihv/HardwareProbeDisplay.tsx
+++ b/src/components/features/ihv/HardwareProbeDisplay.tsx
@@ -110,31 +110,33 @@ export function HardwareProbeDisplay({
                   </span>
                 </p>
               ) : null}
-              <p className="text-xs text-slate-500 pt-1">
-                Recommended target:{" "}
-                <span className="text-electric-blue font-semibold">
-                  {providers.find((p) => p.id === hardwareProbe.recommendedProvider)?.name ??
-                    hardwareProbe.recommendedProvider}
-                </span>
-                {state.ihvProvider !== hardwareProbe.recommendedProvider && (
-                  <button
-                    type="button"
-                    onClick={() =>
-                    {
-                      const patch = prepareProviderChange(
-                        state,
-                        hardwareProbe.recommendedProvider,
-                        hardwareProbe,
-                      );
-                      if (patch) setState(patch);
-                    }
-                    }
-                    className="ml-2 text-sm text-electric-blue hover:text-white cursor-pointer"
-                  >
-                    Apply
-                  </button>
-                )}
-              </p>
+              {!hardwareProbe.detectedProviders?.includes(state.ihvProvider) && (
+                <p className="text-xs text-slate-500 pt-1">
+                  Recommended target:{" "}
+                  <span className="text-electric-blue font-semibold">
+                    {providers.find((p) => p.id === hardwareProbe.recommendedProvider)?.name ??
+                      hardwareProbe.recommendedProvider}
+                  </span>
+                  {state.ihvProvider !== hardwareProbe.recommendedProvider && (
+                    <button
+                      type="button"
+                      onClick={() =>
+                      {
+                        const patch = prepareProviderChange(
+                          state,
+                          hardwareProbe.recommendedProvider,
+                          hardwareProbe,
+                        );
+                        if (patch) setState(patch);
+                      }
+                      }
+                      className="ml-2 text-sm text-electric-blue hover:text-white cursor-pointer"
+                    >
+                      Apply
+                    </button>
+                  )}
+                </p>
+              )}
             </div>
           ) : !probeLoading ? (
             <p className="text-sm text-slate-500">No hardware data yet.</p>

--- a/src/server/services/olive/jobRunner.stubSetup.test.ts
+++ b/src/server/services/olive/jobRunner.stubSetup.test.ts
@@ -37,6 +37,7 @@ beforeEach(() => {
   vi.useFakeTimers();
   process.env.OLIVE_JOB_SETUP_STUB = "1";
   delete process.env.OLIVE_JOB_SETUP_STUB_TIMEOUT_MS;
+  delete process.env.OLIVE_UI_SETUP_TIMEOUT_MS;
   vi.mocked(preflightOliveRecipe).mockImplementation(() => ({
     valid: true,
     provider: "CPUExecutionProvider",
@@ -70,6 +71,7 @@ afterEach(async () => {
     clearIdempotencyIndex();
     delete process.env.OLIVE_JOB_SETUP_STUB;
     delete process.env.OLIVE_JOB_SETUP_STUB_TIMEOUT_MS;
+    delete process.env.OLIVE_UI_SETUP_TIMEOUT_MS;
     vi.useRealTimers();
     vi.clearAllMocks();
   }
@@ -173,5 +175,41 @@ describe("OLIVE_JOB_SETUP_STUB timeout", () => {
     const job = result.jobId ? jobRegistry.get(result.jobId) : undefined;
     expect(job?.status).toBe("failed");
     expect(job?.finishedAt).not.toBeNull();
+  });
+
+  it("bounds the UI path itself when setup hangs past OLIVE_UI_SETUP_TIMEOUT_MS", async () => {
+    process.env.OLIVE_UI_SETUP_TIMEOUT_MS = "1000";
+    // No OLIVE_JOB_SETUP_STUB_TIMEOUT_MS override — the stub's own default
+    // (120s) would otherwise hang the request well past our UI-level cap.
+    const recipe = { input_model: {}, passes: {}, engine: {}, systems: {} } as never;
+
+    const pending = startOliveJob({ recipe, source: "ui" });
+    await vi.advanceTimersByTimeAsync(999);
+    let settled = false;
+    void pending.then(
+      () => {
+        settled = true;
+      },
+      () => {
+        settled = true;
+      },
+    );
+    await Promise.resolve();
+    expect(settled).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(1);
+    const result = await pending;
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    if (result.jobId) trackedJobIds.add(result.jobId);
+    expect(result.httpStatus).toBe(504);
+    expect(result.error).toMatch(/Olive setup timed out after 1000ms/);
+    // The still-running (stubbed) setup must observe cancellation and never
+    // resurrect the job into "running"/"completed" after we've responded.
+    const job = result.jobId ? jobRegistry.get(result.jobId) : undefined;
+    expect(job?.status).toBe("cancelled");
+
+    await vi.advanceTimersByTimeAsync(200);
+    expect(job?.status).toBe("cancelled");
   });
 });

--- a/src/server/services/olive/jobRunner.stubSetup.test.ts
+++ b/src/server/services/olive/jobRunner.stubSetup.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { preflightOliveRecipe } from "./jobPreflight.ts";
 import { clearIdempotencyIndex } from "./jobIdempotency.ts";
 import { finalizeJob, jobRegistry } from "./state.ts";
+import { detachVenvListener, ensureProviderCapability } from "../venv/index.ts";
 
 vi.mock("./jobPreflight.ts", () => ({
   preflightOliveRecipe: vi.fn(() => ({
@@ -25,6 +26,7 @@ vi.mock("../venv/index.ts", () => ({
     family: "default",
   })),
   buildOliveRunEnvironment: vi.fn(async () => ({})),
+  detachVenvListener: vi.fn(),
   resolveOliveCommand: vi.fn(() => ({ executable: "echo", args: ["ok"] })),
 }));
 
@@ -211,5 +213,60 @@ describe("OLIVE_JOB_SETUP_STUB timeout", () => {
 
     await vi.advanceTimersByTimeAsync(200);
     expect(job?.status).toBe("cancelled");
+  });
+
+  it("accepts Node's maximum timer delay and falls back above it", async () => {
+    process.env.OLIVE_JOB_SETUP_STUB_TIMEOUT_MS = "700000";
+    process.env.OLIVE_UI_SETUP_TIMEOUT_MS = "2147483647";
+    const recipe = { input_model: {}, passes: {}, engine: {}, systems: {} } as never;
+
+    const pending = startOliveJob({ recipe, source: "ui" });
+    await vi.advanceTimersByTimeAsync(600_001);
+    let settled = false;
+    void pending.finally(() => {
+      settled = true;
+    });
+    await Promise.resolve();
+    expect(settled).toBe(false);
+
+    const job = [...jobRegistry.values()].at(-1);
+    expect(job).toBeDefined();
+    if (!job) return;
+    job.status = "cancelled";
+    await vi.advanceTimersByTimeAsync(200);
+    await pending;
+
+    process.env.OLIVE_UI_SETUP_TIMEOUT_MS = "2147483648";
+    const fallbackPending = startOliveJob({ recipe, source: "ui" });
+    await vi.advanceTimersByTimeAsync(600_000);
+    const fallbackResult = await fallbackPending;
+    expect(fallbackResult.ok).toBe(false);
+    if (fallbackResult.ok) return;
+    if (fallbackResult.jobId) trackedJobIds.add(fallbackResult.jobId);
+    expect(fallbackResult.error).toMatch(/timed out after 600000ms/);
+  });
+
+  it("detaches the venv listener when UI setup times out", async () => {
+    delete process.env.OLIVE_JOB_SETUP_STUB;
+    process.env.OLIVE_UI_SETUP_TIMEOUT_MS = "1000";
+    let resolveSetup: ((value: { ok: true; python: string; family: "default" }) => void) | undefined;
+    vi.mocked(ensureProviderCapability).mockImplementation(
+      () => new Promise((resolve) => {
+        resolveSetup = resolve;
+      }),
+    );
+    const recipe = { input_model: {}, passes: {}, engine: {}, systems: {} } as never;
+
+    const pending = startOliveJob({ recipe, source: "ui" });
+    await vi.advanceTimersByTimeAsync(1000);
+    const result = await pending;
+    expect(result.ok).toBe(false);
+    if (result.ok || !result.jobId) return;
+    trackedJobIds.add(result.jobId);
+    expect(detachVenvListener).toHaveBeenCalledTimes(1);
+    expect(jobRegistry.get(result.jobId)?.venvListener).toBeUndefined();
+
+    resolveSetup?.({ ok: true, python: "python", family: "default" });
+    await Promise.resolve();
   });
 });

--- a/src/server/services/olive/jobRunner.ts
+++ b/src/server/services/olive/jobRunner.ts
@@ -25,6 +25,7 @@ import { getVenvPython } from "../venv/paths.ts";
 import {
   ensureProviderCapability,
   buildOliveRunEnvironment,
+  detachVenvListener,
   resolveOliveCommand,
 } from "../venv/index.ts";
 import { preflightOliveRecipe } from "./jobPreflight.ts";
@@ -39,7 +40,9 @@ import type { IHVProvider } from "../../../types.ts";
  */
 function getUiSetupTimeoutMs(): number {
   const raw = Number(process.env.OLIVE_UI_SETUP_TIMEOUT_MS);
-  return Number.isFinite(raw) && raw > 0 ? raw : 10 * 60_000;
+  return Number.isFinite(raw) && raw > 0 && raw <= 2_147_483_647
+    ? raw
+    : 10 * 60_000;
 }
 
 export type StartOliveJobOpts = {
@@ -326,6 +329,10 @@ async function registerAndStartOliveJob(opts: {
     const msg = err instanceof Error ? err.message : String(err);
     job.status = "cancelled";
     pushLog(job, `[error] ${msg}`);
+    if (job.venvListener) {
+      detachVenvListener(job.venvListener);
+      job.venvListener = undefined;
+    }
     cleanupJobArtifacts(job);
     finalizeJob(job);
     return { ok: false, error: msg, httpStatus: 504, jobId, fingerprint };

--- a/src/server/services/olive/jobRunner.ts
+++ b/src/server/services/olive/jobRunner.ts
@@ -31,6 +31,17 @@ import { preflightOliveRecipe } from "./jobPreflight.ts";
 import { findJobByIdempotency, rememberIdempotencyKeys } from "./jobIdempotency.ts";
 import type { IHVProvider } from "../../../types.ts";
 
+/**
+ * Upper bound on how long the UI's synchronous /olive/run request waits for
+ * setup (venv/capability checks, wheel installs) before failing the request
+ * instead of hanging indefinitely. Read fresh per call (not cached at module
+ * load) so tests and ops tuning can override it via env var. Overridable.
+ */
+function getUiSetupTimeoutMs(): number {
+  const raw = Number(process.env.OLIVE_UI_SETUP_TIMEOUT_MS);
+  return Number.isFinite(raw) && raw > 0 ? raw : 10 * 60_000;
+}
+
 export type StartOliveJobOpts = {
   recipe: OliveRecipe;
   cudaVersion?: string;
@@ -284,12 +295,43 @@ async function registerAndStartOliveJob(opts: {
     };
   }
 
-  return continueOliveJobSetup(job, {
-    recipe,
-    provider,
-    cudaVersion,
-    fingerprint,
+  // The UI path awaits setup so the initial response reflects spawn readiness
+  // (recipe/hardware errors surface immediately). But unlike the MCP path,
+  // nothing previously bounded this wait: a stalled network call inside
+  // ensureProviderCapability (e.g. a CUDA/TensorRT RTX wheel download that
+  // stops making progress) left the /olive/run request pending indefinitely —
+  // the client shows "Initiating Olive run..." forever with no job id to
+  // cancel against, since the job only appears cancellable once the response
+  // (which never arrives) hands the id back. Cap the wait so setup either
+  // finishes or fails the job and returns within a bounded time, same as the
+  // OLIVE_JOB_SETUP_STUB path already does for CI.
+  const setupTimeoutMs = getUiSetupTimeoutMs();
+  let setupTimer: ReturnType<typeof setTimeout> | undefined;
+  const timedOut = new Promise<never>((_, reject) => {
+    setupTimer = setTimeout(() => {
+      reject(new Error(`Olive setup timed out after ${setupTimeoutMs}ms`));
+    }, setupTimeoutMs);
   });
+  try {
+    return await Promise.race([
+      continueOliveJobSetup(job, { recipe, provider, cudaVersion, fingerprint }),
+      timedOut,
+    ]);
+  } catch (err: unknown) {
+    // Only the timeout races here — continueOliveJobSetup catches its own
+    // errors internally. Mark the job cancelled (not just failed) so the
+    // still-running setup, once its stalled await finally resolves, hits the
+    // same bailIfCancelled() guard a user-initiated cancel does and skips
+    // spawning Olive instead of racing back after we've already responded.
+    const msg = err instanceof Error ? err.message : String(err);
+    job.status = "cancelled";
+    pushLog(job, `[error] ${msg}`);
+    cleanupJobArtifacts(job);
+    finalizeJob(job);
+    return { ok: false, error: msg, httpStatus: 504, jobId, fingerprint };
+  } finally {
+    clearTimeout(setupTimer);
+  }
 }
 
 async function continueOliveJobSetup(


### PR DESCRIPTION
## Summary

- **#273** — Hardware panel kept saying "Recommended target: NVIDIA CUDA" even after the user picked a working `NvTensorRTRTXExecutionProvider` recipe. Fix: only show the recommendation nag + Apply button when the *currently selected* provider isn't itself among the detected providers.
- **#274** — Assistant audit's "Apply" button silently did nothing when the AI's autofix suggestion (e.g. "Apply Float16 Quantization") couldn't be mapped onto a known UI field/value. Fix: surface an error message instead of a silent no-op.
- **#276** (Blocking) — `/olive/run` awaited the entire setup phase (venv/wheel installs) with no timeout, so a stalled network install left the UI stuck at "Initiating Olive run..." forever, with Cancel stuck in "queued" because no job id had reached the client. Fix: bound the wait (`OLIVE_UI_SETUP_TIMEOUT_MS`, default 10min). On timeout, the request fails cleanly (504) and the job is marked `cancelled` so the still-running background setup safely bails via the existing cancel guard instead of spawning Olive after the client was already told it failed.
- **#275** — Investigated deeply (AutoAWQQuantizer "Failed to load parameters" in Step Inspector). Confirmed the MCP `get_pass_parameters` tool returns correct data both via a direct Python call and a live MCP round-trip. No code defect found — likely a transient MCP connectivity blip, possibly correlated with the same job/session as #276. No fix applied; flagging for the reporter rather than guessing at a change.

## Test plan

- [x] `pnpm exec tsc --noEmit` — clean
- [x] `pnpm test:server` — 426/426 passed
- [x] `pnpm test` — 1109/1109 passed
- [x] Targeted component tests (IHV panel, AssistantSidebar, AuditPanel, PassGuidanceCard) — passed
- [x] Added new jobRunner test covering the UI-side setup timeout bound and confirming the abandoned background setup can't spawn Olive after timeout
- [ ] Live E2E run of a small CPU model through Execute Live — not run in this session (no `.venv` present here; running would trigger fresh pip installs + a model download per this repo's "no real Olive runs in CI/VM" guidance). Offered to the user to run themselves or on request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tonythethompson/Olive-Studio/pull/277?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix silent audit-apply errors, EP recommendation nag, and unbounded olive/run wait
> - `applyAutofix` in [`useAiAudit.ts`](https://github.com/tonythethompson/Olive-Studio/pull/277/files#diff-d99b672df356096a037e565026f222ddf999bb1783a50338af9d4d5f9f66fda5) now sets a user-visible error when `resolveAuditAutofix` returns no patch, instead of silently doing nothing.
> - The EP recommendation row in [`HardwareProbeDisplay.tsx`](https://github.com/tonythethompson/Olive-Studio/pull/277/files#diff-08d03e6a7c2359b9526b365fdfa05d41a36092a63d97a3f534b2dadf207e68db) is now hidden when the currently selected provider is already among the detected providers; previously it was always shown.
> - `registerAndStartOliveJob` in [`jobRunner.ts`](https://github.com/tonythethompson/Olive-Studio/pull/277/files#diff-5ac052b716d7d01af8291c74aaf803fc5f534285d71be03680511367d157819d) now races the UI setup phase against a configurable timeout (default 10 min, via `OLIVE_UI_SETUP_TIMEOUT_MS`), returning a 504 and cancelling the job instead of hanging indefinitely. On timeout, the venv listener is detached to prevent a later spawn.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ab27300.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->