### PR TITLE
feat: add shared pipeline validation, review, and catalog libraries

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,11 +16,6 @@
     "bin/"
   ],
   "packageManager": "pnpm@11.17.0",
-  "pnpm": {
-    "overrides": {
-      "nanoid": ">=3.3.18"
-    }
-  },
   "engines": {
     "node": ">=22.16"
   },
@@ -129,7 +124,7 @@
   },
   "pnpm": {
     "overrides": {
-      "nanoid": ">=3.3.18"
+      "nanoid": ">=3.3.18 <4.0.0"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,11 @@
     "bin/"
   ],
   "packageManager": "pnpm@11.17.0",
+  "pnpm": {
+    "overrides": {
+      "nanoid": ">=3.3.18"
+    }
+  },
   "engines": {
     "node": ">=22.16"
   },

--- a/package.json
+++ b/package.json
@@ -121,10 +121,5 @@
     "vite": "^8.2.1",
     "vite-plugin-compression": "^0.5.1",
     "vitest": "^4.1.10"
-  },
-  "pnpm": {
-    "overrides": {
-      "nanoid": ">=3.3.18 <4.0.0"
-    }
   }
 }

--- a/src/components/features/input/useRecipeHub.ts
+++ b/src/components/features/input/useRecipeHub.ts
@@ -148,7 +148,12 @@ export function useRecipeHub({ setState, hardwareProbe }: UseRecipeHubOpts) {
       setImportError(`Recipe targets ${hw.targetDevice} but this machine cannot run it.\n${hw.reason}\nUse "Apply anyway" for remote/cross-compile workflows.`);
       return;
     }
-    setState(deriveUiStateFromOliveRecipe(recipe, { replacePasses: true }));
+    try {
+      setState(deriveUiStateFromOliveRecipe(recipe, { replacePasses: true }));
+    } catch (err) {
+      setImportError(err instanceof Error ? err.message : "Failed to apply imported recipe.");
+      return;
+    }
     setAppliedRecipeLabel("Custom JSON recipe");
     setRecipeRailExpanded(false);
     setSourceConfigExpanded(true);

--- a/src/lib/__tests__/activityLog.test.ts
+++ b/src/lib/__tests__/activityLog.test.ts
@@ -1,0 +1,484 @@
+/**
+ * Property-based tests for the Activity Log utility functions (Task 5.3).
+ * Validates correctness properties from design.md (Properties 9–11).
+ *
+ * Feature: v05-release, Property 9: Activity Log Entry Truncation
+ * Feature: v05-release, Property 10: Activity Log Terminal Entry Correctness
+ * Feature: v05-release, Property 11: Activity Log Bounded FIFO
+ */
+import { describe, it, expect } from "vitest";
+import fc from "fast-check";
+import {
+  truncateEntry,
+  appendEntry,
+  createTerminalEntry,
+  MAX_LOG_ENTRIES,
+  TRUNCATION_LIMITS,
+} from "@/lib/activityLog";
+import type {
+  ActivityEntryKind,
+  ActivityLogEntry,
+  AgentSessionState,
+} from "@/lib/types/agentTypes";
+
+// ─── Constants ───────────────────────────────────────────────────────────────
+
+const ALL_KINDS: ActivityEntryKind[] = [
+  "reasoning",
+  "tool_call",
+  "tool_result",
+  "decision",
+  "error",
+];
+
+// ─── Arbitraries ─────────────────────────────────────────────────────────────
+
+/** Generate a valid ActivityEntryKind. */
+function arbKind(): fc.Arbitrary<ActivityEntryKind> {
+  return fc.constantFrom(...ALL_KINDS);
+}
+
+/** Generate a HH:MM:SS timestamp string. */
+function arbTimestamp(): fc.Arbitrary<string> {
+  return fc
+    .tuple(
+      fc.integer({ min: 0, max: 23 }),
+      fc.integer({ min: 0, max: 59 }),
+      fc.integer({ min: 0, max: 59 }),
+    )
+    .map(
+      ([h, m, s]) =>
+        `${String(h).padStart(2, "0")}:${String(m).padStart(2, "0")}:${String(s).padStart(2, "0")}`,
+    );
+}
+
+/** Generate a unique entry ID. */
+function arbEntryId(): fc.Arbitrary<string> {
+  return fc.uuid();
+}
+
+/** Generate an ActivityLogEntry with arbitrary text length. */
+function arbEntry(textOptions?: {
+  minLength?: number;
+  maxLength?: number;
+}): fc.Arbitrary<ActivityLogEntry> {
+  return fc.record({
+    id: arbEntryId(),
+    kind: arbKind(),
+    timestamp: arbTimestamp(),
+    text: fc.string({
+      minLength: textOptions?.minLength ?? 0,
+      maxLength: textOptions?.maxLength ?? 1024,
+    }),
+  });
+}
+
+/** Generate an entry with text guaranteed to EXCEED its kind-specific limit. */
+function arbEntryExceedingLimit(): fc.Arbitrary<ActivityLogEntry> {
+  return arbKind().chain((kind) => {
+    const limit = TRUNCATION_LIMITS[kind];
+    return fc.record({
+      id: arbEntryId(),
+      kind: fc.constant(kind),
+      timestamp: arbTimestamp(),
+      text: fc.string({ minLength: limit + 1, maxLength: limit + 200 }),
+    });
+  });
+}
+
+/** Generate an entry with text guaranteed to be WITHIN its kind-specific limit. */
+function arbEntryWithinLimit(): fc.Arbitrary<ActivityLogEntry> {
+  return arbKind().chain((kind) => {
+    const limit = TRUNCATION_LIMITS[kind];
+    return fc.record({
+      id: arbEntryId(),
+      kind: fc.constant(kind),
+      timestamp: arbTimestamp(),
+      text: fc.string({ minLength: 0, maxLength: limit }),
+    });
+  });
+}
+
+/** Generate a success outcome. */
+function arbSuccessOutcome(): fc.Arbitrary<AgentSessionState["outcome"]> {
+  return fc.record({
+    status: fc.constant("success" as const),
+    totalSteps: fc.integer({ min: 1, max: 10000 }),
+    elapsedMs: fc.integer({ min: 0, max: 86400000 }),
+  });
+}
+
+/** Generate a failure outcome. */
+function arbFailureOutcome(): fc.Arbitrary<AgentSessionState["outcome"]> {
+  return fc.record({
+    status: fc.constant("failure" as const),
+    totalSteps: fc.integer({ min: 0, max: 10000 }),
+    elapsedMs: fc.integer({ min: 0, max: 86400000 }),
+    errorDescription: fc.string({ minLength: 1, maxLength: 200 }),
+  });
+}
+
+/** Generate a cancelled outcome. */
+function arbCancelledOutcome(): fc.Arbitrary<AgentSessionState["outcome"]> {
+  return fc.record({
+    status: fc.constant("cancelled" as const),
+    totalSteps: fc.integer({ min: 0, max: 10000 }),
+    elapsedMs: fc.integer({ min: 0, max: 86400000 }),
+    cancelledAtStep: fc.integer({ min: 1, max: 10000 }),
+  });
+}
+
+/** Generate any outcome. */
+function arbOutcome(): fc.Arbitrary<NonNullable<AgentSessionState["outcome"]>> {
+  return fc.oneof(arbSuccessOutcome(), arbFailureOutcome(), arbCancelledOutcome()) as fc.Arbitrary<
+    NonNullable<AgentSessionState["outcome"]>
+  >;
+}
+
+/** Generate an array of entries with specified length. */
+function arbEntryArray(
+  minLength: number,
+  maxLength: number,
+): fc.Arbitrary<ActivityLogEntry[]> {
+  return fc.array(arbEntry(), { minLength, maxLength });
+}
+
+// ─── Property 9: Activity Log Entry Truncation ───────────────────────────────
+
+describe("Property 9: Activity Log Entry Truncation", () => {
+  /**
+   * Feature: v05-release, Property 9: Activity Log Entry Truncation
+   *
+   * For any ActivityLogEntry with kind "reasoning", the displayed text must be
+   * at most 512 characters. For any entry with kind "tool_call" or "decision",
+   * text must be at most 256 characters. For any entry with kind "tool_result"
+   * or "error", text must be at most 512 characters. When the original text
+   * exceeds the limit, expandedText must contain the full untruncated value.
+   *
+   * Validates: Requirements 7.2
+   */
+
+  it("entries exceeding the kind-specific limit are truncated to that limit", () => {
+    fc.assert(
+      fc.property(arbEntryExceedingLimit(), (entry) => {
+        const result = truncateEntry(entry);
+        const limit = TRUNCATION_LIMITS[entry.kind];
+
+        // text must be truncated to exactly the limit
+        expect(result.text.length).toBe(limit);
+        expect(result.text.length).toBeLessThanOrEqual(limit);
+      }),
+      { numRuns: 100 },
+    );
+  });
+
+  it("entries exceeding the limit have expandedText set to the original full text", () => {
+    fc.assert(
+      fc.property(arbEntryExceedingLimit(), (entry) => {
+        const result = truncateEntry(entry);
+
+        // expandedText must equal the original full text
+        expect(result.expandedText).toBe(entry.text);
+      }),
+      { numRuns: 100 },
+    );
+  });
+
+  it("entries within the limit are returned as-is with no expandedText", () => {
+    fc.assert(
+      fc.property(arbEntryWithinLimit(), (entry) => {
+        const result = truncateEntry(entry);
+
+        // text unchanged
+        expect(result.text).toBe(entry.text);
+        // no expandedText added
+        expect(result.expandedText).toBeUndefined();
+      }),
+      { numRuns: 100 },
+    );
+  });
+
+  it("truncated text is a prefix of the original text", () => {
+    fc.assert(
+      fc.property(arbEntryExceedingLimit(), (entry) => {
+        const result = truncateEntry(entry);
+        const limit = TRUNCATION_LIMITS[entry.kind];
+
+        // The truncated text must be the first N characters of the original
+        expect(result.text).toBe(entry.text.slice(0, limit));
+      }),
+      { numRuns: 100 },
+    );
+  });
+
+  it("all entry kinds have their correct truncation limits applied", () => {
+    fc.assert(
+      fc.property(arbEntry({ minLength: 0, maxLength: 1024 }), (entry) => {
+        const result = truncateEntry(entry);
+        const limit = TRUNCATION_LIMITS[entry.kind];
+
+        // Result text never exceeds the kind-specific limit
+        expect(result.text.length).toBeLessThanOrEqual(limit);
+      }),
+      { numRuns: 100 },
+    );
+  });
+});
+
+// ─── Property 10: Activity Log Terminal Entry Correctness ────────────────────
+
+describe("Property 10: Activity Log Terminal Entry Correctness", () => {
+  /**
+   * Feature: v05-release, Property 10: Activity Log Terminal Entry Correctness
+   *
+   * For any agent loop termination, the terminal entry must contain: on success
+   * — total step count and elapsed wall-clock duration; on failure — the error
+   * description from the failing step; on cancellation — the step number at
+   * which cancellation occurred.
+   *
+   * Validates: Requirements 7.4
+   */
+
+  it("success outcome produces entry with totalSteps and elapsed duration", () => {
+    fc.assert(
+      fc.property(arbSuccessOutcome(), (outcome) => {
+        const entry = createTerminalEntry(outcome);
+
+        // Entry should be of kind "decision" for success
+        expect(entry.kind).toBe("decision");
+
+        // Text must contain the total steps count
+        expect(entry.text).toContain(String(outcome!.totalSteps));
+
+        // Text must contain "completed" or similar success indicator
+        expect(entry.text.toLowerCase()).toContain("completed");
+
+        // Entry must have a valid timestamp and id
+        expect(entry.id).toBeTruthy();
+        expect(entry.timestamp).toMatch(/^\d{2}:\d{2}:\d{2}$/);
+      }),
+      { numRuns: 100 },
+    );
+  });
+
+  it("failure outcome produces entry with error description", () => {
+    fc.assert(
+      fc.property(arbFailureOutcome(), (outcome) => {
+        const entry = createTerminalEntry(outcome);
+
+        // Entry should be of kind "error" for failure
+        expect(entry.kind).toBe("error");
+
+        // Text must contain the error description
+        expect(entry.text).toContain(outcome!.errorDescription!);
+
+        // Text must contain "failed" indicator
+        expect(entry.text.toLowerCase()).toContain("failed");
+
+        // Entry must have a valid timestamp and id
+        expect(entry.id).toBeTruthy();
+        expect(entry.timestamp).toMatch(/^\d{2}:\d{2}:\d{2}$/);
+      }),
+      { numRuns: 100 },
+    );
+  });
+
+  it("cancelled outcome produces entry with cancelledAtStep", () => {
+    fc.assert(
+      fc.property(arbCancelledOutcome(), (outcome) => {
+        const entry = createTerminalEntry(outcome);
+
+        // Entry should be of kind "decision" for cancellation
+        expect(entry.kind).toBe("decision");
+
+        // Text must contain the cancelled step number
+        expect(entry.text).toContain(String(outcome!.cancelledAtStep));
+
+        // Text must contain "cancelled" indicator
+        expect(entry.text.toLowerCase()).toContain("cancelled");
+
+        // Entry must have a valid timestamp and id
+        expect(entry.id).toBeTruthy();
+        expect(entry.timestamp).toMatch(/^\d{2}:\d{2}:\d{2}$/);
+      }),
+      { numRuns: 100 },
+    );
+  });
+
+  it("null outcome produces a graceful error entry", () => {
+    const entry = createTerminalEntry(undefined);
+    expect(entry.kind).toBe("error");
+    expect(entry.text).toBeTruthy();
+    expect(entry.id).toBeTruthy();
+    expect(entry.timestamp).toMatch(/^\d{2}:\d{2}:\d{2}$/);
+  });
+
+  it("terminal entries always have valid structure regardless of outcome", () => {
+    fc.assert(
+      fc.property(arbOutcome(), (outcome) => {
+        const entry = createTerminalEntry(outcome);
+
+        // Always has required fields
+        expect(entry.id).toBeTruthy();
+        expect(typeof entry.id).toBe("string");
+        expect(entry.kind).toBeTruthy();
+        expect(ALL_KINDS).toContain(entry.kind);
+        expect(entry.timestamp).toMatch(/^\d{2}:\d{2}:\d{2}$/);
+        expect(typeof entry.text).toBe("string");
+        expect(entry.text.length).toBeGreaterThan(0);
+      }),
+      { numRuns: 100 },
+    );
+  });
+});
+
+// ─── Property 11: Activity Log Bounded FIFO ──────────────────────────────────
+
+describe("Property 11: Activity Log Bounded FIFO", () => {
+  /**
+   * Feature: v05-release, Property 11: Activity Log Bounded FIFO
+   *
+   * For any activity log state, the entry count must never exceed 2000. When
+   * at maximum capacity and a new entry is appended, the oldest entry must be
+   * removed such that the count remains exactly 2000. When a new agent session
+   * starts, all entries from the previous session must be cleared before
+   * appending new entries.
+   *
+   * Validates: Requirements 7.5, 7.6
+   */
+
+  it("result length never exceeds MAX_LOG_ENTRIES after append", () => {
+    fc.assert(
+      fc.property(
+        arbEntryArray(0, MAX_LOG_ENTRIES + 50),
+        arbEntry(),
+        (entries, newEntry) => {
+          const result = appendEntry(entries, newEntry);
+          expect(result.length).toBeLessThanOrEqual(MAX_LOG_ENTRIES);
+        },
+      ),
+      { numRuns: 100 },
+    );
+  });
+
+  it("when below capacity, all existing entries plus new entry are preserved", () => {
+    fc.assert(
+      fc.property(
+        arbEntryArray(0, MAX_LOG_ENTRIES - 1),
+        arbEntry(),
+        (entries, newEntry) => {
+          const result = appendEntry(entries, newEntry);
+
+          // Length is entries.length + 1
+          expect(result.length).toBe(entries.length + 1);
+
+          // New entry is at the end
+          expect(result[result.length - 1]).toEqual(newEntry);
+
+          // All original entries preserved in order
+          for (let i = 0; i < entries.length; i++) {
+            expect(result[i]).toEqual(entries[i]);
+          }
+        },
+      ),
+      { numRuns: 100 },
+    );
+  });
+
+  it("when at maximum capacity, oldest entry is evicted and new entry is appended", () => {
+    // Pre-build a base array of MAX_LOG_ENTRIES entries for performance.
+    // The property test varies only the new entry being appended.
+    const baseEntries: ActivityLogEntry[] = Array.from(
+      { length: MAX_LOG_ENTRIES },
+      (_, i) => ({
+        id: `base-${i}`,
+        kind: "reasoning" as ActivityEntryKind,
+        timestamp: "00:00:00",
+        text: `entry-${i}`,
+      }),
+    );
+
+    fc.assert(
+      fc.property(arbEntry(), (newEntry) => {
+        const result = appendEntry(baseEntries, newEntry);
+
+        // Length must remain exactly MAX_LOG_ENTRIES
+        expect(result.length).toBe(MAX_LOG_ENTRIES);
+
+        // New entry is at the end
+        expect(result[result.length - 1]).toEqual(newEntry);
+
+        // First element of original was evicted
+        expect(result[0]).toEqual(baseEntries[1]);
+
+        // Spot-check FIFO order at a few positions
+        expect(result[1]).toEqual(baseEntries[2]);
+        expect(result[MAX_LOG_ENTRIES - 2]).toEqual(
+          baseEntries[MAX_LOG_ENTRIES - 1],
+        );
+      }),
+      { numRuns: 100 },
+    );
+  });
+
+  it("appendEntry always returns a new array (no mutation)", () => {
+    fc.assert(
+      fc.property(
+        arbEntryArray(0, 100),
+        arbEntry(),
+        (entries, newEntry) => {
+          const originalLength = entries.length;
+          const result = appendEntry(entries, newEntry);
+
+          // Original array not mutated
+          expect(entries.length).toBe(originalLength);
+
+          // Result is a different reference
+          expect(result).not.toBe(entries);
+        },
+      ),
+      { numRuns: 100 },
+    );
+  });
+
+  it("when above capacity (overflow scenario), multiple oldest entries are evicted", () => {
+    // Pre-build base entries slightly above the max for performance
+    const overflowCount = 10;
+    const baseEntries: ActivityLogEntry[] = Array.from(
+      { length: MAX_LOG_ENTRIES + overflowCount },
+      (_, i) => ({
+        id: `overflow-${i}`,
+        kind: "tool_call" as ActivityEntryKind,
+        timestamp: "12:00:00",
+        text: `overflow-entry-${i}`,
+      }),
+    );
+
+    fc.assert(
+      fc.property(arbEntry(), (newEntry) => {
+        const result = appendEntry(baseEntries, newEntry);
+
+        // Result must be exactly MAX_LOG_ENTRIES
+        expect(result.length).toBe(MAX_LOG_ENTRIES);
+
+        // New entry is always at the end
+        expect(result[result.length - 1]).toEqual(newEntry);
+      }),
+      { numRuns: 100 },
+    );
+  });
+
+  it("FIFO order: the newest entry is always the last element", () => {
+    fc.assert(
+      fc.property(
+        arbEntryArray(0, MAX_LOG_ENTRIES),
+        arbEntry(),
+        (entries, newEntry) => {
+          const result = appendEntry(entries, newEntry);
+          expect(result[result.length - 1]).toEqual(newEntry);
+        },
+      ),
+      { numRuns: 100 },
+    );
+  });
+});

--- a/src/lib/__tests__/batchComparison.test.ts
+++ b/src/lib/__tests__/batchComparison.test.ts
@@ -212,6 +212,38 @@ describe("batchComparison — parseMcpCompareOutput validation", () => {
     expect(parseMcpCompareOutput(raw as Record<string, unknown>)).toBeNull();
   });
 
+  it("accepts MCP compare_results payloads nested under comparison.metrics", () => {
+    const raw = {
+      comparison: [
+        {
+          job_id: "a",
+          status: "completed",
+          metrics: { latency_ms: 12, model_size_mb: 40, accuracy: 0.8 },
+          score: 0.7,
+        },
+        {
+          job_id: "b",
+          status: "completed",
+          metrics: { latency_ms: 20, model_size_mb: 30, accuracy: null },
+          score: 0.4,
+        },
+      ],
+      winner: "a",
+      reasoning: "a wins",
+      excluded_jobs: [{ job_id: "c", reason: "job_failed" }],
+    };
+    const result = parseMcpCompareOutput(raw);
+    expect(result).toEqual({
+      results: [
+        { job_id: "a", latency_ms: 12, model_size_mb: 40, accuracy: 0.8, score: 0.7 },
+        { job_id: "b", latency_ms: 20, model_size_mb: 30, accuracy: null, score: 0.4 },
+      ],
+      winner: "a",
+      reasoning: "a wins",
+      excluded_jobs: [{ job_id: "c", reason: "job_failed" }],
+    });
+  });
+
   it("returns null when excluded_jobs contains invalid entries", () => {
     const raw = {
       results: [{ job_id: "j1", latency_ms: 10, model_size_mb: 50, accuracy: 0.9, score: 85 }],

--- a/src/lib/__tests__/batchComparison.test.ts
+++ b/src/lib/__tests__/batchComparison.test.ts
@@ -150,12 +150,22 @@ describe("batchComparison — parseMcpCompareOutput validation", () => {
   });
 
   /** Helper: generate a full valid CompareResultsOutput-shaped object. */
-  const arbValidOutput = fc.record({
-    results: fc.array(arbResultEntry, { minLength: 0, maxLength: 10 }),
-    winner: fc.oneof(fc.string({ minLength: 1, maxLength: 20 }), fc.constant(null)),
-    reasoning: fc.string({ minLength: 1, maxLength: 200 }),
-    excluded_jobs: fc.array(arbExcludedJob, { minLength: 0, maxLength: 5 }),
-  });
+  const arbValidOutput = fc
+    .record({
+      results: fc.array(arbResultEntry, { minLength: 0, maxLength: 10 }),
+      reasoning: fc.string({ minLength: 1, maxLength: 200 }),
+      excluded_jobs: fc.array(arbExcludedJob, { minLength: 0, maxLength: 5 }),
+    })
+    .chain((base) =>
+      fc
+        .oneof(
+          fc.constant(null),
+          base.results.length > 0
+            ? fc.constantFrom(...base.results.map((r) => r.job_id))
+            : fc.constant(null),
+        )
+        .map((winner) => ({ ...base, winner })),
+    );
 
   it("returns typed output for valid MCP compare_results responses", () => {
     fc.assert(

--- a/src/lib/__tests__/batchComparison.test.ts
+++ b/src/lib/__tests__/batchComparison.test.ts
@@ -1,0 +1,224 @@
+/**
+ * Property-based tests for batch comparison job count constraint (Task 5.5).
+ * Feature: v05-release, Property 12: Batch Comparison Job Count Constraint
+ *
+ * Validates: Requirements 8.6
+ *
+ * For any invocation of the batch comparison, the input job record count must be
+ * between 2 and 10 inclusive. Inputs outside this range must be rejected without
+ * producing a comparison table.
+ */
+import { describe, it, expect } from "vitest";
+import fc from "fast-check";
+import { validateJobCount, parseMcpCompareOutput } from "@/lib/batchComparison";
+
+describe("batchComparison — Property 12: Batch Comparison Job Count Constraint", () => {
+  /**
+   * **Validates: Requirements 8.6**
+   *
+   * Property 12a: Integers in [2, 10] are accepted.
+   * For any integer count within the valid range, validateJobCount returns true.
+   */
+  it("accepts all integers in [2, 10]", () => {
+    fc.assert(
+      fc.property(
+        fc.integer({ min: 2, max: 10 }),
+        (count) => {
+          expect(validateJobCount(count)).toBe(true);
+        },
+      ),
+      { numRuns: 100 },
+    );
+  });
+
+  /**
+   * **Validates: Requirements 8.6**
+   *
+   * Property 12b: Integers below 2 are rejected.
+   * For any integer less than 2, validateJobCount returns false.
+   */
+  it("rejects all integers below 2", () => {
+    fc.assert(
+      fc.property(
+        fc.integer({ min: -1000, max: 1 }),
+        (count) => {
+          expect(validateJobCount(count)).toBe(false);
+        },
+      ),
+      { numRuns: 100 },
+    );
+  });
+
+  /**
+   * **Validates: Requirements 8.6**
+   *
+   * Property 12c: Integers above 10 are rejected.
+   * For any integer greater than 10, validateJobCount returns false.
+   */
+  it("rejects all integers above 10", () => {
+    fc.assert(
+      fc.property(
+        fc.integer({ min: 11, max: 10000 }),
+        (count) => {
+          expect(validateJobCount(count)).toBe(false);
+        },
+      ),
+      { numRuns: 100 },
+    );
+  });
+
+  /**
+   * **Validates: Requirements 8.6**
+   *
+   * Property 12d: Non-integer edge values are rejected.
+   * NaN, Infinity, -Infinity, and fractional values outside [2, 10] integer
+   * range are rejected by validateJobCount.
+   */
+  it("rejects NaN, Infinity, and -Infinity", () => {
+    expect(validateJobCount(NaN)).toBe(false);
+    expect(validateJobCount(Infinity)).toBe(false);
+    expect(validateJobCount(-Infinity)).toBe(false);
+  });
+
+  /**
+   * **Validates: Requirements 8.6**
+   *
+   * Property 12e: Fractional values within boundary zone are handled correctly.
+   * Values like 1.5 (below 2) are rejected; values like 2.5 (within 2–10) are
+   * accepted by the >= / <= comparison; values like 10.5 (above 10) are rejected.
+   */
+  it("rejects fractional values below 2 and above 10", () => {
+    fc.assert(
+      fc.property(
+        fc.double({ min: -1000, max: 1.999, noNaN: true }),
+        (count) => {
+          expect(validateJobCount(count)).toBe(false);
+        },
+      ),
+      { numRuns: 100 },
+    );
+
+    fc.assert(
+      fc.property(
+        fc.double({ min: 10.001, max: 100000, noNaN: true }),
+        (count) => {
+          expect(validateJobCount(count)).toBe(false);
+        },
+      ),
+      { numRuns: 100 },
+    );
+  });
+
+  /**
+   * **Validates: Requirements 8.6**
+   *
+   * Property 12f: The boundary values 2 and 10 are accepted (inclusive range).
+   */
+  it("accepts exact boundary values 2 and 10", () => {
+    expect(validateJobCount(2)).toBe(true);
+    expect(validateJobCount(10)).toBe(true);
+  });
+
+  /**
+   * **Validates: Requirements 8.6**
+   *
+   * Property 12g: The boundary-adjacent values 1 and 11 are rejected.
+   */
+  it("rejects boundary-adjacent values 1 and 11", () => {
+    expect(validateJobCount(1)).toBe(false);
+    expect(validateJobCount(11)).toBe(false);
+  });
+});
+
+describe("batchComparison — parseMcpCompareOutput validation", () => {
+  /** Helper: generate a finite double (no NaN, no Infinity). */
+  const arbFiniteDouble = fc.double({ noNaN: true, min: -1e15, max: 1e15 });
+
+  /** Helper: generate a valid CompareResultEntry-shaped object. */
+  const arbResultEntry = fc.record({
+    job_id: fc.string({ minLength: 1, maxLength: 20 }),
+    latency_ms: fc.oneof(arbFiniteDouble, fc.constant(null)),
+    model_size_mb: fc.oneof(arbFiniteDouble, fc.constant(null)),
+    accuracy: fc.oneof(arbFiniteDouble, fc.constant(null)),
+    score: arbFiniteDouble,
+  });
+
+  /** Helper: generate a valid ExcludedJob-shaped object. */
+  const arbExcludedJob = fc.record({
+    job_id: fc.string({ minLength: 1, maxLength: 20 }),
+    reason: fc.string({ minLength: 1, maxLength: 100 }),
+  });
+
+  /** Helper: generate a full valid CompareResultsOutput-shaped object. */
+  const arbValidOutput = fc.record({
+    results: fc.array(arbResultEntry, { minLength: 0, maxLength: 10 }),
+    winner: fc.oneof(fc.string({ minLength: 1, maxLength: 20 }), fc.constant(null)),
+    reasoning: fc.string({ minLength: 1, maxLength: 200 }),
+    excluded_jobs: fc.array(arbExcludedJob, { minLength: 0, maxLength: 5 }),
+  });
+
+  it("returns typed output for valid MCP compare_results responses", () => {
+    fc.assert(
+      fc.property(arbValidOutput, (raw) => {
+        const result = parseMcpCompareOutput(raw as Record<string, unknown>);
+        expect(result).not.toBeNull();
+        expect(result!.results).toEqual(raw.results);
+        expect(result!.winner).toEqual(raw.winner);
+        expect(result!.reasoning).toEqual(raw.reasoning);
+        expect(result!.excluded_jobs).toEqual(raw.excluded_jobs);
+      }),
+      { numRuns: 100 },
+    );
+  });
+
+  it("returns null when results is not an array", () => {
+    const invalidInputs = [
+      { results: "not-array", winner: null, reasoning: "x", excluded_jobs: [] },
+      { results: 42, winner: null, reasoning: "x", excluded_jobs: [] },
+      { results: null, winner: null, reasoning: "x", excluded_jobs: [] },
+      { winner: null, reasoning: "x", excluded_jobs: [] }, // missing results
+    ];
+    for (const input of invalidInputs) {
+      expect(parseMcpCompareOutput(input as Record<string, unknown>)).toBeNull();
+    }
+  });
+
+  it("returns null when winner is invalid type (not string or null)", () => {
+    fc.assert(
+      fc.property(
+        fc.array(arbResultEntry, { minLength: 1, maxLength: 3 }),
+        fc.oneof(fc.integer(), fc.boolean(), fc.constant(undefined)),
+        (results, badWinner) => {
+          const raw = {
+            results,
+            winner: badWinner,
+            reasoning: "some reasoning",
+            excluded_jobs: [],
+          };
+          expect(parseMcpCompareOutput(raw as Record<string, unknown>)).toBeNull();
+        },
+      ),
+      { numRuns: 100 },
+    );
+  });
+
+  it("returns null when reasoning is not a string", () => {
+    const raw = {
+      results: [{ job_id: "j1", latency_ms: 10, model_size_mb: 50, accuracy: 0.9, score: 85 }],
+      winner: null,
+      reasoning: 123,
+      excluded_jobs: [],
+    };
+    expect(parseMcpCompareOutput(raw as Record<string, unknown>)).toBeNull();
+  });
+
+  it("returns null when excluded_jobs contains invalid entries", () => {
+    const raw = {
+      results: [{ job_id: "j1", latency_ms: 10, model_size_mb: 50, accuracy: 0.9, score: 85 }],
+      winner: null,
+      reasoning: "ok",
+      excluded_jobs: [{ job_id: 123, reason: "bad" }], // job_id not a string
+    };
+    expect(parseMcpCompareOutput(raw as Record<string, unknown>)).toBeNull();
+  });
+});

--- a/src/lib/__tests__/batchComparison.test.ts
+++ b/src/lib/__tests__/batchComparison.test.ts
@@ -83,9 +83,8 @@ describe("batchComparison — Property 12: Batch Comparison Job Count Constraint
   /**
    * **Validates: Requirements 8.6**
    *
-   * Property 12e: Fractional values within boundary zone are handled correctly.
-   * Values like 1.5 (below 2) are rejected; values like 2.5 (within 2–10) are
-   * accepted by the >= / <= comparison; values like 10.5 (above 10) are rejected.
+   * Property 12e: Fractional values are rejected since validateJobCount requires integer job counts.
+   * Fractional values across all ranges (e.g. 1.5 below range, 2.5 within 2–10 range, 10.5 above range) are rejected.
    */
   it("rejects fractional values below 2 and above 10", () => {
     fc.assert(

--- a/src/lib/__tests__/featureFlagGating.test.ts
+++ b/src/lib/__tests__/featureFlagGating.test.ts
@@ -404,5 +404,44 @@ describe("featureFlagGating — Task 11.3: Gate MultiLoRA UI behind feature flag
       expect(imported.multiLoraAdapters).toEqual([{ path: "/legacy/adapter" }]);
       expect(imported.passes?.peft).toBe(true);
     });
+
+    it("drops non-positive or fractional rank/alpha on import so rebuild does not throw", () => {
+      mockIsMultiLoraEnabled.mockReturnValue(true);
+      const recipe = {
+        input_model: {
+          type: "HfModel",
+          config: { model_path: "meta-llama/Meta-Llama-3-8B" },
+        },
+        systems: {},
+        adapters: [
+          { name: "bad-rank", path: "/adapters/bad-rank", rank: 0, alpha: 32 },
+          { name: "frac-rank", path: "/adapters/frac", rank: 1.5, alpha: 16 },
+          { name: "bad-alpha", path: "/adapters/bad-alpha", rank: 8, alpha: -1 },
+          { name: "ok", path: "/adapters/ok", rank: 8, alpha: 16 },
+        ],
+        passes: {
+          peft: { type: "LoRA", config: {} },
+          extract_adapters: { type: "ExtractAdapters", config: {} },
+        },
+        engine: {},
+      };
+      const imported = deriveUiStateFromOliveRecipe(recipe, { replacePasses: true });
+      expect(imported.multiLoraAdapters).toEqual([
+        { name: "bad-rank", path: "/adapters/bad-rank", alpha: 32 },
+        { name: "frac-rank", path: "/adapters/frac", alpha: 16 },
+        { name: "bad-alpha", path: "/adapters/bad-alpha", rank: 8 },
+        { name: "ok", path: "/adapters/ok", rank: 8, alpha: 16 },
+      ]);
+      expect(() =>
+        buildOliveRecipe(
+          baseState({
+            ...imported,
+            multiLoraAdapters: imported.multiLoraAdapters,
+            passes: { ...DEFAULT_PASSES, ...imported.passes },
+            vramEstimateGb: 24,
+          }),
+        ),
+      ).not.toThrow();
+    });
   });
 });

--- a/src/lib/__tests__/featureFlagGating.test.ts
+++ b/src/lib/__tests__/featureFlagGating.test.ts
@@ -447,5 +447,64 @@ describe("featureFlagGating — Task 11.3: Gate MultiLoRA UI behind feature flag
         /alpha must be a positive finite number/i,
       );
     });
+
+    it("rejects invalid target_modules on import instead of dropping them", () => {
+      mockIsMultiLoraEnabled.mockReturnValue(true);
+      const emptyEntry = {
+        input_model: {
+          type: "HfModel",
+          config: { model_path: "meta-llama/Meta-Llama-3-8B" },
+        },
+        systems: {},
+        adapters: [
+          { name: "bad-modules", path: "/adapters/bad-modules", target_modules: [""] },
+        ],
+        passes: { peft: { type: "LoRA", config: {} } },
+        engine: {},
+      };
+      expect(() => deriveUiStateFromOliveRecipe(emptyEntry, { replacePasses: true })).toThrow(
+        /targetModules must be an array of non-empty strings/i,
+      );
+
+      const mixedTypes = {
+        ...emptyEntry,
+        adapters: [
+          { name: "mixed", path: "/adapters/mixed", targetModules: ["q_proj", 1] },
+        ],
+      };
+      expect(() => deriveUiStateFromOliveRecipe(mixedTypes, { replacePasses: true })).toThrow(
+        /targetModules must be an array of non-empty strings/i,
+      );
+
+      const notArray = {
+        ...emptyEntry,
+        adapters: [
+          { name: "scalar", path: "/adapters/scalar", target_modules: "q_proj" },
+        ],
+      };
+      expect(() => deriveUiStateFromOliveRecipe(notArray, { replacePasses: true })).toThrow(
+        /targetModules must be an array of non-empty strings/i,
+      );
+    });
+
+    it("preserves valid target_modules from snake_case import payloads", () => {
+      mockIsMultiLoraEnabled.mockReturnValue(true);
+      const recipe = {
+        input_model: {
+          type: "HfModel",
+          config: { model_path: "meta-llama/Meta-Llama-3-8B" },
+        },
+        systems: {},
+        adapters: [
+          { name: "style", path: "/adapters/style", target_modules: ["q_proj", "v_proj"] },
+        ],
+        passes: { peft: { type: "LoRA", config: {} } },
+        engine: {},
+      };
+      const imported = deriveUiStateFromOliveRecipe(recipe, { replacePasses: true });
+      expect(imported.multiLoraAdapters).toEqual([
+        { name: "style", path: "/adapters/style", targetModules: ["q_proj", "v_proj"] },
+      ]);
+    });
   });
 });

--- a/src/lib/__tests__/featureFlagGating.test.ts
+++ b/src/lib/__tests__/featureFlagGating.test.ts
@@ -122,6 +122,27 @@ describe("featureFlagGating — Task 11.3: Gate MultiLoRA UI behind feature flag
       expect(result.adapters[0].alpha).toBe(16);
     });
 
+    it("rejects single adapter with explicitly invalid rank instead of defaulting", () => {
+      const adapters = [{ path: "/weights/a", rank: 0, alpha: 16 }];
+      const result = gateMultiLoraAdapters(adapters, 24);
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toMatch(/rank must be a positive integer/i);
+    });
+
+    it("rejects single adapter with explicitly invalid alpha instead of defaulting", () => {
+      const adapters = [{ path: "/weights/a", rank: 8, alpha: -1 }];
+      const result = gateMultiLoraAdapters(adapters, 24);
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toMatch(/alpha must be a positive finite number/i);
+    });
+
+    it("rejects single adapter with explicitly invalid targetModules instead of dropping them", () => {
+      const adapters = [{ path: "/weights/a", targetModules: [""] }];
+      const result = gateMultiLoraAdapters(adapters, 24);
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toMatch(/targetModules must be an array of non-empty strings/i);
+    });
+
     it("rejects single adapter with missing path", () => {
       const adapters = [{ name: "no-path", rank: 8, alpha: 16 }];
       const result = gateMultiLoraAdapters(adapters, 24);
@@ -185,6 +206,13 @@ describe("featureFlagGating — Task 11.3: Gate MultiLoRA UI behind feature flag
       expect(result.adapters).toEqual([
         { name: "style", path: "/adapters/style", rank: 8, alpha: 16 },
       ]);
+    });
+
+    it("rejects explicitly invalid rank when flag is enabled instead of defaulting", () => {
+      const adapters = [{ path: "/adapters/style", rank: 1.5, alpha: 16 }];
+      const result = gateMultiLoraAdapters(adapters, 24);
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toMatch(/rank must be a positive integer/i);
     });
 
     it("normalizes target_modules snake_case from MCP payloads", () => {

--- a/src/lib/__tests__/featureFlagGating.test.ts
+++ b/src/lib/__tests__/featureFlagGating.test.ts
@@ -24,12 +24,38 @@ vi.mock("@/lib/featureFlags", () => ({
 import {
   gateMultiLoraAdapters,
   buildExtractAdaptersPass,
+  buildOliveRecipe,
 } from "@/lib/oliveRecipeBuilder";
+import { deriveUiStateFromOliveRecipe } from "@/lib/oliveRecipeHub";
+import { DEFAULT_PASSES } from "@/lib/defaultPasses";
+import type { UIState, IHVProvider } from "@/types";
 import {
   isMultiLoraEnabled,
   FEATURE_FLAG_MULTI_LORA,
 } from "@/lib/featureFlags";
 
+function baseState(overrides?: Partial<UIState>): UIState {
+  return {
+    modelSource: "huggingface",
+    localFiles: [],
+    azureModelPath: "",
+    hfModelId: "meta-llama/Meta-Llama-3-8B",
+    hfDataset: "",
+    ihvProvider: "CUDAExecutionProvider" as IHVProvider,
+    openvinoTargetDevice: "CPU",
+    memoryOffload: "gpu_only",
+    cudaVersion: "auto",
+    cacheDir: "",
+    azureStr: "",
+    distributedCaching: false,
+    activeJobId: null,
+    ...overrides,
+    passes: {
+      ...DEFAULT_PASSES,
+      ...overrides?.passes,
+    },
+  };
+}
 describe("featureFlagGating — Task 11.3: Gate MultiLoRA UI behind feature flag", () => {
   beforeEach(() => {
     mockIsMultiLoraEnabled.mockReturnValue(false);
@@ -143,13 +169,29 @@ describe("featureFlagGating — Task 11.3: Gate MultiLoRA UI behind feature flag
 
     it("rejects invalid adapters even when flag is enabled", () => {
       const adapters = [
-        { name: "", path: "/weights/a", rank: 8, alpha: 16 },
-        { name: "lora-b", path: "", rank: 4, alpha: 8 },
+        { name: "lora-a", path: "", rank: 8, alpha: 16 },
+        { name: "lora-b", path: "/weights/b", rank: 4, alpha: 8 },
       ];
       const result = gateMultiLoraAdapters(adapters, 24);
       expect(result.allowed).toBe(false);
       expect(result.reason).toBeDefined();
       expect(result.reason!.length).toBeGreaterThan(0);
+    });
+
+    it("normalizes path-only adapters with the same defaults as flag-off mode", () => {
+      const adapters = [{ path: "/adapters/style" }];
+      const result = gateMultiLoraAdapters(adapters, 24);
+      expect(result.allowed).toBe(true);
+      expect(result.adapters).toEqual([
+        { name: "style", path: "/adapters/style", rank: 8, alpha: 16 },
+      ]);
+    });
+
+    it("normalizes target_modules snake_case from MCP payloads", () => {
+      const adapters = [{ path: "/a", target_modules: ["q_proj", "v_proj"] }];
+      const result = gateMultiLoraAdapters(adapters, 24);
+      expect(result.allowed).toBe(true);
+      expect(result.adapters[0].targetModules).toEqual(["q_proj", "v_proj"]);
     });
 
     it("respects VRAM-based adapter count limits (<=12GB: max 2)", () => {
@@ -235,6 +277,88 @@ describe("featureFlagGating — Task 11.3: Gate MultiLoRA UI behind feature flag
       ];
       const result = buildExtractAdaptersPass(adapters);
       expect(result!.config).not.toHaveProperty("adapters");
+    });
+  });
+
+  // ─── MultiLoRA recipe import round-trip ──────────────────────────────
+
+  describe("MultiLoRA recipe round-trip through deriveUiStateFromOliveRecipe", () => {
+    beforeEach(() => {
+      mockIsMultiLoraEnabled.mockReturnValue(true);
+    });
+
+    it("preserves adapter metadata and ExtractAdapters on import → rebuild", () => {
+      const state = baseState({
+        vramEstimateGb: 24,
+        multiLoraAdapters: [
+          { name: "style", path: "/adapters/style", rank: 16, alpha: 32, targetModules: ["q_proj"] },
+          { name: "tone", path: "/adapters/tone", rank: 8, alpha: 16 },
+        ],
+        passes: {
+          ...DEFAULT_PASSES,
+          peft: true,
+          peftMethod: "lora",
+          conversion: true,
+          conversionFormat: "onnx",
+        },
+      });
+
+      const recipe = buildOliveRecipe(state);
+      expect((recipe as Record<string, unknown>).adapters).toEqual([
+        {
+          name: "style",
+          path: "/adapters/style",
+          rank: 16,
+          alpha: 32,
+          target_modules: ["q_proj"],
+        },
+        { name: "tone", path: "/adapters/tone", rank: 8, alpha: 16 },
+      ]);
+      expect(
+        ((recipe.passes as Record<string, unknown>).extract_adapters as { type: string }).type,
+      ).toBe("ExtractAdapters");
+
+      const imported = deriveUiStateFromOliveRecipe(recipe, { replacePasses: true });
+      expect(imported.multiLoraAdapters).toEqual([
+        { name: "style", path: "/adapters/style", rank: 16, alpha: 32, targetModules: ["q_proj"] },
+        { name: "tone", path: "/adapters/tone", rank: 8, alpha: 16 },
+      ]);
+      expect(imported.passes?.peft).toBe(true);
+
+      const rebuilt = buildOliveRecipe(
+        baseState({
+          ...imported,
+          vramEstimateGb: 24,
+          multiLoraAdapters: imported.multiLoraAdapters,
+          passes: { ...DEFAULT_PASSES, ...imported.passes },
+        }),
+      );
+      expect((rebuilt as Record<string, unknown>).adapters).toEqual(
+        (recipe as Record<string, unknown>).adapters,
+      );
+      expect(
+        ((rebuilt.passes as Record<string, unknown>).extract_adapters as { type: string }).type,
+      ).toBe("ExtractAdapters");
+    });
+
+    it("restores legacy adapter_path as multiLoraAdapters on import", () => {
+      const recipe = {
+        input_model: {
+          type: "HfModel",
+          config: {
+            model_path: "meta-llama/Meta-Llama-3-8B",
+            adapter_path: "/legacy/adapter",
+          },
+        },
+        systems: {},
+        passes: {
+          peft: { type: "LoRA", config: {} },
+        },
+        engine: {},
+      };
+      const imported = deriveUiStateFromOliveRecipe(recipe, { replacePasses: true });
+      expect(imported.multiLoraAdapters).toEqual([{ path: "/legacy/adapter" }]);
+      expect(imported.passes?.peft).toBe(true);
     });
   });
 });

--- a/src/lib/__tests__/featureFlagGating.test.ts
+++ b/src/lib/__tests__/featureFlagGating.test.ts
@@ -205,6 +205,18 @@ describe("featureFlagGating — Task 11.3: Gate MultiLoRA UI behind feature flag
       expect(result.reason).toContain("exceeds maximum");
     });
 
+    it("allows up to 8 adapters when VRAM is unknown (import/rebuild path)", () => {
+      const adapters = Array.from({ length: 3 }, (_, i) => ({
+        name: `lora-${i}`,
+        path: `/weights/${i}`,
+        rank: 4,
+        alpha: 8,
+      }));
+      const result = gateMultiLoraAdapters(adapters, Number.NaN);
+      expect(result.allowed).toBe(true);
+      expect(result.adapters).toHaveLength(3);
+    });
+
     it("allows up to 8 adapters for >12GB VRAM", () => {
       const adapters = Array.from({ length: 8 }, (_, i) => ({
         name: `lora-${i}`,
@@ -293,6 +305,7 @@ describe("featureFlagGating — Task 11.3: Gate MultiLoRA UI behind feature flag
         multiLoraAdapters: [
           { name: "style", path: "/adapters/style", rank: 16, alpha: 32, targetModules: ["q_proj"] },
           { name: "tone", path: "/adapters/tone", rank: 8, alpha: 16 },
+          { name: "domain", path: "/adapters/domain", rank: 4, alpha: 8 },
         ],
         passes: {
           ...DEFAULT_PASSES,
@@ -313,6 +326,7 @@ describe("featureFlagGating — Task 11.3: Gate MultiLoRA UI behind feature flag
           target_modules: ["q_proj"],
         },
         { name: "tone", path: "/adapters/tone", rank: 8, alpha: 16 },
+        { name: "domain", path: "/adapters/domain", rank: 4, alpha: 8 },
       ]);
       expect(
         ((recipe.passes as Record<string, unknown>).extract_adapters as { type: string }).type,
@@ -322,13 +336,15 @@ describe("featureFlagGating — Task 11.3: Gate MultiLoRA UI behind feature flag
       expect(imported.multiLoraAdapters).toEqual([
         { name: "style", path: "/adapters/style", rank: 16, alpha: 32, targetModules: ["q_proj"] },
         { name: "tone", path: "/adapters/tone", rank: 8, alpha: 16 },
+        { name: "domain", path: "/adapters/domain", rank: 4, alpha: 8 },
       ]);
       expect(imported.passes?.peft).toBe(true);
+      // Recipes do not persist vramEstimateGb; rebuild must still succeed.
+      expect(imported.vramEstimateGb).toBeUndefined();
 
       const rebuilt = buildOliveRecipe(
         baseState({
           ...imported,
-          vramEstimateGb: 24,
           multiLoraAdapters: imported.multiLoraAdapters,
           passes: { ...DEFAULT_PASSES, ...imported.passes },
         }),

--- a/src/lib/__tests__/featureFlagGating.test.ts
+++ b/src/lib/__tests__/featureFlagGating.test.ts
@@ -1,0 +1,251 @@
+/**
+ * Tests for MultiLoRA feature flag gating (Task 11.3).
+ *
+ * Validates: Requirements 11.1, 11.3
+ *
+ * - `isMultiLoraEnabled()` defaults to false
+ * - `gateMultiLoraAdapters()` rejects multi-adapter configs when flag is disabled
+ * - `gateMultiLoraAdapters()` allows multi-adapter configs when flag is enabled
+ * - `buildExtractAdaptersPass()` emits correct Olive 0.13.0 ExtractAdapters format
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// We need to mock the featureFlags module to control isMultiLoraEnabled
+const mockIsMultiLoraEnabled = vi.fn<() => boolean>().mockReturnValue(false);
+
+vi.mock("@/lib/featureFlags", () => ({
+  isMultiLoraEnabled: () => mockIsMultiLoraEnabled(),
+  isFeatureEnabled: vi.fn().mockReturnValue(false),
+  FEATURE_FLAG_MULTI_LORA: "multiLora",
+  setFeatureFlag: vi.fn(),
+  getAllFlags: vi.fn().mockReturnValue([]),
+}));
+
+import {
+  gateMultiLoraAdapters,
+  buildExtractAdaptersPass,
+} from "@/lib/oliveRecipeBuilder";
+import {
+  isMultiLoraEnabled,
+  FEATURE_FLAG_MULTI_LORA,
+} from "@/lib/featureFlags";
+
+describe("featureFlagGating — Task 11.3: Gate MultiLoRA UI behind feature flag", () => {
+  beforeEach(() => {
+    mockIsMultiLoraEnabled.mockReturnValue(false);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ─── isMultiLoraEnabled ──────────────────────────────────────────────
+
+  describe("isMultiLoraEnabled()", () => {
+    it("defaults to false (disabled)", () => {
+      expect(isMultiLoraEnabled()).toBe(false);
+    });
+
+    it("returns true when mock is set to enabled", () => {
+      mockIsMultiLoraEnabled.mockReturnValue(true);
+      expect(isMultiLoraEnabled()).toBe(true);
+    });
+  });
+
+  describe("FEATURE_FLAG_MULTI_LORA constant", () => {
+    it("has the value 'multiLora'", () => {
+      expect(FEATURE_FLAG_MULTI_LORA).toBe("multiLora");
+    });
+  });
+
+  // ─── gateMultiLoraAdapters — flag disabled ───────────────────────────
+
+  describe("gateMultiLoraAdapters() with flag disabled", () => {
+    beforeEach(() => {
+      mockIsMultiLoraEnabled.mockReturnValue(false);
+    });
+
+    it("rejects multi-adapter configs (>1 adapter)", () => {
+      const adapters = [
+        { name: "lora-a", path: "/weights/a", rank: 8, alpha: 16 },
+        { name: "lora-b", path: "/weights/b", rank: 4, alpha: 8 },
+      ];
+      const result = gateMultiLoraAdapters(adapters, 24);
+      expect(result.allowed).toBe(false);
+      expect(result.adapters).toEqual([]);
+      expect(result.reason).toContain("multiLora feature flag is disabled");
+    });
+
+    it("allows a single valid adapter entry (single-adapter mode)", () => {
+      const adapters = [
+        { name: "lora-a", path: "/weights/a", rank: 8, alpha: 16 },
+      ];
+      const result = gateMultiLoraAdapters(adapters, 24);
+      expect(result.allowed).toBe(true);
+      expect(result.adapters).toHaveLength(1);
+      expect(result.adapters[0].name).toBe("lora-a");
+      expect(result.adapters[0].path).toBe("/weights/a");
+    });
+
+    it("allows single adapter with defaults for missing optional fields", () => {
+      const adapters = [{ path: "/weights/default" }];
+      const result = gateMultiLoraAdapters(adapters, 24);
+      expect(result.allowed).toBe(true);
+      expect(result.adapters[0].name).toBe("default");
+      expect(result.adapters[0].rank).toBe(8);
+      expect(result.adapters[0].alpha).toBe(16);
+    });
+
+    it("rejects single adapter with missing path", () => {
+      const adapters = [{ name: "no-path", rank: 8, alpha: 16 }];
+      const result = gateMultiLoraAdapters(adapters, 24);
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toContain("path must be a non-empty string");
+    });
+
+    it("allows empty adapters array", () => {
+      const result = gateMultiLoraAdapters([], 24);
+      expect(result.allowed).toBe(true);
+      expect(result.adapters).toEqual([]);
+      expect(result.reason).toBeUndefined();
+    });
+
+    it("rejects 3+ adapters", () => {
+      const adapters = [
+        { name: "a", path: "/a", rank: 4, alpha: 8 },
+        { name: "b", path: "/b", rank: 4, alpha: 8 },
+        { name: "c", path: "/c", rank: 4, alpha: 8 },
+      ];
+      const result = gateMultiLoraAdapters(adapters, 24);
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toContain("multiLora feature flag is disabled");
+    });
+  });
+
+  // ─── gateMultiLoraAdapters — flag enabled ────────────────────────────
+
+  describe("gateMultiLoraAdapters() with flag enabled", () => {
+    beforeEach(() => {
+      mockIsMultiLoraEnabled.mockReturnValue(true);
+    });
+
+    it("allows valid multi-adapter configs", () => {
+      const adapters = [
+        { name: "lora-a", path: "/weights/a", rank: 8, alpha: 16 },
+        { name: "lora-b", path: "/weights/b", rank: 4, alpha: 8 },
+      ];
+      const result = gateMultiLoraAdapters(adapters, 24);
+      expect(result.allowed).toBe(true);
+      expect(result.adapters).toHaveLength(2);
+      expect(result.adapters[0].name).toBe("lora-a");
+      expect(result.adapters[1].name).toBe("lora-b");
+    });
+
+    it("rejects invalid adapters even when flag is enabled", () => {
+      const adapters = [
+        { name: "", path: "/weights/a", rank: 8, alpha: 16 },
+        { name: "lora-b", path: "", rank: 4, alpha: 8 },
+      ];
+      const result = gateMultiLoraAdapters(adapters, 24);
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toBeDefined();
+      expect(result.reason!.length).toBeGreaterThan(0);
+    });
+
+    it("respects VRAM-based adapter count limits (<=12GB: max 2)", () => {
+      const adapters = [
+        { name: "a", path: "/a", rank: 4, alpha: 8 },
+        { name: "b", path: "/b", rank: 4, alpha: 8 },
+        { name: "c", path: "/c", rank: 4, alpha: 8 },
+      ];
+      const result = gateMultiLoraAdapters(adapters, 12);
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toContain("exceeds maximum");
+    });
+
+    it("allows up to 8 adapters for >12GB VRAM", () => {
+      const adapters = Array.from({ length: 8 }, (_, i) => ({
+        name: `lora-${i}`,
+        path: `/weights/${i}`,
+        rank: 4,
+        alpha: 8,
+      }));
+      const result = gateMultiLoraAdapters(adapters, 24);
+      expect(result.allowed).toBe(true);
+      expect(result.adapters).toHaveLength(8);
+    });
+
+    it("detects duplicate adapter names", () => {
+      const adapters = [
+        { name: "same", path: "/a", rank: 4, alpha: 8 },
+        { name: "same", path: "/b", rank: 4, alpha: 8 },
+      ];
+      const result = gateMultiLoraAdapters(adapters, 24);
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toContain("Duplicate");
+    });
+
+    it("preserves targetModules in validated output", () => {
+      const adapters = [
+        { name: "lora-a", path: "/weights/a", rank: 8, alpha: 16, targetModules: ["q_proj", "v_proj"] },
+      ];
+      const result = gateMultiLoraAdapters(adapters, 24);
+      expect(result.allowed).toBe(true);
+      expect(result.adapters[0].targetModules).toEqual(["q_proj", "v_proj"]);
+    });
+  });
+
+  // ─── buildExtractAdaptersPass ────────────────────────────────────────
+
+  describe("buildExtractAdaptersPass()", () => {
+    it("returns undefined for empty adapters array", () => {
+      const result = buildExtractAdaptersPass([]);
+      expect(result).toBeUndefined();
+    });
+
+    it("produces ExtractAdapters pass config with correct structure", () => {
+      const adapters = [
+        { name: "lora-a", path: "/weights/a", rank: 8, alpha: 16 },
+        { name: "lora-b", path: "/weights/b", rank: 4, alpha: 8 },
+      ];
+      const result = buildExtractAdaptersPass(adapters);
+      expect(result).toBeDefined();
+      expect(result!.type).toBe("ExtractAdapters");
+      expect(result!.config).toBeDefined();
+      const config = result!.config as { adapters: Record<string, unknown>[] };
+      expect(config.adapters).toHaveLength(2);
+      expect(config.adapters[0]).toEqual({
+        name: "lora-a",
+        path: "/weights/a",
+        rank: 8,
+        alpha: 16,
+      });
+      expect(config.adapters[1]).toEqual({
+        name: "lora-b",
+        path: "/weights/b",
+        rank: 4,
+        alpha: 8,
+      });
+    });
+
+    it("maps targetModules to target_modules in output", () => {
+      const adapters = [
+        { name: "lora-a", path: "/weights/a", rank: 8, alpha: 16, targetModules: ["q_proj"] },
+      ];
+      const result = buildExtractAdaptersPass(adapters);
+      const config = result!.config as { adapters: Record<string, unknown>[] };
+      expect(config.adapters[0]).toHaveProperty("target_modules", ["q_proj"]);
+      expect(config.adapters[0]).not.toHaveProperty("targetModules");
+    });
+
+    it("omits target_modules when not specified", () => {
+      const adapters = [
+        { name: "lora-a", path: "/weights/a", rank: 8, alpha: 16 },
+      ];
+      const result = buildExtractAdaptersPass(adapters);
+      const config = result!.config as { adapters: Record<string, unknown>[] };
+      expect(config.adapters[0]).not.toHaveProperty("target_modules");
+      expect(config.adapters[0]).not.toHaveProperty("targetModules");
+    });
+  });
+});

--- a/src/lib/__tests__/featureFlagGating.test.ts
+++ b/src/lib/__tests__/featureFlagGating.test.ts
@@ -211,41 +211,30 @@ describe("featureFlagGating — Task 11.3: Gate MultiLoRA UI behind feature flag
       const result = buildExtractAdaptersPass(adapters);
       expect(result).toBeDefined();
       expect(result!.type).toBe("ExtractAdapters");
-      expect(result!.config).toBeDefined();
-      const config = result!.config as { adapters: Record<string, unknown>[] };
-      expect(config.adapters).toHaveLength(2);
-      expect(config.adapters[0]).toEqual({
-        name: "lora-a",
-        path: "/weights/a",
-        rank: 8,
-        alpha: 16,
+      expect(result!.config).toEqual({
+        adapter_type: "lora",
+        make_inputs: true,
       });
-      expect(config.adapters[1]).toEqual({
-        name: "lora-b",
-        path: "/weights/b",
-        rank: 4,
-        alpha: 8,
-      });
+      expect(result!.config).not.toHaveProperty("adapters");
     });
 
-    it("maps targetModules to target_modules in output", () => {
+    it("does not emit unsupported adapters[] on ExtractAdapters", () => {
       const adapters = [
         { name: "lora-a", path: "/weights/a", rank: 8, alpha: 16, targetModules: ["q_proj"] },
       ];
       const result = buildExtractAdaptersPass(adapters);
-      const config = result!.config as { adapters: Record<string, unknown>[] };
-      expect(config.adapters[0]).toHaveProperty("target_modules", ["q_proj"]);
-      expect(config.adapters[0]).not.toHaveProperty("targetModules");
+      const config = result!.config as Record<string, unknown>;
+      expect(config.adapter_type).toBe("lora");
+      expect(config).not.toHaveProperty("adapters");
+      expect(config).not.toHaveProperty("targetModules");
     });
 
-    it("omits target_modules when not specified", () => {
+    it("omits adapter list from pass config when not specified", () => {
       const adapters = [
         { name: "lora-a", path: "/weights/a", rank: 8, alpha: 16 },
       ];
       const result = buildExtractAdaptersPass(adapters);
-      const config = result!.config as { adapters: Record<string, unknown>[] };
-      expect(config.adapters[0]).not.toHaveProperty("target_modules");
-      expect(config.adapters[0]).not.toHaveProperty("targetModules");
+      expect(result!.config).not.toHaveProperty("adapters");
     });
   });
 });

--- a/src/lib/__tests__/featureFlagGating.test.ts
+++ b/src/lib/__tests__/featureFlagGating.test.ts
@@ -405,7 +405,7 @@ describe("featureFlagGating — Task 11.3: Gate MultiLoRA UI behind feature flag
       expect(imported.passes?.peft).toBe(true);
     });
 
-    it("drops non-positive or fractional rank/alpha on import so rebuild does not throw", () => {
+    it("rejects non-positive or fractional rank/alpha on import instead of defaulting", () => {
       mockIsMultiLoraEnabled.mockReturnValue(true);
       const recipe = {
         input_model: {
@@ -415,9 +415,6 @@ describe("featureFlagGating — Task 11.3: Gate MultiLoRA UI behind feature flag
         systems: {},
         adapters: [
           { name: "bad-rank", path: "/adapters/bad-rank", rank: 0, alpha: 32 },
-          { name: "frac-rank", path: "/adapters/frac", rank: 1.5, alpha: 16 },
-          { name: "bad-alpha", path: "/adapters/bad-alpha", rank: 8, alpha: -1 },
-          { name: "ok", path: "/adapters/ok", rank: 8, alpha: 16 },
         ],
         passes: {
           peft: { type: "LoRA", config: {} },
@@ -425,23 +422,30 @@ describe("featureFlagGating — Task 11.3: Gate MultiLoRA UI behind feature flag
         },
         engine: {},
       };
-      const imported = deriveUiStateFromOliveRecipe(recipe, { replacePasses: true });
-      expect(imported.multiLoraAdapters).toEqual([
-        { name: "bad-rank", path: "/adapters/bad-rank", alpha: 32 },
-        { name: "frac-rank", path: "/adapters/frac", alpha: 16 },
-        { name: "bad-alpha", path: "/adapters/bad-alpha", rank: 8 },
-        { name: "ok", path: "/adapters/ok", rank: 8, alpha: 16 },
-      ]);
-      expect(() =>
-        buildOliveRecipe(
-          baseState({
-            ...imported,
-            multiLoraAdapters: imported.multiLoraAdapters,
-            passes: { ...DEFAULT_PASSES, ...imported.passes },
-            vramEstimateGb: 24,
-          }),
-        ),
-      ).not.toThrow();
+      expect(() => deriveUiStateFromOliveRecipe(recipe, { replacePasses: true })).toThrow(
+        /rank must be a positive integer/i,
+      );
+    });
+
+    it("rejects non-positive alpha on import instead of defaulting", () => {
+      mockIsMultiLoraEnabled.mockReturnValue(true);
+      const recipe = {
+        input_model: {
+          type: "HfModel",
+          config: { model_path: "meta-llama/Meta-Llama-3-8B" },
+        },
+        systems: {},
+        adapters: [
+          { name: "bad-alpha", path: "/adapters/bad-alpha", rank: 8, alpha: -1 },
+        ],
+        passes: {
+          peft: { type: "LoRA", config: {} },
+        },
+        engine: {},
+      };
+      expect(() => deriveUiStateFromOliveRecipe(recipe, { replacePasses: true })).toThrow(
+        /alpha must be a positive finite number/i,
+      );
     });
   });
 });

--- a/src/lib/__tests__/featureFlags.test.ts
+++ b/src/lib/__tests__/featureFlags.test.ts
@@ -1,0 +1,26 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { isMultiLoraEnabled } from "@/lib/featureFlags";
+
+const ENV_KEY = "VITE_FEATURE_MULTI_LORA";
+
+describe("featureFlags Node env fallback", () => {
+  const previous = process.env[ENV_KEY];
+
+  afterEach(() => {
+    if (previous === undefined) {
+      delete process.env[ENV_KEY];
+    } else {
+      process.env[ENV_KEY] = previous;
+    }
+  });
+
+  it("enables multiLora from process.env when Vite import.meta.env is unset", () => {
+    process.env[ENV_KEY] = "true";
+    expect(isMultiLoraEnabled()).toBe(true);
+  });
+
+  it("treats process.env 1 as enabled", () => {
+    process.env[ENV_KEY] = "1";
+    expect(isMultiLoraEnabled()).toBe(true);
+  });
+});

--- a/src/lib/__tests__/findingContract.test.ts
+++ b/src/lib/__tests__/findingContract.test.ts
@@ -8,7 +8,7 @@
  */
 import { describe, it, expect, beforeEach } from "vitest";
 import fc from "fast-check";
-import { sanitizeChatActionPatch, chatPatchToUiState } from "@/lib/chatActions";
+import { sanitizeChatActionPatch, chatPatchToUiState, type ChatActionPatch } from "@/lib/chatActions";
 import { commitUiStateUpdate, mergeUiState } from "@/lib/pipelineStateCommit";
 import { usePipelineStore, createDefaultPipelineState } from "@/lib/stores/pipelineStore";
 import {
@@ -28,7 +28,6 @@ import type {
   ActionPayloadDocumentation,
   ActionKind,
 } from "@/lib/types/findingTypes";
-import type { ChatActionPatch } from "@/lib/chatActions";
 
 // ─── Constants ───────────────────────────────────────────────────────────────
 

--- a/src/lib/__tests__/findingContract.test.ts
+++ b/src/lib/__tests__/findingContract.test.ts
@@ -1,0 +1,783 @@
+/**
+ * Property-based tests for the Finding/Action contract (Tasks 1.6, 3.6).
+ * Validates correctness properties from design.md (Properties 1–3).
+ *
+ * Feature: v05-release, Property 1: Finding Structural Invariant
+ * Feature: v05-release, Property 2: Action Payload Validity
+ * Feature: v05-release, Property 3: Non-Patch Actions Preserve Store
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import fc from "fast-check";
+import { sanitizeChatActionPatch, chatPatchToUiState } from "@/lib/chatActions";
+import { commitUiStateUpdate, mergeUiState } from "@/lib/pipelineStateCommit";
+import { usePipelineStore, createDefaultPipelineState } from "@/lib/stores/pipelineStore";
+import {
+  executeNavigateAction,
+  executeExplainAction,
+  executeDocumentationAction,
+  executeAction,
+} from "@/lib/actionExecutor";
+import type { UIState } from "@/types";
+import type {
+  Finding,
+  FindingSeverity,
+  Action,
+  ActionPayloadApplyPatch,
+  ActionPayloadNavigate,
+  ActionPayloadExplain,
+  ActionPayloadDocumentation,
+  ActionKind,
+} from "@/lib/types/findingTypes";
+import type { ChatActionPatch } from "@/lib/chatActions";
+
+// ─── Constants ───────────────────────────────────────────────────────────────
+
+const VALID_SEVERITIES: FindingSeverity[] = ["critical", "warning", "info"];
+const VALID_ACTION_KINDS: ActionKind[] = ["applyPatch", "navigate", "explain", "documentation"];
+
+const VALID_IHV_PROVIDERS = [
+  "CPUExecutionProvider",
+  "CUDAExecutionProvider",
+  "TensorrtExecutionProvider",
+  "NvTensorRTRTXExecutionProvider",
+  "DmlExecutionProvider",
+  "OpenVINOExecutionProvider",
+  "QNNExecutionProvider",
+  "ROCMExecutionProvider",
+  "WebGpuExecutionProvider",
+] as const;
+
+const VALID_QUANT_METHODS = ["ptq", "awq", "qat", "gptq", "hqq", "rtn", "kquant", "spinquant", "quarot"] as const;
+const VALID_QUANT_PRECISIONS = ["int4", "int8", "fp16"] as const;
+const VALID_CUDA_VERSIONS = ["auto", "cpu", "cu118", "cu121", "cu124", "cu126", "cu128", "cu130", "cu132"] as const;
+const VALID_MODEL_SOURCES = ["huggingface", "local", "azure"] as const;
+
+// ─── Arbitraries ─────────────────────────────────────────────────────────────
+
+/** Generate a non-empty string of bounded length. */
+function arbBoundedString(maxLength: number): fc.Arbitrary<string> {
+  return fc.string({ minLength: 1, maxLength });
+}
+
+/** Generate an action label (max 80 chars, non-empty). */
+function arbLabel(): fc.Arbitrary<string> {
+  return arbBoundedString(80);
+}
+
+/** Generate a valid ChatActionPatch that will pass sanitizeChatActionPatch. */
+function arbValidChatActionPatch(): fc.Arbitrary<ChatActionPatch> {
+  return fc.record(
+    {
+      ihvProvider: fc.constantFrom(...VALID_IHV_PROVIDERS),
+      cudaVersion: fc.constantFrom(...VALID_CUDA_VERSIONS),
+      modelSource: fc.constantFrom(...VALID_MODEL_SOURCES),
+      hfModelId: fc.string({ minLength: 1, maxLength: 64 }).filter((s) => s.trim().length > 0),
+      passes: fc.record(
+        {
+          quantization: fc.boolean(),
+          quantMethod: fc.constantFrom(...VALID_QUANT_METHODS),
+          quantPrecision: fc.constantFrom(...VALID_QUANT_PRECISIONS),
+          conversion: fc.boolean(),
+        },
+        { requiredKeys: [] },
+      ),
+    },
+    { requiredKeys: [] },
+  ).filter((r) => {
+    // Ensure at least one field is present so sanitize doesn't return null
+    return Object.keys(r).length > 0 && (
+      r.ihvProvider !== undefined ||
+      r.cudaVersion !== undefined ||
+      r.modelSource !== undefined ||
+      (r.hfModelId !== undefined && r.hfModelId.trim().length > 0) ||
+      (r.passes !== undefined && Object.keys(r.passes).length > 0)
+    );
+  });
+}
+
+/** Generate a valid applyPatch action. */
+function arbApplyPatchAction(): fc.Arbitrary<ActionPayloadApplyPatch> {
+  return arbValidChatActionPatch().chain((patch) =>
+    arbLabel().map((label) => ({
+      kind: "applyPatch" as const,
+      label,
+      payload: patch,
+    })),
+  );
+}
+
+/** Generate a valid navigate action. */
+function arbNavigateAction(): fc.Arbitrary<ActionPayloadNavigate> {
+  return fc.record({
+    kind: fc.constant("navigate" as const),
+    label: arbLabel(),
+    payload: fc.record({
+      targetPanel: fc.string({ minLength: 1, maxLength: 50 }),
+    }),
+  });
+}
+
+/** Generate a valid explain action. */
+function arbExplainAction(): fc.Arbitrary<ActionPayloadExplain> {
+  return fc.record({
+    kind: fc.constant("explain" as const),
+    label: arbLabel(),
+    payload: fc.record({
+      body: fc.string({ minLength: 1, maxLength: 500 }),
+    }),
+  });
+}
+
+/** Generate a valid documentation action. */
+function arbDocumentationAction(): fc.Arbitrary<ActionPayloadDocumentation> {
+  return fc.record({
+    kind: fc.constant("documentation" as const),
+    label: arbLabel(),
+    payload: fc.record(
+      {
+        url: fc.webUrl(),
+        topicKey: fc.string({ minLength: 1, maxLength: 50 }),
+      },
+      { requiredKeys: [] },
+    ),
+  });
+}
+
+/** Generate any valid Action (any kind). */
+function arbAction(): fc.Arbitrary<Action> {
+  return fc.oneof(
+    arbApplyPatchAction(),
+    arbNavigateAction(),
+    arbExplainAction(),
+    arbDocumentationAction(),
+  );
+}
+
+/** Generate a valid Finding (all structural invariants satisfied). */
+function arbFinding(): fc.Arbitrary<Finding> {
+  return fc.record({
+    id: fc.uuid(),
+    title: arbBoundedString(120),
+    description: fc.string({ minLength: 0, maxLength: 2000 }),
+    severity: fc.constantFrom(...VALID_SEVERITIES),
+    evidence: fc.string({ minLength: 0, maxLength: 500 }),
+    actions: fc.array(arbAction(), { minLength: 1, maxLength: 10 }),
+  });
+}
+
+/** Generate an array of Findings with unique IDs within a run. */
+function arbFindingsRun(): fc.Arbitrary<Finding[]> {
+  return fc.array(arbFinding(), { minLength: 1, maxLength: 20 }).map((findings) => {
+    // Ensure IDs are unique within the run by appending index
+    return findings.map((f, i) => ({
+      ...f,
+      id: `${f.id}-${i}`,
+    }));
+  });
+}
+
+// ─── Property 4 Helpers: Coercion Detection ──────────────────────────────────
+
+/**
+ * Compare two UIState objects and return the key paths where they differ.
+ * Used to detect which fields were auto-coerced by sanitizePipelineState.
+ */
+function detectCoercedFields(naive: UIState, coerced: UIState): string[] {
+  const diffs: string[] = [];
+
+  // Check top-level scalar fields
+  for (const key of Object.keys(naive) as (keyof UIState)[]) {
+    if (key === "passes") continue; // Handle nested separately
+    if (key === "localFiles" || key === "batchJobs") continue; // Arrays, skip deep compare
+    if (naive[key] !== coerced[key]) {
+      diffs.push(key);
+    }
+  }
+
+  // Check nested passes fields
+  if (naive.passes && coerced.passes) {
+    for (const passKey of Object.keys(naive.passes) as (keyof UIState["passes"])[]) {
+      if (naive.passes[passKey] !== coerced.passes[passKey]) {
+        diffs.push(`passes.${passKey}`);
+      }
+    }
+  }
+
+  return diffs;
+}
+
+/**
+ * Deep-equal comparison for UIState (structural, ignoring prototype/method differences).
+ */
+function deepEqualUIState(a: UIState, b: UIState): boolean {
+  return detectCoercedFields(a, b).length === 0;
+}
+
+/**
+ * Generate a ChatActionPatch that is LIKELY to trigger coercion.
+ * Pairs incompatible provider + pass settings to ensure the coercion logic fires.
+ */
+function arbCoercionTriggeringPatch(): fc.Arbitrary<{ baseState: UIState; patch: ChatActionPatch }> {
+  return fc.oneof(
+    // Scenario: OpenVINO format on non-OpenVINO provider
+    fc.record({
+      provider: fc.constantFrom(
+        "CPUExecutionProvider" as const,
+        "CUDAExecutionProvider" as const,
+        "TensorrtExecutionProvider" as const,
+        "DmlExecutionProvider" as const,
+      ),
+    }).map(({ provider }) => ({
+      baseState: { ...createDefaultPipelineState(), ihvProvider: provider },
+      patch: { passes: { conversion: true, conversionFormat: "openvino" } } as ChatActionPatch,
+    })),
+
+    // Scenario: AWQ on CPU-only provider
+    fc.constant({
+      baseState: { ...createDefaultPipelineState(), ihvProvider: "CPUExecutionProvider" as const },
+      patch: { passes: { quantization: true, quantMethod: "awq" } } as ChatActionPatch,
+    }),
+
+    // Scenario: GPTQ on CPU-only provider
+    fc.constant({
+      baseState: { ...createDefaultPipelineState(), ihvProvider: "CPUExecutionProvider" as const },
+      patch: { passes: { quantization: true, quantMethod: "gptq" } } as ChatActionPatch,
+    }),
+
+    // Scenario: LoRA + quantization → qlora coercion
+    fc.record({
+      precision: fc.constantFrom("int4" as const, "int8" as const),
+    }).map(({ precision }) => ({
+      baseState: { ...createDefaultPipelineState(), ihvProvider: "CUDAExecutionProvider" as const },
+      patch: { passes: { peft: true, peftMethod: "lora", quantization: true, quantPrecision: precision } } as ChatActionPatch,
+    })),
+
+    // Scenario: INT4 + pruning → int8 coercion
+    fc.constant({
+      baseState: { ...createDefaultPipelineState(), ihvProvider: "CUDAExecutionProvider" as const },
+      patch: { passes: { pruning: true, quantization: true, quantPrecision: "int4" } } as ChatActionPatch,
+    }),
+
+    // Scenario: Structured pruning on non-tensor-core provider
+    fc.constantFrom(
+      "CPUExecutionProvider" as const,
+      "OpenVINOExecutionProvider" as const,
+      "QNNExecutionProvider" as const,
+    ).map((provider) => ({
+      baseState: { ...createDefaultPipelineState(), ihvProvider: provider },
+      patch: { passes: { pruning: true, pruningType: "structured" } } as ChatActionPatch,
+    })),
+
+    // Scenario: OpenVINO conversion + onnxTransforms → onnxTransforms disabled
+    fc.constant({
+      baseState: { ...createDefaultPipelineState(), ihvProvider: "OpenVINOExecutionProvider" as const },
+      patch: { passes: { conversion: true, conversionFormat: "openvino", onnxTransforms: true } } as ChatActionPatch,
+    }),
+
+    // Scenario: HQQ/RTN/kquant on non-CPU/CUDA providers
+    fc.record({
+      method: fc.constantFrom("hqq" as const, "rtn" as const, "kquant" as const),
+      provider: fc.constantFrom(
+        "TensorrtExecutionProvider" as const,
+        "DmlExecutionProvider" as const,
+        "OpenVINOExecutionProvider" as const,
+      ),
+    }).map(({ method, provider }) => ({
+      baseState: { ...createDefaultPipelineState(), ihvProvider: provider },
+      patch: { passes: { quantization: true, quantMethod: method } } as ChatActionPatch,
+    })),
+  );
+}
+
+/**
+ * Generate a ChatActionPatch that should NOT trigger any coercion.
+ * These are "safe" combinations where naive merge === committed state.
+ */
+function arbNonCoercingPatch(): fc.Arbitrary<{ baseState: UIState; patch: ChatActionPatch }> {
+  return fc.oneof(
+    // Simple hfModelId change — never coerced
+    fc.string({ minLength: 1, maxLength: 64 }).filter((s) => s.trim().length > 0).map((id) => ({
+      baseState: createDefaultPipelineState(),
+      patch: { hfModelId: id } as ChatActionPatch,
+    })),
+
+    // PTQ quantization on CPU — valid and no coercion
+    fc.constant({
+      baseState: createDefaultPipelineState(),
+      patch: { passes: { quantization: true, quantMethod: "ptq", quantPrecision: "int8" } } as ChatActionPatch,
+    }),
+
+    // ONNX conversion on CPU — the default, no coercion
+    fc.constant({
+      baseState: createDefaultPipelineState(),
+      patch: { passes: { conversion: true, conversionFormat: "onnx" } } as ChatActionPatch,
+    }),
+
+    // Switching to CUDA provider — no pass coercion for default passes
+    fc.constant({
+      baseState: createDefaultPipelineState(),
+      patch: { ihvProvider: "CUDAExecutionProvider" } as ChatActionPatch,
+    }),
+
+    // Unstructured pruning on any provider — always allowed
+    fc.constantFrom(
+      "CPUExecutionProvider" as const,
+      "CUDAExecutionProvider" as const,
+      "OpenVINOExecutionProvider" as const,
+    ).map((provider) => ({
+      baseState: { ...createDefaultPipelineState(), ihvProvider: provider },
+      patch: { passes: { pruning: true, pruningType: "unstructured" } } as ChatActionPatch,
+    })),
+  );
+}
+
+// ─── Property 1: Finding Structural Invariant ────────────────────────────────
+
+describe("Property 1: Finding Structural Invariant", () => {
+  /**
+   * Feature: v05-release, Property 1: Finding Structural Invariant
+   *
+   * For any valid Finding object produced by the review engine, the following
+   * must hold: id is a non-empty string unique within its review run, title is
+   * a non-empty string of at most 120 characters, description is at most 2000
+   * characters, severity is one of "critical" | "warning" | "info", evidence
+   * is a string, and actions is an array with between 1 and 10 elements where
+   * each element has a valid kind and label of at most 80 characters.
+   *
+   * Validates: Requirements 2.1, 2.4
+   */
+
+  it("all generated Findings satisfy field constraints", () => {
+    fc.assert(
+      fc.property(arbFinding(), (finding) => {
+        // id: non-empty string
+        expect(finding.id).toBeTruthy();
+        expect(typeof finding.id).toBe("string");
+        expect(finding.id.length).toBeGreaterThan(0);
+
+        // title: non-empty string, max 120 chars
+        expect(typeof finding.title).toBe("string");
+        expect(finding.title.length).toBeGreaterThan(0);
+        expect(finding.title.length).toBeLessThanOrEqual(120);
+
+        // description: max 2000 chars
+        expect(typeof finding.description).toBe("string");
+        expect(finding.description.length).toBeLessThanOrEqual(2000);
+
+        // severity: valid enum
+        expect(VALID_SEVERITIES).toContain(finding.severity);
+
+        // evidence: is a string
+        expect(typeof finding.evidence).toBe("string");
+
+        // actions: 1–10 elements
+        expect(finding.actions.length).toBeGreaterThanOrEqual(1);
+        expect(finding.actions.length).toBeLessThanOrEqual(10);
+      }),
+      { numRuns: 100 },
+    );
+  });
+
+  it("all actions have valid kind and label within limits", () => {
+    fc.assert(
+      fc.property(arbFinding(), (finding) => {
+        for (const action of finding.actions) {
+          // kind: valid ActionKind
+          expect(VALID_ACTION_KINDS).toContain(action.kind);
+
+          // label: non-empty string, max 80 chars
+          expect(typeof action.label).toBe("string");
+          expect(action.label.length).toBeGreaterThan(0);
+          expect(action.label.length).toBeLessThanOrEqual(80);
+        }
+      }),
+      { numRuns: 100 },
+    );
+  });
+
+  it("Finding IDs are unique within a review run", () => {
+    fc.assert(
+      fc.property(arbFindingsRun(), (findings) => {
+        const ids = findings.map((f) => f.id);
+        const uniqueIds = new Set(ids);
+        expect(uniqueIds.size).toBe(ids.length);
+      }),
+      { numRuns: 100 },
+    );
+  });
+});
+
+// ─── Property 4: Coercion Difference Detection ──────────────────────────────
+
+describe("Property 4: Coercion Difference Detection", () => {
+  /**
+   * Feature: v05-release, Property 4: Coercion Difference Detection
+   *
+   * For any ChatActionPatch applied via commitUiStateUpdate, if the committed
+   * UIState differs from the direct merge of the patch fields onto the prior
+   * state (indicating auto-coercion occurred), the differing fields can be
+   * identified — forming the material for a coercion notice.
+   *
+   * Validates: Requirements 2.7
+   */
+
+  it("coerced fields are detectable when commitUiStateUpdate differs from naive merge", () => {
+    fc.assert(
+      fc.property(arbCoercionTriggeringPatch(), ({ baseState, patch }) => {
+        // Step 1: Compute the naive merge (no coercion)
+        const naiveMerged = mergeUiState(baseState, chatPatchToUiState(baseState, patch));
+
+        // Step 2: Compute the coerced state via commitUiStateUpdate
+        const coerced = commitUiStateUpdate(baseState, chatPatchToUiState(baseState, patch));
+
+        // Step 3: Identify fields that differ between naive merge and coerced result
+        const coercedFields = detectCoercedFields(naiveMerged, coerced);
+
+        // Property assertion: if ANY coercion occurred, differing keys are non-empty
+        const hasCoercion = !deepEqualUIState(naiveMerged, coerced);
+        if (hasCoercion) {
+          expect(coercedFields.length).toBeGreaterThan(0);
+          // Each coerced field identifies a concrete key path
+          for (const field of coercedFields) {
+            expect(field).toBeTruthy();
+            expect(typeof field).toBe("string");
+          }
+        }
+      }),
+      { numRuns: 200 },
+    );
+  });
+
+  it("no coercion means naive merge and committed state are identical", () => {
+    fc.assert(
+      fc.property(arbNonCoercingPatch(), ({ baseState, patch }) => {
+        const naiveMerged = mergeUiState(baseState, chatPatchToUiState(baseState, patch));
+        const coerced = commitUiStateUpdate(baseState, chatPatchToUiState(baseState, patch));
+
+        // When the patch does not trigger coercion, they must be identical
+        const coercedFields = detectCoercedFields(naiveMerged, coerced);
+        expect(coercedFields).toHaveLength(0);
+        expect(deepEqualUIState(naiveMerged, coerced)).toBe(true);
+      }),
+      { numRuns: 100 },
+    );
+  });
+
+  it("specific known coercion scenarios produce the expected coerced field", () => {
+    // Scenario 1: OpenVINO conversion format gets coerced to "onnx" when provider is CPU
+    const base1 = createDefaultPipelineState();
+    base1.ihvProvider = "CPUExecutionProvider";
+    const patch1: ChatActionPatch = { passes: { conversion: true, conversionFormat: "openvino" } };
+    const uiPatch1 = chatPatchToUiState(base1, patch1);
+    const naive1 = mergeUiState(base1, uiPatch1);
+    const coerced1 = commitUiStateUpdate(base1, uiPatch1);
+    const fields1 = detectCoercedFields(naive1, coerced1);
+    expect(fields1).toContain("passes.conversionFormat");
+
+    // Scenario 2: AWQ quant method coerced to "ptq" when provider is CPU
+    const base2 = createDefaultPipelineState();
+    base2.ihvProvider = "CPUExecutionProvider";
+    const patch2: ChatActionPatch = { passes: { quantization: true, quantMethod: "awq" } };
+    const uiPatch2 = chatPatchToUiState(base2, patch2);
+    const naive2 = mergeUiState(base2, uiPatch2);
+    const coerced2 = commitUiStateUpdate(base2, uiPatch2);
+    const fields2 = detectCoercedFields(naive2, coerced2);
+    expect(fields2).toContain("passes.quantMethod");
+
+    // Scenario 3: LoRA + quantization triggers peftMethod coercion to "qlora"
+    const base3 = createDefaultPipelineState();
+    base3.ihvProvider = "CUDAExecutionProvider";
+    const patch3: ChatActionPatch = { passes: { peft: true, peftMethod: "lora", quantization: true, quantPrecision: "int4" } };
+    const uiPatch3 = chatPatchToUiState(base3, patch3);
+    const naive3 = mergeUiState(base3, uiPatch3);
+    const coerced3 = commitUiStateUpdate(base3, uiPatch3);
+    const fields3 = detectCoercedFields(naive3, coerced3);
+    expect(fields3).toContain("passes.peftMethod");
+  });
+});
+
+// ─── Property 2: Action Payload Validity ─────────────────────────────────────
+
+describe("Property 2: Action Payload Validity", () => {
+  /**
+   * Feature: v05-release, Property 2: Action Payload Validity
+   *
+   * For any Action with kind "applyPatch", calling
+   * sanitizeChatActionPatch(action.payload) must return a non-null
+   * ChatActionPatch. For any Finding where all candidate applyPatch payloads
+   * would produce null from sanitizeChatActionPatch, the Finding's actions
+   * array must contain at least one action with kind "explain" or
+   * "documentation".
+   *
+   * Validates: Requirements 2.3, 2.5
+   */
+
+  it("applyPatch payloads always pass sanitizeChatActionPatch", () => {
+    fc.assert(
+      fc.property(arbApplyPatchAction(), (action) => {
+        const result = sanitizeChatActionPatch(action.payload);
+        expect(result).not.toBeNull();
+      }),
+      { numRuns: 100 },
+    );
+  });
+
+  it("when all applyPatch payloads fail sanitization, a fallback explain/documentation action exists", () => {
+    // Generate a Finding where applyPatch actions have INVALID payloads
+    // (empty objects that sanitize to null), then verify fallback exists.
+    const arbFindingWithInvalidPatches: fc.Arbitrary<Finding> = fc.record({
+      id: fc.uuid(),
+      title: arbBoundedString(120),
+      description: fc.string({ minLength: 0, maxLength: 2000 }),
+      severity: fc.constantFrom(...VALID_SEVERITIES),
+      evidence: fc.string({ minLength: 0, maxLength: 500 }),
+      actions: fc
+        .tuple(
+          // At least one invalid applyPatch (payload that sanitizes to null)
+          fc.array(
+            fc.record({
+              kind: fc.constant("applyPatch" as const),
+              label: arbLabel(),
+              // Invalid payload: unknown keys only → sanitizeChatActionPatch returns null
+              payload: fc.record({
+                unknownKey: fc.string(),
+              }) as fc.Arbitrary<Record<string, unknown>> as fc.Arbitrary<ChatActionPatch>,
+            }),
+            { minLength: 1, maxLength: 3 },
+          ),
+          // At least one fallback explain or documentation action
+          fc.oneof(arbExplainAction(), arbDocumentationAction()),
+        )
+        .map(([invalidPatches, fallback]) => [...invalidPatches, fallback]),
+    });
+
+    fc.assert(
+      fc.property(arbFindingWithInvalidPatches, (finding) => {
+        // Verify all applyPatch payloads fail sanitization
+        const patchActions = finding.actions.filter(
+          (a): a is ActionPayloadApplyPatch => a.kind === "applyPatch",
+        );
+        for (const patchAction of patchActions) {
+          const result = sanitizeChatActionPatch(patchAction.payload);
+          expect(result).toBeNull();
+        }
+
+        // Verify there is at least one fallback explain/documentation action
+        const hasFallback = finding.actions.some(
+          (a) => a.kind === "explain" || a.kind === "documentation",
+        );
+        expect(hasFallback).toBe(true);
+      }),
+      { numRuns: 100 },
+    );
+  });
+
+  it("valid applyPatch payloads produce non-null sanitized patches with at least one recognized field", () => {
+    fc.assert(
+      fc.property(arbValidChatActionPatch(), (patch) => {
+        const result = sanitizeChatActionPatch(patch);
+        expect(result).not.toBeNull();
+        // The sanitized patch has at least one key
+        expect(Object.keys(result!).length).toBeGreaterThan(0);
+      }),
+      { numRuns: 100 },
+    );
+  });
+
+  it("navigate/explain/documentation actions have correct payload shapes", () => {
+    fc.assert(
+      fc.property(
+        fc.oneof(arbNavigateAction(), arbExplainAction(), arbDocumentationAction()),
+        (action) => {
+          switch (action.kind) {
+            case "navigate":
+              expect(action.payload).toHaveProperty("targetPanel");
+              expect(typeof action.payload.targetPanel).toBe("string");
+              break;
+            case "explain":
+              expect(action.payload).toHaveProperty("body");
+              expect(typeof action.payload.body).toBe("string");
+              break;
+            case "documentation":
+              // url and topicKey are optional
+              if ("url" in action.payload && action.payload.url !== undefined) {
+                expect(typeof action.payload.url).toBe("string");
+              }
+              if ("topicKey" in action.payload && action.payload.topicKey !== undefined) {
+                expect(typeof action.payload.topicKey).toBe("string");
+              }
+              break;
+          }
+        },
+      ),
+      { numRuns: 100 },
+    );
+  });
+});
+
+
+// ─── Property 3: Non-Patch Actions Preserve Store ────────────────────────────
+
+describe("Property 3: Non-Patch Actions Preserve Store", () => {
+  /**
+   * Feature: v05-release, Property 3: Non-Patch Actions Preserve Store
+   *
+   * For any Action with kind "navigate", "explain", or "documentation",
+   * executing that action must not modify the PipelineStore state — the UIState
+   * before and after execution must be deeply equal.
+   *
+   * Validates: Requirements 2.8
+   */
+
+  beforeEach(() => {
+    // Reset store to a known state before each test
+    usePipelineStore.getState().resetState();
+  });
+
+  it("navigate actions do not modify PipelineStore state", () => {
+    fc.assert(
+      fc.property(arbNavigateAction(), (action) => {
+        // Snapshot state before execution
+        const stateBefore = structuredClone(usePipelineStore.getState().state);
+
+        // Execute the navigate action
+        const result = executeNavigateAction(action);
+
+        // State after must be identical
+        const stateAfter = usePipelineStore.getState().state;
+        expect(stateAfter).toEqual(stateBefore);
+        expect(result.modifiedStore).toBe(false);
+      }),
+      { numRuns: 100 },
+    );
+  });
+
+  it("explain actions do not modify PipelineStore state", () => {
+    fc.assert(
+      fc.property(arbExplainAction(), (action) => {
+        // Snapshot state before execution
+        const stateBefore = structuredClone(usePipelineStore.getState().state);
+
+        // Execute the explain action
+        const result = executeExplainAction(action);
+
+        // State after must be identical
+        const stateAfter = usePipelineStore.getState().state;
+        expect(stateAfter).toEqual(stateBefore);
+        expect(result.modifiedStore).toBe(false);
+      }),
+      { numRuns: 100 },
+    );
+  });
+
+  it("documentation actions do not modify PipelineStore state", () => {
+    fc.assert(
+      fc.property(arbDocumentationAction(), (action) => {
+        // Snapshot state before execution
+        const stateBefore = structuredClone(usePipelineStore.getState().state);
+
+        // Execute the documentation action
+        const result = executeDocumentationAction(action);
+
+        // State after must be identical
+        const stateAfter = usePipelineStore.getState().state;
+        expect(stateAfter).toEqual(stateBefore);
+        expect(result.modifiedStore).toBe(false);
+      }),
+      { numRuns: 100 },
+    );
+  });
+
+  it("any non-patch action via executeAction does not modify PipelineStore state", () => {
+    // Generate only non-patch actions
+    const arbNonPatchAction = fc.oneof(
+      arbNavigateAction(),
+      arbExplainAction(),
+      arbDocumentationAction(),
+    );
+
+    fc.assert(
+      fc.property(arbNonPatchAction, (action) => {
+        // Snapshot state before execution
+        const stateBefore = structuredClone(usePipelineStore.getState().state);
+
+        // Execute via the dispatcher
+        const result = executeAction(action);
+
+        // State after must be identical
+        const stateAfter = usePipelineStore.getState().state;
+        expect(stateAfter).toEqual(stateBefore);
+        expect(result.modifiedStore).toBe(false);
+        expect(result.success).toBe(true);
+      }),
+      { numRuns: 100 },
+    );
+  });
+
+  it("non-patch actions preserve store even with non-default pipeline state", () => {
+    // Set up a modified pipeline state first
+    usePipelineStore.getState().setState({
+      hfModelId: "microsoft/phi-2",
+      ihvProvider: "CUDAExecutionProvider",
+      cudaVersion: "cu121",
+      passes: {
+        ...usePipelineStore.getState().state.passes,
+        quantization: true,
+        quantMethod: "awq",
+        quantPrecision: "int4",
+      },
+    });
+
+    const arbNonPatchAction = fc.oneof(
+      arbNavigateAction(),
+      arbExplainAction(),
+      arbDocumentationAction(),
+    );
+
+    fc.assert(
+      fc.property(arbNonPatchAction, (action) => {
+        // Snapshot state (now non-default) before execution
+        const stateBefore = structuredClone(usePipelineStore.getState().state);
+
+        // Execute the action
+        const result = executeAction(action);
+
+        // State must remain unchanged
+        const stateAfter = usePipelineStore.getState().state;
+        expect(stateAfter).toEqual(stateBefore);
+        expect(result.modifiedStore).toBe(false);
+      }),
+      { numRuns: 100 },
+    );
+  });
+
+  it("sequence of non-patch actions does not accumulate store modifications", () => {
+    // Generate a sequence of non-patch actions and execute them all
+    const arbNonPatchAction = fc.oneof(
+      arbNavigateAction(),
+      arbExplainAction(),
+      arbDocumentationAction(),
+    );
+
+    fc.assert(
+      fc.property(
+        fc.array(arbNonPatchAction, { minLength: 2, maxLength: 10 }),
+        (actions) => {
+          // Snapshot before the entire sequence
+          const stateBefore = structuredClone(usePipelineStore.getState().state);
+
+          // Execute all actions in sequence
+          for (const action of actions) {
+            const result = executeAction(action);
+            expect(result.modifiedStore).toBe(false);
+          }
+
+          // State after entire sequence must be identical
+          const stateAfter = usePipelineStore.getState().state;
+          expect(stateAfter).toEqual(stateBefore);
+        },
+      ),
+      { numRuns: 100 },
+    );
+  });
+});

--- a/src/lib/__tests__/multiLoraValidation.test.ts
+++ b/src/lib/__tests__/multiLoraValidation.test.ts
@@ -364,6 +364,12 @@ describe("multiLoraValidation — Unit Tests", () => {
       expect(getMaxAdapterCount(24)).toBe(8);
       expect(getMaxAdapterCount(80)).toBe(8);
     });
+
+    it("returns 8 when VRAM is unknown (non-finite)", () => {
+      expect(getMaxAdapterCount(Number.NaN)).toBe(8);
+      expect(getMaxAdapterCount(Number.POSITIVE_INFINITY)).toBe(8);
+      expect(getMaxAdapterCount(Number.NEGATIVE_INFINITY)).toBe(8);
+    });
   });
 
   describe("validateAdapters", () => {

--- a/src/lib/__tests__/multiLoraValidation.test.ts
+++ b/src/lib/__tests__/multiLoraValidation.test.ts
@@ -16,8 +16,6 @@ import fc from "fast-check";
 import {
   validateAdapters,
   getMaxAdapterCount,
-  type AdapterEntry,
-  type ValidationResult,
 } from "@/lib/multiLoraValidation";
 
 // ─── Arbitraries ─────────────────────────────────────────────────────────────

--- a/src/lib/__tests__/multiLoraValidation.test.ts
+++ b/src/lib/__tests__/multiLoraValidation.test.ts
@@ -1,0 +1,493 @@
+/**
+ * Property-based and unit tests for MultiLoRA adapter validation (Task 11.1 / 11.2).
+ * Feature: v05-release, Property 16: MultiLoRA Adapter Validation
+ *
+ * Validates: Requirements 11.2, 11.4, 11.5
+ *
+ * For any adapter entry in the `adapters` array (when `multiLora` flag is enabled):
+ * `name` must be a non-empty string unique across all entries, `path` must be a
+ * non-empty string, `rank` must be a positive integer, `alpha` must be a positive
+ * finite number, and optional `targetModules` must be an array of non-empty strings.
+ * The maximum adapter count must be 2 for hardware profiles with <= 12 GB VRAM and
+ * 8 for profiles above 12 GB VRAM.
+ */
+import { describe, it, expect } from "vitest";
+import fc from "fast-check";
+import {
+  validateAdapters,
+  getMaxAdapterCount,
+  type AdapterEntry,
+  type ValidationResult,
+} from "@/lib/multiLoraValidation";
+
+// ─── Arbitraries ─────────────────────────────────────────────────────────────
+
+/** Generate a valid adapter entry. */
+const arbValidAdapter = fc.record({
+  name: fc.string({ minLength: 1, maxLength: 50 }),
+  path: fc.string({ minLength: 1, maxLength: 200 }),
+  rank: fc.integer({ min: 1, max: 256 }),
+  alpha: fc.double({ min: 0.001, max: 1000, noNaN: true }),
+  targetModules: fc.option(
+    fc.array(fc.string({ minLength: 1, maxLength: 50 }), { minLength: 1, maxLength: 10 }),
+    { nil: undefined },
+  ),
+});
+
+/** Generate an array of valid adapters with unique names. */
+function arbUniqueAdapters(min: number, max: number) {
+  return fc
+    .array(arbValidAdapter, { minLength: min, maxLength: max })
+    .map((adapters) => {
+      // Ensure unique names by appending index suffix
+      return adapters.map((a, i) => ({ ...a, name: `adapter-${i}-${a.name}` }));
+    });
+}
+
+/** Generate VRAM values in the low range (<= 12 GB). */
+const arbLowVram = fc.double({ min: 0.5, max: 12, noNaN: true });
+
+/** Generate VRAM values in the high range (> 12 GB). */
+const arbHighVram = fc.double({ min: 12.001, max: 128, noNaN: true });
+
+// ─── Property Tests ──────────────────────────────────────────────────────────
+
+describe("multiLoraValidation — Property 16: MultiLoRA Adapter Validation", () => {
+  /**
+   * **Validates: Requirements 11.2**
+   *
+   * Property 16a: Valid adapter arrays pass validation.
+   * For any array of adapters with unique names, non-empty paths, positive integer
+   * ranks, positive finite alphas, and valid targetModules (within count limits),
+   * validateAdapters returns valid=true with the parsed adapters.
+   */
+  it("accepts valid adapter arrays within count limits", () => {
+    fc.assert(
+      fc.property(
+        arbUniqueAdapters(1, 2),
+        arbLowVram,
+        (adapters, vram) => {
+          const result = validateAdapters(adapters, vram);
+          expect(result.valid).toBe(true);
+          expect(result.errors).toHaveLength(0);
+          expect(result.adapters).toHaveLength(adapters.length);
+        },
+      ),
+      { numRuns: 100 },
+    );
+  });
+
+  /**
+   * **Validates: Requirements 11.4**
+   *
+   * Property 16b: VRAM-based adapter count limit for low VRAM (<=12 GB).
+   * For any hardware with <= 12 GB VRAM, max adapter count is 2.
+   * Arrays exceeding this count are rejected.
+   */
+  it("enforces max 2 adapters for <= 12 GB VRAM", () => {
+    fc.assert(
+      fc.property(
+        arbUniqueAdapters(3, 8),
+        arbLowVram,
+        (adapters, vram) => {
+          const result = validateAdapters(adapters, vram);
+          expect(result.valid).toBe(false);
+          const countError = result.errors.find((e) => e.field === "adapters");
+          expect(countError).toBeDefined();
+          expect(countError!.message).toContain("exceeds maximum of 2");
+        },
+      ),
+      { numRuns: 100 },
+    );
+  });
+
+  /**
+   * **Validates: Requirements 11.4**
+   *
+   * Property 16c: VRAM-based adapter count limit for high VRAM (>12 GB).
+   * For any hardware with > 12 GB VRAM, max adapter count is 8.
+   * Arrays within [1, 8] are accepted; arrays exceeding 8 are rejected.
+   */
+  it("accepts up to 8 adapters for > 12 GB VRAM", () => {
+    fc.assert(
+      fc.property(
+        arbUniqueAdapters(1, 8),
+        arbHighVram,
+        (adapters, vram) => {
+          const result = validateAdapters(adapters, vram);
+          expect(result.valid).toBe(true);
+          expect(result.adapters).toHaveLength(adapters.length);
+        },
+      ),
+      { numRuns: 100 },
+    );
+  });
+
+  it("rejects more than 8 adapters for > 12 GB VRAM", () => {
+    fc.assert(
+      fc.property(
+        arbUniqueAdapters(9, 15),
+        arbHighVram,
+        (adapters, vram) => {
+          const result = validateAdapters(adapters, vram);
+          expect(result.valid).toBe(false);
+          const countError = result.errors.find((e) => e.field === "adapters");
+          expect(countError).toBeDefined();
+          expect(countError!.message).toContain("exceeds maximum of 8");
+        },
+      ),
+      { numRuns: 100 },
+    );
+  });
+
+  /**
+   * **Validates: Requirements 11.2**
+   *
+   * Property 16d: Empty name is rejected.
+   * For any adapter with an empty name string, validation fails with a name error.
+   */
+  it("rejects adapters with empty name", () => {
+    fc.assert(
+      fc.property(
+        fc.string({ minLength: 1, maxLength: 100 }),
+        fc.integer({ min: 1, max: 64 }),
+        fc.double({ min: 0.1, max: 100, noNaN: true }),
+        (path, rank, alpha) => {
+          const adapters = [{ name: "", path, rank, alpha }];
+          const result = validateAdapters(adapters, 24);
+          expect(result.valid).toBe(false);
+          const nameError = result.errors.find(
+            (e) => e.index === 0 && e.field === "name",
+          );
+          expect(nameError).toBeDefined();
+        },
+      ),
+      { numRuns: 100 },
+    );
+  });
+
+  /**
+   * **Validates: Requirements 11.2**
+   *
+   * Property 16e: Empty path is rejected.
+   * For any adapter with an empty path string, validation fails with a path error.
+   */
+  it("rejects adapters with empty path", () => {
+    fc.assert(
+      fc.property(
+        fc.string({ minLength: 1, maxLength: 50 }),
+        fc.integer({ min: 1, max: 64 }),
+        fc.double({ min: 0.1, max: 100, noNaN: true }),
+        (name, rank, alpha) => {
+          const adapters = [{ name, path: "", rank, alpha }];
+          const result = validateAdapters(adapters, 24);
+          expect(result.valid).toBe(false);
+          const pathError = result.errors.find(
+            (e) => e.index === 0 && e.field === "path",
+          );
+          expect(pathError).toBeDefined();
+        },
+      ),
+      { numRuns: 100 },
+    );
+  });
+
+  /**
+   * **Validates: Requirements 11.2**
+   *
+   * Property 16f: Non-positive or non-integer rank is rejected.
+   * For any adapter with rank <= 0 or fractional rank, validation fails.
+   */
+  it("rejects adapters with non-positive rank", () => {
+    fc.assert(
+      fc.property(
+        fc.integer({ min: -100, max: 0 }),
+        (badRank) => {
+          const adapters = [{ name: "test", path: "/model", rank: badRank, alpha: 1.0 }];
+          const result = validateAdapters(adapters, 24);
+          expect(result.valid).toBe(false);
+          const rankError = result.errors.find(
+            (e) => e.index === 0 && e.field === "rank",
+          );
+          expect(rankError).toBeDefined();
+        },
+      ),
+      { numRuns: 100 },
+    );
+  });
+
+  it("rejects adapters with fractional rank", () => {
+    fc.assert(
+      fc.property(
+        fc.double({ min: 0.1, max: 100, noNaN: true }).filter((n) => !Number.isInteger(n)),
+        (fractionalRank) => {
+          const adapters = [{ name: "test", path: "/model", rank: fractionalRank, alpha: 1.0 }];
+          const result = validateAdapters(adapters, 24);
+          expect(result.valid).toBe(false);
+          const rankError = result.errors.find(
+            (e) => e.index === 0 && e.field === "rank",
+          );
+          expect(rankError).toBeDefined();
+        },
+      ),
+      { numRuns: 100 },
+    );
+  });
+
+  /**
+   * **Validates: Requirements 11.2**
+   *
+   * Property 16g: Non-positive or non-finite alpha is rejected.
+   * For any adapter with alpha <= 0, NaN, or Infinity, validation fails.
+   */
+  it("rejects adapters with non-positive alpha", () => {
+    fc.assert(
+      fc.property(
+        fc.double({ min: -1000, max: 0, noNaN: true }),
+        (badAlpha) => {
+          const adapters = [{ name: "test", path: "/model", rank: 4, alpha: badAlpha }];
+          const result = validateAdapters(adapters, 24);
+          expect(result.valid).toBe(false);
+          const alphaError = result.errors.find(
+            (e) => e.index === 0 && e.field === "alpha",
+          );
+          expect(alphaError).toBeDefined();
+        },
+      ),
+      { numRuns: 100 },
+    );
+  });
+
+  it("rejects adapters with NaN or Infinity alpha", () => {
+    const badAlphas = [NaN, Infinity, -Infinity];
+    for (const alpha of badAlphas) {
+      const adapters = [{ name: "test", path: "/model", rank: 4, alpha }];
+      const result = validateAdapters(adapters, 24);
+      expect(result.valid).toBe(false);
+      const alphaError = result.errors.find(
+        (e) => e.index === 0 && e.field === "alpha",
+      );
+      expect(alphaError).toBeDefined();
+    }
+  });
+
+  /**
+   * **Validates: Requirements 11.2**
+   *
+   * Property 16h: Invalid targetModules are rejected.
+   * For any adapter with targetModules containing empty strings or non-strings,
+   * validation fails with a targetModules error.
+   */
+  it("rejects adapters with invalid targetModules", () => {
+    const invalidCases = [
+      { name: "a", path: "/p", rank: 1, alpha: 1.0, targetModules: [""] },
+      { name: "b", path: "/p", rank: 1, alpha: 1.0, targetModules: [123] },
+      { name: "c", path: "/p", rank: 1, alpha: 1.0, targetModules: "not-array" },
+      { name: "d", path: "/p", rank: 1, alpha: 1.0, targetModules: [null] },
+    ];
+    for (const adapter of invalidCases) {
+      const result = validateAdapters([adapter] as unknown[], 24);
+      expect(result.valid).toBe(false);
+      const tmError = result.errors.find(
+        (e) => e.index === 0 && e.field === "targetModules",
+      );
+      expect(tmError).toBeDefined();
+    }
+  });
+
+  /**
+   * **Validates: Requirements 11.5**
+   *
+   * Property 16i: Duplicate adapter names are detected.
+   * For any adapters array containing duplicate names, validation reports an error
+   * identifying the conflicting indices.
+   */
+  it("detects duplicate adapter names with conflicting indices", () => {
+    fc.assert(
+      fc.property(
+        fc.string({ minLength: 1, maxLength: 30 }),
+        (name) => {
+          const adapters = [
+            { name, path: "/path1", rank: 4, alpha: 1.0 },
+            { name, path: "/path2", rank: 8, alpha: 2.0 },
+          ];
+          const result = validateAdapters(adapters, 24);
+          expect(result.valid).toBe(false);
+          const dupError = result.errors.find(
+            (e) => e.field === "name" && e.message.includes("Duplicate"),
+          );
+          expect(dupError).toBeDefined();
+          expect(dupError!.message).toContain("0");
+          expect(dupError!.message).toContain("1");
+        },
+      ),
+      { numRuns: 100 },
+    );
+  });
+
+  /**
+   * **Validates: Requirements 11.2**
+   *
+   * Property 16j: Valid adapters with targetModules pass.
+   * For any valid adapter with a proper targetModules array of non-empty strings,
+   * validation succeeds and preserves the targetModules in the output.
+   */
+  it("preserves valid targetModules in parsed output", () => {
+    fc.assert(
+      fc.property(
+        fc.array(fc.string({ minLength: 1, maxLength: 30 }), { minLength: 1, maxLength: 5 }),
+        (modules) => {
+          const adapters = [{ name: "lora-a", path: "/weights", rank: 16, alpha: 32, targetModules: modules }];
+          const result = validateAdapters(adapters, 24);
+          expect(result.valid).toBe(true);
+          expect(result.adapters[0].targetModules).toEqual(modules);
+        },
+      ),
+      { numRuns: 100 },
+    );
+  });
+});
+
+// ─── Unit Tests ──────────────────────────────────────────────────────────────
+
+describe("multiLoraValidation — Unit Tests", () => {
+  describe("getMaxAdapterCount", () => {
+    it("returns 2 for 12 GB VRAM", () => {
+      expect(getMaxAdapterCount(12)).toBe(2);
+    });
+
+    it("returns 2 for VRAM below 12 GB", () => {
+      expect(getMaxAdapterCount(4)).toBe(2);
+      expect(getMaxAdapterCount(8)).toBe(2);
+    });
+
+    it("returns 8 for VRAM above 12 GB", () => {
+      expect(getMaxAdapterCount(16)).toBe(8);
+      expect(getMaxAdapterCount(24)).toBe(8);
+      expect(getMaxAdapterCount(80)).toBe(8);
+    });
+  });
+
+  describe("validateAdapters", () => {
+    it("returns valid result for a single well-formed adapter", () => {
+      const adapters = [
+        { name: "lora-chat", path: "/models/chat-adapter", rank: 16, alpha: 32 },
+      ];
+      const result = validateAdapters(adapters, 24);
+      expect(result.valid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+      expect(result.adapters).toHaveLength(1);
+      expect(result.adapters[0]).toEqual({
+        name: "lora-chat",
+        path: "/models/chat-adapter",
+        rank: 16,
+        alpha: 32,
+      });
+    });
+
+    it("returns valid result for two adapters with different names", () => {
+      const adapters = [
+        { name: "lora-chat", path: "/models/chat", rank: 8, alpha: 16 },
+        { name: "lora-code", path: "/models/code", rank: 16, alpha: 32, targetModules: ["q_proj", "v_proj"] },
+      ];
+      const result = validateAdapters(adapters, 24);
+      expect(result.valid).toBe(true);
+      expect(result.adapters).toHaveLength(2);
+      expect(result.adapters[1].targetModules).toEqual(["q_proj", "v_proj"]);
+    });
+
+    it("rejects null entries in the array", () => {
+      const adapters = [null];
+      const result = validateAdapters(adapters as unknown[], 24);
+      expect(result.valid).toBe(false);
+      expect(result.errors[0].field).toBe("entry");
+    });
+
+    it("rejects array entries in the array", () => {
+      const adapters = [["not", "an", "object"]];
+      const result = validateAdapters(adapters as unknown[], 24);
+      expect(result.valid).toBe(false);
+      expect(result.errors[0].field).toBe("entry");
+    });
+
+    it("returns multiple errors for multiple invalid fields", () => {
+      const adapters = [
+        { name: "", path: "", rank: -1, alpha: 0 },
+      ];
+      const result = validateAdapters(adapters, 24);
+      expect(result.valid).toBe(false);
+      // Should have errors for name, path, rank, and alpha
+      expect(result.errors.length).toBeGreaterThanOrEqual(4);
+      const fields = result.errors.map((e) => e.field);
+      expect(fields).toContain("name");
+      expect(fields).toContain("path");
+      expect(fields).toContain("rank");
+      expect(fields).toContain("alpha");
+    });
+
+    it("rejects adapter with non-string name", () => {
+      const adapters = [{ name: 123, path: "/p", rank: 4, alpha: 1.0 }];
+      const result = validateAdapters(adapters as unknown[], 24);
+      expect(result.valid).toBe(false);
+      expect(result.errors.some((e) => e.field === "name")).toBe(true);
+    });
+
+    it("rejects adapter with non-string path", () => {
+      const adapters = [{ name: "test", path: null, rank: 4, alpha: 1.0 }];
+      const result = validateAdapters(adapters as unknown[], 24);
+      expect(result.valid).toBe(false);
+      expect(result.errors.some((e) => e.field === "path")).toBe(true);
+    });
+
+    it("detects three-way duplicate names", () => {
+      const adapters = [
+        { name: "dupe", path: "/a", rank: 4, alpha: 1.0 },
+        { name: "dupe", path: "/b", rank: 8, alpha: 2.0 },
+        { name: "dupe", path: "/c", rank: 16, alpha: 4.0 },
+      ];
+      const result = validateAdapters(adapters, 24);
+      expect(result.valid).toBe(false);
+      const dupError = result.errors.find(
+        (e) => e.field === "name" && e.message.includes("Duplicate"),
+      );
+      expect(dupError).toBeDefined();
+      expect(dupError!.message).toContain("0");
+      expect(dupError!.message).toContain("1");
+      expect(dupError!.message).toContain("2");
+    });
+
+    it("returns empty adapters array when validation fails", () => {
+      const adapters = [{ name: "", path: "/p", rank: 4, alpha: 1.0 }];
+      const result = validateAdapters(adapters, 24);
+      expect(result.valid).toBe(false);
+      expect(result.adapters).toHaveLength(0);
+    });
+
+    it("handles adapter entry with undefined targetModules (optional field)", () => {
+      const adapters = [{ name: "test", path: "/p", rank: 4, alpha: 1.0 }];
+      const result = validateAdapters(adapters, 24);
+      expect(result.valid).toBe(true);
+      expect(result.adapters[0].targetModules).toBeUndefined();
+    });
+
+    it("enforces count limit of 2 for exactly 12 GB VRAM", () => {
+      const adapters = [
+        { name: "a", path: "/a", rank: 4, alpha: 1.0 },
+        { name: "b", path: "/b", rank: 4, alpha: 1.0 },
+        { name: "c", path: "/c", rank: 4, alpha: 1.0 },
+      ];
+      const result = validateAdapters(adapters, 12);
+      expect(result.valid).toBe(false);
+      expect(result.errors.some((e) => e.field === "adapters")).toBe(true);
+    });
+
+    it("allows exactly 2 adapters for 12 GB VRAM", () => {
+      const adapters = [
+        { name: "a", path: "/a", rank: 4, alpha: 1.0 },
+        { name: "b", path: "/b", rank: 4, alpha: 1.0 },
+      ];
+      const result = validateAdapters(adapters, 12);
+      expect(result.valid).toBe(true);
+    });
+  });
+});

--- a/src/lib/__tests__/recipeCatalogPin.test.ts
+++ b/src/lib/__tests__/recipeCatalogPin.test.ts
@@ -1,0 +1,262 @@
+/**
+ * Property-based tests for Recipe Catalog Version Pinning (Task 10.2).
+ * Validates correctness property from design.md (Property 15).
+ *
+ * Feature: v05-release, Property 15: Catalog Commit SHA Format
+ *
+ * For any stored CatalogMetadata, the commitSha field must be exactly 40
+ * characters long and consist only of hexadecimal characters ([0-9a-f]).
+ *
+ * Validates: Requirements 10.1, 10.2
+ */
+import { describe, it, expect } from "vitest";
+import fc from "fast-check";
+import {
+  isValidSha,
+  formatCatalogMetadata,
+  isCatalogStale,
+} from "@/lib/recipeCatalogPin";
+import type { CatalogMetadata } from "@/lib/recipeCatalogPin";
+
+// ─── Constants ───────────────────────────────────────────────────────────────
+
+/** Regex matching a valid 40-char lowercase hex SHA. */
+const SHA_PATTERN = /^[0-9a-f]{40}$/;
+
+/** Valid hexadecimal characters. */
+const HEX_CHARS = "0123456789abcdef";
+
+// ─── Arbitraries ─────────────────────────────────────────────────────────────
+
+/** Generate a valid 40-character lowercase hex SHA string. */
+function arbValidSha(): fc.Arbitrary<string> {
+  return fc
+    .array(fc.constantFrom(...HEX_CHARS.split("")), {
+      minLength: 40,
+      maxLength: 40,
+    })
+    .map((chars) => chars.join(""));
+}
+
+/** Generate a SHA with invalid length (not 40 characters). */
+function arbInvalidLengthSha(): fc.Arbitrary<string> {
+  return fc.oneof(
+    // Too short (1–39 chars)
+    fc
+      .array(fc.constantFrom(...HEX_CHARS.split("")), {
+        minLength: 1,
+        maxLength: 39,
+      })
+      .map((chars) => chars.join("")),
+    // Too long (41–80 chars)
+    fc
+      .array(fc.constantFrom(...HEX_CHARS.split("")), {
+        minLength: 41,
+        maxLength: 80,
+      })
+      .map((chars) => chars.join("")),
+    // Empty string
+    fc.constant(""),
+  );
+}
+
+/** Generate a 40-char string that contains at least one non-hex character. */
+function arbInvalidCharsSha(): fc.Arbitrary<string> {
+  // Characters that are NOT valid hex
+  const nonHexChars = "ghijklmnopqrstuvwxyzGHIJKLMNOPQRSTUVWXYZ!@#$%^&*()_+-= ";
+
+  return fc
+    .tuple(
+      // Position to inject the invalid character (0-39)
+      fc.integer({ min: 0, max: 39 }),
+      // The invalid character
+      fc.constantFrom(...nonHexChars.split("")),
+      // Base valid 40-char hex string (we'll replace one char)
+      arbValidSha(),
+    )
+    .map(([pos, invalidChar, validSha]) => {
+      return validSha.slice(0, pos) + invalidChar + validSha.slice(pos + 1);
+    });
+}
+
+/** Generate a 40-char string with uppercase hex chars (should still fail strict check). */
+function arbUppercaseSha(): fc.Arbitrary<string> {
+  const upperHex = "0123456789ABCDEF";
+  return fc
+    .tuple(
+      // Position to inject uppercase (0-39)
+      fc.integer({ min: 0, max: 39 }),
+      // The uppercase hex char (A-F only, not 0-9 which are same in both cases)
+      fc.constantFrom("A", "B", "C", "D", "E", "F"),
+      // Base valid lowercase SHA
+      arbValidSha(),
+    )
+    .map(([pos, upperChar, validSha]) => {
+      return validSha.slice(0, pos) + upperChar + validSha.slice(pos + 1);
+    });
+}
+
+/** Generate a non-empty branch name. */
+function arbBranchName(): fc.Arbitrary<string> {
+  return fc.string({ minLength: 1, maxLength: 50 }).filter((s) => s.trim().length > 0);
+}
+
+// ─── Property 15: Catalog Commit SHA Format ──────────────────────────────────
+
+describe("Property 15: Catalog Commit SHA Format", () => {
+  /**
+   * Feature: v05-release, Property 15: Catalog Commit SHA Format
+   *
+   * For any stored CatalogMetadata, the commitSha field must be exactly 40
+   * characters long and consist only of hexadecimal characters ([0-9a-f]).
+   *
+   * Validates: Requirements 10.1, 10.2
+   */
+
+  describe("isValidSha — accepts valid 40-char hex strings", () => {
+    it("returns true for any valid 40-char lowercase hex string", () => {
+      fc.assert(
+        fc.property(arbValidSha(), (sha) => {
+          expect(isValidSha(sha)).toBe(true);
+        }),
+        { numRuns: 100 },
+      );
+    });
+  });
+
+  describe("isValidSha — rejects invalid strings", () => {
+    it("returns false for strings with invalid length", () => {
+      fc.assert(
+        fc.property(arbInvalidLengthSha(), (sha) => {
+          expect(isValidSha(sha)).toBe(false);
+        }),
+        { numRuns: 100 },
+      );
+    });
+
+    it("returns false for 40-char strings with non-hex characters", () => {
+      fc.assert(
+        fc.property(arbInvalidCharsSha(), (sha) => {
+          expect(isValidSha(sha)).toBe(false);
+        }),
+        { numRuns: 100 },
+      );
+    });
+
+    it("returns false for 40-char strings with uppercase hex characters", () => {
+      fc.assert(
+        fc.property(arbUppercaseSha(), (sha) => {
+          expect(isValidSha(sha)).toBe(false);
+        }),
+        { numRuns: 100 },
+      );
+    });
+  });
+
+  describe("formatCatalogMetadata — produces valid SHA in output", () => {
+    it("resulting commitSha matches ^[0-9a-f]{40}$ for any valid input SHA", () => {
+      fc.assert(
+        fc.property(arbValidSha(), arbBranchName(), (sha, branch) => {
+          const metadata: CatalogMetadata = formatCatalogMetadata(sha, branch);
+
+          // commitSha must be exactly 40 characters
+          expect(metadata.commitSha).toHaveLength(40);
+
+          // commitSha must match the strict pattern
+          expect(metadata.commitSha).toMatch(SHA_PATTERN);
+
+          // commitSha must be lowercase
+          expect(metadata.commitSha).toBe(metadata.commitSha.toLowerCase());
+        }),
+        { numRuns: 100 },
+      );
+    });
+
+    it("normalizes uppercase hex input to lowercase in commitSha", () => {
+      fc.assert(
+        fc.property(arbUppercaseSha(), arbBranchName(), (sha, branch) => {
+          // formatCatalogMetadata calls .toLowerCase() internally
+          const metadata: CatalogMetadata = formatCatalogMetadata(sha, branch);
+
+          // The result must be all lowercase
+          expect(metadata.commitSha).toBe(metadata.commitSha.toLowerCase());
+
+          // The result must be 40 chars
+          expect(metadata.commitSha).toHaveLength(40);
+        }),
+        { numRuns: 100 },
+      );
+    });
+
+    it("preserves the branch name and generates a valid ISO timestamp", () => {
+      fc.assert(
+        fc.property(arbValidSha(), arbBranchName(), (sha, branch) => {
+          const metadata: CatalogMetadata = formatCatalogMetadata(sha, branch);
+
+          // branch is preserved
+          expect(metadata.branch).toBe(branch);
+
+          // fetchedAt is a valid ISO 8601 string
+          expect(metadata.fetchedAt).toBeTruthy();
+          const parsed = new Date(metadata.fetchedAt);
+          expect(parsed.getTime()).not.toBeNaN();
+        }),
+        { numRuns: 100 },
+      );
+    });
+  });
+
+  describe("isCatalogStale — staleness detection", () => {
+    it("returns false when stored SHA matches upstream SHA", () => {
+      fc.assert(
+        fc.property(arbValidSha(), arbBranchName(), (sha, branch) => {
+          const stored: CatalogMetadata = {
+            branch,
+            commitSha: sha,
+            fetchedAt: new Date().toISOString(),
+          };
+          expect(isCatalogStale(stored, sha)).toBe(false);
+        }),
+        { numRuns: 100 },
+      );
+    });
+
+    it("returns true when stored SHA differs from upstream SHA", () => {
+      fc.assert(
+        fc.property(
+          arbValidSha(),
+          arbValidSha(),
+          arbBranchName(),
+          (storedSha, upstreamSha, branch) => {
+            // Only test when SHAs are actually different
+            fc.pre(storedSha !== upstreamSha);
+
+            const stored: CatalogMetadata = {
+              branch,
+              commitSha: storedSha,
+              fetchedAt: new Date().toISOString(),
+            };
+            expect(isCatalogStale(stored, upstreamSha)).toBe(true);
+          },
+        ),
+        { numRuns: 100 },
+      );
+    });
+
+    it("is case-insensitive (normalizes upstream to lowercase for comparison)", () => {
+      fc.assert(
+        fc.property(arbValidSha(), arbBranchName(), (sha, branch) => {
+          const stored: CatalogMetadata = {
+            branch,
+            commitSha: sha,
+            fetchedAt: new Date().toISOString(),
+          };
+          // Pass uppercase version of same SHA — should still be not stale
+          const uppercaseSha = sha.toUpperCase();
+          expect(isCatalogStale(stored, uppercaseSha)).toBe(false);
+        }),
+        { numRuns: 100 },
+      );
+    });
+  });
+});

--- a/src/lib/__tests__/recipeCatalogPin.test.ts
+++ b/src/lib/__tests__/recipeCatalogPin.test.ts
@@ -15,8 +15,9 @@ import {
   isValidSha,
   formatCatalogMetadata,
   isCatalogStale,
+  catalogEntryToRecipeItem,
 } from "@/lib/recipeCatalogPin";
-import type { CatalogMetadata } from "@/lib/recipeCatalogPin";
+import type { CatalogEntry, CatalogMetadata } from "@/lib/recipeCatalogPin";
 
 // ─── Constants ───────────────────────────────────────────────────────────────
 
@@ -258,5 +259,23 @@ describe("Property 15: Catalog Commit SHA Format", () => {
         { numRuns: 100 },
       );
     });
+  });
+});
+
+describe("catalogEntryToRecipeItem", () => {
+  it("carries pinned.commitSha so deferred loads stay on the pin", () => {
+    const sha = "a".repeat(40);
+    const entry: CatalogEntry = {
+      id: "Qwen-Qwen2.5-1.5B-Instruct/aitk/qwen2_5_dml_config.json",
+      name: "LLM / qwen2_5_dml_config",
+      architecture: "LLM",
+      deviceTarget: "DirectML",
+      content: null,
+      pinned: { branch: "main", commitSha: sha, fetchedAt: "2026-01-01T00:00:00.000Z" },
+    };
+    const item = catalogEntryToRecipeItem(entry);
+    expect(item.repoPath).toBe(entry.id);
+    expect(item.commitSha).toBe(sha);
+    expect(item.device).toBe("DirectML");
   });
 });

--- a/src/lib/__tests__/recipeCatalogPin.test.ts
+++ b/src/lib/__tests__/recipeCatalogPin.test.ts
@@ -84,7 +84,6 @@ function arbInvalidCharsSha(): fc.Arbitrary<string> {
 
 /** Generate a 40-char string with uppercase hex chars (should still fail strict check). */
 function arbUppercaseSha(): fc.Arbitrary<string> {
-  const upperHex = "0123456789ABCDEF";
   return fc
     .tuple(
       // Position to inject uppercase (0-39)

--- a/src/lib/__tests__/recipeCatalogPin.test.ts
+++ b/src/lib/__tests__/recipeCatalogPin.test.ts
@@ -16,6 +16,7 @@ import {
   formatCatalogMetadata,
   isCatalogStale,
   catalogEntryToRecipeItem,
+  inferDeviceTarget,
 } from "@/lib/recipeCatalogPin";
 import type { CatalogEntry, CatalogMetadata } from "@/lib/recipeCatalogPin";
 
@@ -277,5 +278,9 @@ describe("catalogEntryToRecipeItem", () => {
     expect(item.repoPath).toBe(entry.id);
     expect(item.commitSha).toBe(sha);
     expect(item.device).toBe("DirectML");
+  });
+
+  it("labels ROCm recipe paths as CUDA to match catalog device comparison", () => {
+    expect(inferDeviceTarget("Llama-3-8B/rocm/llama3_rocm_gptq.json")).toBe("CUDA");
   });
 });

--- a/src/lib/__tests__/recipeCatalogPin.test.ts
+++ b/src/lib/__tests__/recipeCatalogPin.test.ts
@@ -17,8 +17,9 @@ import {
   isCatalogStale,
   catalogEntryToRecipeItem,
   inferDeviceTarget,
+  type CatalogEntry,
+  type CatalogMetadata,
 } from "@/lib/recipeCatalogPin";
-import type { CatalogEntry, CatalogMetadata } from "@/lib/recipeCatalogPin";
 
 // ─── Constants ───────────────────────────────────────────────────────────────
 

--- a/src/lib/__tests__/reportGenerator.test.ts
+++ b/src/lib/__tests__/reportGenerator.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
-import { generateMarkdownReport } from "@/lib/reportGenerator";
+import fc from "fast-check";
+import { generateMarkdownReport, getReportFilename } from "@/lib/reportGenerator";
 import type { JobHistoryRecord } from "@/lib/jobHistoryStore";
 
 function makeRecord(overrides: Partial<JobHistoryRecord> = {}): JobHistoryRecord {
@@ -72,5 +73,358 @@ describe("generateMarkdownReport", () => {
     const rec = makeRecord({ status: "failed", exitCode: 1 });
     const md = generateMarkdownReport([rec]);
     expect(md).toContain("❌");
+  });
+});
+
+// ─── Arbitraries ─────────────────────────────────────────────────────────────
+
+const VALID_STATUSES: JobHistoryRecord["status"][] = ["completed", "failed", "cancelled"];
+
+const PASS_NAME_POOL = [
+  "OnnxConversion",
+  "OrtTransformersOptimization",
+  "OnnxQuantization",
+  "OnnxDynamicQuantization",
+  "IncQuantization",
+  "OnnxFloatToFloat16",
+  "GptqQuantizer",
+  "AwqQuantizer",
+  "VitisAIQuantization",
+  "QLoRA",
+  "LoRA",
+  "OrtPerfTuning",
+  "AppendPrePostProcessingOps",
+];
+
+/** Generate a realistic non-empty model ID. */
+function arbModelId(): fc.Arbitrary<string> {
+  return fc.oneof(
+    fc.constantFrom(
+      "meta-llama/Llama-3-8B",
+      "microsoft/Phi-3-mini-4k-instruct",
+      "mistralai/Mistral-7B-v0.1",
+      "google/gemma-2b",
+      "stabilityai/stable-diffusion-xl-base-1.0",
+    ),
+    fc.stringMatching(/^[a-z][a-z0-9-]*\/[A-Za-z0-9._-]+$/),
+  );
+}
+
+/** Generate a realistic IHV provider string. */
+function arbProvider(): fc.Arbitrary<string> {
+  return fc.constantFrom(
+    "CUDAExecutionProvider",
+    "CPUExecutionProvider",
+    "DmlExecutionProvider",
+    "TensorrtExecutionProvider",
+    "QNNExecutionProvider",
+    "OpenVINOExecutionProvider",
+  );
+}
+
+/** Generate a valid pass names array (1–8 passes). */
+function arbPassNames(): fc.Arbitrary<string[]> {
+  return fc.array(fc.constantFrom(...PASS_NAME_POOL), { minLength: 1, maxLength: 8 });
+}
+
+/** Generate a valid JobHistoryRecord. */
+function arbJobRecord(): fc.Arbitrary<JobHistoryRecord> {
+  return fc
+    .record({
+      id: fc.uuid(),
+      modelId: arbModelId(),
+      ihvProvider: arbProvider(),
+      memoryOffload: fc.constantFrom("none", "partial", "full"),
+      status: fc.constantFrom(...VALID_STATUSES),
+      exitCode: fc.oneof(fc.constant(0), fc.constant(1), fc.constant(null)),
+      durationMs: fc.integer({ min: 100, max: 3_600_000 }),
+      passNames: arbPassNames(),
+      vramEstimateGb: fc.oneof(
+        fc.constant(undefined),
+        fc.double({ min: 1, max: 80, noNaN: true }),
+      ),
+      recipeJson: fc.oneof(
+        fc.constant(""),
+        fc.constant('{"input_model":{"type":"PyTorchModel"},"passes":{"quantize":{}}}'),
+      ),
+      logSummary: fc.oneof(
+        fc.constant(undefined),
+        fc.record({
+          totalLogs: fc.integer({ min: 0, max: 5000 }),
+          errorCount: fc.integer({ min: 0, max: 500 }),
+          lastLog: fc.oneof(
+            fc.constant(undefined),
+            fc.string({ minLength: 1, maxLength: 300 }),
+          ),
+        }),
+      ),
+    })
+    .map((rec) => ({
+      ...rec,
+      jobId: rec.id,
+      timestamp: new Date(
+        2024 + Math.floor(Math.random() * 2),
+        Math.floor(Math.random() * 12),
+        1 + Math.floor(Math.random() * 28),
+      ).toISOString(),
+      passCount: rec.passNames.length,
+    }));
+}
+
+/** Generate an array of 1–10 job records. */
+function arbJobRecordArray(
+  minLength = 1,
+  maxLength = 10,
+): fc.Arbitrary<JobHistoryRecord[]> {
+  return fc.array(arbJobRecord(), { minLength, maxLength });
+}
+
+// ─── Property 13: Report Content Completeness ────────────────────────────────
+
+describe("Property 13: Report Content Completeness", () => {
+  /**
+   * Feature: v05-release, Property 13: Report Content Completeness
+   *
+   * For any set of JobHistoryRecord[] passed to the report generator with
+   * Markdown format: the output must contain the model identifier, hardware
+   * provider, pass names in order, duration, and terminal status for each job.
+   * When includeRecipeJson is true, the output must contain a recipe JSON section.
+   * When includeLogSummary is true, the output must contain total log count,
+   * error count, and last log line (truncated to 200 chars). When 2 or more
+   * completed jobs are present, the output must contain a comparison section
+   * with fastest job, lowest VRAM (if present), and average duration.
+   *
+   * Validates: Requirements 9.2, 9.3, 9.7, 9.9
+   */
+
+  it("output contains model ID, provider, at least one pass name, duration, and status for each job", () => {
+    fc.assert(
+      fc.property(arbJobRecordArray(1, 10), (records) => {
+        const md = generateMarkdownReport(records);
+
+        for (const rec of records) {
+          // Model ID present
+          expect(md).toContain(rec.modelId);
+
+          // Provider present
+          expect(md).toContain(rec.ihvProvider);
+
+          // At least one pass name present
+          const hasPassName = rec.passNames.some((p) => md.includes(p));
+          expect(hasPassName).toBe(true);
+
+          // Status present
+          expect(md).toContain(rec.status);
+        }
+      }),
+      { numRuns: 100 },
+    );
+  });
+
+  it("output contains formatted duration for each job", () => {
+    fc.assert(
+      fc.property(arbJobRecordArray(1, 10), (records) => {
+        const md = generateMarkdownReport(records);
+
+        for (const rec of records) {
+          // Duration should appear somewhere in a recognizable format
+          // formatDuration produces: Xms, Xs, or Xm Ys
+          const secs = Math.floor(rec.durationMs / 1000);
+          if (rec.durationMs < 1000) {
+            expect(md).toContain(`${rec.durationMs}ms`);
+          } else if (secs < 60) {
+            expect(md).toContain(`${secs}s`);
+          } else {
+            const mins = Math.floor(secs / 60);
+            const remSecs = secs % 60;
+            expect(md).toContain(`${mins}m ${remSecs}s`);
+          }
+        }
+      }),
+      { numRuns: 100 },
+    );
+  });
+
+  it("when includeRecipeJson is true and recipeJson is non-empty, output contains Recipe JSON section with code fence", () => {
+    fc.assert(
+      fc.property(arbJobRecordArray(1, 5), (records) => {
+        // Ensure at least one record has recipeJson
+        const testRecords = records.map((r, i) =>
+          i === 0
+            ? { ...r, recipeJson: '{"passes":{"conv":{}}}' }
+            : r,
+        );
+
+        const md = generateMarkdownReport(testRecords, { includeRecipeJson: true });
+
+        // Should contain "Recipe JSON" text or a code fence
+        const hasRecipeSection = md.includes("Recipe JSON") || md.includes("```json");
+        expect(hasRecipeSection).toBe(true);
+      }),
+      { numRuns: 100 },
+    );
+  });
+
+  it("when includeLogSummary is true and logSummary exists, output contains log counts", () => {
+    fc.assert(
+      fc.property(arbJobRecordArray(1, 5), (records) => {
+        // Ensure at least one record has logSummary
+        const testRecords = records.map((r, i) =>
+          i === 0
+            ? {
+              ...r,
+              logSummary: { totalLogs: 150, errorCount: 3, lastLog: "Done" },
+            }
+            : r,
+        );
+
+        const md = generateMarkdownReport(testRecords, { includeLogSummary: true });
+
+        // Should contain the total log count and error count for the first record
+        expect(md).toContain("150");
+        expect(md).toContain("3");
+      }),
+      { numRuns: 100 },
+    );
+  });
+
+  it("when 2+ completed jobs are present, output contains Comparison section", () => {
+    fc.assert(
+      fc.property(
+        arbJobRecordArray(2, 10).map((records) =>
+          records.map((r, i) => (i < 2 ? { ...r, status: "completed" as const } : r)),
+        ),
+        (records) => {
+          const md = generateMarkdownReport(records);
+
+          // Must contain the comparison section
+          expect(md).toContain("## Comparison");
+          expect(md).toContain("Fastest");
+          expect(md).toContain("Average duration");
+        },
+      ),
+      { numRuns: 100 },
+    );
+  });
+
+  it("when fewer than 2 completed jobs, output does NOT contain Comparison section", () => {
+    fc.assert(
+      fc.property(arbJobRecordArray(1, 5), (records) => {
+        // Force all records to be non-completed
+        const testRecords = records.map((r) => ({
+          ...r,
+          status: "failed" as const,
+        }));
+
+        const md = generateMarkdownReport(testRecords);
+
+        expect(md).not.toContain("## Comparison");
+      }),
+      { numRuns: 100 },
+    );
+  });
+
+  it("comparison section identifies the fastest job correctly", () => {
+    fc.assert(
+      fc.property(
+        arbJobRecordArray(2, 10).map((records) =>
+          records.map((r) => ({ ...r, status: "completed" as const })),
+        ),
+        (records) => {
+          const md = generateMarkdownReport(records);
+
+          // Find the actual fastest
+          const fastest = records.reduce((a, b) =>
+            a.durationMs < b.durationMs ? a : b,
+          );
+
+          // The fastest model ID should appear after "Fastest"
+          const comparisonSection = md.slice(md.indexOf("## Comparison"));
+          expect(comparisonSection).toContain(fastest.modelId);
+        },
+      ),
+      { numRuns: 100 },
+    );
+  });
+
+  it("comparison section shows lowest VRAM when VRAM data is present", () => {
+    fc.assert(
+      fc.property(
+        arbJobRecordArray(2, 5).map((records) =>
+          records.map((r, i) => ({
+            ...r,
+            status: "completed" as const,
+            vramEstimateGb: 4 + i * 2, // deterministic ascending VRAM
+          })),
+        ),
+        (records) => {
+          const md = generateMarkdownReport(records);
+
+          const comparisonSection = md.slice(md.indexOf("## Comparison"));
+          expect(comparisonSection).toContain("Lowest VRAM");
+
+          // The lowest VRAM model should be the first record (4 GB)
+          expect(comparisonSection).toContain(records[0].modelId);
+        },
+      ),
+      { numRuns: 100 },
+    );
+  });
+});
+
+// ─── Property 14: Report Filename Pattern ────────────────────────────────────
+
+describe("Property 14: Report Filename Pattern", () => {
+  /**
+   * Feature: v05-release, Property 14: Report Filename Pattern
+   *
+   * For any Markdown export, the downloaded filename must match the regex
+   * pattern ^olive-report-\d{4}-\d{2}-\d{2}\.md$ where the date portion
+   * equals the current UTC date.
+   *
+   * Validates: Requirements 9.9
+   */
+
+  it("filename matches the required pattern ^olive-report-YYYY-MM-DD.md$", () => {
+    fc.assert(
+      fc.property(fc.constant(null), () => {
+        const filename = getReportFilename();
+        expect(filename).toMatch(/^olive-report-\d{4}-\d{2}-\d{2}\.md$/);
+      }),
+      { numRuns: 100 },
+    );
+  });
+
+  it("filename date matches the current UTC date", () => {
+    fc.assert(
+      fc.property(fc.constant(null), () => {
+        const filename = getReportFilename();
+        const today = new Date().toISOString().slice(0, 10);
+        expect(filename).toBe(`olive-report-${today}.md`);
+      }),
+      { numRuns: 100 },
+    );
+  });
+
+  it("filename prefix is exactly 'olive-report-' and suffix is exactly '.md'", () => {
+    fc.assert(
+      fc.property(fc.constant(null), () => {
+        const filename = getReportFilename();
+        expect(filename.startsWith("olive-report-")).toBe(true);
+        expect(filename.endsWith(".md")).toBe(true);
+      }),
+      { numRuns: 100 },
+    );
+  });
+
+  it("filename has exactly 27 characters (olive-report-YYYY-MM-DD.md = 27 chars)", () => {
+    fc.assert(
+      fc.property(fc.constant(null), () => {
+        const filename = getReportFilename();
+        // "olive-report-" (13) + "YYYY-MM-DD" (10) + ".md" (3) = 26
+        expect(filename.length).toBe(26);
+      }),
+      { numRuns: 100 },
+    );
   });
 });

--- a/src/lib/__tests__/reportGenerator.test.ts
+++ b/src/lib/__tests__/reportGenerator.test.ts
@@ -417,7 +417,7 @@ describe("Property 14: Report Filename Pattern", () => {
     );
   });
 
-  it("filename has exactly 27 characters (olive-report-YYYY-MM-DD.md = 27 chars)", () => {
+  it("filename has exactly 26 characters (olive-report-YYYY-MM-DD.md = 26 chars)", () => {
     fc.assert(
       fc.property(fc.constant(null), () => {
         const filename = getReportFilename();

--- a/src/lib/__tests__/reviewReconciler.test.ts
+++ b/src/lib/__tests__/reviewReconciler.test.ts
@@ -355,6 +355,65 @@ describe("Property 7: Deterministic Validation Authority", () => {
     );
   });
 
+  it("discards AI findings that patch the same top-level autofix key as a deterministic issue", () => {
+    const detIssue: PipelineIssue = {
+      id: "provider-hardware-cpu",
+      severity: "critical",
+      title: "CPU not available on this machine",
+      description: "Use detected CUDA hardware",
+      affectedPasses: ["provider"],
+      actionLabel: "Use detected hardware",
+      autofix: { ihvProvider: "CUDAExecutionProvider" },
+    };
+    const aiFinding: Finding = {
+      id: "ai-switch-cpu",
+      title: "Switch to CPU",
+      description: "Prefer CPUExecutionProvider",
+      severity: "info",
+      evidence: "model suggested CPU",
+      actions: [
+        {
+          kind: "applyPatch",
+          label: "Use CPU",
+          payload: { ihvProvider: "CPUExecutionProvider" },
+        },
+      ],
+    };
+
+    const result = reconcileFindings([aiFinding], [detIssue], []);
+    expect(result.find((f) => f.id === aiFinding.id)).toBeUndefined();
+    expect(result.find((f) => f.id === `det-${detIssue.id}`)).toBeDefined();
+  });
+
+  it("preserves AI findings that patch a different top-level key than the deterministic autofix", () => {
+    const detIssue: PipelineIssue = {
+      id: "provider-hardware-cpu",
+      severity: "critical",
+      title: "CPU not available on this machine",
+      description: "Use detected CUDA hardware",
+      affectedPasses: ["provider"],
+      actionLabel: "Use detected hardware",
+      autofix: { ihvProvider: "CUDAExecutionProvider" },
+    };
+    const aiFinding: Finding = {
+      id: "ai-cache-dir",
+      title: "Set cache directory",
+      description: "Point cacheDir at a local folder",
+      severity: "info",
+      evidence: "model suggested cacheDir",
+      actions: [
+        {
+          kind: "applyPatch",
+          label: "Set cache",
+          payload: { cacheDir: "/tmp/olive-cache" },
+        },
+      ],
+    };
+
+    const result = reconcileFindings([aiFinding], [detIssue], []);
+    expect(result.find((f) => f.id === aiFinding.id)).toBeDefined();
+  });
+
   it("deterministic findings appear before AI findings in output ordering", () => {
     fc.assert(
       fc.property(

--- a/src/lib/__tests__/reviewReconciler.test.ts
+++ b/src/lib/__tests__/reviewReconciler.test.ts
@@ -1,0 +1,533 @@
+/**
+ * Property-based tests for the Review Reconciler (Task 1.5).
+ * Validates correctness properties from design.md (Properties 7–8).
+ *
+ * Feature: v05-release, Property 7: Deterministic Validation Authority
+ * Feature: v05-release, Property 8: Review Isolation from Chat History
+ */
+import { describe, it, expect } from "vitest";
+import fc from "fast-check";
+import { reconcileFindings } from "@/lib/reviewReconciler";
+import type { ProviderConflict } from "@/lib/reviewReconciler";
+import type { PipelineIssue, IssueSeverity } from "@/lib/pipelineValidation";
+import type {
+  Finding,
+  FindingSeverity,
+  ActionPayloadApplyPatch,
+  ActionPayloadExplain,
+} from "@/lib/types/findingTypes";
+import type { UIState } from "@/types";
+
+// ─── Constants ───────────────────────────────────────────────────────────────
+
+const VALID_SEVERITIES: FindingSeverity[] = ["critical", "warning", "info"];
+
+const PASS_FIELD_KEYS = [
+  "quantization",
+  "quantMethod",
+  "quantPrecision",
+  "conversion",
+  "conversionFormat",
+  "conversionOpset",
+  "pruning",
+  "pruningType",
+  "pruningMethod",
+  "peft",
+  "peftMethod",
+  "splitting",
+] as const;
+
+type PassFieldKey = (typeof PASS_FIELD_KEYS)[number];
+
+// ─── Arbitraries ─────────────────────────────────────────────────────────────
+
+/** Generate a non-empty bounded string. */
+function arbBoundedString(maxLength: number): fc.Arbitrary<string> {
+  return fc.string({ minLength: 1, maxLength });
+}
+
+/** Generate a valid pass field key from the known set. */
+function arbPassFieldKey(): fc.Arbitrary<PassFieldKey> {
+  return fc.constantFrom(...PASS_FIELD_KEYS);
+}
+
+/** Generate a random pass field value (string or boolean). */
+function arbPassFieldValue(): fc.Arbitrary<string | boolean> {
+  return fc.oneof(
+    fc.constantFrom("ptq", "awq", "gptq", "int4", "int8", "onnx", "openvino", "structured"),
+    fc.boolean(),
+  );
+}
+
+/** Generate a PipelineIssue targeting a specific pass field via autofix. */
+function arbPipelineIssue(opts?: {
+  severity?: IssueSeverity;
+  targetPassField?: PassFieldKey;
+}): fc.Arbitrary<PipelineIssue> {
+  const severityArb = opts?.severity
+    ? fc.constant(opts.severity)
+    : fc.constantFrom<IssueSeverity>("critical", "warning", "info");
+  const passFieldArb = opts?.targetPassField
+    ? fc.constant(opts.targetPassField)
+    : arbPassFieldKey();
+
+  return fc.tuple(
+    fc.uuid(),
+    severityArb,
+    arbBoundedString(80),
+    arbBoundedString(200),
+    passFieldArb,
+    arbPassFieldValue(),
+  ).map(([id, severity, title, description, passField, passValue]) => ({
+    id,
+    severity,
+    title,
+    description,
+    affectedPasses: [passField],
+    actionLabel: `Fix ${passField}`,
+    autofix: {
+      passes: { [passField]: passValue } as unknown as UIState["passes"],
+    } as Partial<UIState>,
+  }));
+}
+
+/** Generate a ProviderConflict (HardwareConflict) targeting a specific pass key. */
+function arbProviderConflict(opts?: {
+  passKey?: PassFieldKey;
+  severity?: IssueSeverity;
+  autofixValue?: string | boolean;
+}): fc.Arbitrary<ProviderConflict> {
+  const passKeyArb = opts?.passKey ? fc.constant(opts.passKey) : arbPassFieldKey();
+  const severityArb = opts?.severity
+    ? fc.constant(opts.severity)
+    : fc.constantFrom<IssueSeverity>("critical", "warning", "info");
+  const autofixValueArb = opts?.autofixValue !== undefined
+    ? fc.constant(opts.autofixValue)
+    : arbPassFieldValue();
+
+  return fc.tuple(
+    passKeyArb,
+    arbBoundedString(60),
+    arbBoundedString(200),
+    severityArb,
+    autofixValueArb,
+  ).map(([passKey, passName, reason, severity, autofixValue]) => ({
+    passKey,
+    passName,
+    reason,
+    severity,
+    autofix: () => ({ [passKey]: autofixValue }) as Partial<UIState["passes"]>,
+  }));
+}
+
+/** Generate an AI Finding with an applyPatch action targeting a specific pass field. */
+function arbAiFindingTargetingPassField(opts?: {
+  passField?: PassFieldKey;
+  passValue?: string | boolean;
+  severity?: FindingSeverity;
+}): fc.Arbitrary<Finding> {
+  const passFieldArb = opts?.passField ? fc.constant(opts.passField) : arbPassFieldKey();
+  const valueArb = opts?.passValue !== undefined ? fc.constant(opts.passValue) : arbPassFieldValue();
+  const severityArb = opts?.severity
+    ? fc.constant(opts.severity)
+    : fc.constantFrom<FindingSeverity>(...VALID_SEVERITIES);
+
+  return fc.tuple(
+    fc.uuid(),
+    arbBoundedString(100),
+    arbBoundedString(300),
+    severityArb,
+    arbBoundedString(150),
+    arbBoundedString(60),
+    passFieldArb,
+    valueArb,
+  ).map(([id, title, description, severity, evidence, label, passField, value]) => ({
+    id: `ai-${id}`,
+    title,
+    description,
+    severity,
+    evidence,
+    actions: [
+      {
+        kind: "applyPatch" as const,
+        label,
+        payload: {
+          passes: { [passField]: value } as unknown as Partial<UIState["passes"]>,
+        },
+      } satisfies ActionPayloadApplyPatch,
+    ],
+  }));
+}
+
+/** Generate an AI Finding with an explain action only (no applyPatch). */
+function arbAiFindingExplainOnly(): fc.Arbitrary<Finding> {
+  return fc.tuple(
+    fc.uuid(),
+    arbBoundedString(100),
+    arbBoundedString(300),
+    fc.constantFrom<FindingSeverity>(...VALID_SEVERITIES),
+    arbBoundedString(150),
+    arbBoundedString(60),
+    arbBoundedString(200),
+  ).map(([id, title, description, severity, evidence, label, body]) => ({
+    id: `ai-explain-${id}`,
+    title,
+    description,
+    severity,
+    evidence,
+    actions: [
+      {
+        kind: "explain" as const,
+        label,
+        payload: { body },
+      } satisfies ActionPayloadExplain,
+    ],
+  }));
+}
+
+/**
+ * Generate a pair of (PipelineIssue, AI Finding) that target the SAME pass field.
+ * The deterministic issue has the specified severity.
+ */
+function arbConflictingPair(detSeverity: IssueSeverity): fc.Arbitrary<{
+  detIssue: PipelineIssue;
+  aiFinding: Finding;
+  passField: PassFieldKey;
+}> {
+  return arbPassFieldKey().chain((passField) =>
+    fc.tuple(
+      arbPipelineIssue({ severity: detSeverity, targetPassField: passField }),
+      arbAiFindingTargetingPassField({ passField }),
+    ).map(([detIssue, aiFinding]) => ({ detIssue, aiFinding, passField })),
+  );
+}
+
+/**
+ * Generate a (PipelineIssue, AI Finding) pair where the AI Finding targets
+ * a DIFFERENT pass field than the deterministic issue.
+ */
+function arbNonConflictingPair(): fc.Arbitrary<{
+  detIssue: PipelineIssue;
+  aiFinding: Finding;
+}> {
+  // Pick two distinct pass fields
+  return fc.tuple(arbPassFieldKey(), arbPassFieldKey())
+    .filter(([f1, f2]) => f1 !== f2)
+    .chain(([detField, aiField]) =>
+      fc.tuple(
+        arbPipelineIssue({ severity: "critical", targetPassField: detField }),
+        arbAiFindingTargetingPassField({ passField: aiField }),
+      ).map(([detIssue, aiFinding]) => ({ detIssue, aiFinding })),
+    );
+}
+
+/**
+ * Generate a (ProviderConflict, AI Finding) where the AI Finding targets the
+ * same passKey but suggests a DIFFERENT value than the conflict's autofix.
+ */
+function arbConflictWithWrongAiFix(): fc.Arbitrary<{
+  conflict: ProviderConflict;
+  aiFinding: Finding;
+}> {
+  return arbPassFieldKey().chain((passKey) => {
+    // Use two known distinct values
+    const autofixValue = "ptq";
+    const wrongValue = "awq";
+    return fc.tuple(
+      arbProviderConflict({ passKey, severity: "critical", autofixValue }),
+      arbAiFindingTargetingPassField({ passField: passKey, passValue: wrongValue }),
+    ).map(([conflict, aiFinding]) => ({ conflict, aiFinding }));
+  });
+}
+
+/**
+ * Generate a (ProviderConflict, AI Finding) where the AI Finding targets the
+ * same passKey and suggests the SAME value as the conflict's autofix.
+ */
+function arbConflictWithCorrectAiFix(): fc.Arbitrary<{
+  conflict: ProviderConflict;
+  aiFinding: Finding;
+}> {
+  return arbPassFieldKey().chain((passKey) => {
+    const autofixValue = "ptq";
+    return fc.tuple(
+      arbProviderConflict({ passKey, severity: "critical", autofixValue }),
+      arbAiFindingTargetingPassField({ passField: passKey, passValue: autofixValue }),
+    ).map(([conflict, aiFinding]) => ({ conflict, aiFinding }));
+  });
+}
+
+// ─── Property 7: Deterministic Validation Authority ──────────────────────────
+
+describe("Property 7: Deterministic Validation Authority", () => {
+  /**
+   * Feature: v05-release, Property 7: Deterministic Validation Authority
+   *
+   * For any pair of (deterministic PipelineIssue, AI AuditSuggestion) targeting
+   * the same pass field: if the deterministic issue has severity "critical" and
+   * the AI suggestion's recommended value would not resolve the conflict (as
+   * determined by getProviderConflicts()), the AI suggestion must be suppressed
+   * from displayed results. The displayed severity for that pass field must
+   * always be the deterministic issue's severity, regardless of AI assessment.
+   *
+   * Validates: Requirements 5.1, 5.2, 5.5
+   */
+
+  it("AI findings contradicting deterministic issues on the same pass field are discarded", () => {
+    fc.assert(
+      fc.property(
+        arbConflictingPair("critical"),
+        ({ detIssue, aiFinding }) => {
+          const result = reconcileFindings([aiFinding], [detIssue], []);
+
+          // The AI finding must NOT appear in the output
+          const aiInOutput = result.find((f) => f.id === aiFinding.id);
+          expect(aiInOutput).toBeUndefined();
+        },
+      ),
+      { numRuns: 100 },
+    );
+  });
+
+  it("deterministic critical severity is preserved in output regardless of AI severity", () => {
+    fc.assert(
+      fc.property(
+        arbConflictingPair("critical"),
+        ({ detIssue }) => {
+          const result = reconcileFindings([], [detIssue], []);
+
+          // Find the deterministic finding in the output
+          const detFinding = result.find((f) => f.id === `det-${detIssue.id}`);
+          expect(detFinding).toBeDefined();
+          // Its severity must remain "critical" (never downgraded)
+          expect(detFinding!.severity).toBe("critical");
+        },
+      ),
+      { numRuns: 100 },
+    );
+  });
+
+  it("AI finding suppressed when its patch would not resolve a critical provider conflict", () => {
+    fc.assert(
+      fc.property(
+        arbConflictWithWrongAiFix(),
+        ({ conflict, aiFinding }) => {
+          const result = reconcileFindings([aiFinding], [], [conflict]);
+
+          // The AI finding should be suppressed because its suggested value
+          // doesn't match the provider conflict's autofix resolution
+          const aiInOutput = result.find((f) => f.id === aiFinding.id);
+          expect(aiInOutput).toBeUndefined();
+        },
+      ),
+      { numRuns: 100 },
+    );
+  });
+
+  it("AI finding NOT suppressed when its patch matches the provider conflict autofix value", () => {
+    fc.assert(
+      fc.property(
+        arbConflictWithCorrectAiFix(),
+        ({ conflict, aiFinding }) => {
+          const result = reconcileFindings([aiFinding], [], [conflict]);
+
+          // The AI finding should survive because its suggestion matches the resolution
+          const aiInOutput = result.find((f) => f.id === aiFinding.id);
+          expect(aiInOutput).toBeDefined();
+        },
+      ),
+      { numRuns: 100 },
+    );
+  });
+
+  it("AI findings not targeting any deterministic pass field are preserved", () => {
+    fc.assert(
+      fc.property(
+        arbNonConflictingPair(),
+        ({ detIssue, aiFinding }) => {
+          const result = reconcileFindings([aiFinding], [detIssue], []);
+
+          // The AI finding should survive since it targets a different field
+          const aiInOutput = result.find((f) => f.id === aiFinding.id);
+          expect(aiInOutput).toBeDefined();
+        },
+      ),
+      { numRuns: 100 },
+    );
+  });
+
+  it("deterministic findings appear before AI findings in output ordering", () => {
+    fc.assert(
+      fc.property(
+        arbNonConflictingPair(),
+        ({ detIssue, aiFinding }) => {
+          const result = reconcileFindings([aiFinding], [detIssue], []);
+
+          // Find positions
+          const detIdx = result.findIndex((f) => f.id === `det-${detIssue.id}`);
+          const aiIdx = result.findIndex((f) => f.id === aiFinding.id);
+
+          // Deterministic findings come before AI findings
+          expect(detIdx).toBeGreaterThanOrEqual(0);
+          expect(aiIdx).toBeGreaterThanOrEqual(0);
+          expect(detIdx).toBeLessThan(aiIdx);
+        },
+      ),
+      { numRuns: 100 },
+    );
+  });
+
+  it("provider conflict findings preserve their severity in output", () => {
+    fc.assert(
+      fc.property(
+        fc.constantFrom<IssueSeverity>("critical", "warning", "info"),
+        arbPassFieldKey(),
+        (severity, passKey) => {
+          const conflict: ProviderConflict = {
+            passKey,
+            passName: `Test ${passKey}`,
+            reason: "Test reason",
+            severity,
+            autofix: () => ({ [passKey]: "ptq" }) as Partial<UIState["passes"]>,
+          };
+
+          const result = reconcileFindings([], [], [conflict]);
+
+          const conflictFinding = result.find((f) => f.id === `prov-${passKey}`);
+          expect(conflictFinding).toBeDefined();
+          expect(conflictFinding!.severity).toBe(severity);
+        },
+      ),
+      { numRuns: 100 },
+    );
+  });
+});
+
+// ─── Property 8: Review Isolation from Chat History ──────────────────────────
+
+describe("Property 8: Review Isolation from Chat History", () => {
+  /**
+   * Feature: v05-release, Property 8: Review Isolation from Chat History
+   *
+   * For any automatic review refresh cycle triggered by /api/ai/analyze-state,
+   * the chatHistory array and chatMessages state must remain identical before
+   * and after the review completes — no elements appended, prepended, or
+   * modified.
+   *
+   * The reconcileFindings function is a pure function — it never receives
+   * chatHistory or chatMessages as parameters, guaranteeing by design that
+   * reconciliation cannot mutate chat state. This property verifies:
+   * 1. reconcileFindings does not accept or modify external state
+   * 2. The function is pure (same inputs → same outputs, no side effects)
+   * 3. Input arrays are not mutated by the reconciler
+   *
+   * Validates: Requirements 5.3
+   */
+
+  it("reconcileFindings does not mutate its input arrays", () => {
+    fc.assert(
+      fc.property(
+        fc.tuple(
+          fc.array(arbAiFindingTargetingPassField(), { minLength: 0, maxLength: 5 }),
+          fc.array(arbPipelineIssue(), { minLength: 0, maxLength: 3 }),
+          fc.array(arbProviderConflict(), { minLength: 0, maxLength: 3 }),
+        ),
+        ([aiFindings, deterministicIssues, providerConflicts]) => {
+          // Deep clone inputs to compare after call
+          const aiOriginal = JSON.parse(JSON.stringify(aiFindings));
+          const detOriginal = JSON.parse(JSON.stringify(deterministicIssues));
+          // ProviderConflict has functions, so we compare structural fields
+          const conflictOriginalFields = providerConflicts.map((c) => ({
+            passKey: c.passKey,
+            passName: c.passName,
+            reason: c.reason,
+            severity: c.severity,
+          }));
+
+          reconcileFindings(aiFindings, deterministicIssues, providerConflicts);
+
+          // Input arrays must not be mutated
+          expect(aiFindings).toEqual(aiOriginal);
+          expect(deterministicIssues).toEqual(detOriginal);
+          expect(
+            providerConflicts.map((c) => ({
+              passKey: c.passKey,
+              passName: c.passName,
+              reason: c.reason,
+              severity: c.severity,
+            })),
+          ).toEqual(conflictOriginalFields);
+        },
+      ),
+      { numRuns: 100 },
+    );
+  });
+
+  it("reconcileFindings is a pure function — same inputs produce identical outputs", () => {
+    fc.assert(
+      fc.property(
+        fc.tuple(
+          fc.array(arbAiFindingExplainOnly(), { minLength: 0, maxLength: 5 }),
+          fc.array(arbPipelineIssue(), { minLength: 0, maxLength: 3 }),
+          fc.array(arbProviderConflict(), { minLength: 0, maxLength: 3 }),
+        ),
+        ([aiFindings, deterministicIssues, providerConflicts]) => {
+          const result1 = reconcileFindings(aiFindings, deterministicIssues, providerConflicts);
+          const result2 = reconcileFindings(aiFindings, deterministicIssues, providerConflicts);
+
+          // Pure function: identical inputs → identical outputs
+          expect(result1).toEqual(result2);
+        },
+      ),
+      { numRuns: 100 },
+    );
+  });
+
+  it("chatHistory and chatMessages arrays remain untouched during reconciliation", () => {
+    fc.assert(
+      fc.property(
+        fc.tuple(
+          fc.nat({ max: 20 }),
+          fc.nat({ max: 20 }),
+          fc.array(arbAiFindingExplainOnly(), { minLength: 0, maxLength: 5 }),
+          fc.array(arbPipelineIssue(), { minLength: 0, maxLength: 3 }),
+          fc.array(arbProviderConflict(), { minLength: 0, maxLength: 3 }),
+        ),
+        ([chatHistoryLength, chatMessagesLength, aiFindings, issues, conflicts]) => {
+          // Create simulated chat state arrays (as they would exist in the store)
+          const chatHistory: Array<{ role: string; content: string }> = Array.from(
+            { length: chatHistoryLength },
+            (_, i) => ({ role: i % 2 === 0 ? "user" : "assistant", content: `msg-${i}` }),
+          );
+          const chatMessages: Array<{ id: string; text: string }> = Array.from(
+            { length: chatMessagesLength },
+            (_, i) => ({ id: `msg-${i}`, text: `message content ${i}` }),
+          );
+
+          // Deep clone for comparison
+          const chatHistoryBefore = JSON.parse(JSON.stringify(chatHistory));
+          const chatMessagesBefore = JSON.parse(JSON.stringify(chatMessages));
+
+          // Run reconciliation — it should have no access to chat arrays
+          reconcileFindings(aiFindings, issues, conflicts);
+
+          // Chat state must be completely unchanged
+          expect(chatHistory).toEqual(chatHistoryBefore);
+          expect(chatMessages).toEqual(chatMessagesBefore);
+        },
+      ),
+      { numRuns: 100 },
+    );
+  });
+
+  it("reconcileFindings function signature excludes chat parameters (structural guarantee)", () => {
+    // This test verifies at the type/structural level that reconcileFindings
+    // accepts exactly 3 parameters and none of them are chat-related.
+    // The function's parameter count proves it cannot access external mutable state.
+    expect(reconcileFindings.length).toBe(3);
+
+    // Calling with exactly the 3 expected arguments succeeds
+    const result = reconcileFindings([], [], []);
+    expect(Array.isArray(result)).toBe(true);
+  });
+});

--- a/src/lib/__tests__/reviewReconciler.test.ts
+++ b/src/lib/__tests__/reviewReconciler.test.ts
@@ -7,8 +7,7 @@
  */
 import { describe, it, expect } from "vitest";
 import fc from "fast-check";
-import { reconcileFindings } from "@/lib/reviewReconciler";
-import type { ProviderConflict } from "@/lib/reviewReconciler";
+import { reconcileFindings, type ProviderConflict } from "@/lib/reviewReconciler";
 import type { PipelineIssue, IssueSeverity } from "@/lib/pipelineValidation";
 import type {
   Finding,

--- a/src/lib/__tests__/workspaceFingerprint.test.ts
+++ b/src/lib/__tests__/workspaceFingerprint.test.ts
@@ -114,19 +114,38 @@ function arbUIState(): fc.Arbitrary<UIState> {
 }
 
 /**
- * Generate a pair of UIState objects that are deeply equal after transient
- * field exclusion but may differ in transient fields (activeJobId).
+ * Generate a pair of UIState objects that are deeply equal in recipe-relevant
+ * state but differ only in transient fields (activeJobId, localFiles metadata/paths).
  */
 function arbUIStatePairDifferingOnlyInTransient(): fc.Arbitrary<[UIState, UIState]> {
   return arbUIState().chain((baseState) =>
-    fc.option(fc.uuid(), { nil: null }).map((altJobId) => {
-      const state1: UIState = { ...baseState };
-      const state2: UIState = {
-        ...baseState,
-        activeJobId: altJobId,
-      };
-      return [state1, state2] as [UIState, UIState];
-    }),
+    fc
+      .tuple(
+        fc.option(fc.uuid(), { nil: null }),
+        fc.array(
+          fc.record({
+            path: fc.string({ minLength: 1, maxLength: 50 }),
+            size: fc.integer({ min: 1, max: 100000 }),
+          }),
+          {
+            minLength: baseState.localFiles?.length ?? 0,
+            maxLength: baseState.localFiles?.length ?? 0,
+          },
+        ),
+      )
+      .map(([altJobId, altFileMeta]) => {
+        const state1: UIState = { ...baseState };
+        const state2: UIState = {
+          ...baseState,
+          activeJobId: altJobId,
+          localFiles: baseState.localFiles?.map((file, i) => ({
+            ...file,
+            path: altFileMeta[i]?.path ?? file.path,
+            size: altFileMeta[i]?.size ?? file.size,
+          })),
+        };
+        return [state1, state2] as [UIState, UIState];
+      }),
   );
 }
 

--- a/src/lib/__tests__/workspaceFingerprint.test.ts
+++ b/src/lib/__tests__/workspaceFingerprint.test.ts
@@ -11,10 +11,9 @@ import {
   computeFingerprint,
   _serializeForFingerprint,
 } from "@/lib/workspaceFingerprint";
-import { FINGERPRINT_EXCLUDED_KEYS } from "@/lib/types/findingTypes";
+import { FINGERPRINT_EXCLUDED_KEYS, type ReviewResult } from "@/lib/types/findingTypes";
 import { createDefaultPipelineState } from "@/lib/stores/pipelineStore";
 import type { UIState } from "@/types";
-import type { ReviewResult } from "@/lib/types/findingTypes";
 
 // ─── Constants ───────────────────────────────────────────────────────────────
 

--- a/src/lib/__tests__/workspaceFingerprint.test.ts
+++ b/src/lib/__tests__/workspaceFingerprint.test.ts
@@ -116,25 +116,15 @@ function arbUIState(): fc.Arbitrary<UIState> {
 
 /**
  * Generate a pair of UIState objects that are deeply equal after transient
- * field exclusion but may differ in transient fields (activeJobId, localFiles).
+ * field exclusion but may differ in transient fields (activeJobId).
  */
 function arbUIStatePairDifferingOnlyInTransient(): fc.Arbitrary<[UIState, UIState]> {
   return arbUIState().chain((baseState) =>
-    fc.tuple(
-      fc.option(fc.uuid(), { nil: null }),
-      fc.array(
-        fc.record({
-          name: fc.string({ minLength: 1, maxLength: 50 }),
-          size: fc.nat({ max: 1_000_000_000 }),
-        }),
-        { minLength: 0, maxLength: 5 },
-      ),
-    ).map(([altJobId, altLocalFiles]) => {
+    fc.option(fc.uuid(), { nil: null }).map((altJobId) => {
       const state1: UIState = { ...baseState };
       const state2: UIState = {
         ...baseState,
         activeJobId: altJobId,
-        localFiles: altLocalFiles,
       };
       return [state1, state2] as [UIState, UIState];
     }),
@@ -249,7 +239,6 @@ describe("Property 5: Fingerprint Determinism and Transient Exclusion", () => {
         const clone: UIState = JSON.parse(JSON.stringify(state));
         // Set different transient values to ensure exclusion works
         clone.activeJobId = state.activeJobId === "test-id" ? null : "test-id";
-        clone.localFiles = [{ name: "different.bin", size: 999 }];
 
         const fp1 = await computeFingerprint(state);
         const fp2 = await computeFingerprint(clone);

--- a/src/lib/__tests__/workspaceFingerprint.test.ts
+++ b/src/lib/__tests__/workspaceFingerprint.test.ts
@@ -1,0 +1,460 @@
+/**
+ * Property-based tests for workspace fingerprint determinism and staleness (Task 1.3).
+ * Validates correctness properties from design.md (Properties 5–6).
+ *
+ * Feature: v05-release, Property 5: Fingerprint Determinism and Transient Exclusion
+ * Feature: v05-release, Property 6: Fingerprint Staleness Consistency
+ */
+import { describe, it, expect } from "vitest";
+import fc from "fast-check";
+import {
+  computeFingerprint,
+  _serializeForFingerprint,
+} from "@/lib/workspaceFingerprint";
+import { FINGERPRINT_EXCLUDED_KEYS } from "@/lib/types/findingTypes";
+import { createDefaultPipelineState } from "@/lib/stores/pipelineStore";
+import type { UIState } from "@/types";
+import type { ReviewResult } from "@/lib/types/findingTypes";
+
+// ─── Constants ───────────────────────────────────────────────────────────────
+
+const VALID_IHV_PROVIDERS = [
+  "CPUExecutionProvider",
+  "CUDAExecutionProvider",
+  "TensorrtExecutionProvider",
+  "NvTensorRTRTXExecutionProvider",
+  "DmlExecutionProvider",
+  "OpenVINOExecutionProvider",
+  "QNNExecutionProvider",
+  "ROCMExecutionProvider",
+  "WebGpuExecutionProvider",
+] as const;
+
+const VALID_MODEL_SOURCES = ["huggingface", "local", "azure"] as const;
+const VALID_CUDA_VERSIONS = ["auto", "cpu", "cu118", "cu121", "cu124", "cu126", "cu128", "cu130", "cu132"] as const;
+const VALID_OPENVINO_TARGETS = ["CPU", "GPU", "NPU"] as const;
+const VALID_MEMORY_OFFLOADS = ["gpu_only", "auto"] as const;
+const VALID_QUANT_METHODS = ["ptq", "awq", "qat", "gptq", "hqq", "rtn", "kquant", "spinquant", "quarot"] as const;
+const VALID_QUANT_PRECISIONS = ["int4", "int8", "fp16"] as const;
+const VALID_PRUNING_TYPES = ["structured", "unstructured"] as const;
+const VALID_PRUNING_METHODS = ["magnitude", "sparsegpt", "wanda"] as const;
+const VALID_PRUNING_CRITERIA = ["l1_norm", "l2_norm"] as const;
+const VALID_PEFT_METHODS = ["lora", "qlora"] as const;
+const VALID_CONVERSION_FORMATS = ["onnx", "openvino", "qnn", "tensorrt"] as const;
+const VALID_CONVERSION_SOURCE_FORMATS = ["pytorch", "tensorflow", "jax"] as const;
+
+// ─── Arbitraries ─────────────────────────────────────────────────────────────
+
+/** Generate random UIState passes object with realistic values. */
+function arbPasses() {
+  return fc.record({
+    conversion: fc.boolean(),
+    conversionSourceFormat: fc.constantFrom(...VALID_CONVERSION_SOURCE_FORMATS),
+    conversionFormat: fc.constantFrom(...VALID_CONVERSION_FORMATS),
+    conversionOpset: fc.integer({ min: 11, max: 21 }),
+    conversionInputTargetTypes: fc.string({ minLength: 0, maxLength: 30 }),
+    quantization: fc.boolean(),
+    quantMethod: fc.constantFrom(...VALID_QUANT_METHODS),
+    quantPrecision: fc.constantFrom(...VALID_QUANT_PRECISIONS),
+    gptqBlockSize: fc.constantFrom(32, 64, 128),
+    gptqDescAct: fc.boolean(),
+    gptqGroupSize: fc.constantFrom(32, 64, 128),
+    awqGroupSize: fc.constantFrom(32, 64, 128),
+    awqDampPercent: fc.double({ min: 0.001, max: 0.1, noNaN: true }),
+    awqSym: fc.boolean(),
+    qatQuantPrecision: fc.constantFrom("int4", "int8") as fc.Arbitrary<"int4" | "int8">,
+    qatCalibrateMethod: fc.constantFrom("minmax", "percentile", "entropy") as fc.Arbitrary<"minmax" | "percentile" | "entropy">,
+    qatCalibrateSteps: fc.integer({ min: 1, max: 1000 }),
+    quantPreset: fc.string({ minLength: 0, maxLength: 30 }),
+    pruning: fc.boolean(),
+    pruningSparsity: fc.double({ min: 0, max: 1, noNaN: true }),
+    pruningType: fc.constantFrom(...VALID_PRUNING_TYPES),
+    pruningMethod: fc.constantFrom(...VALID_PRUNING_METHODS),
+    pruningCriteria: fc.constantFrom(...VALID_PRUNING_CRITERIA),
+    splitting: fc.boolean(),
+    onnxTransforms: fc.boolean(),
+    peft: fc.boolean(),
+    peftMethod: fc.constantFrom(...VALID_PEFT_METHODS),
+    diffusionLora: fc.boolean(),
+    trustRemoteCode: fc.boolean(),
+    mobiusBuilder: fc.boolean(),
+    qairtPipeline: fc.boolean(),
+    quantizeEmbeddingInt8: fc.boolean(),
+    shareEmbeddingLmHead: fc.boolean(),
+    simplifiedLayerNormToRMSNorm: fc.boolean(),
+    onnxDiscrepancyCheck: fc.boolean(),
+  });
+}
+
+/** Generate a realistic UIState (non-transient fields vary). */
+function arbUIState(): fc.Arbitrary<UIState> {
+  return arbPasses().chain((passes) =>
+    fc.record({
+      modelSource: fc.constantFrom(...VALID_MODEL_SOURCES),
+      localFiles: fc.array(
+        fc.record({
+          name: fc.string({ minLength: 1, maxLength: 50 }),
+          size: fc.nat({ max: 1_000_000_000 }),
+        }),
+        { minLength: 0, maxLength: 5 },
+      ),
+      azureModelPath: fc.string({ minLength: 0, maxLength: 100 }),
+      hfModelId: fc.string({ minLength: 0, maxLength: 100 }),
+      hfDataset: fc.string({ minLength: 0, maxLength: 100 }),
+      ihvProvider: fc.constantFrom(...VALID_IHV_PROVIDERS),
+      openvinoTargetDevice: fc.constantFrom(...VALID_OPENVINO_TARGETS),
+      memoryOffload: fc.constantFrom(...VALID_MEMORY_OFFLOADS),
+      cudaVersion: fc.constantFrom(...VALID_CUDA_VERSIONS),
+      cacheDir: fc.string({ minLength: 0, maxLength: 100 }),
+      azureStr: fc.string({ minLength: 0, maxLength: 100 }),
+      distributedCaching: fc.boolean(),
+      activeJobId: fc.option(fc.uuid(), { nil: null }),
+      passes: fc.constant(passes),
+    }) as fc.Arbitrary<UIState>,
+  );
+}
+
+/**
+ * Generate a pair of UIState objects that are deeply equal after transient
+ * field exclusion but may differ in transient fields (activeJobId, localFiles).
+ */
+function arbUIStatePairDifferingOnlyInTransient(): fc.Arbitrary<[UIState, UIState]> {
+  return arbUIState().chain((baseState) =>
+    fc.tuple(
+      fc.option(fc.uuid(), { nil: null }),
+      fc.array(
+        fc.record({
+          name: fc.string({ minLength: 1, maxLength: 50 }),
+          size: fc.nat({ max: 1_000_000_000 }),
+        }),
+        { minLength: 0, maxLength: 5 },
+      ),
+    ).map(([altJobId, altLocalFiles]) => {
+      const state1: UIState = { ...baseState };
+      const state2: UIState = {
+        ...baseState,
+        activeJobId: altJobId,
+        localFiles: altLocalFiles,
+      };
+      return [state1, state2] as [UIState, UIState];
+    }),
+  );
+}
+
+/**
+ * Generate a pair of UIState objects guaranteed to differ in at least one
+ * non-transient field.
+ */
+function arbUIStatePairDifferingInNonTransient(): fc.Arbitrary<[UIState, UIState]> {
+  return fc.tuple(arbUIState(), arbUIState()).filter(([a, b]) => {
+    // Verify they actually differ in non-transient fields via serialization
+    const serA = _serializeForFingerprint(a);
+    const serB = _serializeForFingerprint(b);
+    return serA !== serB;
+  });
+}
+
+// ─── Staleness Helper ────────────────────────────────────────────────────────
+
+/**
+ * Simulates the staleness detection logic from the design:
+ * - If result fingerprint !== current fingerprint → stale (discard/mark)
+ * - If result fingerprint === current fingerprint → findings are fresh
+ */
+function isFindingsStale(
+  reviewFingerprint: string,
+  currentFingerprint: string,
+): boolean {
+  return reviewFingerprint !== currentFingerprint;
+}
+
+// ─── Property 5: Fingerprint Determinism and Transient Exclusion ─────────────
+
+describe("Property 5: Fingerprint Determinism and Transient Exclusion", () => {
+  /**
+   * Feature: v05-release, Property 5: Fingerprint Determinism and Transient Exclusion
+   *
+   * For any two UIState objects that are deeply equal after excluding transient
+   * fields (activeJobId, localFiles), the computed workspace fingerprint must be
+   * byte-identical. Conversely, for any two UIState objects that differ only in
+   * transient fields, the fingerprints must still be identical.
+   *
+   * Validates: Requirements 3.1, 3.5
+   */
+
+  it("same UIState always produces the same fingerprint (idempotency)", async () => {
+    await fc.assert(
+      fc.asyncProperty(arbUIState(), async (state) => {
+        const fp1 = await computeFingerprint(state);
+        const fp2 = await computeFingerprint(state);
+        expect(fp1).toBe(fp2);
+      }),
+      { numRuns: 100 },
+    );
+  });
+
+  it("fingerprint is a 64-character lowercase hex string", async () => {
+    await fc.assert(
+      fc.asyncProperty(arbUIState(), async (state) => {
+        const fp = await computeFingerprint(state);
+        expect(fp).toMatch(/^[0-9a-f]{64}$/);
+      }),
+      { numRuns: 100 },
+    );
+  });
+
+  it("states differing only in transient fields produce identical fingerprints", async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        arbUIStatePairDifferingOnlyInTransient(),
+        async ([state1, state2]) => {
+          const fp1 = await computeFingerprint(state1);
+          const fp2 = await computeFingerprint(state2);
+          expect(fp1).toBe(fp2);
+        },
+      ),
+      { numRuns: 100 },
+    );
+  });
+
+  it("serialization excludes exactly the FINGERPRINT_EXCLUDED_KEYS", () => {
+    fc.assert(
+      fc.property(arbUIState(), (state) => {
+        const serialized = _serializeForFingerprint(state);
+        const parsed = JSON.parse(serialized) as Record<string, unknown>;
+
+        // None of the excluded keys should appear in the serialized output
+        for (const excludedKey of FINGERPRINT_EXCLUDED_KEYS) {
+          expect(parsed).not.toHaveProperty(excludedKey);
+        }
+
+        // All non-excluded keys present in state should appear
+        for (const key of Object.keys(state)) {
+          if (
+            !FINGERPRINT_EXCLUDED_KEYS.includes(key as keyof UIState) &&
+            (state as unknown as Record<string, unknown>)[key] !== undefined
+          ) {
+            expect(parsed).toHaveProperty(key);
+          }
+        }
+      }),
+      { numRuns: 100 },
+    );
+  });
+
+  it("deeply-equal states (after transient exclusion) produce byte-identical fingerprints", async () => {
+    await fc.assert(
+      fc.asyncProperty(arbUIState(), async (state) => {
+        // Create a deep clone of the state (same non-transient content)
+        const clone: UIState = JSON.parse(JSON.stringify(state));
+        // Set different transient values to ensure exclusion works
+        clone.activeJobId = state.activeJobId === "test-id" ? null : "test-id";
+        clone.localFiles = [{ name: "different.bin", size: 999 }];
+
+        const fp1 = await computeFingerprint(state);
+        const fp2 = await computeFingerprint(clone);
+        expect(fp1).toBe(fp2);
+      }),
+      { numRuns: 100 },
+    );
+  });
+
+  it("serialization is deterministic: object key order does not affect output", () => {
+    fc.assert(
+      fc.property(arbUIState(), (state) => {
+        // Create a version with keys in reverse order
+        const keys = Object.keys(state);
+        const reversed: Record<string, unknown> = {};
+        for (let i = keys.length - 1; i >= 0; i--) {
+          reversed[keys[i]] = (state as unknown as Record<string, unknown>)[keys[i]];
+        }
+
+        const ser1 = _serializeForFingerprint(state);
+        const ser2 = _serializeForFingerprint(reversed as unknown as UIState);
+        expect(ser1).toBe(ser2);
+      }),
+      { numRuns: 100 },
+    );
+  });
+
+  it("the default pipeline state produces a consistent fingerprint", async () => {
+    const state1 = createDefaultPipelineState();
+    const state2 = createDefaultPipelineState();
+    const fp1 = await computeFingerprint(state1);
+    const fp2 = await computeFingerprint(state2);
+    expect(fp1).toBe(fp2);
+    expect(fp1).toMatch(/^[0-9a-f]{64}$/);
+  });
+});
+
+// ─── Property 6: Fingerprint Staleness Consistency ───────────────────────────
+
+describe("Property 6: Fingerprint Staleness Consistency", () => {
+  /**
+   * Feature: v05-release, Property 6: Fingerprint Staleness Consistency
+   *
+   * For any review result whose attached fingerprint does not match the current
+   * workspace fingerprint, those findings must be discarded or marked stale.
+   * For any UIState update that produces the same fingerprint as before (no-op
+   * patch), existing findings must remain unmarked. For any UIState update that
+   * produces a different fingerprint, all existing findings must be marked stale.
+   *
+   * Validates: Requirements 3.3, 3.4, 3.7
+   */
+
+  it("mismatched fingerprint marks findings as stale", async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        arbUIStatePairDifferingInNonTransient(),
+        async ([stateAtReview, currentState]) => {
+          const reviewFingerprint = await computeFingerprint(stateAtReview);
+          const currentFingerprint = await computeFingerprint(currentState);
+
+          // Since states differ in non-transient fields, fingerprints must differ
+          expect(reviewFingerprint).not.toBe(currentFingerprint);
+
+          // Staleness detection: findings are stale when fingerprints mismatch
+          expect(isFindingsStale(reviewFingerprint, currentFingerprint)).toBe(true);
+        },
+      ),
+      { numRuns: 100 },
+    );
+  });
+
+  it("same fingerprint retains findings as fresh (no-op patch)", async () => {
+    await fc.assert(
+      fc.asyncProperty(arbUIState(), async (state) => {
+        const fingerprint = await computeFingerprint(state);
+
+        // Simulate a no-op patch: compute fingerprint again on the same state
+        const afterPatchFingerprint = await computeFingerprint(state);
+
+        // Fingerprints match → findings remain valid
+        expect(isFindingsStale(fingerprint, afterPatchFingerprint)).toBe(false);
+      }),
+      { numRuns: 100 },
+    );
+  });
+
+  it("transient-only change retains findings as fresh", async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        arbUIStatePairDifferingOnlyInTransient(),
+        async ([stateBefore, stateAfter]) => {
+          const fpBefore = await computeFingerprint(stateBefore);
+          const fpAfter = await computeFingerprint(stateAfter);
+
+          // Transient-only changes should not invalidate findings
+          expect(isFindingsStale(fpBefore, fpAfter)).toBe(false);
+        },
+      ),
+      { numRuns: 100 },
+    );
+  });
+
+  it("non-transient state change invalidates all existing findings", async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        arbUIStatePairDifferingInNonTransient(),
+        async ([stateBefore, stateAfter]) => {
+          const fpAtReview = await computeFingerprint(stateBefore);
+          const fpCurrent = await computeFingerprint(stateAfter);
+
+          // States differ in non-transient fields → fingerprints differ
+          expect(fpAtReview).not.toBe(fpCurrent);
+
+          // All findings from the review must be marked stale
+          expect(isFindingsStale(fpAtReview, fpCurrent)).toBe(true);
+        },
+      ),
+      { numRuns: 100 },
+    );
+  });
+
+  it("review result with matching fingerprint is not discarded", async () => {
+    await fc.assert(
+      fc.asyncProperty(arbUIState(), async (state) => {
+        const currentFp = await computeFingerprint(state);
+
+        // Simulate a review result that was computed on the same state
+        const reviewResult: ReviewResult = {
+          findings: [],
+          score: 85,
+          level: "Optimized",
+          summary: "Test review",
+          fingerprint: currentFp,
+          timestamp: new Date().toISOString(),
+        };
+
+        // Result is fresh — should NOT be discarded
+        expect(isFindingsStale(reviewResult.fingerprint, currentFp)).toBe(false);
+      }),
+      { numRuns: 100 },
+    );
+  });
+
+  it("review result with stale fingerprint must be discarded", async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        arbUIStatePairDifferingInNonTransient(),
+        async ([stateAtReview, currentState]) => {
+          const reviewFp = await computeFingerprint(stateAtReview);
+          const currentFp = await computeFingerprint(currentState);
+
+          const reviewResult: ReviewResult = {
+            findings: [
+              {
+                id: "test-finding-1",
+                title: "Test",
+                description: "A test finding",
+                severity: "warning",
+                evidence: "test evidence",
+                actions: [
+                  { kind: "explain", label: "Learn more", payload: { body: "explanation" } },
+                ],
+              },
+            ],
+            score: 60,
+            level: "Suboptimal",
+            summary: "Stale review",
+            fingerprint: reviewFp,
+            timestamp: new Date().toISOString(),
+          };
+
+          // Result from a different pipeline state must be stale
+          expect(isFindingsStale(reviewResult.fingerprint, currentFp)).toBe(true);
+        },
+      ),
+      { numRuns: 100 },
+    );
+  });
+
+  it("fingerprint changes iff non-transient state changes", async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        arbUIState(),
+        fc.constantFrom(...VALID_IHV_PROVIDERS),
+        async (state, altProvider) => {
+          const fpBefore = await computeFingerprint(state);
+
+          // Create a state with a different non-transient field
+          const modifiedState: UIState = {
+            ...state,
+            ihvProvider: altProvider,
+          };
+
+          const fpAfter = await computeFingerprint(modifiedState);
+
+          if (state.ihvProvider === altProvider) {
+            // No actual change → fingerprint unchanged
+            expect(fpBefore).toBe(fpAfter);
+          } else {
+            // Real change → fingerprint must differ
+            expect(fpBefore).not.toBe(fpAfter);
+          }
+        },
+      ),
+      { numRuns: 100 },
+    );
+  });
+});

--- a/src/lib/__tests__/workspaceFingerprint.test.ts
+++ b/src/lib/__tests__/workspaceFingerprint.test.ts
@@ -124,7 +124,6 @@ function arbUIStatePairDifferingOnlyInTransient(): fc.Arbitrary<[UIState, UIStat
         fc.option(fc.uuid(), { nil: null }),
         fc.array(
           fc.record({
-            path: fc.string({ minLength: 1, maxLength: 50 }),
             size: fc.integer({ min: 1, max: 100000 }),
           }),
           {
@@ -140,7 +139,6 @@ function arbUIStatePairDifferingOnlyInTransient(): fc.Arbitrary<[UIState, UIStat
           activeJobId: altJobId,
           localFiles: baseState.localFiles?.map((file, i) => ({
             ...file,
-            path: altFileMeta[i]?.path ?? file.path,
             size: altFileMeta[i]?.size ?? file.size,
           })),
         };

--- a/src/lib/actionExecutor.ts
+++ b/src/lib/actionExecutor.ts
@@ -1,0 +1,132 @@
+/**
+ * Action execution logic for Finding actions.
+ *
+ * Provides pure, testable handlers for each action kind. ActionButton (task 3.2)
+ * delegates to these functions. The key invariant: non-patch actions (navigate,
+ * explain, documentation) NEVER modify PipelineStore state.
+ *
+ * @module actionExecutor
+ */
+
+import type {
+  Action,
+  ActionPayloadNavigate,
+  ActionPayloadExplain,
+  ActionPayloadDocumentation,
+  ActionPayloadApplyPatch,
+} from "@/lib/types/findingTypes";
+import { usePipelineStore } from "@/lib/stores/pipelineStore";
+import { commitUiStateUpdate } from "@/lib/pipelineValidation";
+import { sanitizeChatActionPatch, chatPatchToUiState } from "@/lib/chatActions";
+
+// ─── Result Types ────────────────────────────────────────────────────────────
+
+export interface ActionExecutionResult {
+  success: boolean;
+  /** Describes what happened (e.g. "Navigated to panel X"). */
+  summary: string;
+  /** True only when the action modified pipeline state. */
+  modifiedStore: boolean;
+  /** The committed UIState after applying the patch (when modifiedStore is true). */
+  committedState?: import("@/types").UIState;
+}
+
+// ─── Non-Patch Action Handlers ───────────────────────────────────────────────
+
+/**
+ * Execute a navigate action.
+ * Scrolls/focuses a target panel element. Does NOT modify PipelineStore.
+ */
+export function executeNavigateAction(
+  action: ActionPayloadNavigate,
+): ActionExecutionResult {
+  // In a real UI, this would call scrollIntoView or focus. Pure logic only.
+  const { targetPanel } = action.payload;
+  return {
+    success: true,
+    summary: `Navigated to panel: ${targetPanel}`,
+    modifiedStore: false,
+  };
+}
+
+/**
+ * Execute an explain action.
+ * Injects explanation text into the chat display. Does NOT modify PipelineStore.
+ */
+export function executeExplainAction(
+  action: ActionPayloadExplain,
+): ActionExecutionResult {
+  // In a real UI, this would append to a chat messages list (separate from PipelineStore).
+  const { body } = action.payload;
+  return {
+    success: true,
+    summary: `Explanation injected (${body.length} chars)`,
+    modifiedStore: false,
+  };
+}
+
+/**
+ * Execute a documentation action.
+ * Opens a KB article or external URL. Does NOT modify PipelineStore.
+ */
+export function executeDocumentationAction(
+  action: ActionPayloadDocumentation,
+): ActionExecutionResult {
+  const { url, topicKey } = action.payload;
+  const target = url ?? topicKey ?? "unknown";
+  return {
+    success: true,
+    summary: `Documentation opened: ${target}`,
+    modifiedStore: false,
+  };
+}
+
+/**
+ * Execute an applyPatch action.
+ * Applies the patch through commitUiStateUpdate. DOES modify PipelineStore.
+ */
+export function executeApplyPatchAction(
+  action: ActionPayloadApplyPatch,
+): ActionExecutionResult {
+  const patch = sanitizeChatActionPatch(action.payload);
+  if (!patch) {
+    return {
+      success: false,
+      summary: "Patch failed sanitization",
+      modifiedStore: false,
+    };
+  }
+  const currentState = usePipelineStore.getState().state;
+  const partial = chatPatchToUiState(currentState, patch);
+  // Pass through commitUiStateUpdate to get the committed result, then
+  // apply via replaceState so callers can detect coercion differences.
+  const committed = commitUiStateUpdate(currentState, partial);
+  usePipelineStore.getState().replaceState(committed);
+  return {
+    success: true,
+    summary: "Patch applied to pipeline store",
+    modifiedStore: true,
+    committedState: committed,
+  };
+}
+
+// ─── Dispatcher ──────────────────────────────────────────────────────────────
+
+/**
+ * Execute any Finding action by dispatching on `kind`.
+ *
+ * **Key invariant:** navigate, explain, and documentation actions return
+ * `modifiedStore: false` and never call PipelineStore.setState.
+ */
+export function executeAction(action: Action): ActionExecutionResult {
+  switch (action.kind) {
+    case "applyPatch":
+      return executeApplyPatchAction(action);
+    case "navigate":
+      return executeNavigateAction(action);
+    case "explain":
+      return executeExplainAction(action);
+    case "documentation":
+      return executeDocumentationAction(action);
+  }
+}

--- a/src/lib/actionExecutor.ts
+++ b/src/lib/actionExecutor.ts
@@ -48,7 +48,14 @@ export function executeNavigateAction(
   const { targetPanel } = action.payload;
   if (typeof window !== "undefined") {
     if (isPipelineViewId(targetPanel)) {
-      navigatePipeline(targetPanel);
+      const navigated = navigatePipeline(targetPanel);
+      if (!navigated) {
+        return {
+          success: false,
+          summary: `Navigation blocked while an Olive run is in progress: ${targetPanel}`,
+          modifiedStore: false,
+        };
+      }
     } else {
       window.dispatchEvent(
         new CustomEvent("olive-studio:navigate-panel", { detail: { targetPanel } }),

--- a/src/lib/actionExecutor.ts
+++ b/src/lib/actionExecutor.ts
@@ -18,6 +18,10 @@ import type {
 import { usePipelineStore } from "@/lib/stores/pipelineStore";
 import { commitUiStateUpdate } from "@/lib/pipelineValidation";
 import { sanitizeChatActionPatch, chatPatchToUiState } from "@/lib/chatActions";
+import {
+  isPipelineViewId,
+  navigatePipeline,
+} from "@/lib/pipelineNavigation";
 
 // ─── Result Types ────────────────────────────────────────────────────────────
 
@@ -42,6 +46,15 @@ export function executeNavigateAction(
 ): ActionExecutionResult {
   // In a real UI, this would call scrollIntoView or focus. Pure logic only.
   const { targetPanel } = action.payload;
+  if (typeof window !== "undefined") {
+    if (isPipelineViewId(targetPanel)) {
+      navigatePipeline(targetPanel);
+    } else {
+      window.dispatchEvent(
+        new CustomEvent("olive-studio:navigate-panel", { detail: { targetPanel } }),
+      );
+    }
+  }
   return {
     success: true,
     summary: `Navigated to panel: ${targetPanel}`,
@@ -58,6 +71,9 @@ export function executeExplainAction(
 ): ActionExecutionResult {
   // In a real UI, this would append to a chat messages list (separate from PipelineStore).
   const { body } = action.payload;
+  if (typeof window !== "undefined") {
+    window.dispatchEvent(new CustomEvent("olive-studio:explain", { detail: { body } }));
+  }
   return {
     success: true,
     summary: `Explanation injected (${body.length} chars)`,
@@ -74,6 +90,13 @@ export function executeDocumentationAction(
 ): ActionExecutionResult {
   const { url, topicKey } = action.payload;
   const target = url ?? topicKey ?? "unknown";
+  if (typeof window !== "undefined" && typeof url === "string" && url.length > 0) {
+    window.open(url, "_blank", "noopener,noreferrer");
+  } else if (typeof window !== "undefined" && topicKey) {
+    window.dispatchEvent(
+      new CustomEvent("olive-studio:documentation", { detail: { topicKey } }),
+    );
+  }
   return {
     success: true,
     summary: `Documentation opened: ${target}`,
@@ -106,7 +129,7 @@ export function executeApplyPatchAction(
     success: true,
     summary: "Patch applied to pipeline store",
     modifiedStore: true,
-    committedState: committed,
+    committedState: usePipelineStore.getState().state,
   };
 }
 

--- a/src/lib/activityLog.ts
+++ b/src/lib/activityLog.ts
@@ -1,0 +1,176 @@
+/**
+ * Activity log utility functions for the Agent execution mode (Workstream 2, v0.5.0).
+ *
+ * Provides truncation, bounded FIFO append, and terminal entry creation
+ * for the agent activity log.
+ *
+ * Requirements: 7.2, 7.4, 7.5, 7.6
+ */
+
+import type {
+  ActivityEntryKind,
+  ActivityLogEntry,
+  AgentSessionState,
+} from "@/lib/types/agentTypes";
+
+// ─── Constants ──────────────────────────────────────────────────────────────────
+
+/** Maximum number of entries retained in the activity log. */
+export const MAX_LOG_ENTRIES = 2000;
+
+/**
+ * Kind-specific character truncation limits for entry text.
+ *  - reasoning: 512
+ *  - tool_call: 256
+ *  - tool_result: 512
+ *  - decision: 256
+ *  - error: 512
+ */
+export const TRUNCATION_LIMITS: Record<ActivityEntryKind, number> = {
+  reasoning: 512,
+  tool_call: 256,
+  tool_result: 512,
+  decision: 256,
+  error: 512,
+};
+
+// ─── Truncation ─────────────────────────────────────────────────────────────────
+
+/**
+ * Apply kind-specific truncation limits to an activity log entry.
+ *
+ * If the entry's `text` exceeds its kind's limit, the returned entry has:
+ *  - `text` set to the first N characters (where N is the limit)
+ *  - `expandedText` set to the original full text
+ *
+ * If the text is already within the limit, the entry is returned as-is
+ * (no `expandedText` added).
+ */
+export function truncateEntry(entry: ActivityLogEntry): ActivityLogEntry {
+  const limit = TRUNCATION_LIMITS[entry.kind];
+
+  if (entry.text.length <= limit) {
+    return entry;
+  }
+
+  return {
+    ...entry,
+    text: entry.text.slice(0, limit),
+    expandedText: entry.text,
+  };
+}
+
+// ─── Bounded FIFO Append ────────────────────────────────────────────────────────
+
+/**
+ * Append an entry to the activity log with FIFO eviction at MAX_LOG_ENTRIES.
+ *
+ * Returns a NEW array (never mutates the input). If the current entries array
+ * is at or above the maximum capacity, the oldest entries (from the front) are
+ * removed to make room for the new entry such that the result has at most
+ * MAX_LOG_ENTRIES elements.
+ */
+export function appendEntry(
+  entries: ActivityLogEntry[],
+  entry: ActivityLogEntry,
+): ActivityLogEntry[] {
+  if (entries.length < MAX_LOG_ENTRIES) {
+    return [...entries, entry];
+  }
+
+  // Evict oldest entries to maintain the cap.
+  // When exactly at limit, drop the first entry to make room.
+  const overflow = entries.length - MAX_LOG_ENTRIES + 1;
+  return [...entries.slice(overflow), entry];
+}
+
+// ─── Terminal Entry Creation ────────────────────────────────────────────────────
+
+/**
+ * Format elapsed milliseconds into a human-readable duration string.
+ * Examples: "1.2s", "45.0s", "2m 30s", "1h 5m 12s"
+ */
+function formatElapsed(ms: number): string {
+  const totalSeconds = Math.floor(ms / 1000);
+
+  if (totalSeconds < 60) {
+    return `${(ms / 1000).toFixed(1)}s`;
+  }
+
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+
+  if (hours > 0) {
+    return `${hours}h ${minutes}m ${seconds}s`;
+  }
+
+  return `${minutes}m ${seconds}s`;
+}
+
+/**
+ * Generate the HH:MM:SS timestamp string for the current time.
+ */
+function currentTimestamp(): string {
+  const now = new Date();
+  const h = String(now.getHours()).padStart(2, "0");
+  const m = String(now.getMinutes()).padStart(2, "0");
+  const s = String(now.getSeconds()).padStart(2, "0");
+  return `${h}:${m}:${s}`;
+}
+
+/**
+ * Generate a unique entry ID using a combination of timestamp and random suffix.
+ */
+function generateEntryId(): string {
+  return `terminal-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+/**
+ * Create a terminal activity log entry based on the agent session outcome.
+ *
+ * Formats text depending on outcome status:
+ *  - success: "Agent completed: {totalSteps} steps in {formatted elapsed time}"
+ *  - failure: "Agent failed: {errorDescription}"
+ *  - cancelled: "Agent cancelled at step {cancelledAtStep}"
+ *
+ * Returns an entry with kind "decision" for success/cancelled, or "error" for failure.
+ */
+export function createTerminalEntry(
+  outcome: AgentSessionState["outcome"],
+): ActivityLogEntry {
+  if (!outcome) {
+    return {
+      id: generateEntryId(),
+      kind: "error",
+      timestamp: currentTimestamp(),
+      text: "Agent terminated with unknown outcome",
+    };
+  }
+
+  switch (outcome.status) {
+    case "success":
+      return {
+        id: generateEntryId(),
+        kind: "decision",
+        timestamp: currentTimestamp(),
+        text: `Agent completed: ${outcome.totalSteps} steps in ${formatElapsed(outcome.elapsedMs)}`,
+      };
+
+    case "failure":
+      return {
+        id: generateEntryId(),
+        kind: "error",
+        timestamp: currentTimestamp(),
+        text: `Agent failed: ${outcome.errorDescription ?? "unknown error"}`,
+      };
+
+    case "cancelled":
+      return {
+        id: generateEntryId(),
+        kind: "decision",
+        timestamp: currentTimestamp(),
+        text: `Agent cancelled at step ${outcome.cancelledAtStep ?? "unknown"}`,
+      };
+  }
+}

--- a/src/lib/activityLog.ts
+++ b/src/lib/activityLog.ts
@@ -94,7 +94,8 @@ function formatElapsed(ms: number): string {
   const totalSeconds = Math.floor(ms / 1000);
 
   if (totalSeconds < 60) {
-    return `${(ms / 1000).toFixed(1)}s`;
+    const tenths = Math.floor(ms / 100) / 10;
+    return `${tenths.toFixed(1)}s`;
   }
 
   const hours = Math.floor(totalSeconds / 3600);

--- a/src/lib/batchComparison.ts
+++ b/src/lib/batchComparison.ts
@@ -104,8 +104,14 @@ export function parseMcpCompareOutput(
     results.push(parsed);
   }
 
-  // Validate `winner` is string or null
+  // Validate `winner` is string or null, and refers to a compared job when set
   if (raw.winner !== null && !isString(raw.winner)) return null;
+  if (
+    typeof raw.winner === "string" &&
+    !results.some((entry) => entry.job_id === raw.winner)
+  ) {
+    return null;
+  }
 
   // Validate `reasoning` is a string
   if (!isString(raw.reasoning)) return null;

--- a/src/lib/batchComparison.ts
+++ b/src/lib/batchComparison.ts
@@ -38,17 +38,32 @@ function isNumberOrNull(value: unknown): value is number | null {
 /**
  * Validates a single result entry from the MCP compare_results output.
  */
-function isValidResultEntry(entry: unknown): entry is CompareResultEntry {
-  if (entry === null || typeof entry !== "object") return false;
+function flattenCompareEntry(entry: unknown): CompareResultEntry | null {
+  if (entry === null || typeof entry !== "object") return null;
   const obj = entry as Record<string, unknown>;
-  return (
-    isString(obj.job_id) &&
-    isNumberOrNull(obj.latency_ms) &&
-    isNumberOrNull(obj.model_size_mb) &&
-    isNumberOrNull(obj.accuracy) &&
-    typeof obj.score === "number" &&
-    Number.isFinite(obj.score)
-  );
+  if (!isString(obj.job_id)) return null;
+  if (typeof obj.score !== "number" || !Number.isFinite(obj.score)) return null;
+
+  const metrics =
+    obj.metrics !== null && typeof obj.metrics === "object" && !Array.isArray(obj.metrics)
+      ? (obj.metrics as Record<string, unknown>)
+      : obj;
+
+  if (
+    !isNumberOrNull(metrics.latency_ms) ||
+    !isNumberOrNull(metrics.model_size_mb) ||
+    !isNumberOrNull(metrics.accuracy)
+  ) {
+    return null;
+  }
+
+  return {
+    job_id: obj.job_id,
+    latency_ms: metrics.latency_ms,
+    model_size_mb: metrics.model_size_mb,
+    accuracy: metrics.accuracy,
+    score: obj.score,
+  };
 }
 
 /**
@@ -76,9 +91,18 @@ function isValidExcludedJob(entry: unknown): entry is ExcludedJob {
 export function parseMcpCompareOutput(
   raw: Record<string, unknown>
 ): CompareResultsOutput | null {
-  // Validate `results` is an array of valid entries
-  if (!Array.isArray(raw.results)) return null;
-  if (!raw.results.every(isValidResultEntry)) return null;
+  const rows = Array.isArray(raw.comparison)
+    ? raw.comparison
+    : Array.isArray(raw.results)
+      ? raw.results
+      : null;
+  if (!rows) return null;
+  const results: CompareResultEntry[] = [];
+  for (const row of rows) {
+    const parsed = flattenCompareEntry(row);
+    if (!parsed) return null;
+    results.push(parsed);
+  }
 
   // Validate `winner` is string or null
   if (raw.winner !== null && !isString(raw.winner)) return null;
@@ -91,7 +115,7 @@ export function parseMcpCompareOutput(
   if (!raw.excluded_jobs.every(isValidExcludedJob)) return null;
 
   return {
-    results: raw.results as CompareResultEntry[],
+    results,
     winner: raw.winner as string | null,
     reasoning: raw.reasoning as string,
     excluded_jobs: raw.excluded_jobs as ExcludedJob[],

--- a/src/lib/batchComparison.ts
+++ b/src/lib/batchComparison.ts
@@ -1,0 +1,99 @@
+/**
+ * Batch comparison validation utilities.
+ * Validates job count constraints and parses MCP `compare_results` tool output
+ * into the typed `CompareResultsOutput` structure.
+ */
+
+import type {
+  CompareResultEntry,
+  CompareResultsOutput,
+  ExcludedJob,
+} from "@/lib/types/agentTypes";
+
+/**
+ * Validates that the job count is within the accepted range for batch comparison.
+ * The MCP `compare_results` tool requires between 2 and 10 jobs inclusive.
+ *
+ * @param count - Number of job records to compare
+ * @returns true if count is in [2, 10], false otherwise
+ */
+export function validateJobCount(count: number): boolean {
+  return Number.isInteger(count) && count >= 2 && count <= 10;
+}
+
+/**
+ * Validates that a value is a string.
+ */
+function isString(value: unknown): value is string {
+  return typeof value === "string";
+}
+
+/**
+ * Validates that a value is a number or null.
+ */
+function isNumberOrNull(value: unknown): value is number | null {
+  return value === null || (typeof value === "number" && Number.isFinite(value));
+}
+
+/**
+ * Validates a single result entry from the MCP compare_results output.
+ */
+function isValidResultEntry(entry: unknown): entry is CompareResultEntry {
+  if (entry === null || typeof entry !== "object") return false;
+  const obj = entry as Record<string, unknown>;
+  return (
+    isString(obj.job_id) &&
+    isNumberOrNull(obj.latency_ms) &&
+    isNumberOrNull(obj.model_size_mb) &&
+    isNumberOrNull(obj.accuracy) &&
+    typeof obj.score === "number" &&
+    Number.isFinite(obj.score)
+  );
+}
+
+/**
+ * Validates a single excluded job entry.
+ */
+function isValidExcludedJob(entry: unknown): entry is ExcludedJob {
+  if (entry === null || typeof entry !== "object") return false;
+  const obj = entry as Record<string, unknown>;
+  return isString(obj.job_id) && isString(obj.reason);
+}
+
+/**
+ * Parses and validates raw MCP `compare_results` tool output into a typed
+ * `CompareResultsOutput`. Returns null if the structure is invalid.
+ *
+ * Validates:
+ * - `results` is an array of valid CompareResultEntry objects
+ * - `winner` is a string or null
+ * - `reasoning` is a string
+ * - `excluded_jobs` is an array of valid ExcludedJob objects
+ *
+ * @param raw - The raw untyped response from the MCP tool
+ * @returns Typed CompareResultsOutput or null if validation fails
+ */
+export function parseMcpCompareOutput(
+  raw: Record<string, unknown>
+): CompareResultsOutput | null {
+  // Validate `results` is an array of valid entries
+  if (!Array.isArray(raw.results)) return null;
+  if (!raw.results.every(isValidResultEntry)) return null;
+
+  // Validate `winner` is string or null
+  if (raw.winner !== null && !isString(raw.winner)) return null;
+
+  // Validate `reasoning` is a string
+  if (!isString(raw.reasoning)) return null;
+
+  // Validate `excluded_jobs` is an array of valid entries
+  if (!Array.isArray(raw.excluded_jobs)) return null;
+  if (!raw.excluded_jobs.every(isValidExcludedJob)) return null;
+
+  return {
+    results: raw.results as CompareResultEntry[],
+    winner: raw.winner as string | null,
+    reasoning: raw.reasoning as string,
+    excluded_jobs: raw.excluded_jobs as ExcludedJob[],
+  };
+}

--- a/src/lib/featureFlags.ts
+++ b/src/lib/featureFlags.ts
@@ -1,7 +1,7 @@
 /**
  * Feature flag infrastructure for gating experimental features.
- * Flags are read from Vite env vars, URL query params (?flagName=1), and localStorage.
- * Zero runtime cost when flags are off — checks are simple boolean reads.
+ * Flags are read from Vite env vars, Node process.env, URL query params (?flagName=1),
+ * and localStorage. Zero runtime cost when flags are off — checks are simple boolean reads.
  */
 
 export type FlagKey = "multiLora" | "lazyCatalog" | "batchComparison" | "reportExport";
@@ -46,18 +46,31 @@ const FLAG_ENV_VARS: Partial<Record<FlagKey, string>> = {
   multiLora: "VITE_FEATURE_MULTI_LORA",
 };
 
+function parseFlagEnvValue(val: unknown): boolean | null {
+  if (typeof val === "boolean") return val;
+  if (val === "true" || val === "1") return true;
+  if (val === "false" || val === "0") return false;
+  return null;
+}
+
+function readNodeProcessEnv(envKey: string): unknown {
+  const nodeProcess = (globalThis as { process?: { env?: Record<string, string | undefined> } })
+    .process;
+  return nodeProcess?.env?.[envKey];
+}
+
 function readEnvVar(key: FlagKey): boolean | null {
   try {
     const envKey = FLAG_ENV_VARS[key];
     if (!envKey) return null;
-    // Vite exposes env vars on import.meta.env at build time.
+    // Vite exposes env vars on import.meta.env at build time (client bundle).
     if (typeof import.meta !== "undefined" && import.meta.env) {
-      const val = import.meta.env[envKey];
-      // Vite may inline boolean values directly (e.g. VITE_FEATURE_X=true in .env)
-      if (typeof val === "boolean") return val;
-      if (val === "true" || val === "1") return true;
-      if (val === "false" || val === "0") return false;
+      const fromVite = parseFlagEnvValue(import.meta.env[envKey]);
+      if (fromVite !== null) return fromVite;
     }
+    // Node / MCP / esbuild server: same VITE_* key via process.env.
+    const fromProcess = parseFlagEnvValue(readNodeProcessEnv(envKey));
+    if (fromProcess !== null) return fromProcess;
   } catch {
     // SSR / non-browser / env not available
   }
@@ -89,7 +102,7 @@ function readStorage(key: string): boolean | null {
 
 /**
  * Check if a feature flag is enabled.
- * Priority: URL param > localStorage > env var (build-time) > default.
+ * Priority: URL param > localStorage > env var (Vite or Node) > default.
  *
  * The env var is the lowest-priority fallback so that runtime overrides
  * (URL param, localStorage) take precedence over build-time settings,
@@ -113,7 +126,7 @@ export function isFeatureEnabled(key: FlagKey): boolean {
  * Convenience check for the MultiLoRA feature flag.
  *
  * Enabled via:
- * - Build-time env var: `VITE_FEATURE_MULTI_LORA=true`
+ * - Env var: `VITE_FEATURE_MULTI_LORA=true` (Vite `import.meta.env` or Node `process.env`)
  * - URL param: `?multiLora=1`
  * - localStorage key: `olive:flag:multiLora` set to `"1"`
  *

--- a/src/lib/featureFlags.ts
+++ b/src/lib/featureFlags.ts
@@ -1,10 +1,15 @@
 /**
  * Feature flag infrastructure for gating experimental features.
- * Flags are read from URL query params (?flagName=1) and localStorage.
+ * Flags are read from Vite env vars, URL query params (?flagName=1), and localStorage.
  * Zero runtime cost when flags are off — checks are simple boolean reads.
  */
 
 export type FlagKey = "multiLora" | "lazyCatalog" | "batchComparison" | "reportExport";
+
+// ─── Named Flag Constants ────────────────────────────────────────────────────
+
+/** Constant for the MultiLoRA feature flag key. */
+export const FEATURE_FLAG_MULTI_LORA: FlagKey = "multiLora";
 
 interface FlagDefinition {
   key: FlagKey;
@@ -33,6 +38,32 @@ const FLAG_DEFINITIONS: FlagDefinition[] = [
 
 const STORAGE_PREFIX = "olive:flag:";
 
+/**
+ * Maps FlagKey → Vite env var name (VITE_FEATURE_<SCREAMING_SNAKE>).
+ * Only flags with an env-var mapping are listed here.
+ */
+const FLAG_ENV_VARS: Partial<Record<FlagKey, string>> = {
+  multiLora: "VITE_FEATURE_MULTI_LORA",
+};
+
+function readEnvVar(key: FlagKey): boolean | null {
+  try {
+    const envKey = FLAG_ENV_VARS[key];
+    if (!envKey) return null;
+    // Vite exposes env vars on import.meta.env at build time.
+    if (typeof import.meta !== "undefined" && import.meta.env) {
+      const val = import.meta.env[envKey];
+      // Vite may inline boolean values directly (e.g. VITE_FEATURE_X=true in .env)
+      if (typeof val === "boolean") return val;
+      if (val === "true" || val === "1") return true;
+      if (val === "false" || val === "0") return false;
+    }
+  } catch {
+    // SSR / non-browser / env not available
+  }
+  return null;
+}
+
 function readUrlParam(key: string): boolean | null {
   try {
     const params = new URLSearchParams(window.location.search);
@@ -58,7 +89,11 @@ function readStorage(key: string): boolean | null {
 
 /**
  * Check if a feature flag is enabled.
- * Priority: URL param > localStorage > default.
+ * Priority: URL param > localStorage > env var (build-time) > default.
+ *
+ * The env var is the lowest-priority fallback so that runtime overrides
+ * (URL param, localStorage) take precedence over build-time settings,
+ * preserving runtime overrides when the environment flag is false.
  */
 export function isFeatureEnabled(key: FlagKey): boolean {
   const urlVal = readUrlParam(key);
@@ -67,8 +102,25 @@ export function isFeatureEnabled(key: FlagKey): boolean {
   const storageVal = readStorage(key);
   if (storageVal !== null) return storageVal;
 
+  const envVal = readEnvVar(key);
+  if (envVal !== null) return envVal;
+
   const def = FLAG_DEFINITIONS.find((d) => d.key === key);
   return def?.defaultEnabled ?? false;
+}
+
+/**
+ * Convenience check for the MultiLoRA feature flag.
+ *
+ * Enabled via:
+ * - Build-time env var: `VITE_FEATURE_MULTI_LORA=true`
+ * - URL param: `?multiLora=1`
+ * - localStorage key: `olive:flag:multiLora` set to `"1"`
+ *
+ * Defaults to `false` (disabled).
+ */
+export function isMultiLoraEnabled(): boolean {
+  return isFeatureEnabled(FEATURE_FLAG_MULTI_LORA);
 }
 
 /**

--- a/src/lib/hooks/useCatalogPin.test.ts
+++ b/src/lib/hooks/useCatalogPin.test.ts
@@ -79,6 +79,18 @@ describe("loadStoredMetadata", () => {
     expect(loadStoredMetadata()).toBeNull();
   });
 
+  it("returns null when commitSha is 40 non-hex characters", () => {
+    localStorageMock.setItem(
+      CATALOG_PIN_STORAGE_KEY,
+      JSON.stringify({
+        branch: "main",
+        commitSha: "z".repeat(40),
+        fetchedAt: "2025-01-01T00:00:00.000Z",
+      }),
+    );
+    expect(loadStoredMetadata()).toBeNull();
+  });
+
   it("returns valid metadata when all fields are present and SHA is 40 chars", () => {
     const validMetadata: CatalogMetadata = {
       branch: "main",

--- a/src/lib/hooks/useCatalogPin.test.ts
+++ b/src/lib/hooks/useCatalogPin.test.ts
@@ -1,0 +1,183 @@
+/**
+ * Unit tests for useCatalogPin hook utilities.
+ *
+ * Tests the exported pure utility functions (loadStoredMetadata, saveStoredMetadata)
+ * and validates the localStorage persistence contract for catalog pinning.
+ *
+ * The React hook logic is tested via component tests in the jsdom environment.
+ *
+ * @see Requirements 10.2, 10.3, 10.5, 10.6
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  loadStoredMetadata,
+  saveStoredMetadata,
+  CATALOG_PIN_STORAGE_KEY,
+} from "./useCatalogPin";
+import type { CatalogMetadata } from "@/lib/recipeCatalogPin";
+
+// ─── localStorage mock ───────────────────────────────────────────────────────
+
+const localStorageMock = (() => {
+  let store: Record<string, string> = {};
+  return {
+    getItem: (key: string) => store[key] ?? null,
+    setItem: (key: string, value: string) => {
+      store[key] = value;
+    },
+    removeItem: (key: string) => {
+      delete store[key];
+    },
+    clear: () => {
+      store = {};
+    },
+    get length() {
+      return Object.keys(store).length;
+    },
+    key: (index: number) => Object.keys(store)[index] ?? null,
+  };
+})();
+
+beforeEach(() => {
+  localStorageMock.clear();
+  vi.stubGlobal("localStorage", localStorageMock);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe("loadStoredMetadata", () => {
+  it("returns null when nothing is stored", () => {
+    expect(loadStoredMetadata()).toBeNull();
+  });
+
+  it("returns null for invalid JSON in localStorage", () => {
+    localStorageMock.setItem(CATALOG_PIN_STORAGE_KEY, "not-valid-json{");
+    expect(loadStoredMetadata()).toBeNull();
+  });
+
+  it("returns null when stored object is missing required fields", () => {
+    localStorageMock.setItem(
+      CATALOG_PIN_STORAGE_KEY,
+      JSON.stringify({ branch: "main" }),
+    );
+    expect(loadStoredMetadata()).toBeNull();
+  });
+
+  it("returns null when commitSha is not 40 characters", () => {
+    localStorageMock.setItem(
+      CATALOG_PIN_STORAGE_KEY,
+      JSON.stringify({
+        branch: "main",
+        commitSha: "abc123",
+        fetchedAt: "2025-01-01T00:00:00.000Z",
+      }),
+    );
+    expect(loadStoredMetadata()).toBeNull();
+  });
+
+  it("returns valid metadata when all fields are present and SHA is 40 chars", () => {
+    const validMetadata: CatalogMetadata = {
+      branch: "main",
+      commitSha: "a".repeat(40),
+      fetchedAt: "2025-07-01T12:00:00.000Z",
+    };
+    localStorageMock.setItem(CATALOG_PIN_STORAGE_KEY, JSON.stringify(validMetadata));
+
+    const result = loadStoredMetadata();
+    expect(result).toEqual(validMetadata);
+  });
+
+  it("returns metadata for 40-char alphanumeric SHA", () => {
+    const validMetadata: CatalogMetadata = {
+      branch: "release/v2",
+      commitSha: "1234567890abcdef1234567890abcdef12345678",
+      fetchedAt: "2025-06-15T08:30:00.000Z",
+    };
+    localStorageMock.setItem(CATALOG_PIN_STORAGE_KEY, JSON.stringify(validMetadata));
+
+    const result = loadStoredMetadata();
+    expect(result).toEqual(validMetadata);
+  });
+});
+
+describe("saveStoredMetadata", () => {
+  it("persists metadata to localStorage under the correct key", () => {
+    const metadata: CatalogMetadata = {
+      branch: "main",
+      commitSha: "b".repeat(40),
+      fetchedAt: "2025-07-01T12:00:00.000Z",
+    };
+
+    saveStoredMetadata(metadata);
+
+    const raw = localStorageMock.getItem(CATALOG_PIN_STORAGE_KEY);
+    expect(raw).not.toBeNull();
+    expect(JSON.parse(raw!)).toEqual(metadata);
+  });
+
+  it("overwrites previously stored metadata", () => {
+    const first: CatalogMetadata = {
+      branch: "main",
+      commitSha: "a".repeat(40),
+      fetchedAt: "2025-01-01T00:00:00.000Z",
+    };
+    const second: CatalogMetadata = {
+      branch: "develop",
+      commitSha: "f".repeat(40),
+      fetchedAt: "2025-07-01T12:00:00.000Z",
+    };
+
+    saveStoredMetadata(first);
+    saveStoredMetadata(second);
+
+    const result = loadStoredMetadata();
+    expect(result).toEqual(second);
+  });
+
+  it("does not throw when localStorage is unavailable", () => {
+    // Simulate localStorage quota exceeded
+    vi.stubGlobal("localStorage", {
+      getItem: () => null,
+      setItem: () => {
+        throw new DOMException("QuotaExceededError");
+      },
+      removeItem: () => {},
+      clear: () => {},
+      length: 0,
+      key: () => null,
+    });
+
+    const metadata: CatalogMetadata = {
+      branch: "main",
+      commitSha: "c".repeat(40),
+      fetchedAt: "2025-07-01T12:00:00.000Z",
+    };
+
+    // Should not throw
+    expect(() => saveStoredMetadata(metadata)).not.toThrow();
+  });
+});
+
+describe("CATALOG_PIN_STORAGE_KEY", () => {
+  it("is the expected key value", () => {
+    expect(CATALOG_PIN_STORAGE_KEY).toBe("olive-studio:catalog-pin");
+  });
+});
+
+describe("roundtrip: save then load", () => {
+  it("preserves metadata across save/load cycle", () => {
+    const metadata: CatalogMetadata = {
+      branch: "feature/test-branch",
+      commitSha: "0123456789abcdef0123456789abcdef01234567",
+      fetchedAt: "2025-07-20T15:45:30.123Z",
+    };
+
+    saveStoredMetadata(metadata);
+    const loaded = loadStoredMetadata();
+    expect(loaded).toEqual(metadata);
+  });
+});

--- a/src/lib/hooks/useCatalogPin.ts
+++ b/src/lib/hooks/useCatalogPin.ts
@@ -39,6 +39,9 @@ const DEBOUNCE_RESOLVE_MS = 2_000;
  */
 const STALE_CHECK_THRESHOLD_MS = 60_000;
 
+/** Shared across hook instances so remounts still honor the debounce window. */
+let lastResolveTimeMs = 0;
+
 // ─── localStorage Helpers ────────────────────────────────────────────────────
 
 /**
@@ -124,7 +127,6 @@ export function useCatalogPin(options: UseCatalogPinOptions = {}): UseCatalogPin
   const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const mountedRef = useRef(true);
   // Track the last resolve time to avoid hammering the API
-  const lastResolveTimeRef = useRef<number>(0);
   // Track whether a resolve is already in-flight to prevent duplicate calls
   const resolvingRef = useRef(false);
   // Track whether a refresh is in-flight to prevent duplicate refresh calls
@@ -153,20 +155,21 @@ export function useCatalogPin(options: UseCatalogPinOptions = {}): UseCatalogPin
       if (elapsed < STALE_CHECK_THRESHOLD_MS) {
         // Last fetch was recent enough, skip the upstream check
         setMetadata(stored);
+        setUpstreamSha(stored.commitSha);
         return;
       }
     }
 
     // Debounce the resolution to prevent rapid API calls on remounts
     const now = Date.now();
-    const timeSinceLastResolve = now - lastResolveTimeRef.current;
+    const timeSinceLastResolve = now - lastResolveTimeMs;
     const delay = Math.max(0, DEBOUNCE_RESOLVE_MS - timeSinceLastResolve);
 
     debounceTimerRef.current = setTimeout(() => {
       // Guard against duplicate in-flight resolves
       if (resolvingRef.current) return;
       resolvingRef.current = true;
-      lastResolveTimeRef.current = Date.now();
+      lastResolveTimeMs = Date.now();
 
       void resolveHeadSha()
         .then((sha) => {

--- a/src/lib/hooks/useCatalogPin.ts
+++ b/src/lib/hooks/useCatalogPin.ts
@@ -18,6 +18,7 @@ import {
   fetchCatalogAtSha,
   isCatalogStale,
   formatCatalogMetadata,
+  isValidSha,
   CatalogPinError,
 } from "@/lib/recipeCatalogPin";
 import type { CatalogMetadata, CatalogEntry } from "@/lib/recipeCatalogPin";
@@ -57,9 +58,13 @@ export function loadStoredMetadata(): CatalogMetadata | null {
       typeof parsed.branch === "string" &&
       typeof parsed.commitSha === "string" &&
       typeof parsed.fetchedAt === "string" &&
-      parsed.commitSha.length === 40
+      isValidSha(parsed.commitSha.toLowerCase())
     ) {
-      return parsed as unknown as CatalogMetadata;
+      return {
+        branch: parsed.branch,
+        commitSha: parsed.commitSha.toLowerCase(),
+        fetchedAt: parsed.fetchedAt,
+      };
     }
     return null;
   } catch {

--- a/src/lib/hooks/useCatalogPin.ts
+++ b/src/lib/hooks/useCatalogPin.ts
@@ -1,0 +1,266 @@
+/**
+ * Hook for integrating recipe catalog version pinning into the loading flow.
+ *
+ * On mount (when enabled), resolves the upstream HEAD SHA via `resolveHeadSha()`,
+ * compares against the stored catalog metadata in localStorage, and exposes
+ * staleness state, refresh control, and error handling.
+ *
+ * Consumed by Recipe Catalog panels to show `CatalogUpdateNotice` when newer
+ * recipes are available upstream.
+ *
+ * @module useCatalogPin
+ * @see Requirements 10.2, 10.3, 10.5, 10.6, 10.7
+ */
+
+import { useState, useEffect, useCallback, useRef } from "react";
+import {
+  resolveHeadSha,
+  fetchCatalogAtSha,
+  isCatalogStale,
+  formatCatalogMetadata,
+  CatalogPinError,
+} from "@/lib/recipeCatalogPin";
+import type { CatalogMetadata, CatalogEntry } from "@/lib/recipeCatalogPin";
+
+// ─── Constants ───────────────────────────────────────────────────────────────
+
+/** localStorage key for persisted catalog pin metadata. */
+export const CATALOG_PIN_STORAGE_KEY = "olive-studio:catalog-pin";
+
+/**
+ * Minimum interval (in ms) between successive SHA resolution calls.
+ * Prevents hammering the GitHub API on rapid remounts.
+ */
+const DEBOUNCE_RESOLVE_MS = 2_000;
+
+/**
+ * Minimum time (in ms) since last fetch before checking upstream again.
+ * Requirement 10.3: "last catalog fetch occurred more than 60 seconds ago".
+ */
+const STALE_CHECK_THRESHOLD_MS = 60_000;
+
+// ─── localStorage Helpers ────────────────────────────────────────────────────
+
+/**
+ * Loads stored catalog metadata from localStorage.
+ * Returns `null` if nothing is stored or the data is invalid.
+ */
+export function loadStoredMetadata(): CatalogMetadata | null {
+  try {
+    const raw = localStorage.getItem(CATALOG_PIN_STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
+    if (
+      typeof parsed.branch === "string" &&
+      typeof parsed.commitSha === "string" &&
+      typeof parsed.fetchedAt === "string" &&
+      parsed.commitSha.length === 40
+    ) {
+      return parsed as unknown as CatalogMetadata;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Persists catalog metadata to localStorage.
+ */
+export function saveStoredMetadata(metadata: CatalogMetadata): void {
+  try {
+    localStorage.setItem(CATALOG_PIN_STORAGE_KEY, JSON.stringify(metadata));
+  } catch {
+    // Silently fail if localStorage is unavailable (e.g. quota exceeded)
+  }
+}
+
+// ─── Hook Return Type ────────────────────────────────────────────────────────
+
+export interface UseCatalogPinReturn {
+  /** Whether the stored catalog is outdated relative to upstream. */
+  isStale: boolean;
+  /** Whether a catalog refresh is currently in progress. */
+  isRefreshing: boolean;
+  /** The currently stored commit SHA (from localStorage), or null if none. */
+  currentSha: string | null;
+  /** The upstream HEAD SHA resolved from GitHub, or null if not yet resolved. */
+  upstreamSha: string | null;
+  /** Error message if SHA resolution or catalog fetch failed. */
+  error: string | null;
+  /** Trigger a catalog refresh: fetches new catalog at the upstream SHA. */
+  refresh: () => Promise<CatalogEntry[] | null>;
+  /** The full stored metadata (branch + SHA + fetchedAt), or null. */
+  metadata: CatalogMetadata | null;
+}
+
+export interface UseCatalogPinOptions {
+  /** Whether the hook should actively check for updates. Defaults to true. */
+  enabled?: boolean;
+}
+
+// ─── Hook ────────────────────────────────────────────────────────────────────
+
+/**
+ * Integrates recipe catalog version pinning into the recipe loading flow.
+ *
+ * Behavior:
+ * 1. On mount (when enabled): loads stored metadata from localStorage.
+ * 2. Resolves upstream HEAD SHA (debounced to avoid rapid API calls).
+ * 3. Compares using `isCatalogStale(stored, upstream)`.
+ * 4. Exposes `isStale`, `isRefreshing`, `refresh()`, `currentSha`, `error`.
+ * 5. On `refresh()`: fetches catalog at upstream SHA, persists new metadata.
+ * 6. On failure: sets error state, retains previous catalog.
+ */
+export function useCatalogPin(options: UseCatalogPinOptions = {}): UseCatalogPinReturn {
+  const { enabled = true } = options;
+
+  const [metadata, setMetadata] = useState<CatalogMetadata | null>(() => loadStoredMetadata());
+  const [upstreamSha, setUpstreamSha] = useState<string | null>(null);
+  const [isRefreshing, setIsRefreshing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Track the debounce timer and mount state
+  const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const mountedRef = useRef(true);
+  // Track the last resolve time to avoid hammering the API
+  const lastResolveTimeRef = useRef<number>(0);
+  // Track whether a resolve is already in-flight to prevent duplicate calls
+  const resolvingRef = useRef(false);
+  // Track whether a refresh is in-flight to prevent duplicate refresh calls
+  const refreshingRef = useRef(false);
+
+  // Cleanup on unmount
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+      if (debounceTimerRef.current !== null) {
+        clearTimeout(debounceTimerRef.current);
+      }
+    };
+  }, []);
+
+  // Resolve upstream HEAD SHA on mount (debounced)
+  useEffect(() => {
+    if (!enabled) return;
+
+    // Check if we should skip based on freshness threshold
+    const stored = loadStoredMetadata();
+    if (stored) {
+      const fetchedAt = new Date(stored.fetchedAt).getTime();
+      const elapsed = Date.now() - fetchedAt;
+      if (elapsed < STALE_CHECK_THRESHOLD_MS) {
+        // Last fetch was recent enough, skip the upstream check
+        setMetadata(stored);
+        return;
+      }
+    }
+
+    // Debounce the resolution to prevent rapid API calls on remounts
+    const now = Date.now();
+    const timeSinceLastResolve = now - lastResolveTimeRef.current;
+    const delay = Math.max(0, DEBOUNCE_RESOLVE_MS - timeSinceLastResolve);
+
+    debounceTimerRef.current = setTimeout(() => {
+      // Guard against duplicate in-flight resolves
+      if (resolvingRef.current) return;
+      resolvingRef.current = true;
+      lastResolveTimeRef.current = Date.now();
+
+      void resolveHeadSha()
+        .then((sha) => {
+          if (!mountedRef.current) return;
+          setUpstreamSha(sha);
+          setError(null);
+        })
+        .catch((err: unknown) => {
+          if (!mountedRef.current) return;
+          const message =
+            err instanceof CatalogPinError
+              ? err.message
+              : err instanceof Error
+                ? err.message
+                : "Failed to check for catalog updates";
+          setError(message);
+        })
+        .finally(() => {
+          resolvingRef.current = false;
+        });
+    }, delay);
+
+    return () => {
+      if (debounceTimerRef.current !== null) {
+        clearTimeout(debounceTimerRef.current);
+      }
+    };
+  }, [enabled]);
+
+  // Compute staleness
+  const isStale =
+    upstreamSha !== null && metadata !== null && isCatalogStale(metadata, upstreamSha);
+
+  // Current SHA from stored metadata
+  const currentSha = metadata?.commitSha ?? null;
+
+  /**
+   * Refresh the catalog: fetch at the resolved upstream SHA and persist new metadata.
+   * On failure, retains the previous catalog and sets error state.
+   */
+  const refresh = useCallback(async (): Promise<CatalogEntry[] | null> => {
+    // Guard against duplicate in-flight refreshes
+    if (refreshingRef.current) return null;
+
+    const sha = upstreamSha;
+    if (!sha) {
+      setError("No upstream SHA resolved — cannot refresh catalog.");
+      return null;
+    }
+
+    refreshingRef.current = true;
+    setIsRefreshing(true);
+    setError(null);
+
+    try {
+      const entries = await fetchCatalogAtSha(sha);
+      // Use the branch from the first entry's pinned metadata, or fall back
+      // to the currently stored metadata's branch, or "main".
+      const branch = entries[0]?.pinned.branch ?? metadata?.branch ?? "main";
+      const newMetadata = formatCatalogMetadata(sha, branch);
+      // Persist to localStorage
+      saveStoredMetadata(newMetadata);
+      if (mountedRef.current) {
+        setMetadata(newMetadata);
+        setUpstreamSha(sha);
+        setIsRefreshing(false);
+        setError(null);
+      }
+      return entries;
+    } catch (err: unknown) {
+      if (mountedRef.current) {
+        const message =
+          err instanceof CatalogPinError
+            ? err.message
+            : err instanceof Error
+              ? err.message
+              : "Failed to refresh catalog";
+        setError(message);
+        setIsRefreshing(false);
+      }
+      // Retain previous catalog on failure (Requirement 10.5)
+      return null;
+    } finally {
+      refreshingRef.current = false;
+    }
+  }, [upstreamSha, metadata]);
+
+  return {
+    isStale,
+    isRefreshing,
+    currentSha,
+    upstreamSha,
+    error,
+    refresh,
+    metadata,
+  };
+}

--- a/src/lib/hooks/useCatalogPin.ts
+++ b/src/lib/hooks/useCatalogPin.ts
@@ -20,8 +20,9 @@ import {
   formatCatalogMetadata,
   isValidSha,
   CatalogPinError,
+  type CatalogMetadata,
+  type CatalogEntry,
 } from "@/lib/recipeCatalogPin";
-import type { CatalogMetadata, CatalogEntry } from "@/lib/recipeCatalogPin";
 
 // ─── Constants ───────────────────────────────────────────────────────────────
 

--- a/src/lib/hooks/useWorkspaceFingerprint.ts
+++ b/src/lib/hooks/useWorkspaceFingerprint.ts
@@ -10,6 +10,7 @@
 
 import { useState, useEffect, useCallback, useRef } from "react";
 import { usePipelineStore } from "@/lib/stores/pipelineStore";
+import type { UIState } from "@/types";
 import { computeFingerprint } from "@/lib/workspaceFingerprint";
 import type { WorkspaceFingerprintState } from "@/lib/types/findingTypes";
 

--- a/src/lib/hooks/useWorkspaceFingerprint.ts
+++ b/src/lib/hooks/useWorkspaceFingerprint.ts
@@ -59,6 +59,9 @@ export function useWorkspaceFingerprint(): UseWorkspaceFingerprintReturn {
     // Increment the generation counter immediately so that any in-flight
     // computation from a prior state is invalidated.
     const generation = ++computeIdRef.current;
+    setFpState((prev) =>
+      prev.fingerprint === "" ? prev : { fingerprint: "", computedAt: 0 },
+    );
 
     // Schedule debounced recomputation
     timerRef.current = setTimeout(() => {
@@ -89,7 +92,7 @@ export function useWorkspaceFingerprint(): UseWorkspaceFingerprintReturn {
   const isStale = useCallback(
     (resultFingerprint: string): boolean => {
       // If we haven't computed a fingerprint yet, we can't determine staleness
-      if (fpState.fingerprint === "") return false;
+      if (fpState.fingerprint === "") return resultFingerprint.length > 0;
       return resultFingerprint !== fpState.fingerprint;
     },
     [fpState.fingerprint],

--- a/src/lib/hooks/useWorkspaceFingerprint.ts
+++ b/src/lib/hooks/useWorkspaceFingerprint.ts
@@ -1,0 +1,103 @@
+/**
+ * Hook for tracking workspace fingerprint and staleness detection.
+ *
+ * Subscribes to the pipeline store and recomputes a SHA-256 fingerprint
+ * (debounced) whenever pipeline-relevant state changes. Provides O(1)
+ * staleness comparison for review results.
+ *
+ * @module useWorkspaceFingerprint
+ */
+
+import { useState, useEffect, useCallback, useRef } from "react";
+import { usePipelineStore } from "@/lib/stores/pipelineStore";
+import { computeFingerprint } from "@/lib/workspaceFingerprint";
+import type { WorkspaceFingerprintState } from "@/lib/types/findingTypes";
+
+/** Debounce interval in milliseconds for fingerprint recomputation. */
+const DEBOUNCE_MS = 200;
+
+export interface UseWorkspaceFingerprintReturn {
+  /** Current SHA-256 hex fingerprint of the pipeline state. */
+  fingerprint: string;
+  /** Timestamp (Date.now()) when the fingerprint was last computed. */
+  computedAt: number;
+  /**
+   * Compares a review result's fingerprint against the current workspace
+   * fingerprint. Returns `true` if the result is stale (mismatch).
+   */
+  isStale: (resultFingerprint: string) => boolean;
+}
+
+/**
+ * Tracks the workspace fingerprint derived from the pipeline store state.
+ *
+ * - Subscribes to `usePipelineStore` state changes via a selector.
+ * - Debounces fingerprint recomputation (200ms) to avoid excessive hashing.
+ * - Exposes `fingerprint`, `computedAt`, and an `isStale()` comparator.
+ *
+ * @returns The current fingerprint state and staleness check utility.
+ */
+export function useWorkspaceFingerprint(): UseWorkspaceFingerprintReturn {
+  const state = usePipelineStore((s) => s.state);
+
+  const [fpState, setFpState] = useState<WorkspaceFingerprintState>({
+    fingerprint: "",
+    computedAt: 0,
+  });
+
+  // Ref to track the latest debounce timer for cleanup
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Ref to track in-flight computation to discard stale results
+  const computeIdRef = useRef(0);
+
+  useEffect(() => {
+    // Clear any pending debounce timer
+    if (timerRef.current !== null) {
+      clearTimeout(timerRef.current);
+    }
+
+    // Increment the generation counter immediately so that any in-flight
+    // computation from a prior state is invalidated.
+    const generation = ++computeIdRef.current;
+
+    // Schedule debounced recomputation
+    timerRef.current = setTimeout(() => {
+      void computeFingerprint(state).then((hash) => {
+        // Only commit if this generation is still the latest —
+        // a newer state change would have incremented computeIdRef further.
+        if (generation === computeIdRef.current) {
+          setFpState({
+            fingerprint: hash,
+            computedAt: Date.now(),
+          });
+        }
+      });
+    }, DEBOUNCE_MS);
+
+    // Cleanup on unmount or before next effect
+    return () => {
+      if (timerRef.current !== null) {
+        clearTimeout(timerRef.current);
+      }
+    };
+  }, [state]);
+
+  /**
+   * Returns true if the given result fingerprint does not match the current
+   * workspace fingerprint, indicating the result is stale.
+   */
+  const isStale = useCallback(
+    (resultFingerprint: string): boolean => {
+      // If we haven't computed a fingerprint yet, we can't determine staleness
+      if (fpState.fingerprint === "") return false;
+      return resultFingerprint !== fpState.fingerprint;
+    },
+    [fpState.fingerprint],
+  );
+
+  return {
+    fingerprint: fpState.fingerprint,
+    computedAt: fpState.computedAt,
+    isStale,
+  };
+}

--- a/src/lib/hooks/useWorkspaceFingerprint.ts
+++ b/src/lib/hooks/useWorkspaceFingerprint.ts
@@ -49,6 +49,8 @@ export function useWorkspaceFingerprint(): UseWorkspaceFingerprintReturn {
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   // Ref to track in-flight computation to discard stale results
   const computeIdRef = useRef(0);
+  // Ref to track the store state reference for which the current fingerprint was computed
+  const computedStateRef = useRef<UIState | null>(null);
 
   useEffect(() => {
     // Clear any pending debounce timer
@@ -59,9 +61,6 @@ export function useWorkspaceFingerprint(): UseWorkspaceFingerprintReturn {
     // Increment the generation counter immediately so that any in-flight
     // computation from a prior state is invalidated.
     const generation = ++computeIdRef.current;
-    setFpState((prev) =>
-      prev.fingerprint === "" ? prev : { fingerprint: "", computedAt: 0 },
-    );
 
     // Schedule debounced recomputation
     timerRef.current = setTimeout(() => {
@@ -69,6 +68,7 @@ export function useWorkspaceFingerprint(): UseWorkspaceFingerprintReturn {
         // Only commit if this generation is still the latest —
         // a newer state change would have incremented computeIdRef further.
         if (generation === computeIdRef.current) {
+          computedStateRef.current = state;
           setFpState({
             fingerprint: hash,
             computedAt: Date.now(),
@@ -91,11 +91,13 @@ export function useWorkspaceFingerprint(): UseWorkspaceFingerprintReturn {
    */
   const isStale = useCallback(
     (resultFingerprint: string): boolean => {
-      // If we haven't computed a fingerprint yet, we can't determine staleness
-      if (fpState.fingerprint === "") return resultFingerprint.length > 0;
+      // If we haven't computed a fingerprint yet or state has changed since computation
+      if (fpState.fingerprint === "" || state !== computedStateRef.current) {
+        return resultFingerprint.length > 0;
+      }
       return resultFingerprint !== fpState.fingerprint;
     },
-    [fpState.fingerprint],
+    [fpState.fingerprint, state],
   );
 
   return {

--- a/src/lib/multiLoraValidation.ts
+++ b/src/lib/multiLoraValidation.ts
@@ -110,7 +110,7 @@ export function validateAdapters(
     errors.push({
       index: -1,
       field: "adapters",
-      message: `Adapter count ${adapters.length} exceeds maximum of ${maxCount} for ${vramGb <= LOW_VRAM_THRESHOLD_GB ? "<= 12" : "> 12"} GB VRAM`,
+      message: `Adapter count ${adapters.length} exceeds maximum of ${maxCount} for ${!Number.isFinite(vramGb) || vramGb <= LOW_VRAM_THRESHOLD_GB ? "<= 12" : "> 12"} GB VRAM`,
     });
   }
 

--- a/src/lib/multiLoraValidation.ts
+++ b/src/lib/multiLoraValidation.ts
@@ -82,6 +82,124 @@ export function getMaxAdapterCount(vramGb: number): number {
     : HIGH_VRAM_MAX_ADAPTERS;
 }
 
+function validateSingleAdapterEntry(
+  entry: unknown,
+  i: number,
+): { errors: ValidationError[]; name?: string } {
+  const errors: ValidationError[] = [];
+  if (entry === null || typeof entry !== "object" || Array.isArray(entry)) {
+    return {
+      errors: [
+        {
+          index: i,
+          field: "entry",
+          message: `Adapter at index ${i} must be a non-null object`,
+        },
+      ],
+    };
+  }
+
+  const obj = entry as Record<string, unknown>;
+  let name: string | undefined;
+
+  if (typeof obj.name !== "string" || obj.name.length === 0) {
+    errors.push({
+      index: i,
+      field: "name",
+      message: `Adapter at index ${i}: name must be a non-empty string`,
+    });
+  } else {
+    name = obj.name;
+  }
+
+  if (typeof obj.path !== "string" || obj.path.length === 0) {
+    errors.push({
+      index: i,
+      field: "path",
+      message: `Adapter at index ${i}: path must be a non-empty string`,
+    });
+  }
+
+  if (
+    typeof obj.rank !== "number" ||
+    !Number.isInteger(obj.rank) ||
+    obj.rank <= 0
+  ) {
+    errors.push({
+      index: i,
+      field: "rank",
+      message: `Adapter at index ${i}: rank must be a positive integer`,
+    });
+  }
+
+  if (
+    typeof obj.alpha !== "number" ||
+    !Number.isFinite(obj.alpha) ||
+    obj.alpha <= 0
+  ) {
+    errors.push({
+      index: i,
+      field: "alpha",
+      message: `Adapter at index ${i}: alpha must be a positive finite number`,
+    });
+  }
+
+  if (obj.targetModules !== undefined) {
+    if (!Array.isArray(obj.targetModules)) {
+      errors.push({
+        index: i,
+        field: "targetModules",
+        message: `Adapter at index ${i}: targetModules must be an array of non-empty strings`,
+      });
+    } else {
+      const allValid = obj.targetModules.every(
+        (m: unknown) => typeof m === "string" && m.length > 0,
+      );
+      if (!allValid) {
+        errors.push({
+          index: i,
+          field: "targetModules",
+          message: `Adapter at index ${i}: targetModules must contain only non-empty strings`,
+        });
+      }
+    }
+  }
+
+  return { errors, name };
+}
+
+function detectDuplicateAdapterNames(
+  nameToIndices: Map<string, number[]>,
+): ValidationError[] {
+  const errors: ValidationError[] = [];
+  for (const [name, indices] of nameToIndices) {
+    if (indices.length > 1) {
+      errors.push({
+        index: indices[0],
+        field: "name",
+        message: `Duplicate adapter name "${name}" found at indices ${indices.join(", ")}`,
+      });
+    }
+  }
+  return errors;
+}
+
+function parseValidAdapterEntries(adapters: unknown[]): AdapterEntry[] {
+  return adapters.map((entry) => {
+    const obj = entry as Record<string, unknown>;
+    const result: AdapterEntry = {
+      name: obj.name as string,
+      path: obj.path as string,
+      rank: obj.rank as number,
+      alpha: obj.alpha as number,
+    };
+    if (obj.targetModules !== undefined) {
+      result.targetModules = obj.targetModules as string[];
+    }
+    return result;
+  });
+}
+
 /**
  * Validates an array of adapter entries against MultiLoRA constraints.
  *
@@ -119,125 +237,32 @@ export function validateAdapters(
 
   // Validate each entry
   for (let i = 0; i < adapters.length; i++) {
-    const entry = adapters[i];
-
-    // Entry must be a non-null object
-    if (entry === null || typeof entry !== "object" || Array.isArray(entry)) {
-      errors.push({
-        index: i,
-        field: "entry",
-        message: `Adapter at index ${i} must be a non-null object`,
-      });
-      continue;
-    }
-
-    const obj = entry as Record<string, unknown>;
-
-    // Validate name: non-empty string
-    if (typeof obj.name !== "string" || obj.name.length === 0) {
-      errors.push({
-        index: i,
-        field: "name",
-        message: `Adapter at index ${i}: name must be a non-empty string`,
-      });
-    } else {
-      // Track for duplicate detection
-      const existing = nameToIndices.get(obj.name);
+    const { errors: entryErrors, name } = validateSingleAdapterEntry(
+      adapters[i],
+      i,
+    );
+    errors.push(...entryErrors);
+    if (name) {
+      const existing = nameToIndices.get(name);
       if (existing) {
         existing.push(i);
       } else {
-        nameToIndices.set(obj.name, [i]);
-      }
-    }
-
-    // Validate path: non-empty string
-    if (typeof obj.path !== "string" || obj.path.length === 0) {
-      errors.push({
-        index: i,
-        field: "path",
-        message: `Adapter at index ${i}: path must be a non-empty string`,
-      });
-    }
-
-    // Validate rank: positive integer
-    if (
-      typeof obj.rank !== "number" ||
-      !Number.isInteger(obj.rank) ||
-      obj.rank <= 0
-    ) {
-      errors.push({
-        index: i,
-        field: "rank",
-        message: `Adapter at index ${i}: rank must be a positive integer`,
-      });
-    }
-
-    // Validate alpha: positive finite number
-    if (
-      typeof obj.alpha !== "number" ||
-      !Number.isFinite(obj.alpha) ||
-      obj.alpha <= 0
-    ) {
-      errors.push({
-        index: i,
-        field: "alpha",
-        message: `Adapter at index ${i}: alpha must be a positive finite number`,
-      });
-    }
-
-    // Validate targetModules: if present, must be an array of non-empty strings
-    if (obj.targetModules !== undefined) {
-      if (!Array.isArray(obj.targetModules)) {
-        errors.push({
-          index: i,
-          field: "targetModules",
-          message: `Adapter at index ${i}: targetModules must be an array of non-empty strings`,
-        });
-      } else {
-        const allValid = obj.targetModules.every(
-          (m: unknown) => typeof m === "string" && m.length > 0,
-        );
-        if (!allValid) {
-          errors.push({
-            index: i,
-            field: "targetModules",
-            message: `Adapter at index ${i}: targetModules must contain only non-empty strings`,
-          });
-        }
+        nameToIndices.set(name, [i]);
       }
     }
   }
 
   // Detect and report duplicate names
-  for (const [name, indices] of nameToIndices) {
-    if (indices.length > 1) {
-      errors.push({
-        index: indices[0],
-        field: "name",
-        message: `Duplicate adapter name "${name}" found at indices ${indices.join(", ")}`,
-      });
-    }
-  }
+  errors.push(...detectDuplicateAdapterNames(nameToIndices));
 
   // Build result
   if (errors.length > 0) {
     return { valid: false, errors, adapters: [] };
   }
 
-  // Parse valid entries
-  const parsed: AdapterEntry[] = adapters.map((entry) => {
-    const obj = entry as Record<string, unknown>;
-    const result: AdapterEntry = {
-      name: obj.name as string,
-      path: obj.path as string,
-      rank: obj.rank as number,
-      alpha: obj.alpha as number,
-    };
-    if (obj.targetModules !== undefined) {
-      result.targetModules = obj.targetModules as string[];
-    }
-    return result;
-  });
-
-  return { valid: true, errors: [], adapters: parsed };
+  return {
+    valid: true,
+    errors: [],
+    adapters: parseValidAdapterEntries(adapters),
+  };
 }

--- a/src/lib/multiLoraValidation.ts
+++ b/src/lib/multiLoraValidation.ts
@@ -1,0 +1,243 @@
+/**
+ * MultiLoRA adapter validation utilities.
+ *
+ * Validates adapter entries for multi-LoRA configurations, enforcing constraints
+ * on name uniqueness, path presence, numeric field validity, and VRAM-based
+ * adapter count limits.
+ *
+ * Gated behind the `multiLora` feature flag — when disabled, the recipe builder
+ * rejects multi-adapter configurations and operates in single-adapter mode.
+ *
+ * @module multiLoraValidation
+ */
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+/**
+ * A validated LoRA adapter entry.
+ */
+export interface AdapterEntry {
+  /** Unique adapter name within the configuration. */
+  name: string;
+  /** Filesystem path to the adapter weights. */
+  path: string;
+  /** LoRA rank (positive integer). */
+  rank: number;
+  /** LoRA alpha scaling factor (positive finite number). */
+  alpha: number;
+  /** Optional target module names for adapter injection. */
+  targetModules?: string[];
+}
+
+/**
+ * A single validation error identifying the adapter index and invalid field.
+ */
+export interface ValidationError {
+  /** Index of the adapter entry in the input array. */
+  index: number;
+  /** Field name that failed validation. */
+  field: string;
+  /** Human-readable error description. */
+  message: string;
+}
+
+/**
+ * Result of adapter array validation.
+ * When valid, `adapters` contains the parsed entries. When invalid, `errors`
+ * describes each failed constraint.
+ */
+export interface ValidationResult {
+  /** Whether the entire adapter array passed validation. */
+  valid: boolean;
+  /** Per-entry validation errors (empty when valid). */
+  errors: ValidationError[];
+  /** Parsed adapter entries (populated only when valid). */
+  adapters: AdapterEntry[];
+}
+
+// ─── Constants ───────────────────────────────────────────────────────────────
+
+/** VRAM threshold (GB) below or equal to which a lower adapter limit applies. */
+const LOW_VRAM_THRESHOLD_GB = 12;
+
+/** Maximum adapter count for hardware with <= 12 GB VRAM. */
+const LOW_VRAM_MAX_ADAPTERS = 2;
+
+/** Maximum adapter count for hardware with > 12 GB VRAM. */
+const HIGH_VRAM_MAX_ADAPTERS = 8;
+
+// ─── Validation ──────────────────────────────────────────────────────────────
+
+/**
+ * Returns the maximum number of adapters allowed given the available VRAM.
+ *
+ * @param vramGb - Available VRAM in gigabytes
+ * @returns Maximum adapter count (2 for <= 12 GB, 8 for > 12 GB)
+ */
+export function getMaxAdapterCount(vramGb: number): number {
+  // Non-finite values (NaN, Infinity) get the restrictive limit
+  if (!Number.isFinite(vramGb)) return LOW_VRAM_MAX_ADAPTERS;
+  return vramGb <= LOW_VRAM_THRESHOLD_GB
+    ? LOW_VRAM_MAX_ADAPTERS
+    : HIGH_VRAM_MAX_ADAPTERS;
+}
+
+/**
+ * Validates an array of adapter entries against MultiLoRA constraints.
+ *
+ * Validation rules:
+ * 1. `name`: non-empty string, unique across all entries
+ * 2. `path`: non-empty string
+ * 3. `rank`: positive integer (> 0, Number.isInteger)
+ * 4. `alpha`: positive finite number (> 0, Number.isFinite)
+ * 5. `targetModules`: if present, must be an array of non-empty strings
+ * 6. Max adapter count: 2 for <= 12 GB VRAM, 8 for > 12 GB VRAM
+ * 7. Duplicate name detection: identify both conflicting indices
+ *
+ * @param adapters - Untyped adapter entries from runtime input
+ * @param vramGb - Available VRAM in gigabytes for enforcing adapter count limits
+ * @returns Validation result with parsed adapters (when valid) or errors (when invalid)
+ */
+export function validateAdapters(
+  adapters: unknown[],
+  vramGb: number,
+): ValidationResult {
+  const errors: ValidationError[] = [];
+  const maxCount = getMaxAdapterCount(vramGb);
+
+  // Check adapter count limit
+  if (adapters.length > maxCount) {
+    errors.push({
+      index: -1,
+      field: "adapters",
+      message: `Adapter count ${adapters.length} exceeds maximum of ${maxCount} for ${vramGb <= LOW_VRAM_THRESHOLD_GB ? "<= 12" : "> 12"} GB VRAM`,
+    });
+  }
+
+  // Track names for duplicate detection
+  const nameToIndices = new Map<string, number[]>();
+
+  // Validate each entry
+  for (let i = 0; i < adapters.length; i++) {
+    const entry = adapters[i];
+
+    // Entry must be a non-null object
+    if (entry === null || typeof entry !== "object" || Array.isArray(entry)) {
+      errors.push({
+        index: i,
+        field: "entry",
+        message: `Adapter at index ${i} must be a non-null object`,
+      });
+      continue;
+    }
+
+    const obj = entry as Record<string, unknown>;
+
+    // Validate name: non-empty string
+    if (typeof obj.name !== "string" || obj.name.length === 0) {
+      errors.push({
+        index: i,
+        field: "name",
+        message: `Adapter at index ${i}: name must be a non-empty string`,
+      });
+    } else {
+      // Track for duplicate detection
+      const existing = nameToIndices.get(obj.name);
+      if (existing) {
+        existing.push(i);
+      } else {
+        nameToIndices.set(obj.name, [i]);
+      }
+    }
+
+    // Validate path: non-empty string
+    if (typeof obj.path !== "string" || obj.path.length === 0) {
+      errors.push({
+        index: i,
+        field: "path",
+        message: `Adapter at index ${i}: path must be a non-empty string`,
+      });
+    }
+
+    // Validate rank: positive integer
+    if (
+      typeof obj.rank !== "number" ||
+      !Number.isInteger(obj.rank) ||
+      obj.rank <= 0
+    ) {
+      errors.push({
+        index: i,
+        field: "rank",
+        message: `Adapter at index ${i}: rank must be a positive integer`,
+      });
+    }
+
+    // Validate alpha: positive finite number
+    if (
+      typeof obj.alpha !== "number" ||
+      !Number.isFinite(obj.alpha) ||
+      obj.alpha <= 0
+    ) {
+      errors.push({
+        index: i,
+        field: "alpha",
+        message: `Adapter at index ${i}: alpha must be a positive finite number`,
+      });
+    }
+
+    // Validate targetModules: if present, must be an array of non-empty strings
+    if (obj.targetModules !== undefined) {
+      if (!Array.isArray(obj.targetModules)) {
+        errors.push({
+          index: i,
+          field: "targetModules",
+          message: `Adapter at index ${i}: targetModules must be an array of non-empty strings`,
+        });
+      } else {
+        const allValid = obj.targetModules.every(
+          (m: unknown) => typeof m === "string" && m.length > 0,
+        );
+        if (!allValid) {
+          errors.push({
+            index: i,
+            field: "targetModules",
+            message: `Adapter at index ${i}: targetModules must contain only non-empty strings`,
+          });
+        }
+      }
+    }
+  }
+
+  // Detect and report duplicate names
+  for (const [name, indices] of nameToIndices) {
+    if (indices.length > 1) {
+      errors.push({
+        index: indices[0],
+        field: "name",
+        message: `Duplicate adapter name "${name}" found at indices ${indices.join(", ")}`,
+      });
+    }
+  }
+
+  // Build result
+  if (errors.length > 0) {
+    return { valid: false, errors, adapters: [] };
+  }
+
+  // Parse valid entries
+  const parsed: AdapterEntry[] = adapters.map((entry) => {
+    const obj = entry as Record<string, unknown>;
+    const result: AdapterEntry = {
+      name: obj.name as string,
+      path: obj.path as string,
+      rank: obj.rank as number,
+      alpha: obj.alpha as number,
+    };
+    if (obj.targetModules !== undefined) {
+      result.targetModules = obj.targetModules as string[];
+    }
+    return result;
+  });
+
+  return { valid: true, errors: [], adapters: parsed };
+}

--- a/src/lib/multiLoraValidation.ts
+++ b/src/lib/multiLoraValidation.ts
@@ -72,11 +72,13 @@ const HIGH_VRAM_MAX_ADAPTERS = 8;
  * Returns the maximum number of adapters allowed given the available VRAM.
  *
  * @param vramGb - Available VRAM in gigabytes
- * @returns Maximum adapter count (2 for <= 12 GB, 8 for > 12 GB)
+ * @returns Maximum adapter count (2 for <= 12 GB, 8 for > 12 GB or unknown)
  */
 export function getMaxAdapterCount(vramGb: number): number {
-  // Non-finite values (NaN, Infinity) get the restrictive limit
-  if (!Number.isFinite(vramGb)) return LOW_VRAM_MAX_ADAPTERS;
+  // Unknown / non-finite VRAM: allow the absolute max. Olive recipes do not
+  // persist vramEstimateGb, so import → rebuild must not treat missing VRAM as
+  // <=12 GB and reject otherwise-valid 3–8 adapter configs.
+  if (!Number.isFinite(vramGb)) return HIGH_VRAM_MAX_ADAPTERS;
   return vramGb <= LOW_VRAM_THRESHOLD_GB
     ? LOW_VRAM_MAX_ADAPTERS
     : HIGH_VRAM_MAX_ADAPTERS;
@@ -209,7 +211,7 @@ function parseValidAdapterEntries(adapters: unknown[]): AdapterEntry[] {
  * 3. `rank`: positive integer (> 0, Number.isInteger)
  * 4. `alpha`: positive finite number (> 0, Number.isFinite)
  * 5. `targetModules`: if present, must be an array of non-empty strings
- * 6. Max adapter count: 2 for <= 12 GB VRAM, 8 for > 12 GB VRAM
+ * 6. Max adapter count: 2 for <= 12 GB VRAM, 8 for > 12 GB or unknown VRAM
  * 7. Duplicate name detection: identify both conflicting indices
  *
  * @param adapters - Untyped adapter entries from runtime input
@@ -225,10 +227,15 @@ export function validateAdapters(
 
   // Check adapter count limit
   if (adapters.length > maxCount) {
+    const vramBand = Number.isFinite(vramGb)
+      ? vramGb <= LOW_VRAM_THRESHOLD_GB
+        ? "<= 12"
+        : "> 12"
+      : "unknown";
     errors.push({
       index: -1,
       field: "adapters",
-      message: `Adapter count ${adapters.length} exceeds maximum of ${maxCount} for ${!Number.isFinite(vramGb) || vramGb <= LOW_VRAM_THRESHOLD_GB ? "<= 12" : "> 12"} GB VRAM`,
+      message: `Adapter count ${adapters.length} exceeds maximum of ${maxCount} for ${vramBand} GB VRAM`,
     });
   }
 

--- a/src/lib/oliveRecipeBuilder.ts
+++ b/src/lib/oliveRecipeBuilder.ts
@@ -4,6 +4,8 @@ import { openvinoTargetToOliveDevice } from "@/lib/openvinoDeps";
 import {
   isReplacementExportPipeline,
 } from "@/lib/replacementExportPipeline";
+import { isMultiLoraEnabled } from "@/lib/featureFlags";
+import { validateAdapters, type AdapterEntry } from "@/lib/multiLoraValidation";
 
 const GPU_PROVIDERS: IHVProvider[] = [
   "CUDAExecutionProvider",
@@ -790,9 +792,134 @@ export function buildOliveRecipe(state: UIState): Record<string, unknown> {
   }
 
   // Order: Convert → Optimize → Quantize (ONNX path), then MCP pass overrides
+  // Multi-LoRA adapter gating — when PEFT is active and adapters are configured
+  const passesAny = state.passes as Record<string, unknown>;
+  const multiLoraAdapters = passesAny.multiLoraAdapters;
+  if (state.passes.peft && Array.isArray(multiLoraAdapters) && multiLoraAdapters.length > 0) {
+    const vram = typeof (state as unknown as Record<string, unknown>).vramEstimateGb === "number"
+      ? (state as unknown as Record<string, unknown>).vramEstimateGb as number
+      : 16;
+    const gateResult = gateMultiLoraAdapters(multiLoraAdapters, vram);
+    if (gateResult.allowed && gateResult.adapters.length > 0) {
+      const extractPass = buildExtractAdaptersPass(gateResult.adapters);
+      if (extractPass) {
+        passes["extract_adapters"] = extractPass;
+      }
+    }
+  }
+
   recipe.passes = finalizePasses(passes, state.passRecipeOverrides, torchQuantActive);
 
   memoState = state;
   memoRecipe = recipe;
   return recipe;
+}
+
+// ─── Multi-LoRA Adapter Gating ────────────────────────────────────────────────
+
+/**
+ * Result of adapter gating — either a validated adapters array (when the
+ * multiLora flag is enabled and adapters are valid) or a rejection reason.
+ */
+export interface AdapterGateResult {
+  /** Whether the adapters passed gating and can be emitted in the recipe. */
+  allowed: boolean;
+  /** Validated adapter entries (populated only when `allowed` is true). */
+  adapters: AdapterEntry[];
+  /** Human-readable reason when adapters are rejected. */
+  reason?: string;
+}
+
+/**
+ * Gates multi-adapter configurations based on the `multiLora` feature flag.
+ *
+ * - When the flag is **disabled** (default): rejects any configuration with
+ *   more than one adapter entry. Single-adapter configs are allowed through
+ *   in single-adapter mode (using only `adapter_path`).
+ * - When the flag is **enabled**: validates adapters using `validateAdapters`
+ *   and returns the validated entries for emission in Olive 0.13.0
+ *   `ExtractAdapters` pass format.
+ *
+ * @param adapters - Raw adapter entries from the recipe configuration
+ * @param vramGb - Available VRAM in gigabytes (for count limit enforcement)
+ * @returns Gating result with validated adapters or rejection reason
+ */
+export function gateMultiLoraAdapters(
+  adapters: unknown[],
+  vramGb: number,
+): AdapterGateResult {
+  // When flag is disabled, reject multi-adapter configs
+  if (!isMultiLoraEnabled()) {
+    if (adapters.length > 1) {
+      return {
+        allowed: false,
+        adapters: [],
+        reason:
+          "Multi-adapter configuration rejected: multiLora feature flag is disabled. " +
+          "Use single-adapter mode (adapter_path) or enable the multiLora flag.",
+      };
+    }
+    // Single adapter (or empty) is allowed even with flag off — treated as legacy single-adapter mode
+    if (adapters.length === 1) {
+      const entry = adapters[0];
+      if (entry && typeof entry === "object" && !Array.isArray(entry)) {
+        const obj = entry as Record<string, unknown>;
+        if (typeof obj.path === "string" && obj.path.length > 0) {
+          return {
+            allowed: true,
+            adapters: [{
+              name: (typeof obj.name === "string" && obj.name.length > 0) ? obj.name : "default",
+              path: obj.path,
+              rank: (typeof obj.rank === "number" && Number.isInteger(obj.rank) && obj.rank > 0) ? obj.rank : 8,
+              alpha: (typeof obj.alpha === "number" && Number.isFinite(obj.alpha) && obj.alpha > 0) ? obj.alpha : 16,
+              ...(Array.isArray(obj.targetModules) ? { targetModules: obj.targetModules as string[] } : {}),
+            }],
+            reason: undefined,
+          };
+        }
+      }
+      return {
+        allowed: false,
+        adapters: [],
+        reason: "Invalid single-adapter entry: path must be a non-empty string.",
+      };
+    }
+    // Empty array — nothing to gate
+    return { allowed: true, adapters: [], reason: undefined };
+  }
+
+  // Flag is enabled — validate via multiLoraValidation
+  const result = validateAdapters(adapters, vramGb);
+  if (result.valid) {
+    return { allowed: true, adapters: result.adapters, reason: undefined };
+  }
+
+  return {
+    allowed: false,
+    adapters: [],
+    reason: result.errors.map((e) => e.message).join("; "),
+  };
+}
+
+/**
+ * Builds the `ExtractAdapters` pass config from validated adapter entries.
+ * Only emitted when the `multiLora` feature flag is enabled and adapters are validated.
+ *
+ * @param adapters - Validated adapter entries
+ * @returns Olive 0.13.0 `ExtractAdapters` pass specification, or undefined if empty
+ */
+export function buildExtractAdaptersPass(adapters: AdapterEntry[]): Record<string, unknown> | undefined {
+  if (adapters.length === 0) return undefined;
+  return {
+    type: "ExtractAdapters",
+    config: {
+      adapters: adapters.map((a) => ({
+        name: a.name,
+        path: a.path,
+        rank: a.rank,
+        alpha: a.alpha,
+        ...(a.targetModules ? { target_modules: a.targetModules } : {}),
+      })),
+    },
+  };
 }

--- a/src/lib/oliveRecipeBuilder.ts
+++ b/src/lib/oliveRecipeBuilder.ts
@@ -859,6 +859,27 @@ export interface AdapterGateResult {
  * @returns Gating result with validated adapters or rejection reason
  */
 /**
+ * Last path segment without regex (CodeQL: polynomial regex on uncontrolled paths).
+ * Accepts `/` and `\` separators; strips trailing separators.
+ */
+function basenameFromFsPath(path: string): string {
+  let end = path.length;
+  while (end > 0) {
+    const c = path.charCodeAt(end - 1);
+    if (c !== 47 /* / */ && c !== 92 /* \ */) break;
+    end -= 1;
+  }
+  if (end === 0) return "";
+  let start = end;
+  while (start > 0) {
+    const c = path.charCodeAt(start - 1);
+    if (c === 47 || c === 92) break;
+    start -= 1;
+  }
+  return path.slice(start, end);
+}
+
+/**
  * Normalize a path-bearing adapter entry so MCP path-only payloads and
  * flag-off single-adapter mode share the same name/rank/alpha defaults.
  * Returns null when `path` is missing or empty (still invalid).
@@ -882,7 +903,7 @@ function normalizePathBearingAdapter(
       ? (rawModules as string[])
       : undefined;
 
-  const pathBase = obj.path.replace(/[\\/]+$/, "").split(/[\\/]/).pop() || "";
+  const pathBase = basenameFromFsPath(obj.path);
   const fallbackName = pathBase || (index === 0 ? "default" : `adapter-${index}`);
 
   return {

--- a/src/lib/oliveRecipeBuilder.ts
+++ b/src/lib/oliveRecipeBuilder.ts
@@ -158,14 +158,14 @@ function preferredPassOrder(torchQuantActive: boolean): string[] {
       "peft", "pruning", "quantization", "conversion", "transformer_opt",
       "mobius_builder", "quantize_embedding_int8", "share_embedding_lm_head",
       "simplified_layer_norm_to_rms_norm", "float16", "splitting",
-      "qairt_pipeline", "onnx_discrepancy_check",
+      "qairt_pipeline", "extract_adapters", "onnx_discrepancy_check",
     ];
   }
   return [
     "peft", "pruning", "conversion", "transformer_opt", "quantization",
     "mobius_builder", "quantize_embedding_int8", "share_embedding_lm_head",
     "simplified_layer_norm_to_rms_norm", "float16", "splitting",
-    "qairt_pipeline", "onnx_discrepancy_check",
+    "qairt_pipeline", "extract_adapters", "onnx_discrepancy_check",
   ];
 }
 
@@ -791,16 +791,20 @@ export function buildOliveRecipe(state: UIState): Record<string, unknown> {
     };
   }
 
-  // Order: Convert → Optimize → Quantize (ONNX path), then MCP pass overrides
-  // Multi-LoRA adapter gating — when PEFT is active and adapters are configured
-  const passesAny = state.passes as Record<string, unknown>;
-  const multiLoraAdapters = passesAny.multiLoraAdapters;
+  // Multi-LoRA adapter gating — PEFT + UIState.multiLoraAdapters
+  const multiLoraAdapters = state.multiLoraAdapters;
   if (state.passes.peft && Array.isArray(multiLoraAdapters) && multiLoraAdapters.length > 0) {
-    const vram = typeof (state as unknown as Record<string, unknown>).vramEstimateGb === "number"
-      ? (state as unknown as Record<string, unknown>).vramEstimateGb as number
+    const vram = typeof state.vramEstimateGb === "number" && Number.isFinite(state.vramEstimateGb)
+      ? state.vramEstimateGb
       : 16;
     const gateResult = gateMultiLoraAdapters(multiLoraAdapters, vram);
-    if (gateResult.allowed && gateResult.adapters.length > 0) {
+    if (!gateResult.allowed) {
+      throw new Error(
+        `Multi-LoRA adapter configuration rejected: ${gateResult.reason ?? "invalid adapter configuration"}`,
+      );
+    }
+    // ExtractAdapters is experimental and only emitted when the feature flag is on.
+    if (isMultiLoraEnabled() && gateResult.adapters.length > 0) {
       const extractPass = buildExtractAdaptersPass(gateResult.adapters);
       if (extractPass) {
         passes["extract_adapters"] = extractPass;

--- a/src/lib/oliveRecipeBuilder.ts
+++ b/src/lib/oliveRecipeBuilder.ts
@@ -879,6 +879,33 @@ function basenameFromFsPath(path: string): string {
   return path.slice(start, end);
 }
 
+function readOptionalTargetModules(obj: Record<string, unknown>): string[] | undefined {
+  const rawModules = Array.isArray(obj.targetModules)
+    ? obj.targetModules
+    : Array.isArray(obj.target_modules)
+      ? obj.target_modules
+      : undefined;
+  if (
+    !Array.isArray(rawModules) ||
+    !rawModules.every((m): m is string => typeof m === "string" && m.length > 0)
+  ) {
+    return undefined;
+  }
+  return rawModules;
+}
+
+function resolveAdapterFallbackName(path: string, index: number): string {
+  return basenameFromFsPath(path) || (index === 0 ? "default" : `adapter-${index}`);
+}
+
+function resolvePositiveInt(value: unknown, fallback: number): number {
+  return typeof value === "number" && Number.isInteger(value) && value > 0 ? value : fallback;
+}
+
+function resolvePositiveFinite(value: unknown, fallback: number): number {
+  return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : fallback;
+}
+
 /**
  * Normalize a path-bearing adapter entry so MCP path-only payloads and
  * flag-off single-adapter mode share the same name/rank/alpha defaults.
@@ -892,32 +919,15 @@ function normalizePathBearingAdapter(
   const obj = entry as Record<string, unknown>;
   if (typeof obj.path !== "string" || obj.path.length === 0) return null;
 
-  const rawModules = Array.isArray(obj.targetModules)
-    ? obj.targetModules
-    : Array.isArray(obj.target_modules)
-      ? obj.target_modules
-      : undefined;
-  const targetModules =
-    Array.isArray(rawModules) &&
-    rawModules.every((m): m is string => typeof m === "string" && m.length > 0)
-      ? (rawModules as string[])
-      : undefined;
-
-  const pathBase = basenameFromFsPath(obj.path);
-  const fallbackName = pathBase || (index === 0 ? "default" : `adapter-${index}`);
+  const targetModules = readOptionalTargetModules(obj);
+  const fallbackName = resolveAdapterFallbackName(obj.path, index);
 
   return {
     name:
       typeof obj.name === "string" && obj.name.length > 0 ? obj.name : fallbackName,
     path: obj.path,
-    rank:
-      typeof obj.rank === "number" && Number.isInteger(obj.rank) && obj.rank > 0
-        ? obj.rank
-        : 8,
-    alpha:
-      typeof obj.alpha === "number" && Number.isFinite(obj.alpha) && obj.alpha > 0
-        ? obj.alpha
-        : 16,
+    rank: resolvePositiveInt(obj.rank, 8),
+    alpha: resolvePositiveFinite(obj.alpha, 16),
     ...(targetModules ? { targetModules } : {}),
   };
 }

--- a/src/lib/oliveRecipeBuilder.ts
+++ b/src/lib/oliveRecipeBuilder.ts
@@ -898,37 +898,67 @@ function resolveAdapterFallbackName(path: string, index: number): string {
   return basenameFromFsPath(path) || (index === 0 ? "default" : `adapter-${index}`);
 }
 
-function resolvePositiveInt(value: unknown, fallback: number): number {
-  return typeof value === "number" && Number.isInteger(value) && value > 0 ? value : fallback;
-}
-
-function resolvePositiveFinite(value: unknown, fallback: number): number {
-  return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : fallback;
-}
+type NormalizeAdapterResult =
+  | { ok: true; adapter: AdapterEntry }
+  | { ok: false; reason: string };
 
 /**
  * Normalize a path-bearing adapter entry so MCP path-only payloads and
  * flag-off single-adapter mode share the same name/rank/alpha defaults.
- * Returns null when `path` is missing or empty (still invalid).
+ *
+ * Missing optional fields get defaults. Present-but-invalid rank/alpha/
+ * targetModules are rejected so callers cannot silently rewrite bad values.
  */
 function normalizePathBearingAdapter(
   entry: unknown,
   index: number,
-): AdapterEntry | null {
-  if (!entry || typeof entry !== "object" || Array.isArray(entry)) return null;
+): NormalizeAdapterResult {
+  if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+    return { ok: false, reason: "Adapter entry must be a non-null object." };
+  }
   const obj = entry as Record<string, unknown>;
-  if (typeof obj.path !== "string" || obj.path.length === 0) return null;
+  if (typeof obj.path !== "string" || obj.path.length === 0) {
+    return { ok: false, reason: "path must be a non-empty string." };
+  }
 
+  const hasTargetModulesKey = "targetModules" in obj || "target_modules" in obj;
   const targetModules = readOptionalTargetModules(obj);
-  const fallbackName = resolveAdapterFallbackName(obj.path, index);
+  if (hasTargetModulesKey && targetModules === undefined) {
+    return {
+      ok: false,
+      reason: "targetModules must be an array of non-empty strings.",
+    };
+  }
 
+  let rank: number;
+  if (obj.rank === undefined) {
+    rank = 8;
+  } else if (typeof obj.rank === "number" && Number.isInteger(obj.rank) && obj.rank > 0) {
+    rank = obj.rank;
+  } else {
+    return { ok: false, reason: "rank must be a positive integer." };
+  }
+
+  let alpha: number;
+  if (obj.alpha === undefined) {
+    alpha = 16;
+  } else if (typeof obj.alpha === "number" && Number.isFinite(obj.alpha) && obj.alpha > 0) {
+    alpha = obj.alpha;
+  } else {
+    return { ok: false, reason: "alpha must be a positive finite number." };
+  }
+
+  const fallbackName = resolveAdapterFallbackName(obj.path, index);
   return {
-    name:
-      typeof obj.name === "string" && obj.name.length > 0 ? obj.name : fallbackName,
-    path: obj.path,
-    rank: resolvePositiveInt(obj.rank, 8),
-    alpha: resolvePositiveFinite(obj.alpha, 16),
-    ...(targetModules ? { targetModules } : {}),
+    ok: true,
+    adapter: {
+      name:
+        typeof obj.name === "string" && obj.name.length > 0 ? obj.name : fallbackName,
+      path: obj.path,
+      rank,
+      alpha,
+      ...(targetModules ? { targetModules } : {}),
+    },
   };
 }
 
@@ -950,13 +980,13 @@ export function gateMultiLoraAdapters(
     // Single adapter (or empty) is allowed even with flag off — treated as legacy single-adapter mode
     if (adapters.length === 1) {
       const normalized = normalizePathBearingAdapter(adapters[0], 0);
-      if (normalized) {
-        return { allowed: true, adapters: [normalized], reason: undefined };
+      if (normalized.ok) {
+        return { allowed: true, adapters: [normalized.adapter], reason: undefined };
       }
       return {
         allowed: false,
         adapters: [],
-        reason: "Invalid single-adapter entry: path must be a non-empty string.",
+        reason: `Invalid single-adapter entry: ${normalized.reason}`,
       };
     }
     // Empty array — nothing to gate
@@ -966,10 +996,29 @@ export function gateMultiLoraAdapters(
   // Flag is enabled — normalize path-only MCP bridge entries, then validate.
   // Path-only payloads are accepted by the bridge; apply the same defaults as
   // flag-off mode so evaluate/build do not reject otherwise usable adapters.
-  const normalized = adapters.map((entry, i) => {
-    const withDefaults = normalizePathBearingAdapter(entry, i);
-    return withDefaults ?? entry;
-  });
+  const normalized: unknown[] = [];
+  for (let i = 0; i < adapters.length; i += 1) {
+    const withDefaults = normalizePathBearingAdapter(adapters[i], i);
+    if (!withDefaults.ok) {
+      // Missing path / non-object: let validateAdapters report the raw entry.
+      // Present-but-invalid rank/alpha/targetModules: reject here so defaults
+      // cannot mask the caller's bad values.
+      if (
+        withDefaults.reason.includes("rank") ||
+        withDefaults.reason.includes("alpha") ||
+        withDefaults.reason.includes("targetModules")
+      ) {
+        return {
+          allowed: false,
+          adapters: [],
+          reason: `Adapter at index ${i}: ${withDefaults.reason}`,
+        };
+      }
+      normalized.push(adapters[i]);
+      continue;
+    }
+    normalized.push(withDefaults.adapter);
+  }
   const result = validateAdapters(normalized, vramGb);
   if (result.valid) {
     return { allowed: true, adapters: result.adapters, reason: undefined };

--- a/src/lib/oliveRecipeBuilder.ts
+++ b/src/lib/oliveRecipeBuilder.ts
@@ -858,6 +858,49 @@ export interface AdapterGateResult {
  * @param vramGb - Available VRAM in gigabytes (for count limit enforcement)
  * @returns Gating result with validated adapters or rejection reason
  */
+/**
+ * Normalize a path-bearing adapter entry so MCP path-only payloads and
+ * flag-off single-adapter mode share the same name/rank/alpha defaults.
+ * Returns null when `path` is missing or empty (still invalid).
+ */
+function normalizePathBearingAdapter(
+  entry: unknown,
+  index: number,
+): AdapterEntry | null {
+  if (!entry || typeof entry !== "object" || Array.isArray(entry)) return null;
+  const obj = entry as Record<string, unknown>;
+  if (typeof obj.path !== "string" || obj.path.length === 0) return null;
+
+  const rawModules = Array.isArray(obj.targetModules)
+    ? obj.targetModules
+    : Array.isArray(obj.target_modules)
+      ? obj.target_modules
+      : undefined;
+  const targetModules =
+    Array.isArray(rawModules) &&
+    rawModules.every((m): m is string => typeof m === "string" && m.length > 0)
+      ? (rawModules as string[])
+      : undefined;
+
+  const pathBase = obj.path.replace(/[\\/]+$/, "").split(/[\\/]/).pop() || "";
+  const fallbackName = pathBase || (index === 0 ? "default" : `adapter-${index}`);
+
+  return {
+    name:
+      typeof obj.name === "string" && obj.name.length > 0 ? obj.name : fallbackName,
+    path: obj.path,
+    rank:
+      typeof obj.rank === "number" && Number.isInteger(obj.rank) && obj.rank > 0
+        ? obj.rank
+        : 8,
+    alpha:
+      typeof obj.alpha === "number" && Number.isFinite(obj.alpha) && obj.alpha > 0
+        ? obj.alpha
+        : 16,
+    ...(targetModules ? { targetModules } : {}),
+  };
+}
+
 export function gateMultiLoraAdapters(
   adapters: unknown[],
   vramGb: number,
@@ -875,22 +918,9 @@ export function gateMultiLoraAdapters(
     }
     // Single adapter (or empty) is allowed even with flag off — treated as legacy single-adapter mode
     if (adapters.length === 1) {
-      const entry = adapters[0];
-      if (entry && typeof entry === "object" && !Array.isArray(entry)) {
-        const obj = entry as Record<string, unknown>;
-        if (typeof obj.path === "string" && obj.path.length > 0) {
-          return {
-            allowed: true,
-            adapters: [{
-              name: (typeof obj.name === "string" && obj.name.length > 0) ? obj.name : "default",
-              path: obj.path,
-              rank: (typeof obj.rank === "number" && Number.isInteger(obj.rank) && obj.rank > 0) ? obj.rank : 8,
-              alpha: (typeof obj.alpha === "number" && Number.isFinite(obj.alpha) && obj.alpha > 0) ? obj.alpha : 16,
-              ...(Array.isArray(obj.targetModules) ? { targetModules: obj.targetModules as string[] } : {}),
-            }],
-            reason: undefined,
-          };
-        }
+      const normalized = normalizePathBearingAdapter(adapters[0], 0);
+      if (normalized) {
+        return { allowed: true, adapters: [normalized], reason: undefined };
       }
       return {
         allowed: false,
@@ -902,8 +932,14 @@ export function gateMultiLoraAdapters(
     return { allowed: true, adapters: [], reason: undefined };
   }
 
-  // Flag is enabled — validate via multiLoraValidation
-  const result = validateAdapters(adapters, vramGb);
+  // Flag is enabled — normalize path-only MCP bridge entries, then validate.
+  // Path-only payloads are accepted by the bridge; apply the same defaults as
+  // flag-off mode so evaluate/build do not reject otherwise usable adapters.
+  const normalized = adapters.map((entry, i) => {
+    const withDefaults = normalizePathBearingAdapter(entry, i);
+    return withDefaults ?? entry;
+  });
+  const result = validateAdapters(normalized, vramGb);
   if (result.valid) {
     return { allowed: true, adapters: result.adapters, reason: undefined };
   }

--- a/src/lib/oliveRecipeBuilder.ts
+++ b/src/lib/oliveRecipeBuilder.ts
@@ -158,14 +158,14 @@ function preferredPassOrder(torchQuantActive: boolean): string[] {
       "peft", "pruning", "quantization", "conversion", "transformer_opt",
       "mobius_builder", "quantize_embedding_int8", "share_embedding_lm_head",
       "simplified_layer_norm_to_rms_norm", "float16", "splitting",
-      "qairt_pipeline", "extract_adapters", "onnx_discrepancy_check",
+      "qairt_pipeline", "onnx_discrepancy_check",
     ];
   }
   return [
     "peft", "pruning", "conversion", "transformer_opt", "quantization",
     "mobius_builder", "quantize_embedding_int8", "share_embedding_lm_head",
     "simplified_layer_norm_to_rms_norm", "float16", "splitting",
-    "qairt_pipeline", "extract_adapters", "onnx_discrepancy_check",
+    "qairt_pipeline", "onnx_discrepancy_check",
   ];
 }
 
@@ -791,23 +791,24 @@ export function buildOliveRecipe(state: UIState): Record<string, unknown> {
     };
   }
 
-  // Multi-LoRA adapter gating — PEFT + UIState.multiLoraAdapters
-  const multiLoraAdapters = state.multiLoraAdapters;
+  // Order: Convert → Optimize → Quantize (ONNX path), then MCP pass overrides
+  // Multi-LoRA adapter gating — when PEFT is active and adapters are configured
+  const passesAny = state.passes as Record<string, unknown>;
+  const multiLoraAdapters = passesAny.multiLoraAdapters;
   if (state.passes.peft && Array.isArray(multiLoraAdapters) && multiLoraAdapters.length > 0) {
-    const vram = typeof state.vramEstimateGb === "number" && Number.isFinite(state.vramEstimateGb)
-      ? state.vramEstimateGb
-      : 16;
+    const vram = typeof (state as unknown as Record<string, unknown>).vramEstimateGb === "number"
+      ? (state as unknown as Record<string, unknown>).vramEstimateGb as number
+      : Number.NaN;
     const gateResult = gateMultiLoraAdapters(multiLoraAdapters, vram);
-    if (!gateResult.allowed) {
-      throw new Error(
-        `Multi-LoRA adapter configuration rejected: ${gateResult.reason ?? "invalid adapter configuration"}`,
-      );
-    }
-    // ExtractAdapters is experimental and only emitted when the feature flag is on.
-    if (isMultiLoraEnabled() && gateResult.adapters.length > 0) {
-      const extractPass = buildExtractAdaptersPass(gateResult.adapters);
-      if (extractPass) {
-        passes["extract_adapters"] = extractPass;
+    if (gateResult.allowed && gateResult.adapters.length > 0) {
+      if (isMultiLoraEnabled()) {
+        const extractPass = buildExtractAdaptersPass(gateResult.adapters);
+        if (extractPass) {
+          passes["extract_adapters"] = extractPass;
+        }
+      } else {
+        // Feature-off single-adapter configurations use Olive's legacy field.
+        inputConfig.adapter_path = gateResult.adapters[0].path;
       }
     }
   }

--- a/src/lib/oliveRecipeBuilder.ts
+++ b/src/lib/oliveRecipeBuilder.ts
@@ -793,19 +793,28 @@ export function buildOliveRecipe(state: UIState): Record<string, unknown> {
 
   // Order: Convert → Optimize → Quantize (ONNX path), then MCP pass overrides
   // Multi-LoRA adapter gating — when PEFT is active and adapters are configured
-  const passesAny = state.passes as Record<string, unknown>;
-  const multiLoraAdapters = passesAny.multiLoraAdapters;
+  const multiLoraAdapters = state.multiLoraAdapters;
   if (state.passes.peft && Array.isArray(multiLoraAdapters) && multiLoraAdapters.length > 0) {
-    const vram = typeof (state as unknown as Record<string, unknown>).vramEstimateGb === "number"
-      ? (state as unknown as Record<string, unknown>).vramEstimateGb as number
-      : Number.NaN;
+    const vram = typeof state.vramEstimateGb === "number" ? state.vramEstimateGb : Number.NaN;
     const gateResult = gateMultiLoraAdapters(multiLoraAdapters, vram);
-    if (gateResult.allowed && gateResult.adapters.length > 0) {
+    if (!gateResult.allowed) {
+      throw new Error(
+        `Multi-LoRA adapter configuration rejected: ${gateResult.reason ?? "invalid adapter configuration"}`,
+      );
+    }
+    if (gateResult.adapters.length > 0) {
       if (isMultiLoraEnabled()) {
         const extractPass = buildExtractAdaptersPass(gateResult.adapters);
         if (extractPass) {
           passes["extract_adapters"] = extractPass;
         }
+        (recipe as Record<string, unknown>).adapters = gateResult.adapters.map((a) => ({
+          name: a.name,
+          path: a.path,
+          rank: a.rank,
+          alpha: a.alpha,
+          ...(a.targetModules ? { target_modules: a.targetModules } : {}),
+        }));
       } else {
         // Feature-off single-adapter configurations use Olive's legacy field.
         inputConfig.adapter_path = gateResult.adapters[0].path;
@@ -915,16 +924,13 @@ export function gateMultiLoraAdapters(
  */
 export function buildExtractAdaptersPass(adapters: AdapterEntry[]): Record<string, unknown> | undefined {
   if (adapters.length === 0) return undefined;
+  // Olive ExtractAdapters unwraps adapters already embedded in ONNX.
+  // Multi-adapter switching is recipe-level `adapters[]`, not this pass config.
   return {
     type: "ExtractAdapters",
     config: {
-      adapters: adapters.map((a) => ({
-        name: a.name,
-        path: a.path,
-        rank: a.rank,
-        alpha: a.alpha,
-        ...(a.targetModules ? { target_modules: a.targetModules } : {}),
-      })),
+      adapter_type: "lora",
+      make_inputs: true,
     },
   };
 }

--- a/src/lib/oliveRecipeBuilder.ts
+++ b/src/lib/oliveRecipeBuilder.ts
@@ -902,6 +902,44 @@ type NormalizeAdapterResult =
   | { ok: true; adapter: AdapterEntry }
   | { ok: false; reason: string };
 
+type ResolveFieldResult<T> = { ok: true; value: T } | { ok: false; reason: string };
+
+/** Missing rank defaults to 8; present-but-invalid rank is rejected. */
+function resolveAdapterRank(value: unknown): ResolveFieldResult<number> {
+  if (value === undefined) return { ok: true, value: 8 };
+  if (typeof value === "number" && Number.isInteger(value) && value > 0) {
+    return { ok: true, value };
+  }
+  return { ok: false, reason: "rank must be a positive integer." };
+}
+
+/** Missing alpha defaults to 16; present-but-invalid alpha is rejected. */
+function resolveAdapterAlpha(value: unknown): ResolveFieldResult<number> {
+  if (value === undefined) return { ok: true, value: 16 };
+  if (typeof value === "number" && Number.isFinite(value) && value > 0) {
+    return { ok: true, value };
+  }
+  return { ok: false, reason: "alpha must be a positive finite number." };
+}
+
+/**
+ * Absent targetModules/target_modules is fine. If either key is present, the
+ * value must be a non-empty-string array (or we reject).
+ */
+function resolveAdapterTargetModules(
+  obj: Record<string, unknown>,
+): ResolveFieldResult<string[] | undefined> {
+  const hasTargetModulesKey = "targetModules" in obj || "target_modules" in obj;
+  const targetModules = readOptionalTargetModules(obj);
+  if (hasTargetModulesKey && targetModules === undefined) {
+    return {
+      ok: false,
+      reason: "targetModules must be an array of non-empty strings.",
+    };
+  }
+  return { ok: true, value: targetModules };
+}
+
 /**
  * Normalize a path-bearing adapter entry so MCP path-only payloads and
  * flag-off single-adapter mode share the same name/rank/alpha defaults.
@@ -921,32 +959,14 @@ function normalizePathBearingAdapter(
     return { ok: false, reason: "path must be a non-empty string." };
   }
 
-  const hasTargetModulesKey = "targetModules" in obj || "target_modules" in obj;
-  const targetModules = readOptionalTargetModules(obj);
-  if (hasTargetModulesKey && targetModules === undefined) {
-    return {
-      ok: false,
-      reason: "targetModules must be an array of non-empty strings.",
-    };
-  }
+  const targetModules = resolveAdapterTargetModules(obj);
+  if (!targetModules.ok) return targetModules;
 
-  let rank: number;
-  if (obj.rank === undefined) {
-    rank = 8;
-  } else if (typeof obj.rank === "number" && Number.isInteger(obj.rank) && obj.rank > 0) {
-    rank = obj.rank;
-  } else {
-    return { ok: false, reason: "rank must be a positive integer." };
-  }
+  const rank = resolveAdapterRank(obj.rank);
+  if (!rank.ok) return rank;
 
-  let alpha: number;
-  if (obj.alpha === undefined) {
-    alpha = 16;
-  } else if (typeof obj.alpha === "number" && Number.isFinite(obj.alpha) && obj.alpha > 0) {
-    alpha = obj.alpha;
-  } else {
-    return { ok: false, reason: "alpha must be a positive finite number." };
-  }
+  const alpha = resolveAdapterAlpha(obj.alpha);
+  if (!alpha.ok) return alpha;
 
   const fallbackName = resolveAdapterFallbackName(obj.path, index);
   return {
@@ -955,9 +975,9 @@ function normalizePathBearingAdapter(
       name:
         typeof obj.name === "string" && obj.name.length > 0 ? obj.name : fallbackName,
       path: obj.path,
-      rank,
-      alpha,
-      ...(targetModules ? { targetModules } : {}),
+      rank: rank.value,
+      alpha: alpha.value,
+      ...(targetModules.value ? { targetModules: targetModules.value } : {}),
     },
   };
 }

--- a/src/lib/oliveRecipeHub.ts
+++ b/src/lib/oliveRecipeHub.ts
@@ -81,6 +81,10 @@ function isStringArray(value: unknown): value is string[] {
   return Array.isArray(value) && value.every((entry) => typeof entry === "string");
 }
 
+function readNonEmptyString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
 function readOptionalRecipeTargetModules(
   item: Record<string, unknown>,
 ): string[] | undefined {
@@ -121,35 +125,44 @@ type RecipeAdaptersParseResult =
   | { ok: true; adapters?: UIState["multiLoraAdapters"] }
   | { ok: false; reason: string };
 
+type RecipeOptionalNumberResult =
+  | { ok: true; value?: number }
+  | { ok: false; reason: string };
+
+/** Absent rank is omitted. Present-but-invalid rank is rejected. */
+function parseRecipeAdapterRank(item: Record<string, unknown>): RecipeOptionalNumberResult {
+  if (!("rank" in item)) return { ok: true, value: undefined };
+  const value = item.rank;
+  if (typeof value === "number" && Number.isInteger(value) && value > 0) {
+    return { ok: true, value };
+  }
+  return { ok: false, reason: "rank must be a positive integer" };
+}
+
+/** Absent alpha is omitted. Present-but-invalid alpha is rejected. */
+function parseRecipeAdapterAlpha(item: Record<string, unknown>): RecipeOptionalNumberResult {
+  if (!("alpha" in item)) return { ok: true, value: undefined };
+  const value = item.alpha;
+  if (typeof value === "number" && Number.isFinite(value) && value > 0) {
+    return { ok: true, value };
+  }
+  return { ok: false, reason: "alpha must be a positive finite number" };
+}
+
 /**
  * Parse one recipe `adapters[]` entry into UIState MultiLoRA shape.
  * Absent rank/alpha/targetModules stay omitted (builder defaults). Present-but-invalid
  * values are rejected so import cannot silently rewrite adapter parameters.
  */
 function parseRecipeAdapterEntry(item: Record<string, unknown>): RecipeAdapterParseResult {
-  const path =
-    typeof item.path === "string" && item.path.length > 0 ? item.path : undefined;
+  const path = readNonEmptyString(item.path);
   if (!path) return { ok: false, reason: "path must be a non-empty string" };
 
-  const name =
-    typeof item.name === "string" && item.name.length > 0 ? item.name : undefined;
-
-  let rank: number | undefined;
-  if ("rank" in item) {
-    if (!(typeof item.rank === "number" && Number.isInteger(item.rank) && item.rank > 0)) {
-      return { ok: false, reason: "rank must be a positive integer" };
-    }
-    rank = item.rank;
-  }
-
-  let alpha: number | undefined;
-  if ("alpha" in item) {
-    if (!(typeof item.alpha === "number" && Number.isFinite(item.alpha) && item.alpha > 0)) {
-      return { ok: false, reason: "alpha must be a positive finite number" };
-    }
-    alpha = item.alpha;
-  }
-
+  const name = readNonEmptyString(item.name);
+  const rankResult = parseRecipeAdapterRank(item);
+  if (!rankResult.ok) return rankResult;
+  const alphaResult = parseRecipeAdapterAlpha(item);
+  if (!alphaResult.ok) return alphaResult;
   const targetModulesResult = parseRecipeAdapterTargetModules(item);
   if (!targetModulesResult.ok) return targetModulesResult;
 
@@ -158,8 +171,8 @@ function parseRecipeAdapterEntry(item: Record<string, unknown>): RecipeAdapterPa
     adapter: {
       path,
       ...(name ? { name } : {}),
-      ...(rank !== undefined ? { rank } : {}),
-      ...(alpha !== undefined ? { alpha } : {}),
+      ...(rankResult.value !== undefined ? { rank: rankResult.value } : {}),
+      ...(alphaResult.value !== undefined ? { alpha: alphaResult.value } : {}),
       ...(targetModulesResult.modules ? { targetModules: targetModulesResult.modules } : {}),
     },
   };
@@ -168,10 +181,7 @@ function parseRecipeAdapterEntry(item: Record<string, unknown>): RecipeAdapterPa
 function legacyAdapterPathFromInput(
   inputConfig: Record<string, unknown>,
 ): UIState["multiLoraAdapters"] | undefined {
-  const adapterPath =
-    typeof inputConfig.adapter_path === "string" && inputConfig.adapter_path.length > 0
-      ? inputConfig.adapter_path
-      : undefined;
+  const adapterPath = readNonEmptyString(inputConfig.adapter_path);
   return adapterPath ? [{ path: adapterPath }] : undefined;
 }
 

--- a/src/lib/oliveRecipeHub.ts
+++ b/src/lib/oliveRecipeHub.ts
@@ -98,37 +98,54 @@ function readOptionalRecipeTargetModules(
   return rawModules;
 }
 
+type RecipeAdapterParseResult =
+  | { ok: true; adapter: NonNullable<UIState["multiLoraAdapters"]>[number] | null }
+  | { ok: false; reason: string };
+
+type RecipeAdaptersParseResult =
+  | { ok: true; adapters?: UIState["multiLoraAdapters"] }
+  | { ok: false; reason: string };
+
 /**
  * Parse one recipe `adapters[]` entry into UIState MultiLoRA shape.
- * Rank/alpha must already satisfy builder rules; present-but-invalid values are
- * dropped so import does not leave workspace state that fails on rebuild.
+ * Absent rank/alpha stay omitted (builder defaults). Present-but-invalid values
+ * are rejected so import cannot silently rewrite adapter parameters.
  */
-function parseRecipeAdapterEntry(
-  item: Record<string, unknown>,
-): NonNullable<UIState["multiLoraAdapters"]>[number] | null {
+function parseRecipeAdapterEntry(item: Record<string, unknown>): RecipeAdapterParseResult {
   const path =
     typeof item.path === "string" && item.path.length > 0 ? item.path : undefined;
-  if (!path) return null;
+  if (!path) return { ok: true, adapter: null };
 
   const name =
     typeof item.name === "string" && item.name.length > 0 ? item.name : undefined;
-  // Match oliveRecipeBuilder: positive integer rank, positive finite alpha.
-  const rank =
-    typeof item.rank === "number" && Number.isInteger(item.rank) && item.rank > 0
-      ? item.rank
-      : undefined;
-  const alpha =
-    typeof item.alpha === "number" && Number.isFinite(item.alpha) && item.alpha > 0
-      ? item.alpha
-      : undefined;
+
+  let rank: number | undefined;
+  if ("rank" in item) {
+    if (!(typeof item.rank === "number" && Number.isInteger(item.rank) && item.rank > 0)) {
+      return { ok: false, reason: "rank must be a positive integer" };
+    }
+    rank = item.rank;
+  }
+
+  let alpha: number | undefined;
+  if ("alpha" in item) {
+    if (!(typeof item.alpha === "number" && Number.isFinite(item.alpha) && item.alpha > 0)) {
+      return { ok: false, reason: "alpha must be a positive finite number" };
+    }
+    alpha = item.alpha;
+  }
+
   const targetModules = readOptionalRecipeTargetModules(item);
 
   return {
-    path,
-    ...(name ? { name } : {}),
-    ...(rank !== undefined ? { rank } : {}),
-    ...(alpha !== undefined ? { alpha } : {}),
-    ...(targetModules ? { targetModules } : {}),
+    ok: true,
+    adapter: {
+      path,
+      ...(name ? { name } : {}),
+      ...(rank !== undefined ? { rank } : {}),
+      ...(alpha !== undefined ? { alpha } : {}),
+      ...(targetModules ? { targetModules } : {}),
+    },
   };
 }
 
@@ -148,19 +165,20 @@ function legacyAdapterPathFromInput(
 function parseMultiLoraAdaptersFromRecipe(
   recipe: Record<string, unknown> | undefined,
   inputConfig: Record<string, unknown>,
-): UIState["multiLoraAdapters"] | undefined {
+): RecipeAdaptersParseResult {
   const rawAdapters = recipe?.adapters;
   if (Array.isArray(rawAdapters) && rawAdapters.length > 0) {
     const out: NonNullable<UIState["multiLoraAdapters"]> = [];
     for (const item of rawAdapters) {
       if (!isRecord(item)) continue;
       const parsed = parseRecipeAdapterEntry(item);
-      if (parsed) out.push(parsed);
+      if (!parsed.ok) return parsed;
+      if (parsed.adapter) out.push(parsed.adapter);
     }
-    if (out.length > 0) return out;
+    if (out.length > 0) return { ok: true, adapters: out };
   }
 
-  return legacyAdapterPathFromInput(inputConfig);
+  return { ok: true, adapters: legacyAdapterPathFromInput(inputConfig) };
 }
 
 /**
@@ -680,6 +698,7 @@ function mapPassesFromRecipe(recipePasses: Record<string, unknown>): UIState["pa
  * @param parsed - The parsed Olive recipe.
  * @param options - Options controlling whether mapped passes replace or merge with existing passes.
  * @returns The UI state values derived from the recipe.
+ * @throws {Error} When recipe adapters include present-but-invalid rank or alpha.
  */
 export function deriveUiStateFromOliveRecipe(parsed: unknown, options?: DeriveUiStateOptions): Partial<UIState> {
   const recipe = isRecord(parsed) ? parsed : undefined;
@@ -757,9 +776,12 @@ export function deriveUiStateFromOliveRecipe(parsed: unknown, options?: DeriveUi
     }
   }
 
-  const adapters = parseMultiLoraAdaptersFromRecipe(recipe, icfg);
-  if (adapters) {
-    incomingState.multiLoraAdapters = adapters;
+  const adaptersResult = parseMultiLoraAdaptersFromRecipe(recipe, icfg);
+  if (!adaptersResult.ok) {
+    throw new Error(`Multi-LoRA adapter import rejected: ${adaptersResult.reason}`);
+  }
+  if (adaptersResult.adapters) {
+    incomingState.multiLoraAdapters = adaptersResult.adapters;
     const basePasses = incomingState.passes ?? options?.basePasses ?? DEFAULT_PASSES;
     incomingState.passes = {
       ...basePasses,

--- a/src/lib/oliveRecipeHub.ts
+++ b/src/lib/oliveRecipeHub.ts
@@ -129,7 +129,7 @@ type RecipeAdaptersParseResult =
 function parseRecipeAdapterEntry(item: Record<string, unknown>): RecipeAdapterParseResult {
   const path =
     typeof item.path === "string" && item.path.length > 0 ? item.path : undefined;
-  if (!path) return { ok: true, adapter: null };
+  if (!path) return { ok: false, reason: "path must be a non-empty string" };
 
   const name =
     typeof item.name === "string" && item.name.length > 0 ? item.name : undefined;

--- a/src/lib/oliveRecipeHub.ts
+++ b/src/lib/oliveRecipeHub.ts
@@ -98,6 +98,21 @@ function readOptionalRecipeTargetModules(
   return rawModules;
 }
 
+/**
+ * Absent targetModules/target_modules is fine. If either key is present, the
+ * value must be an array of non-empty strings (or we reject).
+ */
+function parseRecipeAdapterTargetModules(
+  item: Record<string, unknown>,
+): { ok: true; modules?: string[] } | { ok: false; reason: string } {
+  const hasTargetModulesKey = "targetModules" in item || "target_modules" in item;
+  const targetModules = readOptionalRecipeTargetModules(item);
+  if (hasTargetModulesKey && targetModules === undefined) {
+    return { ok: false, reason: "targetModules must be an array of non-empty strings" };
+  }
+  return { ok: true, modules: targetModules };
+}
+
 type RecipeAdapterParseResult =
   | { ok: true; adapter: NonNullable<UIState["multiLoraAdapters"]>[number] | null }
   | { ok: false; reason: string };
@@ -108,8 +123,8 @@ type RecipeAdaptersParseResult =
 
 /**
  * Parse one recipe `adapters[]` entry into UIState MultiLoRA shape.
- * Absent rank/alpha stay omitted (builder defaults). Present-but-invalid values
- * are rejected so import cannot silently rewrite adapter parameters.
+ * Absent rank/alpha/targetModules stay omitted (builder defaults). Present-but-invalid
+ * values are rejected so import cannot silently rewrite adapter parameters.
  */
 function parseRecipeAdapterEntry(item: Record<string, unknown>): RecipeAdapterParseResult {
   const path =
@@ -135,7 +150,8 @@ function parseRecipeAdapterEntry(item: Record<string, unknown>): RecipeAdapterPa
     alpha = item.alpha;
   }
 
-  const targetModules = readOptionalRecipeTargetModules(item);
+  const targetModulesResult = parseRecipeAdapterTargetModules(item);
+  if (!targetModulesResult.ok) return targetModulesResult;
 
   return {
     ok: true,
@@ -144,7 +160,7 @@ function parseRecipeAdapterEntry(item: Record<string, unknown>): RecipeAdapterPa
       ...(name ? { name } : {}),
       ...(rank !== undefined ? { rank } : {}),
       ...(alpha !== undefined ? { alpha } : {}),
-      ...(targetModules ? { targetModules } : {}),
+      ...(targetModulesResult.modules ? { targetModules: targetModulesResult.modules } : {}),
     },
   };
 }
@@ -698,7 +714,7 @@ function mapPassesFromRecipe(recipePasses: Record<string, unknown>): UIState["pa
  * @param parsed - The parsed Olive recipe.
  * @param options - Options controlling whether mapped passes replace or merge with existing passes.
  * @returns The UI state values derived from the recipe.
- * @throws {Error} When recipe adapters include present-but-invalid rank or alpha.
+ * @throws {Error} When recipe adapters include present-but-invalid rank, alpha, or targetModules.
  */
 export function deriveUiStateFromOliveRecipe(parsed: unknown, options?: DeriveUiStateOptions): Partial<UIState> {
   const recipe = isRecord(parsed) ? parsed : undefined;

--- a/src/lib/oliveRecipeHub.ts
+++ b/src/lib/oliveRecipeHub.ts
@@ -186,7 +186,9 @@ function parseMultiLoraAdaptersFromRecipe(
   if (Array.isArray(rawAdapters) && rawAdapters.length > 0) {
     const out: NonNullable<UIState["multiLoraAdapters"]> = [];
     for (const item of rawAdapters) {
-      if (!isRecord(item)) continue;
+      if (!isRecord(item)) {
+        return { ok: false, reason: "each adapter must be a non-null object" };
+      }
       const parsed = parseRecipeAdapterEntry(item);
       if (!parsed.ok) return parsed;
       if (parsed.adapter) out.push(parsed.adapter);

--- a/src/lib/oliveRecipeHub.ts
+++ b/src/lib/oliveRecipeHub.ts
@@ -81,6 +81,60 @@ function isStringArray(value: unknown): value is string[] {
   return Array.isArray(value) && value.every((entry) => typeof entry === "string");
 }
 
+function readOptionalRecipeTargetModules(
+  item: Record<string, unknown>,
+): string[] | undefined {
+  const rawModules = Array.isArray(item.targetModules)
+    ? item.targetModules
+    : Array.isArray(item.target_modules)
+      ? item.target_modules
+      : undefined;
+  if (
+    !Array.isArray(rawModules) ||
+    !rawModules.every((m): m is string => typeof m === "string" && m.length > 0)
+  ) {
+    return undefined;
+  }
+  return rawModules;
+}
+
+/**
+ * Parse one recipe `adapters[]` entry into UIState MultiLoRA shape.
+ */
+function parseRecipeAdapterEntry(
+  item: Record<string, unknown>,
+): NonNullable<UIState["multiLoraAdapters"]>[number] | null {
+  const path =
+    typeof item.path === "string" && item.path.length > 0 ? item.path : undefined;
+  if (!path) return null;
+
+  const name =
+    typeof item.name === "string" && item.name.length > 0 ? item.name : undefined;
+  const rank =
+    typeof item.rank === "number" && Number.isFinite(item.rank) ? item.rank : undefined;
+  const alpha =
+    typeof item.alpha === "number" && Number.isFinite(item.alpha) ? item.alpha : undefined;
+  const targetModules = readOptionalRecipeTargetModules(item);
+
+  return {
+    path,
+    ...(name ? { name } : {}),
+    ...(rank !== undefined ? { rank } : {}),
+    ...(alpha !== undefined ? { alpha } : {}),
+    ...(targetModules ? { targetModules } : {}),
+  };
+}
+
+function legacyAdapterPathFromInput(
+  inputConfig: Record<string, unknown>,
+): UIState["multiLoraAdapters"] | undefined {
+  const adapterPath =
+    typeof inputConfig.adapter_path === "string" && inputConfig.adapter_path.length > 0
+      ? inputConfig.adapter_path
+      : undefined;
+  return adapterPath ? [{ path: adapterPath }] : undefined;
+}
+
 /**
  * Parse recipe-level multi-LoRA adapters (or legacy adapter_path) into UIState shape.
  */
@@ -93,44 +147,13 @@ function parseMultiLoraAdaptersFromRecipe(
     const out: NonNullable<UIState["multiLoraAdapters"]> = [];
     for (const item of rawAdapters) {
       if (!isRecord(item)) continue;
-      const path =
-        typeof item.path === "string" && item.path.length > 0 ? item.path : undefined;
-      if (!path) continue;
-      const name =
-        typeof item.name === "string" && item.name.length > 0 ? item.name : undefined;
-      const rank =
-        typeof item.rank === "number" && Number.isFinite(item.rank) ? item.rank : undefined;
-      const alpha =
-        typeof item.alpha === "number" && Number.isFinite(item.alpha) ? item.alpha : undefined;
-      const rawModules = Array.isArray(item.targetModules)
-        ? item.targetModules
-        : Array.isArray(item.target_modules)
-          ? item.target_modules
-          : undefined;
-      const targetModules =
-        Array.isArray(rawModules) &&
-        rawModules.every((m): m is string => typeof m === "string" && m.length > 0)
-          ? rawModules
-          : undefined;
-      out.push({
-        path,
-        ...(name ? { name } : {}),
-        ...(rank !== undefined ? { rank } : {}),
-        ...(alpha !== undefined ? { alpha } : {}),
-        ...(targetModules ? { targetModules } : {}),
-      });
+      const parsed = parseRecipeAdapterEntry(item);
+      if (parsed) out.push(parsed);
     }
     if (out.length > 0) return out;
   }
 
-  const adapterPath =
-    typeof inputConfig.adapter_path === "string" && inputConfig.adapter_path.length > 0
-      ? inputConfig.adapter_path
-      : undefined;
-  if (adapterPath) {
-    return [{ path: adapterPath }];
-  }
-  return undefined;
+  return legacyAdapterPathFromInput(inputConfig);
 }
 
 /**

--- a/src/lib/oliveRecipeHub.ts
+++ b/src/lib/oliveRecipeHub.ts
@@ -45,6 +45,8 @@ export interface RecipeCatalogItem {
   description: string;
   /** How architecture/device tags were derived. Folder inference is approximate. */
   metadataSource?: "folder" | "recipe";
+  /** Pinned catalog commit; when set, content is fetched at this SHA, not branch HEAD. */
+  commitSha?: string;
 }
 
 export interface ParsedGitHubTarget {
@@ -183,7 +185,8 @@ export async function fetchOliveRecipesCatalogItem(
   repo = OLIVE_RECIPES_REPO,
   branch = getRecipesBranch(),
 ): Promise<unknown> {
-  const { json } = await fetchGitHubRecipeJson(repo, branch, item.repoPath);
+  const ref = item.commitSha || branch;
+  const { json } = await fetchGitHubRecipeJson(repo, ref, item.repoPath);
   return json;
 }
 

--- a/src/lib/oliveRecipeHub.ts
+++ b/src/lib/oliveRecipeHub.ts
@@ -82,6 +82,58 @@ function isStringArray(value: unknown): value is string[] {
 }
 
 /**
+ * Parse recipe-level multi-LoRA adapters (or legacy adapter_path) into UIState shape.
+ */
+function parseMultiLoraAdaptersFromRecipe(
+  recipe: Record<string, unknown> | undefined,
+  inputConfig: Record<string, unknown>,
+): UIState["multiLoraAdapters"] | undefined {
+  const rawAdapters = recipe?.adapters;
+  if (Array.isArray(rawAdapters) && rawAdapters.length > 0) {
+    const out: NonNullable<UIState["multiLoraAdapters"]> = [];
+    for (const item of rawAdapters) {
+      if (!isRecord(item)) continue;
+      const path =
+        typeof item.path === "string" && item.path.length > 0 ? item.path : undefined;
+      if (!path) continue;
+      const name =
+        typeof item.name === "string" && item.name.length > 0 ? item.name : undefined;
+      const rank =
+        typeof item.rank === "number" && Number.isFinite(item.rank) ? item.rank : undefined;
+      const alpha =
+        typeof item.alpha === "number" && Number.isFinite(item.alpha) ? item.alpha : undefined;
+      const rawModules = Array.isArray(item.targetModules)
+        ? item.targetModules
+        : Array.isArray(item.target_modules)
+          ? item.target_modules
+          : undefined;
+      const targetModules =
+        Array.isArray(rawModules) &&
+        rawModules.every((m): m is string => typeof m === "string" && m.length > 0)
+          ? rawModules
+          : undefined;
+      out.push({
+        path,
+        ...(name ? { name } : {}),
+        ...(rank !== undefined ? { rank } : {}),
+        ...(alpha !== undefined ? { alpha } : {}),
+        ...(targetModules ? { targetModules } : {}),
+      });
+    }
+    if (out.length > 0) return out;
+  }
+
+  const adapterPath =
+    typeof inputConfig.adapter_path === "string" && inputConfig.adapter_path.length > 0
+      ? inputConfig.adapter_path
+      : undefined;
+  if (adapterPath) {
+    return [{ path: adapterPath }];
+  }
+  return undefined;
+}
+
+/**
  * Parses a GitHub repository or file URL into its repository, branch, and file path components.
  *
  * @param repoInput - A GitHub repository URL, raw file URL, or `owner/repo` value
@@ -557,6 +609,12 @@ function mapPassesFromRecipe(recipePasses: Record<string, unknown>): UIState["pa
       continue;
     }
 
+    if (lowerType.includes("extractadapters") || key === "extract_adapters") {
+      next.peft = true;
+      if (!next.peftMethod) next.peftMethod = "lora";
+      continue;
+    }
+
     if (lowerType.includes("lora") || key === "peft") {
       next.peft = true;
       next.peftMethod = "lora";
@@ -667,6 +725,17 @@ export function deriveUiStateFromOliveRecipe(parsed: unknown, options?: DeriveUi
       const base = options?.basePasses ?? DEFAULT_PASSES;
       incomingState.passes = { ...base, ...mapped };
     }
+  }
+
+  const adapters = parseMultiLoraAdaptersFromRecipe(recipe, icfg);
+  if (adapters) {
+    incomingState.multiLoraAdapters = adapters;
+    const basePasses = incomingState.passes ?? options?.basePasses ?? DEFAULT_PASSES;
+    incomingState.passes = {
+      ...basePasses,
+      peft: true,
+      peftMethod: basePasses.peftMethod || "lora",
+    };
   }
 
   return incomingState;

--- a/src/lib/oliveRecipeHub.ts
+++ b/src/lib/oliveRecipeHub.ts
@@ -100,6 +100,8 @@ function readOptionalRecipeTargetModules(
 
 /**
  * Parse one recipe `adapters[]` entry into UIState MultiLoRA shape.
+ * Rank/alpha must already satisfy builder rules; present-but-invalid values are
+ * dropped so import does not leave workspace state that fails on rebuild.
  */
 function parseRecipeAdapterEntry(
   item: Record<string, unknown>,
@@ -110,10 +112,15 @@ function parseRecipeAdapterEntry(
 
   const name =
     typeof item.name === "string" && item.name.length > 0 ? item.name : undefined;
+  // Match oliveRecipeBuilder: positive integer rank, positive finite alpha.
   const rank =
-    typeof item.rank === "number" && Number.isFinite(item.rank) ? item.rank : undefined;
+    typeof item.rank === "number" && Number.isInteger(item.rank) && item.rank > 0
+      ? item.rank
+      : undefined;
   const alpha =
-    typeof item.alpha === "number" && Number.isFinite(item.alpha) ? item.alpha : undefined;
+    typeof item.alpha === "number" && Number.isFinite(item.alpha) && item.alpha > 0
+      ? item.alpha
+      : undefined;
   const targetModules = readOptionalRecipeTargetModules(item);
 
   return {

--- a/src/lib/pipelineNavigation.ts
+++ b/src/lib/pipelineNavigation.ts
@@ -83,9 +83,10 @@ export function attemptPipelineNavigate(id: PipelineViewId): boolean {
 }
 
 /** Switch the main pipeline step from nested panels (graph inspectors, etc.). */
-export const navigatePipeline = (id: PipelineViewId) => {
-  if (!attemptPipelineNavigate(id)) return;
+export const navigatePipeline = (id: PipelineViewId): boolean => {
+  if (!attemptPipelineNavigate(id)) return false;
   window.dispatchEvent(new CustomEvent(OLIVE_PIPELINE_NAVIGATE, { detail: id }));
+  return true;
 };
 
 let pendingExpandValidation = false;

--- a/src/lib/recipeCatalogPin.ts
+++ b/src/lib/recipeCatalogPin.ts
@@ -1,0 +1,420 @@
+/**
+ * Recipe Catalog Version Pinning — utilities for resolving, tracking, and
+ * validating the commit SHA at which recipe catalog entries were fetched.
+ *
+ * The catalog is fetched from the `microsoft/Olive` (or configured) recipes
+ * repository. Each entry is pinned to a specific commit SHA so that loaded
+ * recipes remain reproducible even when the upstream catalog updates.
+ *
+ * @module recipeCatalogPin
+ */
+
+import {
+  getRecipesBranch,
+  OLIVE_RECIPES_BRANCH_DEFAULT,
+  OLIVE_RECIPES_REPO,
+} from "@/lib/oliveRecipeHub";
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+export interface CatalogMetadata {
+  /** Branch name from which the catalog was fetched. */
+  branch: string;
+  /** Full 40-character hexadecimal Git commit SHA. */
+  commitSha: string;
+  /** ISO 8601 timestamp of when the catalog was fetched. */
+  fetchedAt: string;
+}
+
+export interface CatalogEntry {
+  /** Unique recipe identifier (typically derived from repo path). */
+  id: string;
+  /** Display name of the recipe. */
+  name: string;
+  /** Model architecture (e.g. "LLM", "Whisper", "Other"). */
+  architecture: string;
+  /** Target device/accelerator (e.g. "CPU", "CUDA", "TRT-RTX"). */
+  deviceTarget: string;
+  /** Full recipe content parsed from the repository, or null when not yet loaded (deferred). */
+  content: Record<string, unknown> | null;
+  /** Pinned metadata recording exact source revision. */
+  pinned: CatalogMetadata;
+}
+
+// ─── Constants ───────────────────────────────────────────────────────────────
+
+/** Regex for a valid 40-character lowercase hexadecimal SHA. */
+const SHA_HEX_RE = /^[0-9a-f]{40}$/;
+
+/** GitHub API base URL for commit resolution. */
+const GITHUB_API_BASE = "https://api.github.com";
+
+/** Default fetch timeout in milliseconds. */
+const FETCH_TIMEOUT_MS = 10_000;
+
+// ─── SHA Validation ──────────────────────────────────────────────────────────
+
+/**
+ * Validates that a string is a well-formed 40-character hexadecimal Git SHA.
+ *
+ * @param sha - The string to validate.
+ * @returns `true` if the SHA is valid, `false` otherwise.
+ */
+export function isValidSha(sha: string): boolean {
+  return SHA_HEX_RE.test(sha);
+}
+
+// ─── Resolve HEAD SHA ────────────────────────────────────────────────────────
+
+/**
+ * Error class for catalog pin-related failures.
+ */
+export class CatalogPinError extends Error {
+  constructor(
+    message: string,
+    public readonly reason:
+      | "network"
+      | "authentication"
+      | "branch-not-found"
+      | "invalid-response"
+      | "rate-limit",
+  ) {
+    super(message);
+    this.name = "CatalogPinError";
+  }
+}
+
+/**
+ * Resolves the HEAD commit SHA for the given branch of the recipes repository
+ * via the GitHub API.
+ *
+ * @param branch - The branch to resolve (defaults to `getRecipesBranch()`).
+ * @param repo - The GitHub repository (defaults to `OLIVE_RECIPES_REPO`).
+ * @returns The 40-character lowercase hex commit SHA string.
+ * @throws {CatalogPinError} If the request fails (network, auth, or branch not found).
+ */
+export async function resolveHeadSha(
+  branch: string = getRecipesBranch(),
+  repo: string = OLIVE_RECIPES_REPO,
+  token?: string,
+): Promise<string> {
+  const url = `${GITHUB_API_BASE}/repos/${repo}/commits/${encodeURIComponent(branch)}`;
+
+  const headers: Record<string, string> = {
+    Accept: "application/vnd.github.v3+json",
+    "User-Agent": "olive-studio",
+  };
+
+  // Use caller-provided token for higher rate limits (server-side only).
+  // WebView callers should not pass a token.
+  if (token) {
+    headers["Authorization"] = `Bearer ${token}`;
+  }
+
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      headers,
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    });
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new CatalogPinError(
+      `Failed to resolve HEAD sha for branch "${branch}": ${message}`,
+      "network",
+    );
+  }
+
+  if (response.status === 429 || response.headers.get("x-ratelimit-remaining") === "0") {
+    throw new CatalogPinError(
+      `Rate limit exceeded resolving HEAD SHA (HTTP ${response.status}).`,
+      "rate-limit",
+    );
+  }
+
+  if (response.status === 401) {
+    throw new CatalogPinError(
+      `Authentication error resolving HEAD SHA (HTTP ${response.status}).`,
+      "authentication",
+    );
+  }
+
+  if (response.status === 403) {
+    // 403 can be rate-limit or auth; check ratelimit header first
+    if (response.headers.get("x-ratelimit-remaining") === "0") {
+      throw new CatalogPinError(
+        `Rate limit exceeded resolving HEAD SHA (HTTP 403).`,
+        "rate-limit",
+      );
+    }
+    throw new CatalogPinError(
+      `Authentication error resolving HEAD SHA (HTTP 403).`,
+      "authentication",
+    );
+  }
+
+  if (response.status === 404 || response.status === 422) {
+    throw new CatalogPinError(
+      `Branch "${branch}" not found in repository "${repo}".`,
+      "branch-not-found",
+    );
+  }
+
+  if (!response.ok) {
+    throw new CatalogPinError(
+      `Failed to resolve HEAD SHA (HTTP ${response.status}).`,
+      "network",
+    );
+  }
+
+  let data: Record<string, unknown>;
+  try {
+    data = (await response.json()) as Record<string, unknown>;
+  } catch {
+    throw new CatalogPinError(
+      "Invalid JSON response from GitHub API.",
+      "invalid-response",
+    );
+  }
+
+  const sha = typeof data.sha === "string" ? data.sha.toLowerCase() : "";
+
+  if (!isValidSha(sha)) {
+    throw new CatalogPinError(
+      `Unexpected SHA format from GitHub API: "${sha}".`,
+      "invalid-response",
+    );
+  }
+
+  return sha;
+}
+
+// ─── Fetch Catalog at SHA ────────────────────────────────────────────────────
+
+/**
+ * Fetches the recipe catalog content at a specific commit SHA.
+ *
+ * This retrieves the catalog items from the repository at the exact revision
+ * identified by `sha`, ensuring reproducibility. Each returned entry is pinned
+ * with the commit metadata.
+ *
+ * @param sha - The 40-character hex commit SHA to fetch at.
+ * @param branch - The branch name (recorded in metadata).
+ * @param repo - The GitHub repository (defaults to `OLIVE_RECIPES_REPO`).
+ * @returns Array of catalog entries pinned to the given SHA.
+ * @throws {CatalogPinError} If the SHA is invalid or the fetch fails.
+ */
+export async function fetchCatalogAtSha(
+  sha: string,
+  branch: string = getRecipesBranch(),
+  repo: string = OLIVE_RECIPES_REPO,
+  token?: string,
+): Promise<CatalogEntry[]> {
+  if (!isValidSha(sha)) {
+    throw new CatalogPinError(
+      `Invalid commit SHA: "${sha}" (must be 40-char hex).`,
+      "invalid-response",
+    );
+  }
+
+  // Fetch the repository tree at the given SHA to discover recipe files.
+  // Using the Git Trees API with recursive mode to list all files.
+  const treeUrl = `${GITHUB_API_BASE}/repos/${repo}/git/trees/${sha}?recursive=1`;
+
+  const headers: Record<string, string> = {
+    Accept: "application/vnd.github.v3+json",
+    "User-Agent": "olive-studio",
+  };
+
+  if (token) {
+    headers["Authorization"] = `Bearer ${token}`;
+  }
+
+  let response: Response;
+  try {
+    response = await fetch(treeUrl, {
+      headers,
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    });
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new CatalogPinError(
+      `Failed to fetch catalog tree at SHA "${sha}": ${message}`,
+      "network",
+    );
+  }
+
+  if (response.status === 429 || response.headers.get("x-ratelimit-remaining") === "0") {
+    throw new CatalogPinError(
+      `Rate limit exceeded fetching catalog at SHA "${sha}" (HTTP ${response.status}).`,
+      "rate-limit",
+    );
+  }
+
+  if (response.status === 401) {
+    throw new CatalogPinError(
+      `Authentication error fetching catalog at SHA "${sha}" (HTTP ${response.status}).`,
+      "authentication",
+    );
+  }
+
+  if (response.status === 403) {
+    if (response.headers.get("x-ratelimit-remaining") === "0") {
+      throw new CatalogPinError(
+        `Rate limit exceeded fetching catalog at SHA "${sha}" (HTTP 403).`,
+        "rate-limit",
+      );
+    }
+    throw new CatalogPinError(
+      `Authentication error fetching catalog at SHA "${sha}" (HTTP 403).`,
+      "authentication",
+    );
+  }
+
+  if (response.status === 404) {
+    throw new CatalogPinError(
+      `Commit SHA "${sha}" not found in repository "${repo}".`,
+      "branch-not-found",
+    );
+  }
+
+  if (!response.ok) {
+    throw new CatalogPinError(
+      `Failed to fetch catalog tree (HTTP ${response.status}).`,
+      "network",
+    );
+  }
+
+  let treeData: Record<string, unknown>;
+  try {
+    treeData = (await response.json()) as Record<string, unknown>;
+  } catch {
+    throw new CatalogPinError(
+      "Invalid JSON response when fetching catalog tree.",
+      "invalid-response",
+    );
+  }
+
+  const tree = Array.isArray(treeData.tree) ? treeData.tree : [];
+  const metadata = formatCatalogMetadata(sha, branch);
+
+  // Handle the Git Trees API truncated flag: when true, the tree is partial
+  // and must not be pinned (would produce an incomplete catalog).
+  if (treeData.truncated === true) {
+    throw new CatalogPinError(
+      `Catalog tree at SHA "${sha}" is truncated — cannot pin a partial catalog.`,
+      "invalid-response",
+    );
+  }
+
+  // Filter for JSON recipe files (exclude non-recipe files like README, etc.)
+  // Guard each item as a non-null object before reading path/type.
+  const recipeFiles = tree.filter(
+    (item: unknown) => {
+      if (item === null || typeof item !== "object" || Array.isArray(item)) return false;
+      const obj = item as Record<string, unknown>;
+      return (
+        typeof obj.path === "string" &&
+        obj.path.endsWith(".json") &&
+        obj.type === "blob" &&
+        !obj.path.startsWith(".") &&
+        !obj.path.includes("node_modules")
+      );
+    },
+  );
+
+  // Convert tree entries into CatalogEntry records.
+  // The full recipe content is NOT fetched eagerly here — `content` is left as
+  // a stub. The caller (task 10.4) fetches individual recipe content on demand
+  // via the existing `fetchOliveRecipesCatalogItem` pattern.
+  const entries: CatalogEntry[] = recipeFiles.map(
+    (item: Record<string, unknown>) => {
+      const path = String(item.path);
+      const parts = path.split("/");
+      const fileName = parts[parts.length - 1].replace(/\.json$/, "");
+      const architecture = parts.length > 1 ? parts[0] : "Other";
+      const deviceFolder = parts.length > 2 ? parts[1] : "";
+      const deviceTarget = inferDeviceTarget(deviceFolder);
+
+      return {
+        id: path,
+        name: `${architecture} / ${fileName}`,
+        architecture,
+        deviceTarget,
+        content: null,
+        pinned: metadata,
+      };
+    },
+  );
+
+  return entries;
+}
+
+// ─── Staleness Detection ─────────────────────────────────────────────────────
+
+/**
+ * Determines whether the stored catalog is stale relative to the upstream SHA.
+ *
+ * @param stored - The currently persisted catalog metadata.
+ * @param upstreamSha - The latest HEAD SHA from the upstream repository.
+ * @returns `true` if the stored catalog is outdated, `false` if it matches upstream.
+ */
+export function isCatalogStale(stored: CatalogMetadata, upstreamSha: string): boolean {
+  // Normalize both SHAs to the same case before comparing.
+  return stored.commitSha.toLowerCase() !== upstreamSha.toLowerCase();
+}
+
+// ─── Metadata Construction ───────────────────────────────────────────────────
+
+/**
+ * Constructs a `CatalogMetadata` object from a resolved SHA and branch name.
+ *
+ * @param sha - The 40-character hex commit SHA (must be validated beforehand).
+ * @param branch - The branch name from which the SHA was resolved.
+ * @returns A fully populated `CatalogMetadata` with the current ISO 8601 timestamp.
+ */
+export function formatCatalogMetadata(sha: string, branch: string): CatalogMetadata {
+  return {
+    branch,
+    commitSha: sha.toLowerCase(),
+    fetchedAt: new Date().toISOString(),
+  };
+}
+
+// ─── Default Branch Helper ───────────────────────────────────────────────────
+
+/**
+ * Returns the currently configured recipes branch.
+ * Re-exports `getRecipesBranch()` for convenience alongside the pinning utilities.
+ *
+ * @returns The active branch name (from localStorage pin or `OLIVE_RECIPES_BRANCH_DEFAULT`).
+ */
+export function getDefaultBranch(): string {
+  return getRecipesBranch();
+}
+
+/** Re-export the default branch constant for external consumption. */
+export { OLIVE_RECIPES_BRANCH_DEFAULT };
+
+// ─── Internal Helpers ────────────────────────────────────────────────────────
+
+/**
+ * Infers a device target label from a folder name in the recipe repository tree.
+ * Uses common naming conventions from the `microsoft/olive-recipes` layout.
+ */
+function inferDeviceTarget(folder: string): string {
+  const lower = folder.toLowerCase();
+  if (lower.includes("cpu")) return "CPU";
+  if (lower.includes("cuda")) return "CUDA";
+  if (lower.includes("tensorrtrtx") || lower.includes("nvtensorrtrtx") || lower.includes("trt-rtx") || lower.includes("trtrtx")) return "TRT-RTX";
+  if (lower.includes("tensorrt") || lower.includes("trt")) return "TensorRT";
+  if (lower.includes("directml") || lower.includes("dml")) return "DirectML";
+  if (lower.includes("qnn")) return "QNN";
+  if (lower.includes("openvino")) return "OpenVINO";
+  if (lower.includes("webgpu")) return "WebGPU";
+  if (lower.includes("rocm")) return "ROCm";
+  if (lower.includes("coreml")) return "CoreML";
+  if (lower.includes("quant")) return "CPU";
+  if (lower.includes("baseline")) return "CPU";
+  return "Other";
+}

--- a/src/lib/recipeCatalogPin.ts
+++ b/src/lib/recipeCatalogPin.ts
@@ -295,7 +295,13 @@ export async function fetchCatalogAtSha(
     );
   }
 
-  const tree = Array.isArray(treeData.tree) ? treeData.tree : [];
+  if (!Array.isArray(treeData.tree)) {
+    throw new CatalogPinError(
+      "Invalid catalog tree response: tree must be an array.",
+      "invalid-response",
+    );
+  }
+  const tree = treeData.tree;
   const metadata = formatCatalogMetadata(sha, branch);
 
   // Handle the Git Trees API truncated flag: when true, the tree is partial

--- a/src/lib/recipeCatalogPin.ts
+++ b/src/lib/recipeCatalogPin.ts
@@ -10,9 +10,11 @@
  */
 
 import {
+  fetchGitHubRecipeJson,
   getRecipesBranch,
   OLIVE_RECIPES_BRANCH_DEFAULT,
   OLIVE_RECIPES_REPO,
+  type RecipeCatalogItem,
 } from "@/lib/oliveRecipeHub";
 
 // ─── Types ───────────────────────────────────────────────────────────────────
@@ -330,9 +332,8 @@ export async function fetchCatalogAtSha(
   );
 
   // Convert tree entries into CatalogEntry records.
-  // The full recipe content is NOT fetched eagerly here — `content` is left as
-  // a stub. The caller (task 10.4) fetches individual recipe content on demand
-  // via the existing `fetchOliveRecipesCatalogItem` pattern.
+  // Content is deferred: load via `fetchCatalogEntryContent` so the request
+  // is addressed at `pinned.commitSha`, not the live branch tip.
   const entries: CatalogEntry[] = recipeFiles.map(
     (item: Record<string, unknown>) => {
       const path = String(item.path);
@@ -354,6 +355,32 @@ export async function fetchCatalogAtSha(
   );
 
   return entries;
+}
+
+/**
+ * Maps a pinned catalog entry to the hub item shape, carrying the commit SHA
+ * so later content fetches stay on the pin instead of branch HEAD.
+ */
+export function catalogEntryToRecipeItem(entry: CatalogEntry): RecipeCatalogItem {
+  return {
+    name: entry.name,
+    architecture: entry.architecture,
+    device: entry.deviceTarget,
+    repoPath: entry.id,
+    description: "",
+    commitSha: entry.pinned.commitSha,
+  };
+}
+
+/**
+ * Loads recipe JSON for a pinned catalog entry at `pinned.commitSha`.
+ */
+export async function fetchCatalogEntryContent(
+  entry: CatalogEntry,
+  repo: string = OLIVE_RECIPES_REPO,
+): Promise<unknown> {
+  const { json } = await fetchGitHubRecipeJson(repo, entry.pinned.commitSha, entry.id);
+  return json;
 }
 
 // ─── Staleness Detection ─────────────────────────────────────────────────────

--- a/src/lib/recipeCatalogPin.ts
+++ b/src/lib/recipeCatalogPin.ts
@@ -454,7 +454,8 @@ function inferArchitectureFromPath(path: string, fileName: string): string {
   return "Other";
 }
 
-function inferDeviceTarget(pathOrFolder: string): string {
+/** @internal exported for unit tests */
+export function inferDeviceTarget(pathOrFolder: string): string {
   const lower = pathOrFolder.toLowerCase();
   if (lower.includes("cpu")) return "CPU";
   if (lower.includes("cuda")) return "CUDA";
@@ -464,7 +465,8 @@ function inferDeviceTarget(pathOrFolder: string): string {
   if (lower.includes("qnn")) return "QNN";
   if (lower.includes("openvino")) return "OpenVINO";
   if (lower.includes("webgpu")) return "WebGPU";
-  if (lower.includes("rocm")) return "ROCm";
+  // Same as getCatalogDeviceFromRecipe / generate-olive-recipes-catalog: ROCm → CUDA.
+  if (lower.includes("rocm")) return "CUDA";
   if (lower.includes("coreml")) return "CoreML";
   if (lower.includes("quant")) return "CPU";
   if (lower.includes("baseline")) return "CPU";

--- a/src/lib/recipeCatalogPin.ts
+++ b/src/lib/recipeCatalogPin.ts
@@ -338,9 +338,9 @@ export async function fetchCatalogAtSha(
       const path = String(item.path);
       const parts = path.split("/");
       const fileName = parts[parts.length - 1].replace(/\.json$/, "");
-      const architecture = parts.length > 1 ? parts[0] : "Other";
-      const deviceFolder = parts.length > 2 ? parts[1] : "";
-      const deviceTarget = inferDeviceTarget(deviceFolder);
+      // Layout is <model-slug>/<tool-or-provider>/<file>, not architecture/device.
+      const architecture = inferArchitectureFromPath(path, fileName);
+      const deviceTarget = inferDeviceTarget(path);
 
       return {
         id: path,
@@ -408,8 +408,27 @@ export { OLIVE_RECIPES_BRANCH_DEFAULT };
  * Infers a device target label from a folder name in the recipe repository tree.
  * Uses common naming conventions from the `microsoft/olive-recipes` layout.
  */
-function inferDeviceTarget(folder: string): string {
-  const lower = folder.toLowerCase();
+function inferArchitectureFromPath(path: string, fileName: string): string {
+  const hay = `${path} ${fileName}`.toLowerCase();
+  if (hay.includes("whisper")) return "Whisper";
+  if (hay.includes("bert") || hay.includes("roberta") || hay.includes("deberta")) return "Encoder";
+  if (
+    hay.includes("llama") ||
+    hay.includes("phi") ||
+    hay.includes("qwen") ||
+    hay.includes("mistral") ||
+    hay.includes("gpt") ||
+    hay.includes("gemma") ||
+    hay.includes("falcon")
+  ) {
+    return "LLM";
+  }
+  if (hay.includes("resnet") || hay.includes("vit") || hay.includes("yolo")) return "Vision";
+  return "Other";
+}
+
+function inferDeviceTarget(pathOrFolder: string): string {
+  const lower = pathOrFolder.toLowerCase();
   if (lower.includes("cpu")) return "CPU";
   if (lower.includes("cuda")) return "CUDA";
   if (lower.includes("tensorrtrtx") || lower.includes("nvtensorrtrtx") || lower.includes("trt-rtx") || lower.includes("trtrtx")) return "TRT-RTX";

--- a/src/lib/reportGenerator.ts
+++ b/src/lib/reportGenerator.ts
@@ -6,10 +6,25 @@
 
 import type { JobHistoryRecord } from "@/lib/jobHistoryStore";
 
+/** Shared default report title used by both metadata and report body. */
+const DEFAULT_REPORT_TITLE = "Olive Studio Optimization Report";
+
+/** Centralized UTC timestamp formatter: "YYYY-MM-DD HH:mm:ss". */
+function utcTimestamp(): string {
+  return new Date().toISOString().slice(0, 19).replace("T", " ");
+}
+
 export interface ReportOptions {
   title?: string;
   includeRecipeJson?: boolean;
   includeLogSummary?: boolean;
+  format?: "markdown" | "pdf";
+}
+
+export interface ReportMetadata {
+  title: string;
+  generatedAt: string; // UTC YYYY-MM-DD HH:mm:ss
+  jobCount: number;
 }
 
 function formatDuration(ms: number): string {
@@ -39,11 +54,11 @@ function statusEmoji(status: string): string {
  */
 export function generateMarkdownReport(records: JobHistoryRecord[], options: ReportOptions = {}): string {
   const {
-    title = "Olive Studio Optimization Report",
+    title = DEFAULT_REPORT_TITLE,
     includeRecipeJson = false,
     includeLogSummary = true,
   } = options;
-  const now = new Date().toISOString().slice(0, 19).replace("T", " ");
+  const now = utcTimestamp();
   const lines: string[] = [];
 
   lines.push(`# ${title}`);
@@ -110,29 +125,27 @@ export function generateMarkdownReport(records: JobHistoryRecord[], options: Rep
     lines.push("");
   });
 
-  // Comparison section (if multiple records)
-  if (records.length > 1) {
+  // Comparison section (only when 2+ completed jobs exist)
+  const completed = records.filter((r) => r.status === "completed");
+  if (completed.length >= 2) {
     lines.push("## Comparison");
     lines.push("");
 
-    const completed = records.filter((r) => r.status === "completed");
-    if (completed.length > 1) {
-      const fastest = completed.reduce((a, b) => (a.durationMs < b.durationMs ? a : b));
-      const smallest = completed
-        .filter((r) => r.vramEstimateGb != null)
-        .reduce(
-          (a, b) => ((a.vramEstimateGb ?? Infinity) < (b.vramEstimateGb ?? Infinity) ? a : b),
-          completed[0],
-        );
+    const fastest = completed.reduce((a, b) => (a.durationMs < b.durationMs ? a : b));
+    lines.push(`- **Fastest:** ${fastest.modelId} (${formatDuration(fastest.durationMs)})`);
 
-      lines.push(`- **Fastest:** ${fastest.modelId} (${formatDuration(fastest.durationMs)})`);
-      if (smallest.vramEstimateGb != null) {
-        lines.push(`- **Lowest VRAM:** ${smallest.modelId} (${smallest.vramEstimateGb.toFixed(2)} GB)`);
+    const withVram = completed.filter((r) => r.vramEstimateGb != null);
+    if (withVram.length > 0) {
+      const lowestVram = withVram.reduce(
+        (a, b) => ((a.vramEstimateGb ?? Infinity) < (b.vramEstimateGb ?? Infinity) ? a : b),
+      );
+      if (lowestVram.vramEstimateGb != null) {
+        lines.push(`- **Lowest VRAM:** ${lowestVram.modelId} (${lowestVram.vramEstimateGb.toFixed(2)} GB)`);
       }
-
-      const avgDuration = completed.reduce((sum, r) => sum + r.durationMs, 0) / completed.length;
-      lines.push(`- **Average duration:** ${formatDuration(Math.round(avgDuration))}`);
     }
+
+    const avgDuration = completed.reduce((sum, r) => sum + r.durationMs, 0) / completed.length;
+    lines.push(`- **Average duration:** ${formatDuration(Math.round(avgDuration))}`);
 
     lines.push("");
   }
@@ -145,6 +158,26 @@ export function generateMarkdownReport(records: JobHistoryRecord[], options: Rep
 }
 
 /**
+ * Get the standard report filename using current UTC date.
+ * Format: `olive-report-YYYY-MM-DD.md`
+ */
+export function getReportFilename(): string {
+  const date = new Date().toISOString().slice(0, 10);
+  return `olive-report-${date}.md`;
+}
+
+/**
+ * Extract metadata about a generated report.
+ */
+export function getReportMetadata(records: JobHistoryRecord[], title?: string): ReportMetadata {
+  return {
+    title: title ?? DEFAULT_REPORT_TITLE,
+    generatedAt: utcTimestamp(),
+    jobCount: records.length,
+  };
+}
+
+/**
  * Trigger a browser download of the Markdown report.
  */
 export function downloadMarkdownReport(records: JobHistoryRecord[], options: ReportOptions = {}): void {
@@ -153,7 +186,7 @@ export function downloadMarkdownReport(records: JobHistoryRecord[], options: Rep
   const url = URL.createObjectURL(blob);
   const anchor = document.createElement("a");
   anchor.href = url;
-  anchor.download = `olive-report-${new Date().toISOString().slice(0, 10)}.md`;
+  anchor.download = getReportFilename();
   document.body.appendChild(anchor);
   anchor.click();
   document.body.removeChild(anchor);
@@ -162,18 +195,60 @@ export function downloadMarkdownReport(records: JobHistoryRecord[], options: Rep
 
 /**
  * Open a print-friendly window for PDF export via browser print dialog.
+ * Catches popup-blocked scenario without throwing.
  */
 export function printReportAsPdf(records: JobHistoryRecord[], options: ReportOptions = {}): void {
   const markdown = generateMarkdownReport(records, options);
-  // Convert markdown to basic HTML for print
-  const html = markdownToPrintHtml(markdown);
-  const printWindow = window.open("", "_blank", "width=800,height=600");
-  if (!printWindow) return;
-  printWindow.document.write(html);
-  printWindow.document.close();
-  printWindow.focus();
-  // Allow rendering before triggering print
-  setTimeout(() => printWindow.print(), 250);
+  triggerPdfExport(markdown);
+}
+
+/**
+ * Trigger PDF export via a print-friendly browser window.
+ * Opens a new window, renders markdown as HTML, then triggers window.print().
+ * Silently handles popup-blocked scenarios without throwing.
+ */
+export function triggerPdfExport(markdownContent: string): void {
+  const html = markdownToPrintHtml(markdownContent);
+  let printWindow: Window | null = null;
+  try {
+    printWindow = window.open("", "_blank", "width=800,height=600");
+  } catch {
+    // Popup blocked — silently fail per spec
+    return;
+  }
+  if (!printWindow) return; // Popup blocked
+
+  // Close the temporary window after printing (or if printing is cancelled/throws).
+  const closePrintWindow = () => {
+    try {
+      printWindow?.close();
+    } catch {
+      // Silently ignore close errors
+    }
+  };
+
+  // Trigger printing after the generated document loads, then close on completion.
+  printWindow.onload = () => {
+    try {
+      // afterprint fires after the print dialog closes (including cancel).
+      printWindow!.addEventListener("afterprint", closePrintWindow, { once: true });
+      printWindow!.print();
+      // Fallback: if afterprint never fires (e.g. older WebView), close after a delay.
+      setTimeout(closePrintWindow, 60_000);
+    } catch {
+      // Print failed — silently ignore and close
+      closePrintWindow();
+    }
+  };
+
+  try {
+    printWindow.document.write(html);
+    printWindow.document.close();
+    printWindow.focus();
+  } catch {
+    // document.write failed (e.g. CSP restrictions) — silently close
+    closePrintWindow();
+  }
 }
 
 function markdownToPrintHtml(markdown: string): string {

--- a/src/lib/reviewReconciler.ts
+++ b/src/lib/reviewReconciler.ts
@@ -93,17 +93,65 @@ function wouldNotResolveProviderConflict(
       const conflict = conflictsByPassKey.get(passKey);
       if (!conflict || conflict.severity !== "critical") continue;
 
-      // Get the autofix value from the conflict
       const autofixPasses = conflict.autofix();
       const resolveValue = (autofixPasses as Record<string, unknown>)[passKey];
 
-      // If the suggested value doesn't match the resolution → suppress
-      if (resolveValue !== undefined && suggestedValue !== resolveValue) {
+      // Missing autofix for this key still leaves the critical conflict unresolved.
+      if (resolveValue === undefined || suggestedValue !== resolveValue) {
         return true;
       }
     }
   }
   return false;
+}
+
+const KNOWN_PASS_FIELDS = new Set([
+  "conversion",
+  "conversionSourceFormat",
+  "conversionFormat",
+  "conversionOpset",
+  "conversionInputTargetTypes",
+  "quantization",
+  "quantMethod",
+  "quantPrecision",
+  "pruning",
+  "pruningType",
+  "pruningMethod",
+  "pruningSparsity",
+  "peft",
+  "peftMethod",
+  "splitting",
+]);
+
+const AFFECTED_PASS_FIELDS: Record<string, string[]> = {
+  peft: ["peft", "peftMethod"],
+  quantization: ["quantization", "quantMethod", "quantPrecision"],
+  conversion: ["conversion", "conversionFormat", "conversionOpset", "conversionSourceFormat"],
+  pruning: ["pruning", "pruningType", "pruningMethod", "pruningSparsity"],
+  splitting: ["splitting"],
+};
+
+function collectDeterministicPassFields(issue: PipelineIssue): string[] {
+  const passPatch = issue.autofix?.passes;
+  if (!passPatch || typeof passPatch !== "object") {
+    return (issue.affectedPasses ?? []).filter((k) => k !== "provider");
+  }
+  const patch = passPatch as Record<string, unknown>;
+  const concrete = Object.keys(patch).filter((k) => KNOWN_PASS_FIELDS.has(k) && k !== "provider");
+  if (issue.affectedPasses && issue.affectedPasses.length > 0) {
+    const mapped = new Set<string>();
+    for (const passId of issue.affectedPasses) {
+      if (passId in patch && KNOWN_PASS_FIELDS.has(passId)) {
+        mapped.add(passId);
+        continue;
+      }
+      for (const field of AFFECTED_PASS_FIELDS[passId] ?? []) {
+        if (field in patch) mapped.add(field);
+      }
+    }
+    if (mapped.size > 0) return [...mapped];
+  }
+  return concrete;
 }
 
 /**
@@ -133,12 +181,9 @@ function pipelineIssueToFinding(issue: PipelineIssue): Finding {
     if (issue.autofix.passes && typeof issue.autofix.passes === "object") {
       const passPatch = issue.autofix.passes as Record<string, unknown>;
       const targeted: Record<string, unknown> = {};
-      const keys =
-        issue.affectedPasses && issue.affectedPasses.length > 0
-          ? issue.affectedPasses.filter((k) => k in passPatch && k !== "provider")
-          : Object.keys(passPatch);
+      const keys = collectDeterministicPassFields(issue);
       for (const key of keys) {
-        targeted[key] = passPatch[key];
+        if (key in passPatch) targeted[key] = passPatch[key];
       }
       if (Object.keys(targeted).length > 0) {
         payload.passes = targeted as ActionPayloadApplyPatch["payload"]["passes"];
@@ -228,10 +273,8 @@ export function reconcileFindings(
   // and its affectedPasses array
   const deterministicPassFields = new Map<string, PipelineIssue>();
   for (const issue of deterministicIssues) {
-    if (issue.affectedPasses) {
-      for (const passId of issue.affectedPasses) {
-        deterministicPassFields.set(passId, issue);
-      }
+    for (const field of collectDeterministicPassFields(issue)) {
+      deterministicPassFields.set(field, issue);
     }
     if (issue.autofix) {
       for (const key of Object.keys(issue.autofix)) {

--- a/src/lib/reviewReconciler.ts
+++ b/src/lib/reviewReconciler.ts
@@ -1,0 +1,259 @@
+/**
+ * Review Reconciler — merges AI-generated findings with deterministic
+ * pipeline validation issues and provider hardware conflicts.
+ *
+ * Design invariants (Requirement 5):
+ * - Deterministic validation is authoritative: AI findings that contradict
+ *   deterministic issues on the same pass field are discarded.
+ * - Critical severity from deterministic sources is never downgraded.
+ * - AI suggestions whose applyPatch would not resolve a provider conflict
+ *   on the targeted pass field are suppressed.
+ * - This module is a PURE FUNCTION — it never mutates its inputs, never
+ *   accesses chatHistory/chatMessages, and produces no side effects.
+ *
+ * @module reviewReconciler
+ */
+
+import type {
+  Finding,
+  FindingSeverity,
+  Action,
+  ActionPayloadApplyPatch,
+} from "@/lib/types/findingTypes";
+import type { PipelineIssue, HardwareConflict } from "@/lib/pipelineValidation";
+
+// ─── Public Type Alias ───────────────────────────────────────────────────────
+
+/**
+ * ProviderConflict is the public contract name used by the reconciler.
+ * Internally it maps to `HardwareConflict` from pipelineValidation.
+ */
+export type ProviderConflict = HardwareConflict;
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+/**
+ * Extract the set of pass fields targeted by a Finding's applyPatch actions.
+ * A "pass field" is a key within `patch.passes` (e.g. "quantMethod", "conversionFormat").
+ */
+function getAiFindingTargetPassFields(finding: Finding): Set<string> {
+  const fields = new Set<string>();
+  for (const action of finding.actions) {
+    if (action.kind === "applyPatch") {
+      const patch = (action as ActionPayloadApplyPatch).payload;
+      if (patch.passes) {
+        for (const key of Object.keys(patch.passes)) {
+          fields.add(key);
+        }
+      }
+    }
+  }
+  return fields;
+}
+
+/**
+ * Determine if an AI finding contradicts a deterministic issue on the same
+ * pass field. Any AI finding targeting the same pass field as a deterministic
+ * issue is discarded — deterministic validation is authoritative (Req 5.1).
+ */
+function contradictsDeterministicIssue(
+  finding: Finding,
+  deterministicPassFields: Map<string, PipelineIssue>,
+): boolean {
+  const aiTargetFields = getAiFindingTargetPassFields(finding);
+  if (aiTargetFields.size === 0) return false;
+
+  // Any AI finding targeting the same pass field as a deterministic issue
+  // is discarded — deterministic validation is authoritative (Req 5.1).
+  for (const field of aiTargetFields) {
+    if (deterministicPassFields.has(field)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Check if an AI finding's applyPatch action targets a pass field that has
+ * a critical provider conflict, and the suggested value would NOT resolve it.
+ *
+ * A value "resolves" a conflict if it matches the conflict's autofix value
+ * for that same pass key.
+ */
+function wouldNotResolveProviderConflict(
+  finding: Finding,
+  conflictsByPassKey: Map<string, ProviderConflict>,
+): boolean {
+  for (const action of finding.actions) {
+    if (action.kind !== "applyPatch") continue;
+    const patch = (action as ActionPayloadApplyPatch).payload;
+    if (!patch.passes) continue;
+
+    for (const [passKey, suggestedValue] of Object.entries(patch.passes)) {
+      const conflict = conflictsByPassKey.get(passKey);
+      if (!conflict || conflict.severity !== "critical") continue;
+
+      // Get the autofix value from the conflict
+      const autofixPasses = conflict.autofix();
+      const resolveValue = (autofixPasses as Record<string, unknown>)[passKey];
+
+      // If the suggested value doesn't match the resolution → suppress
+      if (resolveValue !== undefined && suggestedValue !== resolveValue) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+/**
+ * Convert a deterministic PipelineIssue into the unified Finding format.
+ */
+function pipelineIssueToFinding(issue: PipelineIssue): Finding {
+  const actions: Action[] = [];
+
+  // If the issue has a valid autofix with passes payload, create an applyPatch action
+  if (
+    issue.autofix &&
+    issue.actionLabel &&
+    issue.autofix.passes &&
+    typeof issue.autofix.passes === "object" &&
+    Object.keys(issue.autofix.passes as Record<string, unknown>).length > 0
+  ) {
+    actions.push({
+      kind: "applyPatch",
+      label: issue.actionLabel.slice(0, 80),
+      payload: { passes: issue.autofix.passes },
+    });
+  }
+
+  // Always provide at least an explain action as fallback
+  if (actions.length === 0) {
+    actions.push({
+      kind: "explain",
+      label: "View details",
+      payload: { body: `**${issue.title}**\n\n${issue.description}` },
+    });
+  }
+
+  return {
+    id: `det-${issue.id}`,
+    title: issue.title.slice(0, 120),
+    description: issue.description.slice(0, 2000),
+    severity: issue.severity as FindingSeverity,
+    evidence: issue.description,
+    actions,
+  };
+}
+
+/**
+ * Convert a provider HardwareConflict into the unified Finding format.
+ */
+function providerConflictToFinding(conflict: ProviderConflict): Finding {
+  const autofixPasses = conflict.autofix();
+  const actions: Action[] = [
+    {
+      kind: "applyPatch",
+      label: `Fix: ${conflict.passName}`.slice(0, 80),
+      payload: { passes: autofixPasses },
+    },
+  ];
+
+  return {
+    id: `prov-${conflict.passKey}`,
+    title: `${conflict.passName} incompatible`.slice(0, 120),
+    description: conflict.reason.slice(0, 2000),
+    severity: conflict.severity as FindingSeverity,
+    evidence: conflict.reason,
+    actions,
+  };
+}
+
+// ─── Main Reconciler ─────────────────────────────────────────────────────────
+
+/**
+ * Reconcile AI-generated findings with deterministic pipeline issues and
+ * provider hardware conflicts.
+ *
+ * Logic:
+ * 1. Build lookup maps for deterministic issues (by affected pass fields)
+ *    and provider conflicts (by passKey).
+ * 2. Filter AI findings:
+ *    - Discard findings that contradict deterministic issues on same pass field.
+ *    - Suppress findings whose applyPatch wouldn't resolve provider conflicts.
+ * 3. Convert deterministic issues and provider conflicts to Finding format.
+ * 4. Return combined array: deterministic findings first (authority), then
+ *    surviving AI findings.
+ *
+ * This function is pure — it never mutates inputs and has no side effects.
+ *
+ * @param aiFindings - Findings produced by the AI review engine
+ * @param deterministicIssues - Issues from CROSS_PASS_RULES validation
+ * @param providerConflicts - Hardware conflicts from getProviderConflicts()
+ * @returns Reconciled findings array
+ */
+export function reconcileFindings(
+  aiFindings: Finding[],
+  deterministicIssues: PipelineIssue[],
+  providerConflicts: ProviderConflict[],
+): Finding[] {
+  // Build lookup: pass field → deterministic issue
+  // A deterministic issue's "affected pass fields" come from its autofix keys
+  // and its affectedPasses array
+  const deterministicPassFields = new Map<string, PipelineIssue>();
+  for (const issue of deterministicIssues) {
+    // Index by autofix pass keys (the concrete field targets)
+    if (issue.autofix) {
+      const passes = issue.autofix.passes;
+      if (passes && typeof passes === "object") {
+        for (const key of Object.keys(passes as Record<string, unknown>)) {
+          deterministicPassFields.set(key, issue);
+        }
+      }
+    }
+    // Also index by affectedPasses (broader coverage)
+    if (issue.affectedPasses) {
+      for (const passId of issue.affectedPasses) {
+        deterministicPassFields.set(passId, issue);
+      }
+    }
+  }
+
+  // Build lookup: passKey → provider conflict (critical only for suppression)
+  const conflictsByPassKey = new Map<string, ProviderConflict>();
+  for (const conflict of providerConflicts) {
+    conflictsByPassKey.set(conflict.passKey, conflict);
+  }
+
+  // Filter AI findings
+  const survivingAiFindings: Finding[] = [];
+  for (const finding of aiFindings) {
+    // Rule 1: Discard AI findings contradicting deterministic issues
+    if (contradictsDeterministicIssue(finding, deterministicPassFields)) {
+      continue;
+    }
+
+    // Rule 2: Suppress AI findings whose patch wouldn't resolve provider conflicts
+    if (wouldNotResolveProviderConflict(finding, conflictsByPassKey)) {
+      continue;
+    }
+
+    survivingAiFindings.push(finding);
+  }
+
+  // Convert deterministic sources to Finding format
+  const deterministicFindings = deterministicIssues.map(pipelineIssueToFinding);
+  const conflictFindings = providerConflicts.map(providerConflictToFinding);
+
+  // Deduplicate: if a provider conflict targets the same passKey as a
+  // deterministic issue, the deterministic issue (which already incorporates
+  // the conflict context) takes precedence
+  const uniqueConflictFindings = conflictFindings.filter((f) => {
+    // Check if the conflict's passKey is already covered by a deterministic issue
+    const passKey = f.id.replace("prov-", "");
+    return !deterministicPassFields.has(passKey);
+  });
+
+  // Combine: deterministic first (authority), then conflicts, then surviving AI
+  return [...deterministicFindings, ...uniqueConflictFindings, ...survivingAiFindings];
+}

--- a/src/lib/reviewReconciler.ts
+++ b/src/lib/reviewReconciler.ts
@@ -33,19 +33,25 @@ export type ProviderConflict = HardwareConflict;
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
 /**
- * Extract the set of pass fields targeted by a Finding's applyPatch actions.
- * A "pass field" is a key within `patch.passes` (e.g. "quantMethod", "conversionFormat").
+ * Extract the set of UIState fields targeted by a Finding's applyPatch actions.
+ * Includes `patch.passes` keys and top-level keys (e.g. ihvProvider, cudaVersion)
+ * so deterministic autofixes outside `passes` stay authoritative.
  */
-function getAiFindingTargetPassFields(finding: Finding): Set<string> {
+function getAiFindingTargetFields(finding: Finding): Set<string> {
   const fields = new Set<string>();
   for (const action of finding.actions) {
-    if (action.kind === "applyPatch") {
-      const patch = (action as ActionPayloadApplyPatch).payload;
-      if (patch.passes) {
-        for (const key of Object.keys(patch.passes)) {
-          fields.add(key);
+    if (action.kind !== "applyPatch") continue;
+    const patch = (action as ActionPayloadApplyPatch).payload;
+    for (const key of Object.keys(patch)) {
+      if (key === "passes") {
+        if (patch.passes) {
+          for (const passKey of Object.keys(patch.passes)) {
+            fields.add(passKey);
+          }
         }
+        continue;
       }
+      fields.add(key);
     }
   }
   return fields;
@@ -53,17 +59,17 @@ function getAiFindingTargetPassFields(finding: Finding): Set<string> {
 
 /**
  * Determine if an AI finding contradicts a deterministic issue on the same
- * pass field. Any AI finding targeting the same pass field as a deterministic
- * issue is discarded — deterministic validation is authoritative (Req 5.1).
+ * field. Any AI finding targeting the same field as a deterministic issue
+ * is discarded — deterministic validation is authoritative (Req 5.1).
  */
 function contradictsDeterministicIssue(
   finding: Finding,
   deterministicPassFields: Map<string, PipelineIssue>,
 ): boolean {
-  const aiTargetFields = getAiFindingTargetPassFields(finding);
+  const aiTargetFields = getAiFindingTargetFields(finding);
   if (aiTargetFields.size === 0) return false;
 
-  // Any AI finding targeting the same pass field as a deterministic issue
+  // Any AI finding targeting the same field as a deterministic issue
   // is discarded — deterministic validation is authoritative (Req 5.1).
   for (const field of aiTargetFields) {
     if (deterministicPassFields.has(field)) {

--- a/src/lib/reviewReconciler.ts
+++ b/src/lib/reviewReconciler.ts
@@ -109,22 +109,48 @@ function wouldNotResolveProviderConflict(
 /**
  * Convert a deterministic PipelineIssue into the unified Finding format.
  */
+const TOP_LEVEL_PATCH_KEYS = [
+  "ihvProvider",
+  "cudaVersion",
+  "memoryOffload",
+  "modelSource",
+  "hfModelId",
+  "hfDataset",
+  "cacheDir",
+] as const;
+
 function pipelineIssueToFinding(issue: PipelineIssue): Finding {
   const actions: Action[] = [];
 
-  // If the issue has a valid autofix with passes payload, create an applyPatch action
-  if (
-    issue.autofix &&
-    issue.actionLabel &&
-    issue.autofix.passes &&
-    typeof issue.autofix.passes === "object" &&
-    Object.keys(issue.autofix.passes as Record<string, unknown>).length > 0
-  ) {
-    actions.push({
-      kind: "applyPatch",
-      label: issue.actionLabel.slice(0, 80),
-      payload: { passes: issue.autofix.passes },
-    });
+  if (issue.autofix && issue.actionLabel) {
+    const payload: ActionPayloadApplyPatch["payload"] = {};
+    const autofix = issue.autofix as Record<string, unknown>;
+    for (const key of TOP_LEVEL_PATCH_KEYS) {
+      if (autofix[key] !== undefined) {
+        (payload as Record<string, unknown>)[key] = autofix[key];
+      }
+    }
+    if (issue.autofix.passes && typeof issue.autofix.passes === "object") {
+      const passPatch = issue.autofix.passes as Record<string, unknown>;
+      const targeted: Record<string, unknown> = {};
+      const keys =
+        issue.affectedPasses && issue.affectedPasses.length > 0
+          ? issue.affectedPasses.filter((k) => k in passPatch && k !== "provider")
+          : Object.keys(passPatch);
+      for (const key of keys) {
+        targeted[key] = passPatch[key];
+      }
+      if (Object.keys(targeted).length > 0) {
+        payload.passes = targeted as ActionPayloadApplyPatch["payload"]["passes"];
+      }
+    }
+    if (Object.keys(payload).length > 0) {
+      actions.push({
+        kind: "applyPatch",
+        label: issue.actionLabel.slice(0, 80),
+        payload,
+      });
+    }
   }
 
   // Always provide at least an explain action as fallback
@@ -202,19 +228,16 @@ export function reconcileFindings(
   // and its affectedPasses array
   const deterministicPassFields = new Map<string, PipelineIssue>();
   for (const issue of deterministicIssues) {
-    // Index by autofix pass keys (the concrete field targets)
-    if (issue.autofix) {
-      const passes = issue.autofix.passes;
-      if (passes && typeof passes === "object") {
-        for (const key of Object.keys(passes as Record<string, unknown>)) {
-          deterministicPassFields.set(key, issue);
-        }
-      }
-    }
-    // Also index by affectedPasses (broader coverage)
     if (issue.affectedPasses) {
       for (const passId of issue.affectedPasses) {
         deterministicPassFields.set(passId, issue);
+      }
+    }
+    if (issue.autofix) {
+      for (const key of Object.keys(issue.autofix)) {
+        if (key !== "passes") {
+          deterministicPassFields.set(key, issue);
+        }
       }
     }
   }

--- a/src/lib/types/agentTypes.ts
+++ b/src/lib/types/agentTypes.ts
@@ -1,0 +1,126 @@
+/**
+ * Agent UI types for Workstream 2 (v0.5.0).
+ *
+ * Defines the data model for the Agent execution mode: activity log entries,
+ * agent session state, batch comparison output, and scoring preferences.
+ */
+
+// ─── Activity Log ───────────────────────────────────────────────────────────────
+
+/**
+ * Discriminated kind for activity log entries.
+ * Each kind has a specific truncation limit:
+ *  - reasoning: 512 chars
+ *  - tool_call: 256 chars
+ *  - tool_result: 512 chars
+ *  - decision: 256 chars
+ *  - error: 512 chars
+ */
+export type ActivityEntryKind =
+  | "reasoning"
+  | "tool_call"
+  | "tool_result"
+  | "decision"
+  | "error";
+
+/**
+ * A single entry in the agent activity log.
+ * Entries are appended chronologically and subject to FIFO eviction at 2000 max.
+ */
+export interface ActivityLogEntry {
+  /** Unique identifier within the session. */
+  id: string;
+  /** Entry kind determines styling and truncation limit. */
+  kind: ActivityEntryKind;
+  /** Display timestamp at HH:MM:SS resolution. */
+  timestamp: string;
+  /** Display text, truncated per kind-specific limits. */
+  text: string;
+  /** Full untruncated text when `text` was shortened. */
+  expandedText?: string;
+  /** Originating step reference for error entries. */
+  stepRef?: string;
+}
+
+// ─── Agent Session ──────────────────────────────────────────────────────────────
+
+/**
+ * Outcome of a completed agent session.
+ * Discriminated by `status` to determine which fields are relevant.
+ */
+export interface AgentOutcome {
+  status: "success" | "failure" | "cancelled";
+  /** Total steps executed in the agent loop. */
+  totalSteps: number;
+  /** Wall-clock duration in milliseconds. */
+  elapsedMs: number;
+  /** Error description from the failing step (present when status is "failure"). */
+  errorDescription?: string;
+  /** Step number at which cancellation occurred (present when status is "cancelled"). */
+  cancelledAtStep?: number;
+}
+
+/**
+ * Full session state for the Agent execution mode.
+ * Lives in a dedicated `useAgentMode` hook (local state, not in pipelineStore).
+ */
+export interface AgentSessionState {
+  /** Current execution mode. */
+  mode: "manual" | "agent";
+  /** Whether the agent loop is currently running. */
+  agentRunning: boolean;
+  /** Chronological activity log entries (max 2000, FIFO eviction). */
+  entries: ActivityLogEntry[];
+  /** ISO 8601 timestamp when the agent session started. */
+  startedAt?: string;
+  /** Terminal outcome when the agent loop has completed. */
+  outcome?: AgentOutcome;
+}
+
+// ─── Batch Comparison ───────────────────────────────────────────────────────────
+
+/**
+ * A single job result row in the batch comparison output.
+ * Nullable metrics indicate the value was unavailable for that job.
+ */
+export interface CompareResultEntry {
+  job_id: string;
+  latency_ms: number | null;
+  model_size_mb: number | null;
+  accuracy: number | null;
+  /** Computed composite score based on the active scoring preference. */
+  score: number;
+}
+
+/**
+ * A job excluded from comparison with the reason for exclusion.
+ */
+export interface ExcludedJob {
+  job_id: string;
+  reason: string;
+}
+
+/**
+ * Output from the MCP `compare_results` tool.
+ * Input must contain 2–10 job records (validated by `validateJobCount`).
+ */
+export interface CompareResultsOutput {
+  /** Per-job metric results with computed scores. */
+  results: CompareResultEntry[];
+  /** Job ID of the winner, or null when no clear winner exists. */
+  winner: string | null;
+  /** Human-readable reasoning for the winner selection (or lack thereof). */
+  reasoning: string;
+  /** Jobs excluded from the comparison with reasons. */
+  excluded_jobs: ExcludedJob[];
+}
+
+/**
+ * Scoring preference for batch comparison.
+ * Determines how the composite score is weighted across metrics.
+ *  - latency: prioritize lowest latency
+ *  - size: prioritize smallest model size
+ *  - accuracy: prioritize highest accuracy
+ *  - balanced: equal weight across all metrics
+ */
+export type ScoringPreference = "latency" | "size" | "accuracy" | "balanced";

--- a/src/lib/types/findingTypes.ts
+++ b/src/lib/types/findingTypes.ts
@@ -1,0 +1,107 @@
+/**
+ * Unified Assistant Finding/Action contract types.
+ *
+ * These types define the shared contract between the AI review engine,
+ * deterministic pipeline validation, and the AssistantPanel UI. They supersede
+ * the legacy `Suggestion` interface.
+ *
+ * @module findingTypes
+ */
+
+import type { UIState } from "@/types";
+import type { ChatActionPatch } from "@/lib/chatActions";
+
+// ─── Severity & Kind ─────────────────────────────────────────────────────────
+
+export type FindingSeverity = "critical" | "warning" | "info";
+
+export type ActionKind = "applyPatch" | "navigate" | "explain" | "documentation";
+
+// ─── Action Discriminated Union ──────────────────────────────────────────────
+
+export interface ActionPayloadApplyPatch {
+  kind: "applyPatch";
+  /** Button label (max 80 chars). */
+  label: string;
+  /** Validated by `sanitizeChatActionPatch`. */
+  payload: ChatActionPatch;
+}
+
+export interface ActionPayloadNavigate {
+  kind: "navigate";
+  /** Button label (max 80 chars). */
+  label: string;
+  payload: { targetPanel: string };
+}
+
+export interface ActionPayloadExplain {
+  kind: "explain";
+  /** Button label (max 80 chars). */
+  label: string;
+  /** Markdown body injected into the chat. */
+  payload: { body: string };
+}
+
+export interface ActionPayloadDocumentation {
+  kind: "documentation";
+  /** Button label (max 80 chars). */
+  label: string;
+  payload: { url?: string; topicKey?: string };
+}
+
+/** Discriminated union on `kind`. */
+export type Action =
+  | ActionPayloadApplyPatch
+  | ActionPayloadNavigate
+  | ActionPayloadExplain
+  | ActionPayloadDocumentation;
+
+// ─── Finding ─────────────────────────────────────────────────────────────────
+
+export interface Finding {
+  /** Unique within a review run. */
+  id: string;
+  /** Max 120 chars. */
+  title: string;
+  /** Max 2000 chars. */
+  description: string;
+  severity: FindingSeverity;
+  /** Supporting evidence text shown beneath the description. */
+  evidence: string;
+  /** 1–10 actions attached to this finding. */
+  actions: Action[];
+}
+
+// ─── Review Result ───────────────────────────────────────────────────────────
+
+export interface ReviewResult {
+  findings: Finding[];
+  /** Pipeline health score (0–100). */
+  score: number;
+  /** Human-readable level label. */
+  level: "Optimized" | "Suboptimal" | "Inefficient";
+  /** Short narrative summary of the review. */
+  summary: string;
+  /** SHA-256 hex of UIState at the time of review. */
+  fingerprint: string;
+  /** ISO 8601 timestamp of review completion. */
+  timestamp: string;
+}
+
+// ─── Workspace Fingerprint ───────────────────────────────────────────────────
+
+export interface WorkspaceFingerprintState {
+  /** SHA-256 hex string (64 chars). */
+  fingerprint: string;
+  /** `Date.now()` timestamp when fingerprint was computed. */
+  computedAt: number;
+}
+
+/**
+ * UIState keys excluded from workspace fingerprint computation.
+ * These are transient fields whose changes should not invalidate review results.
+ */
+export const FINGERPRINT_EXCLUDED_KEYS: (keyof UIState)[] = [
+  "activeJobId",
+  "localFiles",
+];

--- a/src/lib/types/findingTypes.ts
+++ b/src/lib/types/findingTypes.ts
@@ -103,4 +103,5 @@ export interface WorkspaceFingerprintState {
  */
 export const FINGERPRINT_EXCLUDED_KEYS: (keyof UIState)[] = [
   "activeJobId",
+  "localFiles",
 ];

--- a/src/lib/types/findingTypes.ts
+++ b/src/lib/types/findingTypes.ts
@@ -103,5 +103,4 @@ export interface WorkspaceFingerprintState {
  */
 export const FINGERPRINT_EXCLUDED_KEYS: (keyof UIState)[] = [
   "activeJobId",
-  "localFiles",
 ];

--- a/src/lib/workspaceFingerprint.ts
+++ b/src/lib/workspaceFingerprint.ts
@@ -15,17 +15,22 @@ import { FINGERPRINT_EXCLUDED_KEYS } from "@/lib/types/findingTypes";
 
 /**
  * Recursively serializes a value with sorted object keys for deterministic output.
- * Matches JSON.stringify semantics: omits keys whose values are `undefined`.
+ * Matches JSON.stringify semantics: omits keys whose values are `undefined`, `function`, or `symbol`.
  */
 function stableStringify(value: unknown): string {
-  if (value === null || value === undefined) return JSON.stringify(value);
-  if (typeof value !== "object") return JSON.stringify(value);
+  if (value === null || value === undefined) return JSON.stringify(value) ?? "null";
+  if (typeof value !== "object") return JSON.stringify(value) ?? "null";
   if (Array.isArray(value)) {
-    return `[${value.map(stableStringify).join(",")}]`;
+    return `[${value.map((item) => (item === undefined ? "null" : stableStringify(item))).join(",")}]`;
   }
   const obj = value as Record<string, unknown>;
   const keys = Object.keys(obj)
-    .filter((k) => obj[k] !== undefined)
+    .filter(
+      (k) =>
+        obj[k] !== undefined &&
+        typeof obj[k] !== "function" &&
+        typeof obj[k] !== "symbol",
+    )
     .sort();
   return `{${keys.map((k) => `${JSON.stringify(k)}:${stableStringify(obj[k])}`).join(",")}}`;
 }

--- a/src/lib/workspaceFingerprint.ts
+++ b/src/lib/workspaceFingerprint.ts
@@ -58,6 +58,10 @@ export async function computeFingerprint(state: UIState): Promise<string> {
     filtered.localFileNames = state.localFiles.map((file) => file.name);
   }
 
+  if (Array.isArray(state.batchJobs)) {
+    filtered.batchJobs = sanitizeBatchJobsForFingerprint(state.batchJobs);
+  }
+
   // Deterministic serialization with sorted keys
   const serialized = stableStringify(filtered);
 
@@ -96,5 +100,21 @@ export function _serializeForFingerprint(state: UIState): string {
     filtered.localFileNames = state.localFiles.map((file) => file.name);
   }
 
+  if (Array.isArray(state.batchJobs)) {
+    filtered.batchJobs = sanitizeBatchJobsForFingerprint(state.batchJobs);
+  }
+
   return stableStringify(filtered);
+}
+
+function sanitizeBatchJobsForFingerprint(jobs: UIState["batchJobs"]) {
+  return (jobs ?? []).map((job) => ({
+    id: job.id,
+    name: job.name,
+    modelSource: job.modelSource,
+    modelIdentifier: job.modelIdentifier,
+    provider: job.provider,
+    passes: job.passes,
+    recipeJson: job.recipeJson,
+  }));
 }

--- a/src/lib/workspaceFingerprint.ts
+++ b/src/lib/workspaceFingerprint.ts
@@ -53,6 +53,11 @@ export async function computeFingerprint(state: UIState): Promise<string> {
     }
   }
 
+  // File handles and metadata are transient, but selected names affect the recipe.
+  if (Array.isArray(state.localFiles)) {
+    filtered.localFileNames = state.localFiles.map((file) => file.name);
+  }
+
   // Deterministic serialization with sorted keys
   const serialized = stableStringify(filtered);
 
@@ -84,6 +89,11 @@ export function _serializeForFingerprint(state: UIState): string {
     if (!excludeSet.has(key)) {
       filtered[key] = (state as unknown as Record<string, unknown>)[key];
     }
+  }
+
+  // File handles and metadata are transient, but selected names affect the recipe.
+  if (Array.isArray(state.localFiles)) {
+    filtered.localFileNames = state.localFiles.map((file) => file.name);
   }
 
   return stableStringify(filtered);

--- a/src/lib/workspaceFingerprint.ts
+++ b/src/lib/workspaceFingerprint.ts
@@ -1,0 +1,90 @@
+/**
+ * Workspace fingerprint computation utility.
+ *
+ * Produces a deterministic SHA-256 hex digest of the UIState, excluding
+ * transient fields that should not invalidate review results. Used for O(1)
+ * staleness detection on review findings.
+ *
+ * @module workspaceFingerprint
+ */
+
+import type { UIState } from "@/types";
+import { FINGERPRINT_EXCLUDED_KEYS } from "@/lib/types/findingTypes";
+
+// ─── Deterministic Serialization ─────────────────────────────────────────────
+
+/**
+ * Recursively serializes a value with sorted object keys for deterministic output.
+ * Matches JSON.stringify semantics: omits keys whose values are `undefined`.
+ */
+function stableStringify(value: unknown): string {
+  if (value === null || value === undefined) return JSON.stringify(value);
+  if (typeof value !== "object") return JSON.stringify(value);
+  if (Array.isArray(value)) {
+    return `[${value.map(stableStringify).join(",")}]`;
+  }
+  const obj = value as Record<string, unknown>;
+  const keys = Object.keys(obj)
+    .filter((k) => obj[k] !== undefined)
+    .sort();
+  return `{${keys.map((k) => `${JSON.stringify(k)}:${stableStringify(obj[k])}`).join(",")}}`;
+}
+
+// ─── Fingerprint Computation ─────────────────────────────────────────────────
+
+/**
+ * Computes a SHA-256 fingerprint of the UIState, excluding transient fields.
+ *
+ * The result is a 64-character lowercase hex string that changes only when
+ * pipeline-relevant state is modified. Two deeply-equal UIState objects
+ * (after transient field exclusion) always produce identical fingerprints.
+ *
+ * @param state - The full UIState from the pipeline store
+ * @returns A 64-character lowercase hex SHA-256 digest
+ */
+export async function computeFingerprint(state: UIState): Promise<string> {
+  // Build a copy excluding transient keys
+  const filtered: Record<string, unknown> = {};
+  const excludeSet = new Set<string>(FINGERPRINT_EXCLUDED_KEYS as string[]);
+
+  for (const key of Object.keys(state)) {
+    if (!excludeSet.has(key)) {
+      filtered[key] = (state as unknown as Record<string, unknown>)[key];
+    }
+  }
+
+  // Deterministic serialization with sorted keys
+  const serialized = stableStringify(filtered);
+
+  // SHA-256 via Web Crypto API (SubtleCrypto)
+  const encoder = new TextEncoder();
+  const data = encoder.encode(serialized);
+  const hashBuffer = await crypto.subtle.digest("SHA-256", data);
+
+  // Convert ArrayBuffer to lowercase hex string
+  const hashArray = new Uint8Array(hashBuffer);
+  let hex = "";
+  for (let i = 0; i < hashArray.length; i++) {
+    hex += hashArray[i].toString(16).padStart(2, "0");
+  }
+  return hex;
+}
+
+/**
+ * Synchronous deterministic serialization exposed for testing.
+ * Returns the stable JSON string that would be hashed.
+ *
+ * @internal
+ */
+export function _serializeForFingerprint(state: UIState): string {
+  const filtered: Record<string, unknown> = {};
+  const excludeSet = new Set<string>(FINGERPRINT_EXCLUDED_KEYS as string[]);
+
+  for (const key of Object.keys(state)) {
+    if (!excludeSet.has(key)) {
+      filtered[key] = (state as unknown as Record<string, unknown>)[key];
+    }
+  }
+
+  return stableStringify(filtered);
+}

--- a/src/server/services/mcp/studioRecipeBridge.test.ts
+++ b/src/server/services/mcp/studioRecipeBridge.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { mergeBridgeUiState } from "./studioRecipeBridge.ts";
+import { createDefaultPipelineState } from "../../../lib/stores/pipelineStore.ts";
+
+describe("mergeBridgeUiState MultiLoRA", () => {
+  it("keeps adapters and VRAM from the MCP uiState payload", () => {
+    const merged = mergeBridgeUiState(createDefaultPipelineState(), {
+      passes: { peft: true },
+      vramEstimateGb: 24,
+      multiLoraAdapters: [
+        { name: "style", path: "/adapters/style", rank: 16, alpha: 32 },
+      ],
+    });
+    expect(merged.ok).toBe(true);
+    if (!merged.ok) return;
+    expect(merged.state.vramEstimateGb).toBe(24);
+    expect(merged.state.multiLoraAdapters).toEqual([
+      { name: "style", path: "/adapters/style", rank: 16, alpha: 32 },
+    ]);
+  });
+
+  it("accepts snake_case adapter aliases from Python MCP", () => {
+    const merged = mergeBridgeUiState(createDefaultPipelineState(), {
+      vram_estimate_gb: 16,
+      multi_lora_adapters: [{ path: "/a", target_modules: ["q_proj"] }],
+    });
+    expect(merged.ok).toBe(true);
+    if (!merged.ok) return;
+    expect(merged.state.vramEstimateGb).toBe(16);
+    expect(merged.state.multiLoraAdapters).toEqual([
+      { path: "/a", targetModules: ["q_proj"] },
+    ]);
+  });
+});

--- a/src/server/services/mcp/studioRecipeBridge.test.ts
+++ b/src/server/services/mcp/studioRecipeBridge.test.ts
@@ -45,6 +45,26 @@ describe("mergeBridgeUiState MultiLoRA", () => {
     ]);
   });
 
+  it("rejects adapters whose targetModules contain empty or non-string values", () => {
+    const merged = mergeBridgeUiState(createDefaultPipelineState(), {
+      multiLoraAdapters: [{ path: "/a", targetModules: ["q_proj", ""] }],
+    });
+    expect(merged.ok).toBe(false);
+    if (merged.ok) return;
+    expect(merged.code).toBe("invalid_ui_state");
+    expect(merged.error).toMatch(/targetModules must be an array of non-empty strings/i);
+  });
+
+  it("rejects adapters whose target_modules mix strings with non-strings", () => {
+    const merged = mergeBridgeUiState(createDefaultPipelineState(), {
+      multi_lora_adapters: [{ path: "/a", target_modules: ["q_proj", 1] }],
+    });
+    expect(merged.ok).toBe(false);
+    if (merged.ok) return;
+    expect(merged.code).toBe("invalid_ui_state");
+    expect(merged.error).toMatch(/targetModules must be an array of non-empty strings/i);
+  });
+
   it("normalizes path-only adapters at evaluate when PEFT + multiLora are enabled", () => {
     mockIsMultiLoraEnabled.mockReturnValue(true);
     const result = evaluateStudioRecipeBridge({

--- a/src/server/services/mcp/studioRecipeBridge.test.ts
+++ b/src/server/services/mcp/studioRecipeBridge.test.ts
@@ -1,8 +1,21 @@
-import { describe, expect, it } from "vitest";
-import { mergeBridgeUiState } from "./studioRecipeBridge.ts";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockIsMultiLoraEnabled = vi.fn<() => boolean>().mockReturnValue(false);
+vi.mock("@/lib/featureFlags", () => ({
+  isMultiLoraEnabled: () => mockIsMultiLoraEnabled(),
+  isFeatureEnabled: vi.fn().mockReturnValue(false),
+  FEATURE_FLAG_MULTI_LORA: "multiLora",
+  setFeatureFlag: vi.fn(),
+}));
+
+import { evaluateStudioRecipeBridge, mergeBridgeUiState } from "./studioRecipeBridge.ts";
 import { createDefaultPipelineState } from "../../../lib/stores/pipelineStore.ts";
 
 describe("mergeBridgeUiState MultiLoRA", () => {
+  beforeEach(() => {
+    mockIsMultiLoraEnabled.mockReturnValue(false);
+  });
+
   it("keeps adapters and VRAM from the MCP uiState payload", () => {
     const merged = mergeBridgeUiState(createDefaultPipelineState(), {
       passes: { peft: true },
@@ -30,5 +43,20 @@ describe("mergeBridgeUiState MultiLoRA", () => {
     expect(merged.state.multiLoraAdapters).toEqual([
       { path: "/a", targetModules: ["q_proj"] },
     ]);
+  });
+
+  it("rejects path-only adapters at evaluate when PEFT + multiLora require name/rank/alpha", () => {
+    mockIsMultiLoraEnabled.mockReturnValue(true);
+    const result = evaluateStudioRecipeBridge({
+      passes: { peft: true },
+      vramEstimateGb: 24,
+      multiLoraAdapters: [{ path: "/adapters/style" }],
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.code).toBe("invalid_ui_state");
+    expect(result.error).toMatch(/name must be a non-empty string/);
+    expect(result.error).toMatch(/rank must be a positive integer/);
+    expect(result.error).toMatch(/alpha must be a positive finite number/);
   });
 });

--- a/src/server/services/mcp/studioRecipeBridge.test.ts
+++ b/src/server/services/mcp/studioRecipeBridge.test.ts
@@ -45,18 +45,23 @@ describe("mergeBridgeUiState MultiLoRA", () => {
     ]);
   });
 
-  it("rejects path-only adapters at evaluate when PEFT + multiLora require name/rank/alpha", () => {
+  it("normalizes path-only adapters at evaluate when PEFT + multiLora are enabled", () => {
     mockIsMultiLoraEnabled.mockReturnValue(true);
     const result = evaluateStudioRecipeBridge({
       passes: { peft: true },
       vramEstimateGb: 24,
       multiLoraAdapters: [{ path: "/adapters/style" }],
     });
-    expect(result.ok).toBe(false);
-    if (result.ok) return;
-    expect(result.code).toBe("invalid_ui_state");
-    expect(result.error).toMatch(/name must be a non-empty string/);
-    expect(result.error).toMatch(/rank must be a positive integer/);
-    expect(result.error).toMatch(/alpha must be a positive finite number/);
+    expect(result.ok).toBe(true);
+  });
+
+  it("accepts path-only snake_case adapters when multiLora is enabled", () => {
+    mockIsMultiLoraEnabled.mockReturnValue(true);
+    const result = evaluateStudioRecipeBridge({
+      passes: { peft: true },
+      vram_estimate_gb: 24,
+      multi_lora_adapters: [{ path: "/a", target_modules: ["q_proj"] }],
+    });
+    expect(result.ok).toBe(true);
   });
 });

--- a/src/server/services/mcp/studioRecipeBridge.test.ts
+++ b/src/server/services/mcp/studioRecipeBridge.test.ts
@@ -95,6 +95,19 @@ describe("mergeBridgeUiState MultiLoRA", () => {
     expect(merged.error).toMatch(/targetModules must be an array of non-empty strings/i);
   });
 
+  it("rejects non-object adapter entries instead of dropping them", () => {
+    const valid = { path: "/a" };
+    for (const malformed of [null, "adapter-path", ["/a"]]) {
+      const merged = mergeBridgeUiState(createDefaultPipelineState(), {
+        multiLoraAdapters: [valid, malformed],
+      });
+      expect(merged.ok).toBe(false);
+      if (merged.ok) return;
+      expect(merged.code).toBe("invalid_ui_state");
+      expect(merged.error).toMatch(/each adapter must be a non-null object/i);
+    }
+  });
+
   it("normalizes path-only adapters at evaluate when PEFT + multiLora are enabled", () => {
     mockIsMultiLoraEnabled.mockReturnValue(true);
     const result = evaluateStudioRecipeBridge({

--- a/src/server/services/mcp/studioRecipeBridge.test.ts
+++ b/src/server/services/mcp/studioRecipeBridge.test.ts
@@ -95,6 +95,38 @@ describe("mergeBridgeUiState MultiLoRA", () => {
     expect(merged.error).toMatch(/targetModules must be an array of non-empty strings/i);
   });
 
+  it("rejects more than 32 targetModules instead of truncating", () => {
+    const modules = Array.from({ length: 33 }, (_, i) => `mod_${i}`);
+    const merged = mergeBridgeUiState(createDefaultPipelineState(), {
+      multiLoraAdapters: [{ path: "/a", targetModules: modules }],
+    });
+    expect(merged.ok).toBe(false);
+    if (merged.ok) return;
+    expect(merged.code).toBe("invalid_ui_state");
+    expect(merged.error).toMatch(/targetModules exceeds maximum of 32/i);
+  });
+
+  it("rejects a targetModules name longer than 128 characters instead of shortening it", () => {
+    const merged = mergeBridgeUiState(createDefaultPipelineState(), {
+      multi_lora_adapters: [{ path: "/a", target_modules: ["q_proj", "m".repeat(129)] }],
+    });
+    expect(merged.ok).toBe(false);
+    if (merged.ok) return;
+    expect(merged.code).toBe("invalid_ui_state");
+    expect(merged.error).toMatch(/each targetModules entry must be at most 128 characters/i);
+  });
+
+  it("accepts 32 targetModules including a 128-character name", () => {
+    const modules = Array.from({ length: 31 }, (_, i) => `mod_${i}`);
+    modules.push("n".repeat(128));
+    const merged = mergeBridgeUiState(createDefaultPipelineState(), {
+      multiLoraAdapters: [{ path: "/a", targetModules: modules }],
+    });
+    expect(merged.ok).toBe(true);
+    if (!merged.ok) return;
+    expect(merged.state.multiLoraAdapters).toEqual([{ path: "/a", targetModules: modules }]);
+  });
+
   it("rejects non-object adapter entries instead of dropping them", () => {
     const valid = { path: "/a" };
     for (const malformed of [null, "adapter-path", ["/a"]]) {

--- a/src/server/services/mcp/studioRecipeBridge.test.ts
+++ b/src/server/services/mcp/studioRecipeBridge.test.ts
@@ -55,6 +55,36 @@ describe("mergeBridgeUiState MultiLoRA", () => {
     expect(merged.error).toMatch(/targetModules must be an array of non-empty strings/i);
   });
 
+  it("rejects adapters with explicitly invalid rank instead of defaulting", () => {
+    const merged = mergeBridgeUiState(createDefaultPipelineState(), {
+      multiLoraAdapters: [{ path: "/a", rank: "high", alpha: 32 }],
+    });
+    expect(merged.ok).toBe(false);
+    if (merged.ok) return;
+    expect(merged.code).toBe("invalid_ui_state");
+    expect(merged.error).toMatch(/rank must be a positive integer/i);
+  });
+
+  it("rejects adapters with non-finite alpha instead of defaulting", () => {
+    const merged = mergeBridgeUiState(createDefaultPipelineState(), {
+      multiLoraAdapters: [{ path: "/a", rank: 8, alpha: Number.NaN }],
+    });
+    expect(merged.ok).toBe(false);
+    if (merged.ok) return;
+    expect(merged.code).toBe("invalid_ui_state");
+    expect(merged.error).toMatch(/alpha must be a positive finite number/i);
+  });
+
+  it("rejects adapters with non-positive rank instead of defaulting", () => {
+    const merged = mergeBridgeUiState(createDefaultPipelineState(), {
+      multiLoraAdapters: [{ path: "/a", rank: 0, alpha: 16 }],
+    });
+    expect(merged.ok).toBe(false);
+    if (merged.ok) return;
+    expect(merged.code).toBe("invalid_ui_state");
+    expect(merged.error).toMatch(/rank must be a positive integer/i);
+  });
+
   it("rejects adapters whose target_modules mix strings with non-strings", () => {
     const merged = mergeBridgeUiState(createDefaultPipelineState(), {
       multi_lora_adapters: [{ path: "/a", target_modules: ["q_proj", 1] }],

--- a/src/server/services/mcp/studioRecipeBridge.ts
+++ b/src/server/services/mcp/studioRecipeBridge.ts
@@ -203,7 +203,12 @@ function parseBridgeAdapters(raw: unknown): BridgeAdaptersParseResult {
     if (!parsed.ok) return parsed;
     if (parsed.adapter) {
       out.push(parsed.adapter);
-      if (out.length >= MAX_BRIDGE_ADAPTERS) break;
+      if (out.length > MAX_BRIDGE_ADAPTERS) {
+        return {
+          ok: false,
+          reason: `Adapter count exceeds maximum of ${MAX_BRIDGE_ADAPTERS}`,
+        };
+      }
     }
   }
   return { ok: true, adapters: out.length > 0 ? out : undefined };

--- a/src/server/services/mcp/studioRecipeBridge.ts
+++ b/src/server/services/mcp/studioRecipeBridge.ts
@@ -101,46 +101,86 @@ function parseLocalFiles(raw: unknown): UIState["localFiles"] | undefined {
 
 const MAX_BRIDGE_ADAPTERS = 8;
 
-function parseBridgeTargetModules(rawModules: unknown): string[] | undefined {
-  if (!Array.isArray(rawModules)) return undefined;
-  const filtered = rawModules
-    .filter((m): m is string => typeof m === "string")
-    .map((m) => m.trim().slice(0, 128))
-    .filter(Boolean)
-    .slice(0, 32);
-  return filtered.length > 0 ? filtered : undefined;
+type BridgeTargetModulesResult =
+  | { ok: true; modules?: string[] }
+  | { ok: false; reason: string };
+
+function parseBridgeTargetModules(rawModules: unknown): BridgeTargetModulesResult {
+  if (rawModules === undefined) return { ok: true, modules: undefined };
+  if (!Array.isArray(rawModules)) {
+    return {
+      ok: false,
+      reason: "targetModules must be an array of non-empty strings",
+    };
+  }
+  if (rawModules.length === 0) return { ok: true, modules: undefined };
+
+  const modules: string[] = [];
+  for (const entry of rawModules) {
+    if (typeof entry !== "string" || entry.trim().length === 0) {
+      return {
+        ok: false,
+        reason: "targetModules must be an array of non-empty strings",
+      };
+    }
+    modules.push(entry.trim().slice(0, 128));
+    if (modules.length >= 32) break;
+  }
+  return { ok: true, modules };
 }
 
-function parseSingleBridgeAdapter(item: Record<string, unknown>) {
+type BridgeAdapterParseResult =
+  | { ok: true; adapter: NonNullable<UIState["multiLoraAdapters"]>[number] | null }
+  | { ok: false; reason: string };
+
+function parseSingleBridgeAdapter(item: Record<string, unknown>): BridgeAdapterParseResult {
   const adapterPath = clipString(item.path, 1024);
-  if (!adapterPath) return undefined;
+  if (!adapterPath) return { ok: true, adapter: null };
   const name = clipString(item.name, 128);
   const rank = typeof item.rank === "number" && Number.isFinite(item.rank) ? item.rank : undefined;
   const alpha = typeof item.alpha === "number" && Number.isFinite(item.alpha) ? item.alpha : undefined;
-  const rawModules = Array.isArray(item.targetModules) ? item.targetModules : item.target_modules;
-  const targetModules = parseBridgeTargetModules(rawModules);
+  const hasTargetModulesKey = "targetModules" in item || "target_modules" in item;
+  const rawModules = Array.isArray(item.targetModules)
+    ? item.targetModules
+    : Array.isArray(item.target_modules)
+      ? item.target_modules
+      : hasTargetModulesKey
+        ? item.targetModules ?? item.target_modules
+        : undefined;
+  const targetModulesResult = parseBridgeTargetModules(rawModules);
+  if (!targetModulesResult.ok) {
+    return { ok: false, reason: targetModulesResult.reason };
+  }
 
   return {
-    path: adapterPath,
-    ...(name ? { name } : {}),
-    ...(rank !== undefined ? { rank } : {}),
-    ...(alpha !== undefined ? { alpha } : {}),
-    ...(targetModules ? { targetModules } : {}),
+    ok: true,
+    adapter: {
+      path: adapterPath,
+      ...(name ? { name } : {}),
+      ...(rank !== undefined ? { rank } : {}),
+      ...(alpha !== undefined ? { alpha } : {}),
+      ...(targetModulesResult.modules ? { targetModules: targetModulesResult.modules } : {}),
+    },
   };
 }
 
-function parseBridgeAdapters(raw: unknown): UIState["multiLoraAdapters"] | undefined {
-  if (!Array.isArray(raw)) return undefined;
+type BridgeAdaptersParseResult =
+  | { ok: true; adapters?: UIState["multiLoraAdapters"] }
+  | { ok: false; reason: string };
+
+function parseBridgeAdapters(raw: unknown): BridgeAdaptersParseResult {
+  if (!Array.isArray(raw)) return { ok: true, adapters: undefined };
   const out: NonNullable<UIState["multiLoraAdapters"]> = [];
   for (const item of raw) {
     if (!isObjectRecord(item)) continue;
-    const adapter = parseSingleBridgeAdapter(item);
-    if (adapter) {
-      out.push(adapter);
+    const parsed = parseSingleBridgeAdapter(item);
+    if (!parsed.ok) return parsed;
+    if (parsed.adapter) {
+      out.push(parsed.adapter);
       if (out.length >= MAX_BRIDGE_ADAPTERS) break;
     }
   }
-  return out.length > 0 ? out : undefined;
+  return { ok: true, adapters: out.length > 0 ? out : undefined };
 }
 
 function assignClippedBridgeStrings(
@@ -216,8 +256,11 @@ export function mergeBridgeUiState(
   const localFiles = parseLocalFiles(raw.localFiles);
   if (localFiles) partial.localFiles = localFiles;
 
-  const adapters = parseBridgeAdapters(raw.multiLoraAdapters ?? raw.multi_lora_adapters);
-  if (adapters) partial.multiLoraAdapters = adapters;
+  const adaptersResult = parseBridgeAdapters(raw.multiLoraAdapters ?? raw.multi_lora_adapters);
+  if (!adaptersResult.ok) {
+    return { ok: false, code: "invalid_ui_state", error: adaptersResult.reason };
+  }
+  if (adaptersResult.adapters) partial.multiLoraAdapters = adaptersResult.adapters;
 
   const vramRaw = raw.vramEstimateGb ?? raw.vram_estimate_gb;
   if (typeof vramRaw === "number" && Number.isFinite(vramRaw)) {

--- a/src/server/services/mcp/studioRecipeBridge.ts
+++ b/src/server/services/mcp/studioRecipeBridge.ts
@@ -98,6 +98,38 @@ function parseLocalFiles(raw: unknown): UIState["localFiles"] | undefined {
   return out;
 }
 
+const MAX_BRIDGE_ADAPTERS = 8;
+
+function parseBridgeAdapters(raw: unknown): UIState["multiLoraAdapters"] | undefined {
+  if (!Array.isArray(raw)) return undefined;
+  const out: NonNullable<UIState["multiLoraAdapters"]> = [];
+  for (const item of raw) {
+    if (!isObjectRecord(item)) continue;
+    const adapterPath = clipString(item.path, 1024);
+    if (!adapterPath) continue;
+    const name = clipString(item.name, 128);
+    const rank = typeof item.rank === "number" && Number.isFinite(item.rank) ? item.rank : undefined;
+    const alpha = typeof item.alpha === "number" && Number.isFinite(item.alpha) ? item.alpha : undefined;
+    const rawModules = Array.isArray(item.targetModules) ? item.targetModules : item.target_modules;
+    const targetModules = Array.isArray(rawModules)
+      ? rawModules
+          .filter((m): m is string => typeof m === "string")
+          .map((m) => m.trim().slice(0, 128))
+          .filter(Boolean)
+          .slice(0, 32)
+      : undefined;
+    out.push({
+      path: adapterPath,
+      ...(name ? { name } : {}),
+      ...(rank !== undefined ? { rank } : {}),
+      ...(alpha !== undefined ? { alpha } : {}),
+      ...(targetModules && targetModules.length > 0 ? { targetModules } : {}),
+    });
+    if (out.length >= MAX_BRIDGE_ADAPTERS) break;
+  }
+  return out.length > 0 ? out : undefined;
+}
+
 function assignClippedBridgeStrings(
   partial: UiStatePatch,
   raw: Record<string, unknown>,
@@ -170,6 +202,14 @@ export function mergeBridgeUiState(
 
   const localFiles = parseLocalFiles(raw.localFiles);
   if (localFiles) partial.localFiles = localFiles;
+
+  const adapters = parseBridgeAdapters(raw.multiLoraAdapters ?? raw.multi_lora_adapters);
+  if (adapters) partial.multiLoraAdapters = adapters;
+
+  const vramRaw = raw.vramEstimateGb ?? raw.vram_estimate_gb;
+  if (typeof vramRaw === "number" && Number.isFinite(vramRaw)) {
+    partial.vramEstimateGb = vramRaw;
+  }
 
   const passesError = assignBridgePasses(partial, raw);
   if (passesError) return passesError;

--- a/src/server/services/mcp/studioRecipeBridge.ts
+++ b/src/server/services/mcp/studioRecipeBridge.ts
@@ -159,7 +159,7 @@ function parseBridgeAlpha(item: Record<string, unknown>): BridgeOptionalNumberRe
 
 function parseSingleBridgeAdapter(item: Record<string, unknown>): BridgeAdapterParseResult {
   const adapterPath = clipString(item.path, 1024);
-  if (!adapterPath) return { ok: true, adapter: null };
+  if (!adapterPath) return { ok: false, reason: "path must be a non-empty string" };
   const name = clipString(item.name, 128);
   const rankResult = parseBridgeRank(item);
   if (!rankResult.ok) return rankResult;

--- a/src/server/services/mcp/studioRecipeBridge.ts
+++ b/src/server/services/mcp/studioRecipeBridge.ts
@@ -101,32 +101,44 @@ function parseLocalFiles(raw: unknown): UIState["localFiles"] | undefined {
 
 const MAX_BRIDGE_ADAPTERS = 8;
 
+function parseBridgeTargetModules(rawModules: unknown): string[] | undefined {
+  if (!Array.isArray(rawModules)) return undefined;
+  const filtered = rawModules
+    .filter((m): m is string => typeof m === "string")
+    .map((m) => m.trim().slice(0, 128))
+    .filter(Boolean)
+    .slice(0, 32);
+  return filtered.length > 0 ? filtered : undefined;
+}
+
+function parseSingleBridgeAdapter(item: Record<string, unknown>) {
+  const adapterPath = clipString(item.path, 1024);
+  if (!adapterPath) return undefined;
+  const name = clipString(item.name, 128);
+  const rank = typeof item.rank === "number" && Number.isFinite(item.rank) ? item.rank : undefined;
+  const alpha = typeof item.alpha === "number" && Number.isFinite(item.alpha) ? item.alpha : undefined;
+  const rawModules = Array.isArray(item.targetModules) ? item.targetModules : item.target_modules;
+  const targetModules = parseBridgeTargetModules(rawModules);
+
+  return {
+    path: adapterPath,
+    ...(name ? { name } : {}),
+    ...(rank !== undefined ? { rank } : {}),
+    ...(alpha !== undefined ? { alpha } : {}),
+    ...(targetModules ? { targetModules } : {}),
+  };
+}
+
 function parseBridgeAdapters(raw: unknown): UIState["multiLoraAdapters"] | undefined {
   if (!Array.isArray(raw)) return undefined;
   const out: NonNullable<UIState["multiLoraAdapters"]> = [];
   for (const item of raw) {
     if (!isObjectRecord(item)) continue;
-    const adapterPath = clipString(item.path, 1024);
-    if (!adapterPath) continue;
-    const name = clipString(item.name, 128);
-    const rank = typeof item.rank === "number" && Number.isFinite(item.rank) ? item.rank : undefined;
-    const alpha = typeof item.alpha === "number" && Number.isFinite(item.alpha) ? item.alpha : undefined;
-    const rawModules = Array.isArray(item.targetModules) ? item.targetModules : item.target_modules;
-    const targetModules = Array.isArray(rawModules)
-      ? rawModules
-          .filter((m): m is string => typeof m === "string")
-          .map((m) => m.trim().slice(0, 128))
-          .filter(Boolean)
-          .slice(0, 32)
-      : undefined;
-    out.push({
-      path: adapterPath,
-      ...(name ? { name } : {}),
-      ...(rank !== undefined ? { rank } : {}),
-      ...(alpha !== undefined ? { alpha } : {}),
-      ...(targetModules && targetModules.length > 0 ? { targetModules } : {}),
-    });
-    if (out.length >= MAX_BRIDGE_ADAPTERS) break;
+    const adapter = parseSingleBridgeAdapter(item);
+    if (adapter) {
+      out.push(adapter);
+      if (out.length >= MAX_BRIDGE_ADAPTERS) break;
+    }
   }
   return out.length > 0 ? out : undefined;
 }

--- a/src/server/services/mcp/studioRecipeBridge.ts
+++ b/src/server/services/mcp/studioRecipeBridge.ts
@@ -11,6 +11,7 @@
  */
 import type { IHVProvider, ModelSource, OpenVinoTargetDevice, UIState } from "../../../types.ts";
 import { coercePassValue } from "../../../lib/auditAutofix.ts";
+import { gateMultiLoraAdapters } from "../../../lib/oliveRecipeBuilder.ts";
 import { mergeUiState, type UiStatePatch } from "../../../lib/pipelineValidation.ts";
 import {
   projectUiStateToRecipeEvaluation,
@@ -250,6 +251,20 @@ export function evaluateStudioRecipeBridge(
 
   const merged = mergeBridgeUiState(createDefaultState(), rawState);
   if (!merged.ok) return merged;
+
+  const adapters = merged.state.multiLoraAdapters;
+  if (merged.state.passes.peft && Array.isArray(adapters) && adapters.length > 0) {
+    const vram =
+      typeof merged.state.vramEstimateGb === "number" ? merged.state.vramEstimateGb : Number.NaN;
+    const gate = gateMultiLoraAdapters(adapters, vram);
+    if (!gate.allowed) {
+      return {
+        ok: false,
+        code: "invalid_ui_state",
+        error: `Multi-LoRA adapter configuration rejected: ${gate.reason ?? "invalid adapter configuration"}`,
+      };
+    }
+  }
 
   // Exactly one projection call — pure, no Olive / I/O.
   const evaluation = evaluate(merged.state);

--- a/src/server/services/mcp/studioRecipeBridge.ts
+++ b/src/server/services/mcp/studioRecipeBridge.ts
@@ -195,7 +195,10 @@ type BridgeAdaptersParseResult =
   | { ok: false; reason: string };
 
 function parseBridgeAdapters(raw: unknown): BridgeAdaptersParseResult {
-  if (!Array.isArray(raw)) return { ok: true, adapters: undefined };
+  if (raw === undefined) return { ok: true, adapters: undefined };
+  if (!Array.isArray(raw)) {
+    return { ok: false, reason: "adapters must be an array" };
+  }
   const out: NonNullable<UIState["multiLoraAdapters"]> = [];
   for (const item of raw) {
     if (!isObjectRecord(item)) {

--- a/src/server/services/mcp/studioRecipeBridge.ts
+++ b/src/server/services/mcp/studioRecipeBridge.ts
@@ -133,12 +133,38 @@ type BridgeAdapterParseResult =
   | { ok: true; adapter: NonNullable<UIState["multiLoraAdapters"]>[number] | null }
   | { ok: false; reason: string };
 
+type BridgeOptionalNumberResult =
+  | { ok: true; value?: number }
+  | { ok: false; reason: string };
+
+/** Absent rank is fine; present-but-invalid must not become the builder default. */
+function parseBridgeRank(item: Record<string, unknown>): BridgeOptionalNumberResult {
+  if (!("rank" in item)) return { ok: true, value: undefined };
+  const value = item.rank;
+  if (typeof value === "number" && Number.isInteger(value) && value > 0) {
+    return { ok: true, value };
+  }
+  return { ok: false, reason: "rank must be a positive integer" };
+}
+
+/** Absent alpha is fine; present-but-invalid must not become the builder default. */
+function parseBridgeAlpha(item: Record<string, unknown>): BridgeOptionalNumberResult {
+  if (!("alpha" in item)) return { ok: true, value: undefined };
+  const value = item.alpha;
+  if (typeof value === "number" && Number.isFinite(value) && value > 0) {
+    return { ok: true, value };
+  }
+  return { ok: false, reason: "alpha must be a positive finite number" };
+}
+
 function parseSingleBridgeAdapter(item: Record<string, unknown>): BridgeAdapterParseResult {
   const adapterPath = clipString(item.path, 1024);
   if (!adapterPath) return { ok: true, adapter: null };
   const name = clipString(item.name, 128);
-  const rank = typeof item.rank === "number" && Number.isFinite(item.rank) ? item.rank : undefined;
-  const alpha = typeof item.alpha === "number" && Number.isFinite(item.alpha) ? item.alpha : undefined;
+  const rankResult = parseBridgeRank(item);
+  if (!rankResult.ok) return rankResult;
+  const alphaResult = parseBridgeAlpha(item);
+  if (!alphaResult.ok) return alphaResult;
   const hasTargetModulesKey = "targetModules" in item || "target_modules" in item;
   const rawModules = Array.isArray(item.targetModules)
     ? item.targetModules
@@ -157,8 +183,8 @@ function parseSingleBridgeAdapter(item: Record<string, unknown>): BridgeAdapterP
     adapter: {
       path: adapterPath,
       ...(name ? { name } : {}),
-      ...(rank !== undefined ? { rank } : {}),
-      ...(alpha !== undefined ? { alpha } : {}),
+      ...(rankResult.value !== undefined ? { rank: rankResult.value } : {}),
+      ...(alphaResult.value !== undefined ? { alpha: alphaResult.value } : {}),
       ...(targetModulesResult.modules ? { targetModules: targetModulesResult.modules } : {}),
     },
   };

--- a/src/server/services/mcp/studioRecipeBridge.ts
+++ b/src/server/services/mcp/studioRecipeBridge.ts
@@ -198,7 +198,9 @@ function parseBridgeAdapters(raw: unknown): BridgeAdaptersParseResult {
   if (!Array.isArray(raw)) return { ok: true, adapters: undefined };
   const out: NonNullable<UIState["multiLoraAdapters"]> = [];
   for (const item of raw) {
-    if (!isObjectRecord(item)) continue;
+    if (!isObjectRecord(item)) {
+      return { ok: false, reason: "each adapter must be a non-null object" };
+    }
     const parsed = parseSingleBridgeAdapter(item);
     if (!parsed.ok) return parsed;
     if (parsed.adapter) {

--- a/src/server/services/mcp/studioRecipeBridge.ts
+++ b/src/server/services/mcp/studioRecipeBridge.ts
@@ -100,6 +100,8 @@ function parseLocalFiles(raw: unknown): UIState["localFiles"] | undefined {
 }
 
 const MAX_BRIDGE_ADAPTERS = 8;
+const MAX_BRIDGE_TARGET_MODULES = 32;
+const MAX_BRIDGE_TARGET_MODULE_NAME = 128;
 
 type BridgeTargetModulesResult =
   | { ok: true; modules?: string[] }
@@ -114,6 +116,12 @@ function parseBridgeTargetModules(rawModules: unknown): BridgeTargetModulesResul
     };
   }
   if (rawModules.length === 0) return { ok: true, modules: undefined };
+  if (rawModules.length > MAX_BRIDGE_TARGET_MODULES) {
+    return {
+      ok: false,
+      reason: `targetModules exceeds maximum of ${MAX_BRIDGE_TARGET_MODULES}`,
+    };
+  }
 
   const modules: string[] = [];
   for (const entry of rawModules) {
@@ -123,8 +131,14 @@ function parseBridgeTargetModules(rawModules: unknown): BridgeTargetModulesResul
         reason: "targetModules must be an array of non-empty strings",
       };
     }
-    modules.push(entry.trim().slice(0, 128));
-    if (modules.length >= 32) break;
+    const moduleName = entry.trim();
+    if (moduleName.length > MAX_BRIDGE_TARGET_MODULE_NAME) {
+      return {
+        ok: false,
+        reason: `each targetModules entry must be at most ${MAX_BRIDGE_TARGET_MODULE_NAME} characters`,
+      };
+    }
+    modules.push(moduleName);
   }
   return { ok: true, modules };
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -131,6 +131,19 @@ export interface UIState {
   /** Active olive job ID for the Execute Live button */
   activeJobId?: string | null;
   /**
+   * Multi-LoRA adapter entries for ExtractAdapters (when PEFT + multiLora flag).
+   * Empty/omitted means no extra adapters beyond the primary PEFT pass.
+   */
+  multiLoraAdapters?: Array<{
+    name?: string;
+    path: string;
+    rank?: number;
+    alpha?: number;
+    targetModules?: string[];
+  }>;
+  /** Estimated available VRAM in GB used to gate multi-LoRA adapter count. */
+  vramEstimateGb?: number;
+  /**
    * MCP / advanced pass-level recipe overrides (output_name, extra config keys).
    * Applied by `buildOliveRecipe` onto matching pass types.
    */


### PR DESCRIPTION
## Summary
- Add shared type definitions for agent streams and findings (`src/lib/types/`)
- Add feature flag parsing with URL/localStorage/env precedence and safe boolean handling
- Add batch comparison validation: job count (2-10), finite number checks, MCP output structural validation
- Add MultiLoRA validation: finite VRAM handling, adapter name/path/alpha validation, count limits
- Add activity log formatting with floor-based elapsed time and optional stepRef
- Add report generator with correct default title, UTC timestamps, and PDF export trigger
- Add review reconciler: deterministic findings authoritative, AI findings targeting deterministic pass fields suppressed
- Add workspace fingerprinting: deterministic fingerprints excluding transient fields, stale async result handling
- Add recipe catalog pin: GitHub rate-limit handling, truncated tree rejection, content decoding hardening, stale detection with upstream SHA
- Update olive recipe builder: MultiLoRA gating behind PEFT + valid adapters, safe vramEstimateGb default
- Update action executor: state mutations routed through commitUiStateUpdate
- Add hooks: useCatalogPin (refresh guard, resolve debounce, SHA propagation) and useWorkspaceFingerprint (memoization with stale result rejection)
- All libraries include unit and property-based tests (933 lib tests passing)

#### Test plan
- [x] `pnpm vitest run` - 933 lib tests pass (52 test files)
- [x] `pnpm lint` - 0 errors, 20 warnings (all pre-existing)
- [x] `tsc --noEmit` - 0 errors

Generated with [Devin](https://devin.ai)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tonythethompson/Olive-Studio/pull/282?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add shared pipeline validation, review, and catalog pinning libraries
> - Adds [`reviewReconciler.ts`](https://github.com/tonythethompson/Olive-Studio/pull/282/files#diff-70e733a27cd2833b56ceec6acc9d1181546dd39099d51d769a87c2de75329280) with a pure `reconcileFindings` function that merges AI findings with deterministic pipeline issues and provider conflicts, suppressing AI suggestions that contradict deterministic fixes.
> - Adds [`workspaceFingerprint.ts`](https://github.com/tonythethompson/Olive-Studio/pull/282/files#diff-6304aa348dd0c744deecbe1cde908b711286d4b2fc906d33011b38d5788b0cf8) with `computeFingerprint` (SHA-256 of stable UIState) and [`useWorkspaceFingerprint`](https://github.com/tonythethompson/Olive-Studio/pull/282/files#diff-bfeae60759bd1acd9751627a94f4484b5f9d1600129c9e0c82dff903bbf996d3) for debounced staleness detection.
> - Adds [`multiLoraValidation.ts`](https://github.com/tonythethompson/Olive-Studio/pull/282/files#diff-a775f53ce959d1cd6cb9f1bfa2576db92f8be3027f97138b68def7b73efb947c) and extends [`oliveRecipeBuilder.ts`](https://github.com/tonythethompson/Olive-Studio/pull/282/files#diff-c3e993b893f18a80c6ed4fbdfa025e8623c68bf015874fef5e573357c62a4949) to gate multi-LoRA adapter configs based on VRAM limits and a `multiLora` feature flag.
> - Adds [`recipeCatalogPin.ts`](https://github.com/tonythethompson/Olive-Studio/pull/282/files#diff-3aad0ec39d49f4c838242a6da7e894a72b70f7628c7a519ebc15cabb21b478e0) and [`useCatalogPin`](https://github.com/tonythethompson/Olive-Studio/pull/282/files#diff-3de6bf5219a19a1159272184034ada72adee2d08b4c4c6a779f0bcf15edf7f9b) to resolve, validate, and persist pinned catalog commit SHAs with staleness detection.
> - Adds [`activityLog.ts`](https://github.com/tonythethompson/Olive-Studio/pull/282/files#diff-85b91af75ebe372bf27287c2b9c04a0b97fcc189078a3f89a8f6844745f3a510), [`batchComparison.ts`](https://github.com/tonythethompson/Olive-Studio/pull/282/files#diff-f5cd3279b153a5ff8de1b52fabeadc6b8d7972df911dc0ccbaac3d5be2dd1695), and [`actionExecutor.ts`](https://github.com/tonythethompson/Olive-Studio/pull/282/files#diff-61122a3722bf5dbd177ac8a0540d833872b43b02e8842d784886da5bf3f1345e) for activity log truncation, MCP compare-result parsing, and pure action dispatch (navigate/explain/documentation/applyPatch).
> - Extends [`reportGenerator.ts`](https://github.com/tonythethompson/Olive-Studio/pull/282/files#diff-f4eef8130696149855192587c41c053bf797fbf792e50d62b8283af19d023870) with `getReportFilename`, `getReportMetadata`, and a more robust `triggerPdfExport` that handles popup blocking.
> - Risk: `reconcileFindings` silently discards AI findings that conflict with deterministic issues; callers have no visibility into which findings were suppressed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized efb6270.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->