### PR TITLE
feat: auto-setup Olive MCP server venv on install and first launch

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   },
   "scripts": {
     "preinstall": "node -e \"if (!/pnpm/.test(process.env.npm_execpath || \\\"\\\")) { console.error('Use pnpm install, not npm install'); process.exit(1); }\" && node scripts/fix-stale-symlinks.mjs",
+    "postinstall": "node scripts/postinstall-mcp-setup.mjs",
     "dev": "tsx server.ts",
     "generate:recipes": "node scripts/generate-olive-recipes-catalog.mjs",
     "build": "vite build && esbuild server.ts --bundle --platform=node --format=esm --packages=external --outfile=dist/server.mjs",

--- a/scripts/check-mcp-venv.mjs
+++ b/scripts/check-mcp-venv.mjs
@@ -20,7 +20,8 @@ if (!python) {
   process.exit(0);
 }
 
-const r = spawnSync(python, ["-c", "import mcp; print(mcp.__version__)"], {
+// `mcp` (pinned <2) has no __version__ attribute -- just check it imports.
+const r = spawnSync(python, ["-c", "import mcp"], {
   encoding: "utf8",
   env: { ...process.env, PYTHONPATH: mcpDir },
 });

--- a/scripts/mcpVenvProbe.mjs
+++ b/scripts/mcpVenvProbe.mjs
@@ -29,6 +29,7 @@ export function venvPython(mcpDir) {
 /** Whether the given venv python can actually import the pinned `mcp` package. */
 export function venvIsWorking(python, mcpDir) {
   // `mcp` (pinned <2) has no __version__ attribute -- just check it imports.
+  // nosemgrep: javascript.lang.security.detect-child-process -- python/mcpDir are internal-only, see module header
   const r = spawnSync(python, ["-c", "import mcp"], {
     encoding: "utf8",
     env: { ...process.env, PYTHONPATH: mcpDir },
@@ -40,6 +41,7 @@ export function venvIsWorking(python, mcpDir) {
 export function findSystemPython() {
   const candidates = process.platform === "win32" ? ["python", "python3"] : ["python3", "python"];
   for (const cmd of candidates) {
+    // nosemgrep: javascript.lang.security.detect-child-process -- cmd is from the fixed `candidates` list above, see module header
     const r = spawnSync(cmd, ["--version"], { encoding: "utf8" });
     if (r.status === 0) {
       const match = /Python 3\.(\d+)/.exec(r.stdout || r.stderr || "");

--- a/scripts/mcpVenvProbe.mjs
+++ b/scripts/mcpVenvProbe.mjs
@@ -1,0 +1,50 @@
+#!/usr/bin/env node
+/**
+ * Shared Olive MCP server venv/Python probing helpers.
+ *
+ * Used by both scripts/postinstall-mcp-setup.mjs (bare `node`, runs before any
+ * build tooling exists during `pnpm install`) and
+ * src/server/services/mcp/ensureMcpSetup.ts (bundled server code, packaged
+ * desktop first-launch setup). Kept as plain ESM here (not TypeScript) so the
+ * postinstall script can import it with zero build step.
+ *
+ * `python`/`cmd` arguments below are never user-controlled: they only ever
+ * come from a fixed candidate list (`python`/`python3`) or a path this module
+ * itself constructs under a known `.venv` directory, and none of the
+ * spawn calls use a shell -- so there's no command-injection surface here.
+ */
+import { existsSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+
+/** Resolves the venv's python executable for an MCP server dir, if it exists. */
+export function venvPython(mcpDir) {
+  const winPy = path.join(mcpDir, ".venv", "Scripts", "python.exe");
+  const nixPy = path.join(mcpDir, ".venv", "bin", "python");
+  if (existsSync(winPy)) return winPy;
+  if (existsSync(nixPy)) return nixPy;
+  return null;
+}
+
+/** Whether the given venv python can actually import the pinned `mcp` package. */
+export function venvIsWorking(python, mcpDir) {
+  // `mcp` (pinned <2) has no __version__ attribute -- just check it imports.
+  const r = spawnSync(python, ["-c", "import mcp"], {
+    encoding: "utf8",
+    env: { ...process.env, PYTHONPATH: mcpDir },
+  });
+  return r.status === 0;
+}
+
+/** Finds a system Python >= 3.10 on PATH, preferring the platform-native command name first. */
+export function findSystemPython() {
+  const candidates = process.platform === "win32" ? ["python", "python3"] : ["python3", "python"];
+  for (const cmd of candidates) {
+    const r = spawnSync(cmd, ["--version"], { encoding: "utf8" });
+    if (r.status === 0) {
+      const match = /Python 3\.(\d+)/.exec(r.stdout || r.stderr || "");
+      if (match && Number(match[1]) >= 10) return cmd;
+    }
+  }
+  return null;
+}

--- a/scripts/postinstall-mcp-setup.mjs
+++ b/scripts/postinstall-mcp-setup.mjs
@@ -15,6 +15,7 @@ import { existsSync } from "node:fs";
 import { spawnSync } from "node:child_process";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { venvPython, venvIsWorking, findSystemPython } from "./mcpVenvProbe.mjs";
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const mcpDir = path.join(root, "olive-mcp-server");
@@ -38,39 +39,10 @@ if (!existsSync(mcpDir)) {
   process.exit(0);
 }
 
-function venvPython() {
-  const winPy = path.join(mcpDir, ".venv", "Scripts", "python.exe");
-  const nixPy = path.join(mcpDir, ".venv", "bin", "python");
-  if (existsSync(winPy)) return winPy;
-  if (existsSync(nixPy)) return nixPy;
-  return null;
-}
-
-function venvIsWorking(python) {
-  // `mcp` (pinned <2) has no __version__ attribute -- just check it imports.
-  const r = spawnSync(python, ["-c", "import mcp"], {
-    encoding: "utf8",
-    env: { ...process.env, PYTHONPATH: mcpDir },
-  });
-  return r.status === 0;
-}
-
-const existingPython = venvPython();
-if (existingPython && venvIsWorking(existingPython)) {
+const existingPython = venvPython(mcpDir);
+if (existingPython && venvIsWorking(existingPython, mcpDir)) {
   log("MCP server venv already set up, nothing to do.");
   process.exit(0);
-}
-
-function findSystemPython() {
-  const candidates = process.platform === "win32" ? ["python", "python3"] : ["python3", "python"];
-  for (const cmd of candidates) {
-    const r = spawnSync(cmd, ["--version"], { encoding: "utf8" });
-    if (r.status === 0) {
-      const match = /Python 3\.(\d+)/.exec(r.stdout || r.stderr || "");
-      if (match && Number(match[1]) >= 10) return cmd;
-    }
-  }
-  return null;
 }
 
 if (!findSystemPython()) {

--- a/scripts/postinstall-mcp-setup.mjs
+++ b/scripts/postinstall-mcp-setup.mjs
@@ -1,0 +1,104 @@
+#!/usr/bin/env node
+/**
+ * Postinstall: auto-run the Olive MCP server setup (venv + deps) so a plain
+ * `pnpm install` leaves MCP ready to use, without a separate manual step.
+ *
+ * Guarded so it never blocks or fails `pnpm install`:
+ *   - skipped in CI (CI=true)
+ *   - skipped via OLIVE_SKIP_MCP_SETUP=1
+ *   - skipped if olive-mcp-server/ isn't present (e.g. published npm package)
+ *   - no-op if the venv already has a working `mcp` install
+ *   - missing system Python only warns, never fails
+ *   - a failed setup-mcp run only warns, never fails
+ */
+import { existsSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const mcpDir = path.join(root, "olive-mcp-server");
+
+function log(msg) {
+  console.log(`[postinstall-mcp-setup] ${msg}`);
+}
+
+if (process.env.OLIVE_SKIP_MCP_SETUP) {
+  log("skipped (OLIVE_SKIP_MCP_SETUP set).");
+  process.exit(0);
+}
+
+if (process.env.CI) {
+  log("skipped in CI.");
+  process.exit(0);
+}
+
+if (!existsSync(mcpDir)) {
+  // Published npm package / CLI install has no olive-mcp-server source.
+  process.exit(0);
+}
+
+function venvPython() {
+  const winPy = path.join(mcpDir, ".venv", "Scripts", "python.exe");
+  const nixPy = path.join(mcpDir, ".venv", "bin", "python");
+  if (existsSync(winPy)) return winPy;
+  if (existsSync(nixPy)) return nixPy;
+  return null;
+}
+
+function venvIsWorking(python) {
+  // `mcp` (pinned <2) has no __version__ attribute -- just check it imports.
+  const r = spawnSync(python, ["-c", "import mcp"], {
+    encoding: "utf8",
+    env: { ...process.env, PYTHONPATH: mcpDir },
+  });
+  return r.status === 0;
+}
+
+const existingPython = venvPython();
+if (existingPython && venvIsWorking(existingPython)) {
+  log("MCP server venv already set up, nothing to do.");
+  process.exit(0);
+}
+
+function findSystemPython() {
+  const candidates = process.platform === "win32" ? ["python", "python3"] : ["python3", "python"];
+  for (const cmd of candidates) {
+    const r = spawnSync(cmd, ["--version"], { encoding: "utf8" });
+    if (r.status === 0) {
+      const match = /Python 3\.(\d+)/.exec(r.stdout || r.stderr || "");
+      if (match && Number(match[1]) >= 10) return cmd;
+    }
+  }
+  return null;
+}
+
+if (!findSystemPython()) {
+  log(
+    "WARNING: Python >= 3.10 not found on PATH — skipping MCP server setup. " +
+      "Install Python, then run: .\\scripts\\setup-mcp.ps1 (or ./scripts/setup-mcp.sh) to enable it.",
+  );
+  process.exit(0);
+}
+
+log("Setting up Olive MCP server (one-time; subsequent installs will skip this)...");
+
+const result =
+  process.platform === "win32"
+    ? spawnSync("powershell", ["-ExecutionPolicy", "Bypass", "-File", path.join(root, "scripts", "setup-mcp.ps1")], {
+        stdio: "inherit",
+        cwd: root,
+      })
+    : spawnSync("bash", [path.join(root, "scripts", "setup-mcp.sh")], {
+        stdio: "inherit",
+        cwd: root,
+      });
+
+if (result.status !== 0) {
+  log(
+    "WARNING: MCP server setup failed. The app still works without it. " +
+      "Retry manually with: .\\scripts\\setup-mcp.ps1 (or ./scripts/setup-mcp.sh)",
+  );
+}
+
+process.exit(0);

--- a/scripts/setup-mcp.ps1
+++ b/scripts/setup-mcp.ps1
@@ -130,10 +130,14 @@ if (-not $SkipVerify) {
     # Node for postinstall). Redirecting stderr alone doesn't prevent that
     # promotion, so relax EAP just for this native call.
     $prevEap = $ErrorActionPreference
-    $ErrorActionPreference = "Continue"
-    $testOutput = & $pythonVenv -c "from olive_mcp_server.mcp_server import _build_mcp; _build_mcp(); print('OK')" 2>$null
-    $ErrorActionPreference = $prevEap
-    if ($LASTEXITCODE -eq 0 -and $testOutput -match "OK") {
+    try {
+        $ErrorActionPreference = "Continue"
+        $testOutput = & $pythonVenv -c "from olive_mcp_server.mcp_server import _build_mcp; _build_mcp(); print('OK')" 2>$null
+        $testExit = $LASTEXITCODE
+    } finally {
+        $ErrorActionPreference = $prevEap
+    }
+    if ($testExit -eq 0 -and $testOutput -match "OK") {
         Write-Host "      Server module imports successfully." -ForegroundColor Green
     } else {
         Write-Host "      WARNING: Server import check returned unexpected output:" -ForegroundColor Yellow

--- a/scripts/setup-mcp.ps1
+++ b/scripts/setup-mcp.ps1
@@ -123,8 +123,17 @@ if (-not $SkipVerify) {
     if (-not (Test-Path $pythonVenv)) {
         $pythonVenv = Join-Path $VenvDir "bin\python"
     }
-    $testOutput = & $pythonVenv -c "from olive_mcp_server.mcp_server import _build_mcp; _build_mcp(); print('OK')" 2>&1
-    if ($testOutput -match "OK") {
+    # A benign Python warning on stderr (e.g. a pydantic deprecation notice) can
+    # get promoted to a terminating PowerShell error under
+    # $ErrorActionPreference = "Stop" -- especially when this script's own
+    # stdio is piped rather than an interactive console (e.g. spawned from
+    # Node for postinstall). Redirecting stderr alone doesn't prevent that
+    # promotion, so relax EAP just for this native call.
+    $prevEap = $ErrorActionPreference
+    $ErrorActionPreference = "Continue"
+    $testOutput = & $pythonVenv -c "from olive_mcp_server.mcp_server import _build_mcp; _build_mcp(); print('OK')" 2>$null
+    $ErrorActionPreference = $prevEap
+    if ($LASTEXITCODE -eq 0 -and $testOutput -match "OK") {
         Write-Host "      Server module imports successfully." -ForegroundColor Green
     } else {
         Write-Host "      WARNING: Server import check returned unexpected output:" -ForegroundColor Yellow

--- a/server.ts
+++ b/server.ts
@@ -11,6 +11,7 @@ import { mountSystemRoutes, type SystemProbeOptions } from "./src/server/routes/
 import { mountGithubRoutes } from "./src/server/routes/github.ts";
 import { mountAiRoutes } from "./src/server/routes/ai/index.ts";
 import { mountMcpRoutes, performKbSync } from "./src/server/routes/mcp.ts";
+import { ensureMcpSetupInBackground } from "./src/server/services/mcp/ensureMcpSetup.ts";
 import { mountEnvRoutes } from "./src/server/routes/env.ts";
 import { mountOliveRoutes } from "./src/server/routes/olive.ts";
 import { mountArenaRoutes } from "./src/server/routes/arena.ts";
@@ -320,6 +321,12 @@ async function startServer() {
         }
       } catch (err: unknown) {
         console.warn("[kb] startup sync failed:", err instanceof Error ? err.message : err);
+      }
+      // Fire-and-forget: sets up the bundled MCP server venv on first launch of
+      // a packaged desktop build (or a fresh checkout that skipped postinstall).
+      // Never blocks readiness or startup.
+      if (shouldServeProductionStatic()) {
+        ensureMcpSetupInBackground();
       }
       resolve();
     });

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -66,7 +66,11 @@
     ],
     "resources": {
       "../dist": "dist",
-      "../scripts": "scripts"
+      "../scripts": "scripts",
+      "../olive-mcp-server/olive_mcp_server": "olive-mcp-server/olive_mcp_server",
+      "../olive-mcp-server/schemas": "olive-mcp-server/schemas",
+      "../olive-mcp-server/run.py": "olive-mcp-server/run.py",
+      "../olive-mcp-server/pyproject.toml": "olive-mcp-server/pyproject.toml"
     },
     "windows": {
       "certificateThumbprint": null,

--- a/src/server/services/mcp/ensureMcpSetup.ts
+++ b/src/server/services/mcp/ensureMcpSetup.ts
@@ -26,6 +26,7 @@ let attemptedThisProcess = false;
 // without a shell, so there's no command-injection surface here.
 function run(cmd: string, args: string[], cwd: string): Promise<boolean> {
   return new Promise((resolve) => {
+    // nosemgrep: javascript.lang.security.detect-child-process -- cmd is internal-only, see comment above this function
     const child = spawn(cmd, args, { cwd, stdio: "pipe" });
     // eslint-disable-next-line no-console -- intentional background setup progress logging
     child.stdout?.on("data", (d: Buffer) => console.log(`[mcp-setup] ${d.toString().trim()}`));

--- a/src/server/services/mcp/ensureMcpSetup.ts
+++ b/src/server/services/mcp/ensureMcpSetup.ts
@@ -8,26 +8,44 @@
  *
  * Never blocks server startup and never throws — the app works without MCP
  * either way, this only makes it available with zero manual steps when it can.
+ *
+ * Packaged installs can land in a read-only location for a standard user
+ * (macOS /Applications, a Linux AppImage's mounted resources; Tauri's default
+ * Windows NSIS install is per-user and writable, but isn't guaranteed to stay
+ * that way). The rest of this app's venvs already live under `process.cwd()`
+ * the same way (see src/server/services/venv/spec.ts) -- moving all of them to
+ * a proper per-user app-data directory is a larger, separate change. Here we
+ * only make sure a non-writable install degrades to a clean no-op (same as
+ * before this feature existed) instead of a partial failure or a crash.
  */
-import { existsSync } from "fs";
+import { existsSync, writeFileSync, unlinkSync } from "fs";
 import { spawn } from "child_process";
 import path from "path";
 import { mcpServerDir } from "./paths.ts";
 import { readStudioConfig, writeStudioConfig } from "../../config.ts";
+import { findSystemPython } from "../venv/systemPython.ts";
 // Plain ESM (not TS) so scripts/postinstall-mcp-setup.mjs can share it with zero build step.
-import { venvPython, venvIsWorking, findSystemPython as findPathPython } from "../../../../scripts/mcpVenvProbe.mjs";
-// Full resolver (env override -> persisted systemPython -> known install locations -> PATH).
-// Only usable here (TS, bundled server code) -- the plain-.mjs probe above stays PATH-only so
-// the zero-build-step postinstall script can keep importing it directly.
-import { findSystemPython as findConfiguredPython } from "../venv/systemPython.ts";
+import { venvPython, venvIsWorking } from "../../../../scripts/mcpVenvProbe.mjs";
 
 const RETRY_BACKOFF_MS = 60 * 60 * 1000;
 
 let attemptedThisProcess = false;
 
-// `cmd` is always a fixed candidate ("python"/"python3") or a path this module
-// constructs under a known `.venv` dir -- never user input -- and spawn runs
-// without a shell, so there's no command-injection surface here.
+function isWritable(dir: string): boolean {
+  const probe = path.join(dir, `.mcp-setup-write-test-${process.pid}`);
+  try {
+    writeFileSync(probe, "");
+    unlinkSync(probe);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// `cmd` is always a fixed candidate ("python"/"python3"), a path resolved by
+// findSystemPython(), or a path this module constructs under a known `.venv`
+// dir -- never user input -- and spawn runs without a shell, so there's no
+// command-injection surface here.
 function run(cmd: string, args: string[], cwd: string): Promise<boolean> {
   return new Promise((resolve) => {
     // nosemgrep: javascript.lang.security.detect-child-process -- cmd is internal-only, see comment above this function
@@ -42,15 +60,10 @@ function run(cmd: string, args: string[], cwd: string): Promise<boolean> {
 }
 
 function recordResult(lastResult: "ok" | "python-missing" | "failed"): void {
-  // Never throw out of a fire-and-forget setup step: on a packaged install where the
-  // resource dir (and thus .olive-studio/config.json under it) isn't writable, this
-  // write itself can fail. Swallow it -- setup is still best-effort either way, and an
-  // unhandled rejection here would otherwise propagate out of the caller's void-called
-  // promise chain.
   try {
     writeStudioConfig({ mcpAutoSetup: { lastAttemptAt: new Date().toISOString(), lastResult } });
   } catch (err: unknown) {
-    console.warn("[mcp-setup] Failed to persist setup result:", err instanceof Error ? err.message : err);
+    console.warn("[mcp-setup] failed to persist setup result:", err instanceof Error ? err.message : err);
   }
 }
 
@@ -90,20 +103,40 @@ async function performSetup(mcpDir: string, pythonCmd: string): Promise<void> {
   recordResult("ok");
 }
 
-/**
- * Resolves the Python interpreter to use for setup: prefers the full config-aware
- * resolver (OLIVE_STUDIO_PYTHON -> persisted systemPython -> known per-OS install
- * locations -> PATH) so a user who selected Python via Runtime -> Set Python (or has
- * it outside PATH) is honored here too, then falls back to the PATH-only probe.
- */
-async function resolveSetupPython(): Promise<string | null> {
-  try {
-    const configured = await findConfiguredPython();
-    if (configured) return configured;
-  } catch {
-    // fall through to the PATH-only probe below
+async function runEnsureMcpSetup(): Promise<void> {
+  const mcpDir = mcpServerDir();
+  if (!existsSync(mcpDir)) return; // not bundled: npm CLI install, or dev checkout mid-clone
+
+  const existing = venvPython(mcpDir);
+  if (existing && venvIsWorking(existing, mcpDir)) return; // already set up
+
+  const last = readStudioConfig().mcpAutoSetup;
+  if (last && last.lastResult !== "ok" && Date.now() - Date.parse(last.lastAttemptAt) < RETRY_BACKOFF_MS) {
+    return; // avoid re-attempting/re-warning a repeat failure on every relaunch within the backoff window
   }
-  return findPathPython();
+
+  if (!isWritable(mcpDir)) {
+    console.warn(
+      "[mcp-setup] MCP server directory is read-only (common for /Applications or AppImage installs) -- " +
+        "skipping auto-setup. MCP features are unavailable until it's set up from a writable location.",
+    );
+    recordResult("failed");
+    return;
+  }
+
+  // Honors OLIVE_STUDIO_PYTHON / the persisted systemPython setting / standard
+  // per-user install locations, not just a bare "python"/"python3" on PATH.
+  const pythonCmd = await findSystemPython();
+  if (!pythonCmd) {
+    console.warn(
+      "[mcp-setup] No supported system Python found. MCP features are unavailable until Python is installed " +
+        "(will retry automatically).",
+    );
+    recordResult("python-missing");
+    return;
+  }
+
+  await performSetup(mcpDir, pythonCmd);
 }
 
 /** Fire-and-forget: call once at server startup. Safe to call in any context. */
@@ -111,28 +144,7 @@ export function ensureMcpSetupInBackground(): void {
   if (attemptedThisProcess) return;
   attemptedThisProcess = true;
 
-  const mcpDir = mcpServerDir();
-  if (!existsSync(mcpDir)) return; // not bundled: npm CLI install, or dev checkout mid-clone
-
-  const existing = venvPython(mcpDir);
-  if (existing && venvIsWorking(existing, mcpDir)) return; // already set up
-
-  void (async () => {
-    const pythonCmd = await resolveSetupPython();
-    if (!pythonCmd) {
-      console.warn(
-        "[mcp-setup] Python >= 3.10 not found. MCP features are unavailable until Python is installed " +
-          "(the app will retry automatically on next launch).",
-      );
-      recordResult("python-missing");
-      return;
-    }
-
-    const last = readStudioConfig().mcpAutoSetup;
-    if (last?.lastResult === "failed" && Date.now() - Date.parse(last.lastAttemptAt) < RETRY_BACKOFF_MS) {
-      return; // avoid hammering a failing install (e.g. offline) on every relaunch
-    }
-
-    await performSetup(mcpDir, pythonCmd);
-  })();
+  runEnsureMcpSetup().catch((err: unknown) => {
+    console.warn("[mcp-setup] background setup failed unexpectedly:", err instanceof Error ? err.message : err);
+  });
 }

--- a/src/server/services/mcp/ensureMcpSetup.ts
+++ b/src/server/services/mcp/ensureMcpSetup.ts
@@ -15,7 +15,11 @@ import path from "path";
 import { mcpServerDir } from "./paths.ts";
 import { readStudioConfig, writeStudioConfig } from "../../config.ts";
 // Plain ESM (not TS) so scripts/postinstall-mcp-setup.mjs can share it with zero build step.
-import { venvPython, venvIsWorking, findSystemPython } from "../../../../scripts/mcpVenvProbe.mjs";
+import { venvPython, venvIsWorking, findSystemPython as findPathPython } from "../../../../scripts/mcpVenvProbe.mjs";
+// Full resolver (env override -> persisted systemPython -> known install locations -> PATH).
+// Only usable here (TS, bundled server code) -- the plain-.mjs probe above stays PATH-only so
+// the zero-build-step postinstall script can keep importing it directly.
+import { findSystemPython as findConfiguredPython } from "../venv/systemPython.ts";
 
 const RETRY_BACKOFF_MS = 60 * 60 * 1000;
 
@@ -38,7 +42,16 @@ function run(cmd: string, args: string[], cwd: string): Promise<boolean> {
 }
 
 function recordResult(lastResult: "ok" | "python-missing" | "failed"): void {
-  writeStudioConfig({ mcpAutoSetup: { lastAttemptAt: new Date().toISOString(), lastResult } });
+  // Never throw out of a fire-and-forget setup step: on a packaged install where the
+  // resource dir (and thus .olive-studio/config.json under it) isn't writable, this
+  // write itself can fail. Swallow it -- setup is still best-effort either way, and an
+  // unhandled rejection here would otherwise propagate out of the caller's void-called
+  // promise chain.
+  try {
+    writeStudioConfig({ mcpAutoSetup: { lastAttemptAt: new Date().toISOString(), lastResult } });
+  } catch (err: unknown) {
+    console.warn("[mcp-setup] Failed to persist setup result:", err instanceof Error ? err.message : err);
+  }
 }
 
 async function performSetup(mcpDir: string, pythonCmd: string): Promise<void> {
@@ -77,6 +90,22 @@ async function performSetup(mcpDir: string, pythonCmd: string): Promise<void> {
   recordResult("ok");
 }
 
+/**
+ * Resolves the Python interpreter to use for setup: prefers the full config-aware
+ * resolver (OLIVE_STUDIO_PYTHON -> persisted systemPython -> known per-OS install
+ * locations -> PATH) so a user who selected Python via Runtime -> Set Python (or has
+ * it outside PATH) is honored here too, then falls back to the PATH-only probe.
+ */
+async function resolveSetupPython(): Promise<string | null> {
+  try {
+    const configured = await findConfiguredPython();
+    if (configured) return configured;
+  } catch {
+    // fall through to the PATH-only probe below
+  }
+  return findPathPython();
+}
+
 /** Fire-and-forget: call once at server startup. Safe to call in any context. */
 export function ensureMcpSetupInBackground(): void {
   if (attemptedThisProcess) return;
@@ -88,20 +117,22 @@ export function ensureMcpSetupInBackground(): void {
   const existing = venvPython(mcpDir);
   if (existing && venvIsWorking(existing, mcpDir)) return; // already set up
 
-  const pythonCmd = findSystemPython();
-  if (!pythonCmd) {
-    console.warn(
-      "[mcp-setup] Python >= 3.10 not found on PATH. MCP features are unavailable until Python is installed " +
-        "(the app will retry automatically on next launch).",
-    );
-    recordResult("python-missing");
-    return;
-  }
+  void (async () => {
+    const pythonCmd = await resolveSetupPython();
+    if (!pythonCmd) {
+      console.warn(
+        "[mcp-setup] Python >= 3.10 not found. MCP features are unavailable until Python is installed " +
+          "(the app will retry automatically on next launch).",
+      );
+      recordResult("python-missing");
+      return;
+    }
 
-  const last = readStudioConfig().mcpAutoSetup;
-  if (last?.lastResult === "failed" && Date.now() - Date.parse(last.lastAttemptAt) < RETRY_BACKOFF_MS) {
-    return; // avoid hammering a failing install (e.g. offline) on every relaunch
-  }
+    const last = readStudioConfig().mcpAutoSetup;
+    if (last?.lastResult === "failed" && Date.now() - Date.parse(last.lastAttemptAt) < RETRY_BACKOFF_MS) {
+      return; // avoid hammering a failing install (e.g. offline) on every relaunch
+    }
 
-  void performSetup(mcpDir, pythonCmd);
+    await performSetup(mcpDir, pythonCmd);
+  })();
 }

--- a/src/server/services/mcp/ensureMcpSetup.ts
+++ b/src/server/services/mcp/ensureMcpSetup.ts
@@ -10,42 +10,20 @@
  * either way, this only makes it available with zero manual steps when it can.
  */
 import { existsSync } from "fs";
-import { spawn, spawnSync } from "child_process";
+import { spawn } from "child_process";
 import path from "path";
 import { mcpServerDir } from "./paths.ts";
 import { readStudioConfig, writeStudioConfig } from "../../config.ts";
+// Plain ESM (not TS) so scripts/postinstall-mcp-setup.mjs can share it with zero build step.
+import { venvPython, venvIsWorking, findSystemPython } from "../../../../scripts/mcpVenvProbe.mjs";
 
 const RETRY_BACKOFF_MS = 60 * 60 * 1000;
 
 let attemptedThisProcess = false;
 
-function venvPython(mcpDir: string): string | null {
-  const winPy = path.join(mcpDir, ".venv", "Scripts", "python.exe");
-  const nixPy = path.join(mcpDir, ".venv", "bin", "python");
-  if (existsSync(winPy)) return winPy;
-  if (existsSync(nixPy)) return nixPy;
-  return null;
-}
-
-function venvIsWorking(python: string, mcpDir: string): boolean {
-  const r = spawnSync(python, ["-c", "import mcp"], {
-    env: { ...process.env, PYTHONPATH: mcpDir },
-  });
-  return r.status === 0;
-}
-
-function findSystemPython(): string | null {
-  const candidates = process.platform === "win32" ? ["python", "python3"] : ["python3", "python"];
-  for (const cmd of candidates) {
-    const r = spawnSync(cmd, ["--version"], { encoding: "utf8" });
-    if (r.status === 0) {
-      const match = /Python 3\.(\d+)/.exec(r.stdout || r.stderr || "");
-      if (match && Number(match[1]) >= 10) return cmd;
-    }
-  }
-  return null;
-}
-
+// `cmd` is always a fixed candidate ("python"/"python3") or a path this module
+// constructs under a known `.venv` dir -- never user input -- and spawn runs
+// without a shell, so there's no command-injection surface here.
 function run(cmd: string, args: string[], cwd: string): Promise<boolean> {
   return new Promise((resolve) => {
     const child = spawn(cmd, args, { cwd, stdio: "pipe" });

--- a/src/server/services/mcp/ensureMcpSetup.ts
+++ b/src/server/services/mcp/ensureMcpSetup.ts
@@ -49,7 +49,9 @@ function findSystemPython(): string | null {
 function run(cmd: string, args: string[], cwd: string): Promise<boolean> {
   return new Promise((resolve) => {
     const child = spawn(cmd, args, { cwd, stdio: "pipe" });
+    // eslint-disable-next-line no-console -- intentional background setup progress logging
     child.stdout?.on("data", (d: Buffer) => console.log(`[mcp-setup] ${d.toString().trim()}`));
+    // eslint-disable-next-line no-console -- intentional background setup progress logging
     child.stderr?.on("data", (d: Buffer) => console.log(`[mcp-setup] ${d.toString().trim()}`));
     child.on("error", () => resolve(false));
     child.on("exit", (code) => resolve(code === 0));
@@ -62,6 +64,7 @@ function recordResult(lastResult: "ok" | "python-missing" | "failed"): void {
 
 async function performSetup(mcpDir: string, pythonCmd: string): Promise<void> {
   const venvDir = path.join(mcpDir, ".venv");
+  // eslint-disable-next-line no-console -- intentional background setup progress logging
   console.log("[mcp-setup] Setting up Olive MCP server (first launch, one-time)...");
 
   if (!(await run(pythonCmd, ["-m", "venv", venvDir], mcpDir))) {
@@ -90,6 +93,7 @@ async function performSetup(mcpDir: string, pythonCmd: string): Promise<void> {
     return;
   }
 
+  // eslint-disable-next-line no-console -- intentional background setup progress logging
   console.log("[mcp-setup] Olive MCP server is ready.");
   recordResult("ok");
 }

--- a/src/server/services/mcp/ensureMcpSetup.ts
+++ b/src/server/services/mcp/ensureMcpSetup.ts
@@ -1,0 +1,124 @@
+/**
+ * First-launch, best-effort MCP server venv setup for packaged desktop builds.
+ *
+ * A plain `pnpm install` already gets this via postinstall (scripts/postinstall-mcp-setup.mjs).
+ * That doesn't run for a packaged Tauri install, so this covers the same gap
+ * at server startup instead: if the bundled `olive-mcp-server/` resource is
+ * present but its venv isn't set up, set it up in the background.
+ *
+ * Never blocks server startup and never throws — the app works without MCP
+ * either way, this only makes it available with zero manual steps when it can.
+ */
+import { existsSync } from "fs";
+import { spawn, spawnSync } from "child_process";
+import path from "path";
+import { mcpServerDir } from "./paths.ts";
+import { readStudioConfig, writeStudioConfig } from "../../config.ts";
+
+const RETRY_BACKOFF_MS = 60 * 60 * 1000;
+
+let attemptedThisProcess = false;
+
+function venvPython(mcpDir: string): string | null {
+  const winPy = path.join(mcpDir, ".venv", "Scripts", "python.exe");
+  const nixPy = path.join(mcpDir, ".venv", "bin", "python");
+  if (existsSync(winPy)) return winPy;
+  if (existsSync(nixPy)) return nixPy;
+  return null;
+}
+
+function venvIsWorking(python: string, mcpDir: string): boolean {
+  const r = spawnSync(python, ["-c", "import mcp"], {
+    env: { ...process.env, PYTHONPATH: mcpDir },
+  });
+  return r.status === 0;
+}
+
+function findSystemPython(): string | null {
+  const candidates = process.platform === "win32" ? ["python", "python3"] : ["python3", "python"];
+  for (const cmd of candidates) {
+    const r = spawnSync(cmd, ["--version"], { encoding: "utf8" });
+    if (r.status === 0) {
+      const match = /Python 3\.(\d+)/.exec(r.stdout || r.stderr || "");
+      if (match && Number(match[1]) >= 10) return cmd;
+    }
+  }
+  return null;
+}
+
+function run(cmd: string, args: string[], cwd: string): Promise<boolean> {
+  return new Promise((resolve) => {
+    const child = spawn(cmd, args, { cwd, stdio: "pipe" });
+    child.stdout?.on("data", (d: Buffer) => console.log(`[mcp-setup] ${d.toString().trim()}`));
+    child.stderr?.on("data", (d: Buffer) => console.log(`[mcp-setup] ${d.toString().trim()}`));
+    child.on("error", () => resolve(false));
+    child.on("exit", (code) => resolve(code === 0));
+  });
+}
+
+function recordResult(lastResult: "ok" | "python-missing" | "failed"): void {
+  writeStudioConfig({ mcpAutoSetup: { lastAttemptAt: new Date().toISOString(), lastResult } });
+}
+
+async function performSetup(mcpDir: string, pythonCmd: string): Promise<void> {
+  const venvDir = path.join(mcpDir, ".venv");
+  console.log("[mcp-setup] Setting up Olive MCP server (first launch, one-time)...");
+
+  if (!(await run(pythonCmd, ["-m", "venv", venvDir], mcpDir))) {
+    console.warn("[mcp-setup] Failed to create venv.");
+    recordResult("failed");
+    return;
+  }
+
+  const venvPy =
+    process.platform === "win32" ? path.join(venvDir, "Scripts", "python.exe") : path.join(venvDir, "bin", "python");
+
+  const installOk = await run(
+    venvPy,
+    ["-m", "pip", "install", "--upgrade", "pip", "-e", `${mcpDir}[dev]`, "mcp<2", "--quiet"],
+    mcpDir,
+  );
+  if (!installOk) {
+    console.warn("[mcp-setup] pip install failed.");
+    recordResult("failed");
+    return;
+  }
+
+  if (!venvIsWorking(venvPy, mcpDir)) {
+    console.warn("[mcp-setup] Server import check failed after install.");
+    recordResult("failed");
+    return;
+  }
+
+  console.log("[mcp-setup] Olive MCP server is ready.");
+  recordResult("ok");
+}
+
+/** Fire-and-forget: call once at server startup. Safe to call in any context. */
+export function ensureMcpSetupInBackground(): void {
+  if (attemptedThisProcess) return;
+  attemptedThisProcess = true;
+
+  const mcpDir = mcpServerDir();
+  if (!existsSync(mcpDir)) return; // not bundled: npm CLI install, or dev checkout mid-clone
+
+  const existing = venvPython(mcpDir);
+  if (existing && venvIsWorking(existing, mcpDir)) return; // already set up
+
+  const pythonCmd = findSystemPython();
+  if (!pythonCmd) {
+    console.warn(
+      "[mcp-setup] Python >= 3.10 not found on PATH. MCP features are unavailable until Python is installed " +
+        "(the app will retry automatically on next launch).",
+    );
+    recordResult("python-missing");
+    return;
+  }
+
+  const last = readStudioConfig().mcpAutoSetup;
+  if (last?.lastResult === "failed" && Date.now() - Date.parse(last.lastAttemptAt) < RETRY_BACKOFF_MS) {
+    return; // avoid hammering a failing install (e.g. offline) on every relaunch
+  }
+
+  void performSetup(mcpDir, pythonCmd);
+}

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -190,6 +190,11 @@ export interface StudioConfig {
   agentAccess?: AgentAccessPolicy;
   /** MCP server retrieval settings (persisted across restarts). */
   mcpSettings?: McpSettings;
+  /** Result of the last background first-launch MCP venv setup attempt (packaged desktop builds). */
+  mcpAutoSetup?: {
+    lastAttemptAt: string;
+    lastResult: "ok" | "python-missing" | "failed";
+  };
 }
 
 export interface McpSettings {


### PR DESCRIPTION
## Summary

Removes the manual `setup-mcp.ps1`/`.sh` step from the happy path so MCP support is seamless for both dev clones and packaged desktop installs.

- **`postinstall-mcp-setup.mjs`** runs MCP venv setup automatically after `pnpm install`. Guarded so it never blocks or fails the install: skips in CI, skips (with a warning) if Python isn't found, no-ops if the venv already works.
- **Tauri bundle** now ships the `olive-mcp-server` source as explicit resource subpaths (not the whole directory, so a local `.venv` never gets swept into a build) — previously the packaged desktop installer shipped without the MCP server directory at all.
- **`ensureMcpSetup.ts`** triggers the same setup in the background on first launch of a packaged build (gated to production/packaged builds only), with a 1h backoff on repeated failure so an offline machine isn't hammered with install attempts on every relaunch. Result is persisted to `.olive-studio/config.json`.

### Bugs fixed along the way

- `scripts/setup-mcp.ps1`'s server-import verification step merged stderr into its captured output under `$ErrorActionPreference = "Stop"`. That let a benign Python warning (e.g. a pydantic deprecation notice) get promoted into a terminating PowerShell error — specifically whenever the script's stdio was piped rather than an interactive console, i.e. every automated/CI invocation. Fixed by locally relaxing `$ErrorActionPreference` around that one native call and checking `$LASTEXITCODE` directly.
- `import mcp; print(mcp.__version__)` always raised `AttributeError` since the pinned `mcp<2` package has no `__version__`. Both the new postinstall check and the pre-existing `check-mcp-venv.mjs` Kiro session-start hook were silently reporting a false "deps may be incomplete" warning even when the venv was fine. Fixed both to just check that `import mcp` succeeds.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `oxlint` clean on touched files
- [x] Verified `postinstall-mcp-setup.mjs` end-to-end through the actual failure repro path (Node spawning `powershell -File` with piped stdio) — confirmed broken before the `setup-mcp.ps1` fix, fixed after
- [x] Verified idempotent no-op path (`venvIsWorking` check) after fixing the `__version__` bug
- [x] Smoke-tested `pnpm dev` startup with `ensureMcpSetupInBackground` wired in — no crash, correctly skipped (dev is gated out)
- [x] Directly invoked `ensureMcpSetupInBackground()` in a production-env context — no throw, correct no-op given an already-working venv
- [ ] Not tested: actual Tauri packaged build / first-launch flow (requires a full `tauri build`, out of scope for CI-safe local verification)

## Notes for reviewers

- No in-app UI prompt for the "Python missing" case yet — it's console/log-only, matching the existing warn-only pattern elsewhere in the repo (`check-mcp-venv.mjs`). A real dialog would need frontend + IPC work.
- `ensureMcpSetupInBackground()` is gated by `shouldServeProductionStatic()`, matching the existing prod/dev detection convention in `server.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tonythethompson/Olive-Studio/pull/306?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

