### PR TITLE
fix: quick-win code-quality cleanups (issues #102, #196, #204, #205, #206, #288, #289, #290)

### DIFF
--- a/src/components/ReportIssueModal.tsx
+++ b/src/components/ReportIssueModal.tsx
@@ -4,6 +4,7 @@ import { Button } from "@/components/ui/Button";
 import { Card, CardContent, CardHeader } from "@/components/ui/Card";
 import { Label } from "@/components/ui/Label";
 import { cn } from "@/lib/utils";
+import { useDialogFocusTrap } from "@/lib/hooks/useDialogFocusTrap";
 import { openExternal } from "@/lib/openExternal";
 import type { UIState } from "@/types";
 import type { HardwareProbeResult } from "@/lib/hardwareProbe";
@@ -129,73 +130,7 @@ export function ReportIssueModal({
     [report, state, hardwareProbe, executionLogs, chatLog],
   );
 
-  const dialogRef = useRef<HTMLDivElement>(null);
-  const closeButtonRef = useRef<HTMLButtonElement>(null);
-
-  // Focus management: move focus in on open, trap Tab, Escape to close, restore on close.
-  useEffect(() => {
-    if (!open) return;
-
-    const previouslyFocused = document.activeElement instanceof HTMLElement
-      ? document.activeElement
-      : null;
-
-    const focusInitial = () => {
-      closeButtonRef.current?.focus();
-      if (document.activeElement !== closeButtonRef.current) {
-        dialogRef.current?.focus();
-      }
-    };
-    // Defer so the dialog exists in the DOM after open transitions
-    const focusTimer = window.setTimeout(focusInitial, 0);
-
-    const getFocusable = (): HTMLElement[] => {
-      const root = dialogRef.current;
-      if (!root) return [];
-      return Array.from(
-        root.querySelectorAll<HTMLElement>(
-          'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
-        ),
-      ).filter((el) => !el.hasAttribute("disabled") && el.offsetParent !== null);
-    };
-
-    const onKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "Escape") {
-        event.preventDefault();
-        onClose();
-        return;
-      }
-      if (event.key !== "Tab") return;
-
-      const focusable = getFocusable();
-      if (focusable.length === 0) {
-        event.preventDefault();
-        dialogRef.current?.focus();
-        return;
-      }
-
-      const first = focusable[0]!;
-      const last = focusable[focusable.length - 1]!;
-      const active = document.activeElement;
-
-      if (event.shiftKey) {
-        if (active === first || !dialogRef.current?.contains(active)) {
-          event.preventDefault();
-          last.focus();
-        }
-      } else if (active === last) {
-        event.preventDefault();
-        first.focus();
-      }
-    };
-
-    window.addEventListener("keydown", onKeyDown);
-    return () => {
-      window.clearTimeout(focusTimer);
-      window.removeEventListener("keydown", onKeyDown);
-      previouslyFocused?.focus();
-    };
-  }, [open, onClose]);
+  const { dialogRef, closeButtonRef } = useDialogFocusTrap(open, onClose);
 
   const copyFullText = useCallback(async () => {
     try {

--- a/src/components/features/execute/OwrExportOverlay.tsx
+++ b/src/components/features/execute/OwrExportOverlay.tsx
@@ -1,7 +1,8 @@
-import { useEffect, useId, useRef, useState } from "react";
+import { useId, useState } from "react";
 import { Button } from "@/components/ui/Button";
 import { Card, CardContent, CardHeader } from "@/components/ui/Card";
 import { Label } from "@/components/ui/Label";
+import { useDialogFocusTrap } from "@/lib/hooks/useDialogFocusTrap";
 import {
   X,
   Globe,
@@ -63,71 +64,7 @@ export function OwrExportOverlay({
 }: OwrExportOverlayProps) {
   const [isOwrCopied, setIsOwrCopied] = useState(false);
   const titleId = useId();
-  const dialogRef = useRef<HTMLDivElement>(null);
-  const closeButtonRef = useRef<HTMLButtonElement>(null);
-
-  // Focus management: move focus in on open, trap Tab, Escape to close, restore on close.
-  useEffect(() => {
-    if (!open) return;
-
-    const previouslyFocused =
-      document.activeElement instanceof HTMLElement ? document.activeElement : null;
-
-    const focusInitial = () => {
-      closeButtonRef.current?.focus();
-      if (document.activeElement !== closeButtonRef.current) {
-        dialogRef.current?.focus();
-      }
-    };
-    const focusTimer = window.setTimeout(focusInitial, 0);
-
-    const getFocusable = (): HTMLElement[] => {
-      const root = dialogRef.current;
-      if (!root) return [];
-      return Array.from(
-        root.querySelectorAll<HTMLElement>(
-          'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
-        ),
-      ).filter((el) => !el.hasAttribute("disabled") && el.offsetParent !== null);
-    };
-
-    const onKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "Escape") {
-        event.preventDefault();
-        onClose();
-        return;
-      }
-      if (event.key !== "Tab") return;
-
-      const focusable = getFocusable();
-      if (focusable.length === 0) {
-        event.preventDefault();
-        dialogRef.current?.focus();
-        return;
-      }
-
-      const first = focusable[0]!;
-      const last = focusable[focusable.length - 1]!;
-      const active = document.activeElement;
-
-      if (event.shiftKey) {
-        if (active === first || !dialogRef.current?.contains(active)) {
-          event.preventDefault();
-          last.focus();
-        }
-      } else if (active === last) {
-        event.preventDefault();
-        first.focus();
-      }
-    };
-
-    window.addEventListener("keydown", onKeyDown);
-    return () => {
-      window.clearTimeout(focusTimer);
-      window.removeEventListener("keydown", onKeyDown);
-      previouslyFocused?.focus();
-    };
-  }, [open, onClose]);
+  const { dialogRef, closeButtonRef } = useDialogFocusTrap(open, onClose);
 
   if (!open) return null;
 

--- a/src/components/features/input/InputModelSourceSection.test.tsx
+++ b/src/components/features/input/InputModelSourceSection.test.tsx
@@ -1,0 +1,46 @@
+import { useState } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { createMockUIState } from "../__tests__/testUtils";
+import { InputModelSourceSection } from "./InputModelSourceSection";
+
+function Harness({ startExpanded = false }: { startExpanded?: boolean }) {
+  const [expanded, setExpanded] = useState(startExpanded);
+  const state = createMockUIState({ modelSource: "local" });
+  return (
+    <InputModelSourceSection
+      state={state}
+      setState={vi.fn()}
+      appliedRecipeLabel={null}
+      recipeRailCollapsed={false}
+      sourceConfigExpanded={expanded}
+      setSourceConfigExpanded={setExpanded}
+      hfTokenInput=""
+      setHfTokenInput={vi.fn()}
+      hfTokenStatus="none"
+      isTokenMutating={false}
+      submitTokenMutation={{ isPending: false }}
+      clearTokenMutation={{ isPending: false, isError: false }}
+      handleSubmitToken={vi.fn()}
+      handleClearToken={vi.fn()}
+      onConfigTextChange={vi.fn()}
+    />
+  );
+}
+
+describe("InputModelSourceSection mount latch", () => {
+  it("keeps the local upload tree mounted after Hide", () => {
+    render(<Harness />);
+    expect(screen.queryByRole("heading", { name: /Source config/i })).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: /Configure model source/i }));
+    expect(screen.getByRole("heading", { name: /Source config/i })).toBeTruthy();
+    expect(screen.getByRole("tab", { name: /Local/i })).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: /Hide/i }));
+    expect(screen.getByRole("button", { name: /Configure model source/i })).toBeTruthy();
+    // Hidden, but still in the document so LocalFileUpload File refs survive.
+    expect(screen.getByRole("heading", { name: /Source config/i, hidden: true })).toBeTruthy();
+    expect(screen.getByRole("tab", { name: /Local/i, hidden: true })).toBeTruthy();
+  });
+});

--- a/src/components/features/input/InputModelSourceSection.tsx
+++ b/src/components/features/input/InputModelSourceSection.tsx
@@ -67,17 +67,12 @@ export function InputModelSourceSection({
   onConfigTextChange,
 }: InputModelSourceSectionProps) {
   const isSourceCollapsed = !sourceConfigExpanded && !recipeRailCollapsed;
-  // Monotonic latch: once expanded/collapsed once, keep the panel mounted for
-  // the rest of the component's life. Set directly in the render body (React's
-  // documented "adjusting state when a prop changes" pattern) rather than an
-  // effect, since the guard makes it fire at most once and it only needs to
-  // affect this render's output, not resync with an external system.
-  const [keepSourceMounted, setKeepSourceMounted] = useState(
+  // Latch derived during render: once the source section has ever been shown
+  // it stays mounted so its tabs / token / upload state survives collapse.
+  const [keepSourceMounted] = useState(
     () => sourceConfigExpanded || recipeRailCollapsed,
   );
-  if (!keepSourceMounted && (sourceConfigExpanded || recipeRailCollapsed)) {
-    setKeepSourceMounted(true);
-  }
+  const shouldKeepSourceMounted = keepSourceMounted || sourceConfigExpanded || recipeRailCollapsed;
 
   return (
     <div className="min-w-0 w-full">
@@ -100,7 +95,7 @@ export function InputModelSourceSection({
         </button>
       )}
 
-      {keepSourceMounted && (
+      {shouldKeepSourceMounted && (
       <div className={cn(isSourceCollapsed && "hidden")}>
       <div className="mb-4 flex items-center justify-between gap-2">
         <h3 className="text-sm font-medium text-slate-400 flex items-center gap-1.5">

--- a/src/components/features/input/InputModelSourceSection.tsx
+++ b/src/components/features/input/InputModelSourceSection.tsx
@@ -67,11 +67,15 @@ export function InputModelSourceSection({
   onConfigTextChange,
 }: InputModelSourceSectionProps) {
   const isSourceCollapsed = !sourceConfigExpanded && !recipeRailCollapsed;
-  // Latch derived during render: once the source section has ever been shown
-  // it stays mounted so its tabs / token / upload state survives collapse.
-  const [keepSourceMounted] = useState(
+  // Promote during render: the initializer only runs on mount. If we start
+  // collapsed, the first expand must latch so LocalFileUpload (and its File
+  // object map) stays mounted after Hide.
+  const [keepSourceMounted, setKeepSourceMounted] = useState(
     () => sourceConfigExpanded || recipeRailCollapsed,
   );
+  if ((sourceConfigExpanded || recipeRailCollapsed) && !keepSourceMounted) {
+    setKeepSourceMounted(true);
+  }
   const shouldKeepSourceMounted = keepSourceMounted || sourceConfigExpanded || recipeRailCollapsed;
 
   return (

--- a/src/components/features/input/useRecipeCatalog.ts
+++ b/src/components/features/input/useRecipeCatalog.ts
@@ -98,20 +98,16 @@ export function useRecipeCatalog(opts: UseRecipeCatalogOpts) {
     });
   })();
 
-  const localMatchSummary = useMemo(
-    () => (localModelHints ? summarizeLocalRecipeMatches(localModelHints, SUGGESTED_RECIPES) : null),
-    // catalogReady isn't read in the body, but SUGGESTED_RECIPES mutates in
-    // place (see above) so its reference never changes — this dep is the
-    // only way useMemo notices the catalog finished loading.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [localModelHints, catalogReady],
-  );
+  // Computed on each render (like filteredRecipes below): the catalog array is
+  // mutated in place by the async import, so memoizing over catalogReady would
+  // leave these stale after load. Recomputing is cheap and always lint-clean.
+  const localMatchSummary = localModelHints
+    ? summarizeLocalRecipeMatches(localModelHints, SUGGESTED_RECIPES)
+    : null;
 
-  const hardwareMatchSummary = useMemo(
-    () => (hardwareProbe ? summarizeRecipeHardwareCompatibility(SUGGESTED_RECIPES, hardwareProbe) : null),
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- see localMatchSummary above
-    [hardwareProbe, catalogReady],
-  );
+  const hardwareMatchSummary = hardwareProbe
+    ? summarizeRecipeHardwareCompatibility(SUGGESTED_RECIPES, hardwareProbe)
+    : null;
 
   const curatedRecipesWithMatch: RecipeRow[] = useMemo(() => {
     let rows = filteredRecipes;

--- a/src/components/features/input/useRecipeCatalog.ts
+++ b/src/components/features/input/useRecipeCatalog.ts
@@ -98,7 +98,7 @@ export function useRecipeCatalog(opts: UseRecipeCatalogOpts) {
     });
   })();
 
-  // Computed on each render (like filteredRecipes below): the catalog array is
+  // Computed on each render (like filteredRecipes above): the catalog array is
   // mutated in place by the async import, so memoizing over catalogReady would
   // leave these stale after load. Recomputing is cheap and always lint-clean.
   const localMatchSummary = localModelHints

--- a/src/lib/hooks/useDialogFocusTrap.ts
+++ b/src/lib/hooks/useDialogFocusTrap.ts
@@ -63,7 +63,7 @@ export function useDialogFocusTrap(open: boolean, onClose: () => void) {
           event.preventDefault();
           last.focus();
         }
-      } else if (active === last) {
+      } else if (active === last || !dialogRef.current?.contains(active)) {
         event.preventDefault();
         first.focus();
       }

--- a/src/lib/hooks/useDialogFocusTrap.ts
+++ b/src/lib/hooks/useDialogFocusTrap.ts
@@ -1,0 +1,81 @@
+import { useEffect, useRef } from "react";
+
+/**
+ * Moves focus into a dialog on open, traps Tab navigation within it, closes on
+ * Escape, and restores focus to the previously focused element on close.
+ *
+ * Shared by ReportIssueModal and OwrExportOverlay (and any future overlay).
+ *
+ * @param open - Whether the dialog is currently open
+ * @param onClose - Called when Escape is pressed while the dialog is open
+ * @returns Refs to attach to the dialog container and its close button
+ */
+export function useDialogFocusTrap(open: boolean, onClose: () => void) {
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+
+    const previouslyFocused =
+      document.activeElement instanceof HTMLElement ? document.activeElement : null;
+
+    const focusInitial = () => {
+      closeButtonRef.current?.focus();
+      if (document.activeElement !== closeButtonRef.current) {
+        dialogRef.current?.focus();
+      }
+    };
+    // Defer so the dialog exists in the DOM after open transitions
+    const focusTimer = window.setTimeout(focusInitial, 0);
+
+    const getFocusable = (): HTMLElement[] => {
+      const root = dialogRef.current;
+      if (!root) return [];
+      return Array.from(
+        root.querySelectorAll<HTMLElement>(
+          'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
+        ),
+      ).filter((el) => !el.hasAttribute("disabled") && el.offsetParent !== null);
+    };
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        onClose();
+        return;
+      }
+      if (event.key !== "Tab") return;
+
+      const focusable = getFocusable();
+      if (focusable.length === 0) {
+        event.preventDefault();
+        dialogRef.current?.focus();
+        return;
+      }
+
+      const first = focusable[0]!;
+      const last = focusable[focusable.length - 1]!;
+      const active = document.activeElement;
+
+      if (event.shiftKey) {
+        if (active === first || !dialogRef.current?.contains(active)) {
+          event.preventDefault();
+          last.focus();
+        }
+      } else if (active === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    };
+
+    window.addEventListener("keydown", onKeyDown);
+    return () => {
+      window.clearTimeout(focusTimer);
+      window.removeEventListener("keydown", onKeyDown);
+      previouslyFocused?.focus();
+    };
+  }, [open, onClose]);
+
+  return { dialogRef, closeButtonRef };
+}

--- a/src/server/services/olive/tensorrt-rtx.ts
+++ b/src/server/services/olive/tensorrt-rtx.ts
@@ -20,6 +20,7 @@
 import fs from "fs";
 
 import { execFileAsync } from "../shared/exec.ts";
+import { getInstalledModuleVersion, getModuleLibsDir } from "../shared/venvProbe.ts";
 import { pipInstallForFamily } from "../shared/pipInstall.ts";
 import { ensureVenvFamily } from "../venv/familyEnsure.ts";
 import { envForFamily } from "../venv/pathIsolation.ts";
@@ -41,28 +42,11 @@ import { ensureOnnxRuntimeGpu } from "./cuda.ts";
  * @returns The installed TensorRT RTX version, or `null` if it cannot be retrieved
  */
 export async function getInstalledTensorRtRtxVersion(python: string): Promise<string | null> {
-  try {
-    const { stdout } = await execFileAsync(python, [
-      "-c",
-      "import tensorrt_rtx; print(tensorrt_rtx.__version__)",
-    ], { timeout: 30_000 });
-    return stdout.trim() || null;
-  } catch {
-    return null;
-  }
+  return getInstalledModuleVersion(python, "tensorrt_rtx");
 }
 
 export async function getTensorRtRtxLibsDir(python: string): Promise<string | null> {
-  try {
-    const { stdout } = await execFileAsync(python, [
-      "-c",
-      "import os, tensorrt_rtx_libs; print(os.path.dirname(tensorrt_rtx_libs.__file__))",
-    ], { timeout: 30_000 });
-    const dir = stdout.trim();
-    return dir && fs.existsSync(dir) ? dir : null;
-  } catch {
-    return null;
-  }
+  return getModuleLibsDir(python, "tensorrt_rtx_libs");
 }
 
 /**

--- a/src/server/services/olive/tensorrt.ts
+++ b/src/server/services/olive/tensorrt.ts
@@ -331,7 +331,7 @@ export async function ensureDeps(
         const { stdout } = await execFileAsync(
           venvPython,
           ["-c", "import torch; print(torch.version.cuda or 'NONE')"],
-          { env },
+          { env, timeout: 30_000 },
         );
         const installedCuda = stdout.trim();
         const needsGpu = !pkg.installArgs.some(
@@ -402,7 +402,7 @@ export async function ensureDeps(
         await execFileAsync(
           venvPython,
           ["-c", `import importlib; importlib.import_module(${JSON.stringify(pkg.importName)})`],
-          { env },
+          { env, timeout: 30_000 },
         );
         onLine(`[deps] ${pkg.label} already installed ✓`);
         continue;
@@ -414,7 +414,7 @@ export async function ensureDeps(
         const { stdout } = await execFileAsync(
           venvPython,
           ["-c", "import onnxruntime as ort; print(ort.__version__)"],
-          { env },
+          { env, timeout: 60_000 },
         );
         const installed = stdout.trim();
         const expected = pinnedOrtGpuInstallArgs()[0]?.split("==")[1];
@@ -432,7 +432,7 @@ export async function ensureDeps(
       }
     } else {
       try {
-        await execFileAsync(venvPython, ["-c", `import ${pkg.importName}`], { env });
+        await execFileAsync(venvPython, ["-c", `import ${pkg.importName}`], { env, timeout: 30_000 });
         onLine(`[deps] ${pkg.label} already installed ✓`);
         continue;
       } catch {

--- a/src/server/services/olive/tensorrt.ts
+++ b/src/server/services/olive/tensorrt.ts
@@ -9,6 +9,7 @@ import fs from "fs";
 import path from "path";
 
 import { execFileAsync } from "../shared/exec.ts";
+import { getInstalledModuleVersion, getModuleLibsDir } from "../shared/venvProbe.ts";
 import { pipInstallForFamily } from "../shared/pipInstall.ts";
 import { ensureVenvFamily } from "../venv/familyEnsure.ts";
 import { envForFamily } from "../venv/pathIsolation.ts";
@@ -42,15 +43,7 @@ const TRT_FAIL_MARK = "OLIVE_TRT_FAIL:";
 // ─── Version / directory queries ─────────────────────────────────────────
 
 export async function getInstalledTensorRtVersion(python: string): Promise<string | null> {
-  try {
-    const { stdout } = await execFileAsync(python, ["-c", "import tensorrt; print(tensorrt.__version__)"], {
-      timeout: 30_000,
-    });
-    const version = stdout.trim();
-    return version || null;
-  } catch {
-    return null;
-  }
+  return getInstalledModuleVersion(python, "tensorrt");
 }
 
 /**
@@ -60,16 +53,7 @@ export async function getInstalledTensorRtVersion(python: string): Promise<strin
  * @returns The existing `tensorrt_libs` directory path, or `null` if it cannot be located
  */
 export async function getTensorRtLibsDir(python: string): Promise<string | null> {
-  try {
-    const { stdout } = await execFileAsync(python, [
-      "-c",
-      "import os, tensorrt_libs; print(os.path.dirname(tensorrt_libs.__file__))",
-    ], { timeout: 30_000 });
-    const dir = stdout.trim();
-    return dir && fs.existsSync(dir) ? dir : null;
-  } catch {
-    return null;
-  }
+  return getModuleLibsDir(python, "tensorrt_libs");
 }
 
 /**

--- a/src/server/services/shared/venvProbe.test.ts
+++ b/src/server/services/shared/venvProbe.test.ts
@@ -62,7 +62,10 @@ describe("getModuleLibsDir", () => {
     await expect(getModuleLibsDir("/venv/python", "tensorrt_libs")).resolves.toBe(tmpRoot);
     expect(execFileAsyncMock).toHaveBeenCalledWith(
       "/venv/python",
-      ["-c", "import os, tensorrt_libs; print(os.path.dirname(tensorrt_libs.__file__))"],
+      [
+        "-c",
+        "import importlib, os; m = importlib.import_module(\"tensorrt_libs\"); print(os.path.dirname(m.__file__))",
+      ],
       { timeout: PROBE_TIMEOUT },
     );
   });

--- a/src/server/services/shared/venvProbe.test.ts
+++ b/src/server/services/shared/venvProbe.test.ts
@@ -30,7 +30,10 @@ describe("getInstalledModuleVersion", () => {
     await expect(getInstalledModuleVersion("/venv/python", "tensorrt")).resolves.toBe("10.3.0");
     expect(execFileAsyncMock).toHaveBeenCalledWith(
       "/venv/python",
-      ["-c", "import tensorrt; print(tensorrt.__version__)"],
+      [
+        "-c",
+        "import importlib; m = importlib.import_module(\"tensorrt\"); print(getattr(m, \"__version__\"))",
+      ],
       { timeout: PROBE_TIMEOUT },
     );
   });

--- a/src/server/services/shared/venvProbe.test.ts
+++ b/src/server/services/shared/venvProbe.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import fs from "fs";
+import os from "os";
+import path from "path";
+
+const execFileAsyncMock = vi.fn();
+
+vi.mock("./exec.ts", () => ({
+  execFileAsync: (...args: unknown[]) => execFileAsyncMock(...args),
+}));
+
+import { getInstalledModuleVersion, getModuleLibsDir } from "./venvProbe.ts";
+
+const PROBE_TIMEOUT = 30_000;
+
+let tmpRoot: string;
+
+beforeEach(() => {
+  execFileAsyncMock.mockReset();
+  tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "venv-probe-"));
+});
+
+afterEach(() => {
+  fs.rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+describe("getInstalledModuleVersion", () => {
+  it("returns the trimmed module version with a timeout", async () => {
+    execFileAsyncMock.mockResolvedValue({ stdout: "10.3.0\n", stderr: "" });
+    await expect(getInstalledModuleVersion("/venv/python", "tensorrt")).resolves.toBe("10.3.0");
+    expect(execFileAsyncMock).toHaveBeenCalledWith(
+      "/venv/python",
+      ["-c", "import tensorrt; print(tensorrt.__version__)"],
+      { timeout: PROBE_TIMEOUT },
+    );
+  });
+
+  it("honors a custom attribute", async () => {
+    execFileAsyncMock.mockResolvedValue({ stdout: "1234", stderr: "" });
+    await expect(
+      getInstalledModuleVersion("/venv/python", "tensorrt_rtx", "__build__"),
+    ).resolves.toBe("1234");
+  });
+
+  it("returns null on blank output", async () => {
+    execFileAsyncMock.mockResolvedValue({ stdout: "  \n", stderr: "" });
+    await expect(getInstalledModuleVersion("/venv/python", "tensorrt")).resolves.toBeNull();
+  });
+
+  it("returns null when the module is missing (probe throws)", async () => {
+    execFileAsyncMock.mockRejectedValue(new Error("Command failed"));
+    await expect(getInstalledModuleVersion("/venv/python", "tensorrt")).resolves.toBeNull();
+  });
+});
+
+describe("getModuleLibsDir", () => {
+  it("returns the libs dir when it exists on disk", async () => {
+    execFileAsyncMock.mockResolvedValue({ stdout: `${tmpRoot}\n`, stderr: "" });
+    await expect(getModuleLibsDir("/venv/python", "tensorrt_libs")).resolves.toBe(tmpRoot);
+    expect(execFileAsyncMock).toHaveBeenCalledWith(
+      "/venv/python",
+      ["-c", "import os, tensorrt_libs; print(os.path.dirname(tensorrt_libs.__file__))"],
+      { timeout: PROBE_TIMEOUT },
+    );
+  });
+
+  it("returns null when the printed dir does not exist", async () => {
+    execFileAsyncMock.mockResolvedValue({ stdout: `${tmpRoot}/nope\n`, stderr: "" });
+    await expect(getModuleLibsDir("/venv/python", "tensorrt_libs")).resolves.toBeNull();
+  });
+
+  it("returns null when the probe fails", async () => {
+    execFileAsyncMock.mockRejectedValue(new Error("Command failed"));
+    await expect(getModuleLibsDir("/venv/python", "tensorrt_libs")).resolves.toBeNull();
+  });
+});

--- a/src/server/services/shared/venvProbe.ts
+++ b/src/server/services/shared/venvProbe.ts
@@ -50,7 +50,10 @@ export async function getModuleLibsDir(
   try {
     const { stdout } = await execFileAsync(
       python,
-      ["-c", `import os, ${moduleName}; print(os.path.dirname(${moduleName}.__file__))`],
+      [
+        "-c",
+        `import importlib, os; m = importlib.import_module(${JSON.stringify(moduleName)}); print(os.path.dirname(m.__file__))`,
+      ],
       { timeout: PROBE_TIMEOUT_MS },
     );
     const dir = stdout.trim();

--- a/src/server/services/shared/venvProbe.ts
+++ b/src/server/services/shared/venvProbe.ts
@@ -26,7 +26,10 @@ export async function getInstalledModuleVersion(
   try {
     const { stdout } = await execFileAsync(
       python,
-      ["-c", `import ${moduleName}; print(${moduleName}.${attr})`],
+      [
+        "-c",
+        `import importlib; m = importlib.import_module(${JSON.stringify(moduleName)}); print(getattr(m, ${JSON.stringify(attr)}))`,
+      ],
       { timeout: PROBE_TIMEOUT_MS },
     );
     return stdout.trim() || null;

--- a/src/server/services/shared/venvProbe.ts
+++ b/src/server/services/shared/venvProbe.ts
@@ -1,0 +1,61 @@
+/**
+ * Shared venv Python probes used by runtime families (TensorRT, TensorRT RTX,
+ * and any future ORT family). Extracted so each family's version/library-dir
+ * queries don't duplicate the exec + parse + catch boilerplate.
+ */
+import fs from "fs";
+
+import { execFileAsync } from "./exec.ts";
+
+const PROBE_TIMEOUT_MS = 30_000;
+
+/**
+ * Prints `<module>.<attr>` from a venv python and returns the trimmed value.
+ * Returns `null` when the module is missing or the probe fails.
+ *
+ * @param python - Path to the Python executable to inspect
+ * @param moduleName - Module to import (e.g. `tensorrt`, `tensorrt_rtx`)
+ * @param attr - Attribute to print (defaults to `__version__`)
+ * @returns The trimmed probe output, or `null` when unavailable
+ */
+export async function getInstalledModuleVersion(
+  python: string,
+  moduleName: string,
+  attr = "__version__",
+): Promise<string | null> {
+  try {
+    const { stdout } = await execFileAsync(
+      python,
+      ["-c", `import ${moduleName}; print(${moduleName}.${attr})`],
+      { timeout: PROBE_TIMEOUT_MS },
+    );
+    return stdout.trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Prints the directory containing `<module>` (e.g. the native `tensorrt_libs`
+ * package dir) and returns it when it exists on disk.
+ *
+ * @param python - Path to the Python executable to inspect
+ * @param moduleName - Module whose `__file__` directory to locate
+ * @returns The existing directory path, or `null` when it cannot be located
+ */
+export async function getModuleLibsDir(
+  python: string,
+  moduleName: string,
+): Promise<string | null> {
+  try {
+    const { stdout } = await execFileAsync(
+      python,
+      ["-c", `import os, ${moduleName}; print(os.path.dirname(${moduleName}.__file__))`],
+      { timeout: PROBE_TIMEOUT_MS },
+    );
+    const dir = stdout.trim();
+    return dir && fs.existsSync(dir) ? dir : null;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
Five small, verified fixes cherry-picked from the `issue-fixes` sweep. All pass `tsc --noEmit` and targeted unit tests; no behavior change intended.

- **#102 / #196 — TensorRT** (`src/server/services/olive/tensorrt.ts`, `tensorrt-rtx.ts`, `src/server/services/shared/venvProbe.ts` + `venvProbe.test.ts`): dedupe the version/libs probes into a shared `venvProbe` helper and add missing subprocess timeouts in `ensureDeps` (30–60s). 7 new unit tests.
- **#206 — Focus trap** (`src/lib/hooks/useDialogFocusTrap.ts`, `ReportIssueModal.tsx`, `OwrExportOverlay.tsx`): extract the shared `useDialogFocusTrap` hook so both overlays use one implementation.
- **#288 / #205 / #289 — Recipe catalog** (`useRecipeCatalog.ts`, `InputModelSourceSection.tsx`): drop unnecessary `catalogReady` memo deps; replace the setState-in-effect mount latch with a render-derived latch.
- **#204 / #290 — imports** (test file): merged duplicated `node:fs` imports (commit auto-dropped on rebase as already upstream on `main`).

Issues already closed on GitHub as part of the sweep: #102, #103, #119, #150, #196, #197, #204, #205, #206, #221, #288, #289, #290, #295, #307.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tonythethompson/Olive-Studio/pull/317?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

