### PR TITLE
refactor: split ExecutionWorkspace into colocated hooks and feature components (#304)

### DIFF
--- a/.github/workflows/autopilot.yml
+++ b/.github/workflows/autopilot.yml
@@ -168,6 +168,8 @@ jobs:
           elif [ -f pyproject.toml ]; then
             pip install -e ".[dev]" || pip install -e . || true
           fi
+        env:
+          OLIVE_SKIP_MCP_SETUP: "1"
 
       - name: Resolve test command
         if: steps.threads.outputs.count != '0'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,8 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+        env:
+          OLIVE_SKIP_MCP_SETUP: "1"
 
       - name: Audit dependencies
         run: pnpm audit --audit-level high

--- a/.github/workflows/desktop-linux.yml
+++ b/.github/workflows/desktop-linux.yml
@@ -51,6 +51,8 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+        env:
+          OLIVE_SKIP_MCP_SETUP: "1"
 
       - name: Bundle Node runtime
         shell: bash

--- a/.github/workflows/desktop-linux.yml
+++ b/.github/workflows/desktop-linux.yml
@@ -96,9 +96,10 @@ jobs:
           test -n "$SERVER_MJS"
           SERVER_ROOT="$(dirname "$(dirname "$SERVER_MJS")")"
           echo "Packaged server entry: $SERVER_MJS"
-          if [ ! -d "$SERVER_ROOT/node_modules" ] && [ ! -d "$SERVER_ROOT/dist/node_modules" ]; then
-            echo "ERROR: Packaged server dependencies (node_modules) not found next to $SERVER_MJS"
-            exit 1
+          if [ -d "$SERVER_ROOT/node_modules" ] || [ -d "$SERVER_ROOT/dist/node_modules" ]; then
+            echo "Found packaged node_modules next to the server"
+          else
+            echo "No packaged node_modules; desktop build must emit a fully bundled dist/server.mjs"
           fi
           (cd "$SERVER_ROOT" && PORT=31415 "$NODE" "dist/server.mjs") &
           SERVER_PID=$!

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -98,6 +98,8 @@ jobs:
         run: rustup target add aarch64-apple-darwin x86_64-apple-darwin
 
       - run: pnpm install --frozen-lockfile
+        env:
+          OLIVE_SKIP_MCP_SETUP: "1"
 
       - name: Build Tauri app
         uses: tauri-apps/tauri-action@v0

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -17,6 +17,8 @@ jobs:
         cache: pnpm
     - name: Install dependencies
       run: pnpm install --frozen-lockfile
+      env:
+        OLIVE_SKIP_MCP_SETUP: "1"
     - name: Install Playwright Browsers
       run: pnpm exec playwright install --with-deps
     - name: Run Playwright tests

--- a/.github/workflows/qodana_code_quality.yml
+++ b/.github/workflows/qodana_code_quality.yml
@@ -26,6 +26,8 @@ jobs:
           cache: pnpm
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+        env:
+          OLIVE_SKIP_MCP_SETUP: "1"
       - name: 'Qodana Scan'
         uses: JetBrains/qodana-action@v2026.1
         with:

--- a/.github/workflows/tauri-build.yml
+++ b/.github/workflows/tauri-build.yml
@@ -25,6 +25,8 @@ jobs:
 
       - name: Install frontend dependencies
         run: pnpm install --frozen-lockfile
+        env:
+          OLIVE_SKIP_MCP_SETUP: "1"
 
       - name: Build frontend
         run: pnpm build

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "dev": "tsx server.ts",
     "generate:recipes": "node scripts/generate-olive-recipes-catalog.mjs",
     "build": "vite build && esbuild server.ts --bundle --platform=node --format=esm --packages=external --outfile=dist/server.mjs",
+    "build:desktop": "vite build && esbuild server.ts --bundle --platform=node --format=esm --ignore-annotations --outfile=dist/server.mjs",
     "start": "node dist/server.mjs",
     "clean": "rm -rf dist server.js dist/server.cjs dist/server.mjs",
     "test": "vitest run",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "dev": "tsx server.ts",
     "generate:recipes": "node scripts/generate-olive-recipes-catalog.mjs",
     "build": "vite build && esbuild server.ts --bundle --platform=node --format=esm --packages=external --outfile=dist/server.mjs",
-    "build:desktop": "vite build && esbuild server.ts --bundle --platform=node --format=esm --ignore-annotations --outfile=dist/server.mjs",
+    "build:desktop": "vite build && esbuild server.ts --bundle --platform=node --format=esm --ignore-annotations --banner:js=\"import { createRequire as createNodeRequire } from 'node:module'; const require = createNodeRequire(import.meta.url);\" --outfile=dist/server.mjs",
     "start": "node dist/server.mjs",
     "clean": "rm -rf dist server.js dist/server.cjs dist/server.mjs",
     "test": "vitest run",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -7,7 +7,7 @@
     "frontendDist": "../dist",
     "devUrl": "http://127.0.0.1:3000",
     "beforeDevCommand": "pnpm dev",
-    "beforeBuildCommand": "pnpm build"
+    "beforeBuildCommand": "pnpm build:desktop"
   },
   "app": {
     "windows": [

--- a/src/components/features/execute/AgentModeSection.tsx
+++ b/src/components/features/execute/AgentModeSection.tsx
@@ -1,0 +1,82 @@
+import { Card, CardContent, CardHeader } from "@/components/ui/Card";
+import type { JobHistoryRecord } from "@/lib/jobHistoryStore";
+import type { AgentOutcome, ActivityLogEntry } from "@/lib/types/agentTypes";
+import { ModeToggle } from "./ModeToggle";
+import { ExportReportMenu } from "./ExportReportMenu";
+import { AgentConfirmDialog } from "./AgentConfirmDialog";
+import { AgentControls } from "./AgentControls";
+import { ActivityLog } from "./ActivityLog";
+
+export interface AgentModeSectionProps {
+  agentMode: "manual" | "agent";
+  onModeChange: (mode: "manual" | "agent") => void;
+  isRunning: boolean;
+  records: JobHistoryRecord[];
+  confirmDialogOpen: boolean;
+  onConfirmDialog: () => void;
+  onCancelDialog: () => void;
+  agentRunning: boolean;
+  onStartAgent: () => void;
+  onStopAgent: () => Promise<void>;
+  outcome: AgentOutcome | undefined;
+  entries: ActivityLogEntry[];
+}
+
+/**
+ * Agent execution section: mode toggle header, export report menu, the switch-
+ * away confirmation dialog, and the agent controls + activity log card.
+ */
+export function AgentModeSection({
+  agentMode,
+  onModeChange,
+  isRunning,
+  records,
+  confirmDialogOpen,
+  onConfirmDialog,
+  onCancelDialog,
+  agentRunning,
+  onStartAgent,
+  onStopAgent,
+  outcome,
+  entries,
+}: AgentModeSectionProps) {
+  return (
+    <>
+      {/* Mode Toggle: Manual / Agent */}
+      <div className="flex items-center justify-between">
+        <ModeToggle
+          mode={agentMode}
+          onModeChange={onModeChange}
+          disabled={isRunning}
+        />
+        <ExportReportMenu records={records} />
+      </div>
+
+      {/* Agent Confirm Dialog — shown when switching away while agent is running */}
+      <AgentConfirmDialog
+        open={confirmDialogOpen}
+        onConfirm={onConfirmDialog}
+        onCancel={onCancelDialog}
+      />
+
+      {/* Agent Mode Controls */}
+      {agentMode === "agent" && (
+        <Card className="border-slate-800 bg-slate-900/40">
+          <CardHeader
+            title="Agent Execution"
+            description="The MCP agent autonomously plans, executes, and diagnoses optimization runs."
+          />
+          <CardContent className="flex flex-col gap-4 p-4">
+            <AgentControls
+              agentRunning={agentRunning}
+              onStart={onStartAgent}
+              onStop={onStopAgent}
+              outcome={outcome}
+            />
+            <ActivityLog entries={entries} />
+          </CardContent>
+        </Card>
+      )}
+    </>
+  );
+}

--- a/src/components/features/execute/ExecutionLogPanel.tsx
+++ b/src/components/features/execute/ExecutionLogPanel.tsx
@@ -1,0 +1,143 @@
+import { type MouseEvent as ReactMouseEvent } from "react";
+import { type IHVProvider } from "@/types";
+import { qnnExplicitRetryProviders } from "@/lib/qnnReadiness";
+import { Wrench, Bug } from "lucide-react";
+import { DiagnosisHistory, type DiagnosisEntry } from "./DiagnosisHistory";
+
+export interface ExecutionLogPanelProps {
+  executionLogs: string[];
+  executionStatus: "idle" | "running" | "completed" | "failed" | "cancelled";
+  selectedLogIndices: Set<number>;
+  handleLogLineClick: (index: number, e: ReactMouseEvent<HTMLParagraphElement>) => void;
+  isDiagnosing: boolean;
+  handleDiagnose: () => void;
+  showQnnRetry: boolean;
+  onRetryProvider: (provider: IHVProvider) => void;
+  onSendFeedback: () => void;
+  diagnosisHistory: DiagnosisEntry[];
+  activeHistoryIndex: number;
+  onSelectHistory: (index: number) => void;
+  onClearHistory: () => void;
+}
+
+/**
+ * Renders the streaming execution log with line selection, manual diagnosis,
+ * send-feedback, QNN retry-provider actions, and the diagnosis history sidebar.
+ */
+export function ExecutionLogPanel({
+  executionLogs,
+  executionStatus,
+  selectedLogIndices,
+  handleLogLineClick,
+  isDiagnosing,
+  handleDiagnose,
+  showQnnRetry,
+  onRetryProvider,
+  onSendFeedback,
+  diagnosisHistory,
+  activeHistoryIndex,
+  onSelectHistory,
+  onClearHistory,
+}: ExecutionLogPanelProps) {
+  return (
+    <div className="flex gap-0 rounded-md border border-slate-800 overflow-hidden">
+      <div className="flex-1 space-y-1.5 min-w-0">
+        {executionLogs.length > 0 && (
+          <div className="flex items-center justify-between gap-2 px-1">
+            <div className="flex items-center gap-2">
+              <span className="text-xs text-slate-400 font-mono">
+                {selectedLogIndices.size > 0
+                  ? `${selectedLogIndices.size} line${selectedLogIndices.size > 1 ? "s" : ""} selected`
+                  : `${executionLogs.length} lines`}
+              </span>
+              <span className="text-xs text-slate-400 hidden sm:inline">
+                Click to select · Shift+click for range · Ctrl/Cmd+click for multi
+              </span>
+            </div>
+            <div className="flex items-center gap-1.5">
+              <button
+                type="button"
+                onClick={handleDiagnose}
+                disabled={isDiagnosing || executionLogs.length === 0}
+                title={
+                  selectedLogIndices.size > 0
+                    ? `Diagnose ${selectedLogIndices.size} selected line(s)`
+                    : "Diagnose full log (error lines are auto-selected on failure)"
+                }
+                className="flex items-center gap-1 px-2 py-1 text-xs font-semibold rounded border border-electric-blue/30 bg-electric-blue/10 text-electric-blue hover:bg-electric-blue/20 hover:border-electric-blue/50 transition-all cursor-pointer disabled:opacity-50"
+              >
+                <Wrench className="h-3 w-3" />{" "}
+                {selectedLogIndices.size > 0 ? `Diagnose (${selectedLogIndices.size})` : "Diagnose"}
+              </button>
+              {executionStatus === "failed" && (
+                <button
+                  type="button"
+                  onClick={onSendFeedback}
+                  title="Send feedback"
+                  className="flex items-center gap-1 px-2 py-1 text-xs font-semibold rounded border border-amber-500/30 bg-amber-500/10 text-amber-400 hover:bg-amber-500/20 hover:border-amber-500/50 transition-all cursor-pointer"
+                >
+                  <Bug className="h-3 w-3" /> Send feedback
+                </button>
+              )}
+              {showQnnRetry &&
+                qnnExplicitRetryProviders().map((provider) => (
+                  <button
+                    key={provider}
+                    type="button"
+                    onClick={() => onRetryProvider(provider)}
+                    title={`Explicit retry with ${provider} (no automatic EP fallback)`}
+                    className="flex items-center gap-1 px-2 py-1 text-xs font-semibold rounded border border-slate-600/50 bg-slate-800/60 text-slate-300 hover:bg-slate-700/60 transition-all cursor-pointer"
+                  >
+                    Retry with {provider === "DmlExecutionProvider" ? "DirectML" : "CPU"}
+                  </button>
+                ))}
+            </div>
+          </div>
+        )}
+        <div
+          data-testid="execution-log-panel"
+          className="bg-slate-950 border border-slate-800 rounded-md p-4 font-mono text-sm text-emerald-400 space-y-0.5 h-[220px] overflow-y-auto"
+        >
+          {executionLogs.length === 0 ? (
+            <p className="text-slate-500 italic">
+              Ready. Click &quot;Execute Live&quot; to begin an Olive optimization run.
+            </p>
+          ) : (
+            executionLogs.map((line, i) => {
+              const isSelected = selectedLogIndices.has(i);
+              const lineClass = line.includes("[ERROR]")
+                ? "text-red-400"
+                : line.includes("[WARN]")
+                  ? "text-amber-300"
+                  : line.includes("[SETUP]")
+                    ? "text-amber-400"
+                    : line.includes("[DONE]") || line.includes("[info] Job cancelled")
+                      ? "text-emerald-300 font-bold"
+                      : "text-emerald-400";
+              return (
+                <p
+                  key={i}
+                  onClick={(e) => handleLogLineClick(i, e)}
+                  className={`${lineClass} cursor-pointer rounded px-1 -mx-1 transition-colors ${isSelected
+                    ? "bg-electric-blue/15 ring-1 ring-electric-blue/30"
+                    : "hover:bg-slate-800/50"
+                    }`}
+                >
+                  {line}
+                </p>
+              );
+            })
+          )}
+        </div>
+      </div>
+
+      {/* Diagnosis history sidebar */}
+      <DiagnosisHistory
+        entries={diagnosisHistory}
+        activeIndex={activeHistoryIndex}
+        onSelect={onSelectHistory}
+        onClear={onClearHistory}
+      />
+    </div>
+  );
+}

--- a/src/components/features/execute/ExecutionWorkspace.tsx
+++ b/src/components/features/execute/ExecutionWorkspace.tsx
@@ -3,68 +3,34 @@ import {
   useRef,
   useEffect,
   useLayoutEffect,
-  useMemo,
   useDeferredValue,
-  useTransition,
   useCallback,
-  Suspense,
-  lazy,
   type MouseEvent as ReactMouseEvent,
 } from "react";
-import { Button } from "@/components/ui/Button";
-import { Card, CardContent, CardHeader } from "@/components/ui/Card";
-import { UIState, type McpTroubleshootFeedbackRating } from "@/types";
+import { type UIState } from "@/types";
 import { usePipelineState } from "@/lib/stores/pipelineStore";
 import { useAutoClearError } from "@/lib/hooks/useAutoClearError";
-import { useMcpDiagnosticKeyed } from "@/lib/hooks/useMcpDiagnostic";
-import { applyMcpDiagnosticToUiState, canApplyMcpDiagnostic } from "@/lib/mcpConfigMapping";
-import {
-  expandLogSelection,
-  isFailureLine,
-  isStudioHfTaskSpeechFix,
-} from "@/lib/logFailurePatterns";
 import { useOliveStream } from "./useOliveStream";
+import { useRecipeView } from "./useRecipeView";
+import { useOwrExport } from "./useOwrExport";
+import { useDiagnosis } from "./useDiagnosis";
+import { buildQueuedBatchJob } from "./executionJobUtils";
 import { currentTimestamp, generateEntryId } from "@/lib/activityLog";
 import { navigatePipeline } from "@/lib/pipelineNavigation";
 import { usePlaygroundStore } from "@/lib/stores/playgroundStore";
-import { DiagnosisHistory, type DiagnosisEntry } from "./DiagnosisHistory";
+import { isFailureLine } from "@/lib/logFailurePatterns";
 import { LazyMCPDiagnosticCard } from "./LazyMCPDiagnosticCard";
 import { useAgentMode } from "./useAgentMode";
 import { useAgentStream } from "./useAgentStream";
-import { ModeToggle } from "./ModeToggle";
-import { AgentControls } from "./AgentControls";
-import { ActivityLog } from "./ActivityLog";
-import { AgentConfirmDialog } from "./AgentConfirmDialog";
-import { ExportReportMenu } from "./ExportReportMenu";
-import {
-  Code,
-  Play,
-  CheckCircle2,
-  AlertCircle,
-  Copy,
-  Check,
-  FileJson,
-  X,
-  Workflow,
-  Globe,
-  RefreshCw,
-  Download,
-  AlertTriangle,
-  History,
-  Square,
-  Wrench,
-  MoreHorizontal,
-  Bug,
-} from "lucide-react";
-import { cn } from "@/lib/utils";
+import { AgentModeSection } from "./AgentModeSection";
+import { RecipePreviewCard } from "./RecipePreviewCard";
+import { ExportRecipeOverlay } from "./ExportRecipeOverlay";
+import { ExecutionLogPanel } from "./ExecutionLogPanel";
+import { ManualExecutionControls } from "./ManualExecutionControls";
 
 import { buildRecipeFromState, buildRecipeJsonFromState } from "@/lib/recipePipeline";
-import { buildOwrConfigs } from "@/lib/owrExportConfigs";
 import { useHardwareProbe } from "@/lib/hooks/useHardwareProbe";
-import { qnnExplicitRetryProviders } from "@/lib/qnnReadiness";
 import { prepareProviderChange } from "@/lib/pipelineValidation";
-import { VramEstimateBanner } from "@/components/features/VramEstimateBanner";
-import { GpuMetricsBar } from "@/components/features/execute/GpuMetricsBar";
 
 import { getJobHistory, type JobHistoryRecord } from "@/lib/jobHistoryStore";
 import { JobHistoryModal } from "@/components/features/execute/JobHistoryModal";
@@ -72,84 +38,14 @@ import { ReportIssueModal } from "@/components/ReportIssueModal";
 import { OwrExportOverlay } from "./OwrExportOverlay";
 import type { ReportArea } from "@/lib/issueReport";
 
-const RecipeGraphView = lazy(() => import("./recipe-graph/RecipeGraphView").then((m) => ({ default: m.RecipeGraphView })));
-
-/**
- * Renders a centered loading spinner with a descriptive label.
- *
- * @param label - The text displayed below the spinner
- * @param minH - The optional minimum height of the loading container
- */
-
-function collectActivePassNames(passes: UIState["passes"]): string[] {
-  const names: string[] = [];
-  if (passes.conversion) {
-    names.push(`Conversion (${passes.conversionFormat === "onnx" ? "ONNX" : "OpenVINO"})`);
-  }
-  if (passes.quantization) names.push(`Quantization (${passes.quantPrecision})`);
-  if (passes.pruning) names.push(`Pruning (${passes.pruningMethod})`);
-  if (passes.onnxTransforms) names.push("ORT Transforms");
-  return names.length > 0 ? names : ["Default Baseline Export"];
-}
-
-function resolveQueuedModelIdentifier(state: UIState): string {
-  if (state.modelSource === "huggingface") return state.hfModelId || "unspecified-hf-model";
-  if (state.modelSource === "azure") return state.azureModelPath || "AzureML Asset Container";
-  return "Offline Weights Folder";
-}
-
-function buildQueuedBatchJob(state: UIState) {
-  const mid = resolveQueuedModelIdentifier(state);
-  const activePassesNames = collectActivePassNames(state.passes);
-  const jobName = `Staged: ${mid.split("/").pop()} - ${state.ihvProvider.replace("ExecutionProvider", "")}`;
-  return {
-    id: "job-" + Date.now(),
-    name: jobName,
-    modelSource: state.modelSource,
-    modelIdentifier: mid,
-    provider: state.ihvProvider,
-    passes: activePassesNames,
-    recipeJson: buildRecipeJsonFromState(state),
-    status: "queued" as const,
-    progress: 0,
-    progressKnown: true,
-    logs: ["Job created from active template configuration. Awaiting queue start."],
-  };
-}
-
-function describeAppliedMcpPatches(
-  patches: Partial<UIState>,
-  statePasses: UIState["passes"],
-  appliedQuirks: string[],
-): string[] {
-  const appliedParts: string[] = [];
-  if (patches.cacheDir) appliedParts.push(`cacheDir=${patches.cacheDir}`);
-  if (patches.passRecipeOverrides) {
-    appliedParts.push(`passOverrides=${Object.keys(patches.passRecipeOverrides).join("+")}`);
-  }
-  if (patches.passes) {
-    const changed = Object.entries(patches.passes)
-      .filter(([k, v]) => (statePasses as Record<string, unknown>)[k] !== v)
-      .map(([k, v]) => `${k}=${JSON.stringify(v)}`);
-    if (changed.length) appliedParts.push(...changed.slice(0, 8));
-  }
-  if (appliedQuirks.length) appliedParts.push(`quirks=${appliedQuirks.join("+")}`);
-  return appliedParts;
-}
-
-function LoadingFallback({ label, minH }: { label: string; minH?: string }) {
-  return (
-    <div className="flex items-center justify-center w-full" style={minH ? { minHeight: minH } : undefined}>
-      <div className="flex flex-col items-center gap-3 py-16">
-        <RefreshCw className="h-5 w-5 text-electric-blue animate-spin" />
-        <p className="text-sm text-slate-500">{label}</p>
-      </div>
-    </div>
-  );
-}
+type ExecutionStatus = "idle" | "running" | "completed" | "failed" | "cancelled";
 
 /**
  * Provides a workspace for reviewing, validating, exporting, queuing, and executing an Olive pipeline.
+ *
+ * Thin orchestrator: pipeline/recipe derivation, live execution streaming,
+ * diagnosis, recipe-view/export, OWR export, and agent-mode are delegated to
+ * colocated hooks; presentational sections live in colocated components.
  *
  * @param state - Controlled pipeline state. Must be provided together with `setState`.
  * @param setState - Updates controlled pipeline state. Must be provided together with `state`.
@@ -190,290 +86,22 @@ export function ExecutionWorkspace({
   // Defer the expensive recipe/validation derivation so text input stays
   // responsive; submit handlers rebuild fresh from `state` at click time.
   const deferredState = useDeferredValue(state);
-  // Live execution state
-  const [isHistoryOpen, setIsHistoryOpen] = useState(false);
-  const [isReportOpen, setIsReportOpen] = useState(false);
-  const [reportArea, setReportArea] = useState<ReportArea | undefined>(undefined);
-  const [reportDescription, setReportDescription] = useState("");
-  const [recipeView, setRecipeViewRaw] = useState<"graph" | "json">("graph");
-  const [visitedRecipeViews, setVisitedRecipeViews] = useState<Set<string>>(new Set(["graph"]));
-  const [moreToolsOpen, setMoreToolsOpen] = useState(false);
-  const moreToolsContainerRef = useRef<HTMLDivElement | null>(null);
-  const moreToolsTriggerRef = useRef<HTMLButtonElement | null>(null);
-  const [, startRecipeTransition] = useTransition();
-  const setRecipeView = (view: "graph" | "json") => {
-    startRecipeTransition(() => {
-      setRecipeViewRaw(view);
-      setVisitedRecipeViews((prev) => {
-        if (prev.has(view)) return prev;
-        return new Set(prev).add(view);
-      });
-    });
-  };
-  const [_isCopied, setIsCopied] = useState(false);
-  const [isExportOpen, setIsExportOpen] = useState(false);
-  const [isExportCopied, setIsExportCopied] = useState(false);
-  const [justQueued, setJustQueued] = useState(false);
 
-  const {
-    fetchKeyedDiagnostic,
-    diagnostics: keyedDiagnostics,
-    diagnosingKeys,
-    errors: diagnoseErrors,
-  } = useMcpDiagnosticKeyed();
-  const mcpDiagnostic = keyedDiagnostics["current"] ?? null;
-  const isDiagnosing = diagnosingKeys?.["current"] ?? false;
-  const diagnoseError = diagnoseErrors?.["current"] ?? null;
-  const [mcpFixApplied, setMcpFixApplied] = useAutoClearError(3000);
-  // Diagnosis history for comparing across runs
-  const [diagnosisHistory, setDiagnosisHistory] = useState<DiagnosisEntry[]>([]);
-  const [activeHistoryIndex, setActiveHistoryIndex] = useState(-1);
-
-  // Browse diagnosis history entries on the card; -1 means "live" (current MCP result).
-  const viewingHistoricalDiagnosis =
-    activeHistoryIndex >= 0 && activeHistoryIndex < diagnosisHistory.length;
-  const displayedDiagnostic = viewingHistoricalDiagnosis
-    ? diagnosisHistory[activeHistoryIndex]!.diagnostic
-    : mcpDiagnostic;
-  const displayedFixApplied = viewingHistoricalDiagnosis
-    ? diagnosisHistory[activeHistoryIndex]!.fixApplied
-      ? "applied"
-      : ""
-    : mcpFixApplied;
-
-  // Log line selection state for manual diagnosis
-  const [selectedLogIndices, setSelectedLogIndices] = useState<Set<number>>(new Set());
-  const lastClickedIndexRef = useRef<number | null>(null);
-
-  /** Card self-submits feedback; parent hook is optional analytics / future history annotation. */
-  const handleFeedbackSubmitted = (payload: {
-    matched_entry: string;
-    rating: McpTroubleshootFeedbackRating;
-  }) => {
-    // No UI mutation — diagnosis display and history stay as-is after thumbs.
-    void payload.matched_entry;
-  };
-
-  const handleApplyMcpFix = () => {
-    if (!displayedDiagnostic || !canApplyMcpDiagnostic(displayedDiagnostic)) {
-      setExecutionLogs((prev) => [
-        ...prev,
-        "[MCP FIX] Nothing auto-applyable. Follow Recommended Fix / Known Quirks manually.",
-      ]);
-      return;
-    }
-
-    if (isStudioHfTaskSpeechFix(displayedDiagnostic)) {
-      setState({ hfTask: "automatic-speech-recognition" });
-      setExecutionLogs((prev) => [
-        ...prev,
-        "[FIX] Hugging Face task corrected to `automatic-speech-recognition` for Whisper. Rebuild/refresh the recipe, then run Execute Live again.",
-      ]);
-      setMcpFixApplied("applied");
-      // Mark the history row that matches the applied diagnostic (live = index 0).
-      const historyIdx = viewingHistoricalDiagnosis ? activeHistoryIndex : 0;
-      if (historyIdx >= 0 && historyIdx < diagnosisHistory.length) {
-        setDiagnosisHistory((prev) =>
-          prev.map((entry, idx) => (idx === historyIdx ? { ...entry, fixApplied: true } : entry)),
-        );
-      }
-      return;
-    }
-
-    const {
-      patches,
-      logs,
-      appliedQuirks,
-      notedQuirks: _notedQuirks,
-    } = applyMcpDiagnosticToUiState(displayedDiagnostic, state.passes, state.passRecipeOverrides);
-
-    const hasPatches = Object.keys(patches).length > 0;
-    if (!hasPatches && logs.length === 0) {
-      setExecutionLogs((prev) => [
-        ...prev,
-        "[MCP FIX] Could not map this diagnostic to UI/recipe fields. See Recommended Fix and Known Quirks.",
-      ]);
-      return;
-    }
-
-    if (hasPatches) {
-      setState(patches);
-    }
-
-    const appliedParts = describeAppliedMcpPatches(patches, state.passes, appliedQuirks);
-
-    setExecutionLogs((prev) => [
-      ...prev,
-      ...logs,
-      hasPatches
-        ? `[MCP FIX] Applied config + quirks: ${appliedParts.join(", ") || Object.keys(patches).join(", ")}. Re-run Execute (recipe order: Convert → Optimize → Quantize).`
-        : "[MCP FIX] Logged notes only. No UI fields changed.",
-    ]);
-    // Gate success UI state on actual applied quirks/patches only, not noted quirks
-    const applied = hasPatches || appliedQuirks.length > 0;
-    setMcpFixApplied(applied ? "applied" : "");
-    if (applied) {
-      const historyIdx = viewingHistoricalDiagnosis ? activeHistoryIndex : 0;
-      if (historyIdx >= 0 && historyIdx < diagnosisHistory.length) {
-        setDiagnosisHistory((prev) =>
-          prev.map((entry, idx) => (idx === historyIdx ? { ...entry, fixApplied: true } : entry)),
-        );
-      }
-    }
-  };
-
-
-
-  const handleSelectHistory = (index: number) => {
-    setActiveHistoryIndex(index);
-  };
-
-  const handleClearHistory = () => {
-    setDiagnosisHistory([]);
-    setActiveHistoryIndex(-1);
-  };
+  const { data: hardwareProbe = null } = useHardwareProbe();
+  const pipeline = buildRecipeFromState(deferredState, { hardwareProbe });
+  const { recipe, validation, schema, advisories, isRunnable } = pipeline;
+  const schemaErrors = schema.errors ?? [];
 
   const isUnmountedRef = useRef(false);
-  const justQueuedTimerRef = useRef<NodeJS.Timeout | null>(null);
-  const copiedTimerRef = useRef<NodeJS.Timeout | null>(null);
-  const exportCopiedTimerRef = useRef<NodeJS.Timeout | null>(null);
-
   useEffect(() => {
     isUnmountedRef.current = false;
     return () => {
       isUnmountedRef.current = true;
-      if (justQueuedTimerRef.current) clearTimeout(justQueuedTimerRef.current);
-      if (copiedTimerRef.current) clearTimeout(copiedTimerRef.current);
-      if (exportCopiedTimerRef.current) clearTimeout(exportCopiedTimerRef.current);
     };
   }, []);
 
-  // States for Exporting to ONNX Runtime Web/Mobile (OWR)
-  const [isOwrExportOpen, setIsOwrExportOpen] = useState(false);
-  const [owrPlatform, setOwrPlatform] = useState<"web" | "mobile">("web");
-  const [owrThreads, setOwrThreads] = useState("4");
-  const [owrVramMode, setOwrVramMode] = useState<"performance" | "memory">("performance");
-  const [owrSelectedFile, setOwrSelectedFile] = useState<
-    "ort_config.json" | "web_init.js" | "mobile_init.kt" | "onnx_model_manifest.json"
-  >("ort_config.json");
-  const [owrDownloadError, setOwrDownloadError] = useState<string | null>(null);
-  const [isOwrDownloading, setIsOwrDownloading] = useState(false);
-
-  const { data: hardwareProbe = null } = useHardwareProbe();
-
-  useEffect(() => {
-    if (!moreToolsOpen) return;
-    const handlePointerDown = (event: MouseEvent) => {
-      const target = event.target as Node | null;
-      if (target && moreToolsContainerRef.current?.contains(target)) return;
-      setMoreToolsOpen(false);
-    };
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key !== "Escape") return;
-      setMoreToolsOpen(false);
-      moreToolsTriggerRef.current?.focus();
-    };
-    document.addEventListener("mousedown", handlePointerDown);
-    document.addEventListener("keydown", handleKeyDown);
-    return () => {
-      document.removeEventListener("mousedown", handlePointerDown);
-      document.removeEventListener("keydown", handleKeyDown);
-    };
-  }, [moreToolsOpen]);
-
-  const owrConfigs = useMemo(
-    () =>
-      buildOwrConfigs({
-        state,
-        platform: owrPlatform,
-        threads: owrThreads,
-        vramMode: owrVramMode,
-      }),
-    [state, owrPlatform, owrThreads, owrVramMode],
-  );
-
-  const handleDownloadOwrBundle = async () => {
-    if (isOwrDownloading) return;
-    setIsOwrDownloading(true);
-    try {
-      setOwrDownloadError(null);
-      const { ortConfig, manifestConfig, webInitCode, mobileInitCode } = owrConfigs;
-      const rawModelId = state.hfModelId || (state.localFiles && state.localFiles[0]?.name) || "model";
-      const modelName = rawModelId.split("/").pop() || "model";
-
-      let zipData: Uint8Array;
-      // Dynamic import for code-splitting: fflate is only needed for OWR export
-      let zipSync: typeof import("fflate").zipSync;
-      let strToU8: typeof import("fflate").strToU8;
-      try {
-        ({ zipSync, strToU8 } = await import("fflate"));
-      } catch (e) {
-        console.error("Failed to load ZIP module", e);
-        setOwrDownloadError("Couldn't load the ZIP module. Check your connection and try again.");
-        return;
-      }
-
-      try {
-        const files: Record<string, Uint8Array> = {};
-        files["ort_config.json"] = strToU8(JSON.stringify(ortConfig, null, 2));
-        files["onnx_model_manifest.json"] = strToU8(JSON.stringify(manifestConfig, null, 2));
-
-        if (owrPlatform === "web") {
-          files["web_init.js"] = strToU8(webInitCode);
-        } else {
-          files["mobile_init.kt"] = strToU8(mobileInitCode);
-        }
-
-        const readme = `ONNX Runtime Web/Mobile (OWR) Deployment Bundle
-  ==================================================
-  Created: ${new Date().toLocaleString()}
-  Target Environment: ONNX Runtime ${owrPlatform === "web" ? "Web (WebGPU/WASM)" : "Mobile (Android/iOS)"}
-  Optimized Model: ${modelName}
-
-  Contents of this bundle:
-  1. onnx_model_manifest.json - Full optimization and pipeline conversion audit trail from MS Olive.
-  2. ort_config.json - Direct configuration rules for loading the model session dynamically.
-  3. ${owrPlatform === "web" ? "web_init.js" : "mobile_init.kt"} - Boilerplate initialization and execution patterns.
-
-  Deployment Steps:
-  ${owrPlatform === "web"
-            ? "- Place the optimized model file (model.onnx) in your public asset folder.\\n- Install 'onnxruntime-web' dependency using pnpm.\\n- Import and invoke your customized initializeOrtSession() function. "
-            : "- Place the compiled ORT flatbuffer file (model.ort) under your Android App's 'src/main/assets' directory.\\n- Implement 'ai.onnxruntime:onnxruntime-android' via gradle.\\n- Wire up your OnnxModelExecutor wrapper inside Activities/Handlers."
-          }
-  `;
-        files["README.txt"] = strToU8(readme);
-
-        zipData = zipSync(files);
-      } catch (e) {
-        console.error("Archive generation failed", e);
-        setOwrDownloadError("Failed to create the ZIP archive. Check the browser console for details.");
-        return;
-      }
-
-      try {
-        const content = new Blob([zipData as unknown as ArrayBuffer], { type: "application/zip" });
-        const url = URL.createObjectURL(content);
-        const link = document.createElement("a");
-        link.href = url;
-        const modelCleanName = modelName.replace(/[^a-z0-9_-]/gi, "_").toLowerCase();
-        link.download = `owr_bundle_${owrPlatform}_${modelCleanName}.zip`;
-        document.body.appendChild(link);
-        link.click();
-        document.body.removeChild(link);
-        URL.revokeObjectURL(url);
-      } catch (e) {
-        console.error("ZIP Generation failed", e);
-        setOwrDownloadError("ZIP generation failed. Try again, or check the browser console for details.");
-      }
-    } finally {
-      setIsOwrDownloading(false);
-    }
-  };
-
-  const pipeline = buildRecipeFromState(deferredState, { hardwareProbe });
-  const { recipe, recipeJson: _recipeJson, validation, schema, advisories, isRunnable } = pipeline;
-
-  // SSE streaming lifecycle managed by useOliveStream hook
+  // Live execution streaming lifecycle (SSE) — managed by useOliveStream.
+  const [mcpFixApplied, setMcpFixApplied] = useAutoClearError(3000);
   const {
     liveJobId,
     isRunning,
@@ -494,46 +122,9 @@ export function ExecutionWorkspace({
     setMcpFixApplied,
   });
 
-  const schemaErrors = schema.errors ?? [];
-  // Local structure/compat checks only. A green badge must not imply Execute Live succeeded.
-  const localValidationLabel = !schema.valid
-    ? `Schema invalid (${schemaErrors.length} issue${schemaErrors.length === 1 ? "" : "s"})`
-    : validation.statusLabel;
-  const localValidationTone = !schema.valid ? "error" : validation.statusTone;
-  const runFailed = executionStatus === "failed";
-  const validationLabel = runFailed
-    ? `Run failed (exit ${executionExitCode ?? "?"}) · ${localValidationTone === "success" ? "local checks still OK" : localValidationLabel
-    }`
-    : localValidationLabel;
-  const validationTone = runFailed ? "error" : localValidationTone;
-
-  // Clear log selection once when a new live run starts (not on every streamed line).
-  useLayoutEffect(() => {
-    setSelectedLogIndices(new Set()); // eslint-disable-line react-hooks/set-state-in-effect
-    lastClickedIndexRef.current = null;
-  }, [liveJobId]);
-
-  // Auto-select error lines when a job fails so Diagnose can focus on them.
-  const prevStatusRef = useRef<string | null>(null);
-
-  useLayoutEffect(() => {
-    if (executionStatus === "failed" && prevStatusRef.current !== "failed") {
-      if (executionLogs.length > 0) {
-        const errorIndices = new Set<number>();
-        for (let i = 0; i < executionLogs.length; i++) {
-          if (isFailureLine(executionLogs[i]!)) {
-            errorIndices.add(i);
-          }
-        }
-        if (errorIndices.size > 0) {
-          setSelectedLogIndices(errorIndices); // eslint-disable-line react-hooks/set-state-in-effect
-        }
-      }
-    }
-    prevStatusRef.current = executionStatus;
-  }, [executionStatus, executionLogs]);
-
-  // Log line selection for manual diagnosis
+  // Log line selection for manual diagnosis.
+  const [selectedLogIndices, setSelectedLogIndices] = useState<Set<number>>(new Set());
+  const lastClickedIndexRef = useRef<number | null>(null);
   const handleLogLineClick = (index: number, e: ReactMouseEvent<HTMLParagraphElement>) => {
     setSelectedLogIndices((prev) => {
       const next = new Set(prev);
@@ -553,62 +144,62 @@ export function ExecutionWorkspace({
     lastClickedIndexRef.current = index;
   };
 
-  /** Prefer selected lines when present; expand traceback context; else full log. */
-  const handleDiagnose = () => {
-    if (executionLogs.length === 0) return;
-    setMcpFixApplied("");
-    const logs =
-      selectedLogIndices.size > 0
-        ? expandLogSelection(executionLogs, Array.from(selectedLogIndices))
-        : executionLogs;
-    void fetchKeyedDiagnostic("current", logs);
-  };
+  // Clear log selection once when a new live run starts (not on every streamed line).
+  useLayoutEffect(() => {
+    setSelectedLogIndices(new Set()); // eslint-disable-line react-hooks/set-state-in-effect
+    lastClickedIndexRef.current = null;
+  }, [liveJobId]);
 
-  // Auto-diagnose once when a run fails (same pattern as BatchProcessingPanel).
-  const autoDiagnoseRef = useRef(false);
-  useEffect(() => {
-    if (executionStatus === "failed" && executionLogs.length > 0 && !autoDiagnoseRef.current) {
-      autoDiagnoseRef.current = true;
-      const errorIndices: number[] = [];
-      for (let i = 0; i < executionLogs.length; i++) {
-        if (isFailureLine(executionLogs[i]!)) {
-          errorIndices.push(i);
+  // Auto-select error lines when a job fails so Diagnose can focus on them.
+  const prevStatusRef = useRef<ExecutionStatus | null>(null);
+  useLayoutEffect(() => {
+    if (executionStatus === "failed" && prevStatusRef.current !== "failed") {
+      if (executionLogs.length > 0) {
+        const errorIndices = new Set<number>();
+        for (let i = 0; i < executionLogs.length; i++) {
+          if (isFailureLine(executionLogs[i]!)) {
+            errorIndices.add(i);
+          }
+        }
+        if (errorIndices.size > 0) {
+          setSelectedLogIndices(errorIndices); // eslint-disable-line react-hooks/set-state-in-effect
         }
       }
-      const logs = errorIndices.length > 0 ? expandLogSelection(executionLogs, errorIndices) : executionLogs;
-      void fetchKeyedDiagnostic("current", logs);
     }
-    if (executionStatus !== "failed") {
-      autoDiagnoseRef.current = false;
-    }
-  }, [executionStatus, executionLogs, fetchKeyedDiagnostic]);
+    prevStatusRef.current = executionStatus;
+  }, [executionStatus, executionLogs]);
 
-  // Capture the submitted recipe when Execute completes so Playground uses the exact recipe that ran,
-  // not a rebuilt version that might include post-run state edits.
-  const setCapturedRunRecipe = usePlaygroundStore((s) => s.setCapturedRunRecipe);
-  useEffect(() => {
-    if (executionStatus === "completed" && runRecipeJsonRef.current) {
-      setCapturedRunRecipe(runRecipeJsonRef.current);
-    }
-  }, [executionStatus, setCapturedRunRecipe, runRecipeJsonRef]);
+  const diagnosis = useDiagnosis({
+    state,
+    setState,
+    executionLogs,
+    setExecutionLogs,
+    executionStatus,
+    selectedLogIndices,
+    mcpFixApplied,
+    setMcpFixApplied,
+  });
 
-  // Auto-save completed diagnoses to history
-  const prevDiagnosticRef = useRef(mcpDiagnostic);
-  useEffect(() => {
-    if (mcpDiagnostic && mcpDiagnostic !== prevDiagnosticRef.current) {
-      const entry: DiagnosisEntry = {
-        id: `diag-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`,
-        timestamp: Date.now(),
-        diagnostic: mcpDiagnostic,
-        logSnippet: executionLogs.slice(-20).join("\n"),
-        fixApplied: false,
-      };
-      setDiagnosisHistory((prev) => [entry, ...prev].slice(0, 50));
-      setActiveHistoryIndex(0);
-    }
-    prevDiagnosticRef.current = mcpDiagnostic;
-  }, [mcpDiagnostic, executionLogs]);
+  const recipeViewState = useRecipeView({ state });
+  const owrExport = useOwrExport({ state });
 
+  // Local structure/compat checks only. A green badge must not imply Execute Live succeeded.
+  const localValidationLabel = !schema.valid
+    ? `Schema invalid (${schemaErrors.length} issue${schemaErrors.length === 1 ? "" : "s"})`
+    : validation.statusLabel;
+  const localValidationTone = !schema.valid ? "error" : validation.statusTone;
+  const runFailed = executionStatus === "failed";
+  const validationLabel = runFailed
+    ? `Run failed (exit ${executionExitCode ?? "?"}) · ${localValidationTone === "success" ? "local checks still OK" : localValidationLabel
+    }`
+    : localValidationLabel;
+  const validationTone: "success" | "warning" | "error" = runFailed
+    ? "error"
+    : localValidationTone;
+
+  // Queue feedback + batch job creation.
+  const [justQueued, setJustQueued] = useState(false);
+  const justQueuedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const handleQueueJob = () => {
     // Rebuild from live state — the deferred display pipeline may lag the latest keystroke.
     const fresh = buildRecipeFromState(state, { hardwareProbe });
@@ -642,48 +233,27 @@ export function ExecutionWorkspace({
     justQueuedTimerRef.current = setTimeout(() => setJustQueued(false), 3000);
   };
 
+  useEffect(() => {
+    return () => {
+      if (justQueuedTimerRef.current) clearTimeout(justQueuedTimerRef.current);
+    };
+  }, []);
 
+  // Capture the submitted recipe when Execute completes so Playground uses the exact recipe that ran.
+  const setCapturedRunRecipe = usePlaygroundStore((s) => s.setCapturedRunRecipe);
+  useEffect(() => {
+    if (executionStatus === "completed" && runRecipeJsonRef.current) {
+      setCapturedRunRecipe(runRecipeJsonRef.current);
+    }
+  }, [executionStatus, setCapturedRunRecipe, runRecipeJsonRef]);
 
-  const _handleCopy = () => {
-    // Rebuild from live state — the displayed (deferred) recipe may lag the latest keystroke.
-    void navigator.clipboard
-      .writeText(buildRecipeJsonFromState(state))
-      .then(() => {
-        setIsCopied(true);
-        if (copiedTimerRef.current) clearTimeout(copiedTimerRef.current);
-        copiedTimerRef.current = setTimeout(() => setIsCopied(false), 2000);
-      })
-      .catch(() => {});
-  };
+  // Report issue modal state.
+  const [isReportOpen, setIsReportOpen] = useState(false);
+  const [reportArea, setReportArea] = useState<ReportArea | undefined>(undefined);
+  const [reportDescription, setReportDescription] = useState("");
 
-  const handleExportCopy = () => {
-    // Rebuild from live state — the displayed (deferred) recipe may lag the latest keystroke.
-    void navigator.clipboard
-      .writeText(buildRecipeJsonFromState(state))
-      .then(() => {
-        setIsExportCopied(true);
-        if (exportCopiedTimerRef.current) clearTimeout(exportCopiedTimerRef.current);
-        exportCopiedTimerRef.current = setTimeout(() => setIsExportCopied(false), 2000);
-      })
-      .catch(() => {});
-  };
-
-  const handleExportDownload = () => {
-    // Rebuild from live state — the displayed (deferred) recipe may lag the latest keystroke.
-    const jsonString = buildRecipeJsonFromState(state);
-    const blob = new Blob([jsonString], { type: "application/json" });
-    const url = URL.createObjectURL(blob);
-    const link = document.createElement("a");
-    const modelCleanName = (state.hfModelId || (state.localFiles && state.localFiles[0]?.name) || "model")
-      .replace(/[^a-z0-9_-]/gi, "_")
-      .toLowerCase();
-    link.href = url;
-    link.download = `olive_recipe_${modelCleanName}.json`;
-    document.body.appendChild(link);
-    link.click();
-    document.body.removeChild(link);
-    URL.revokeObjectURL(url);
-  };
+  // Job history modal state.
+  const [isHistoryOpen, setIsHistoryOpen] = useState(false);
 
   // ─── Agent Mode State ────────────────────────────────────────────────────────
   const {
@@ -701,7 +271,6 @@ export function ExecutionWorkspace({
     completeAgent,
   } = useAgentMode();
 
-  // Confirmation dialog state for switching away from agent while running
   const [confirmDialogOpen, setConfirmDialogOpen] = useState(false);
   const [exportRecords, setExportRecords] = useState<JobHistoryRecord[]>([]);
 
@@ -783,6 +352,21 @@ export function ExecutionWorkspace({
     [agentMode, agentRunning, setAgentMode],
   );
 
+  const handleAgentStop = useCallback(async () => {
+    const stopped = await stopAgent();
+    if (!stopped) {
+      // stopAgent() intentionally leaves agentRunning true on a failed cancel
+      // (so Stop can be retried) — surface the failure in the log instead of
+      // silently doing nothing.
+      appendAgentEntry({
+        id: generateEntryId(),
+        kind: "error",
+        timestamp: currentTimestamp(),
+        text: "Failed to cancel agent — Stop again to retry.",
+      });
+    }
+  }, [stopAgent, appendAgentEntry]);
+
   /** User confirmed stopping the agent and switching to manual. */
   const handleConfirmStopAndSwitch = useCallback(() => {
     void (async () => {
@@ -803,577 +387,182 @@ export function ExecutionWorkspace({
     setConfirmDialogOpen(false);
   }, []);
 
+  const handleRetryProvider = useCallback(
+    (provider: UIState["ihvProvider"]) => {
+      const patch = prepareProviderChange(state, provider, hardwareProbe, {
+        skipHardwareBlock: true,
+      });
+      setState(patch ?? { ihvProvider: provider });
+      setExecutionLogs((prev) => [
+        ...prev,
+        `[INFO] Switched target to ${provider} (explicit retry, QNN does not auto-fallback). Rebuild/refresh the recipe, then Execute Live again.`,
+      ]);
+    },
+    [state, hardwareProbe, setState, setExecutionLogs],
+  );
+
   return (
     <div
       data-testid="execution-workspace"
       className="flex flex-col gap-6 animate-in fade-in slide-in-from-bottom-2 duration-300 relative"
     >
-      {/* Mode Toggle: Manual / Agent */}
-      <div className="flex items-center justify-between">
-        <ModeToggle
-          mode={agentMode}
-          onModeChange={handleModeChange}
-          disabled={isRunning}
-        />
-        <ExportReportMenu records={exportRecords} />
-      </div>
-
-      {/* Agent Confirm Dialog — shown when switching away while agent is running */}
-      <AgentConfirmDialog
-        open={confirmDialogOpen}
-        onConfirm={handleConfirmStopAndSwitch}
-        onCancel={handleCancelDialog}
+      <AgentModeSection
+        agentMode={agentMode}
+        onModeChange={handleModeChange}
+        isRunning={isRunning}
+        records={exportRecords}
+        confirmDialogOpen={confirmDialogOpen}
+        onConfirmDialog={handleConfirmStopAndSwitch}
+        onCancelDialog={handleCancelDialog}
+        agentRunning={agentRunning}
+        onStartAgent={handleStartAgent}
+        onStopAgent={handleAgentStop}
+        outcome={agentOutcome}
+        entries={agentEntries}
       />
-
-      {/* Agent Mode Controls */}
-      {agentMode === "agent" && (
-        <Card className="border-slate-800 bg-slate-900/40">
-          <CardHeader
-            title="Agent Execution"
-            description="The MCP agent autonomously plans, executes, and diagnoses optimization runs."
-          />
-          <CardContent className="flex flex-col gap-4 p-4">
-            <AgentControls
-              agentRunning={agentRunning}
-              onStart={handleStartAgent}
-              onStop={async () => {
-                const stopped = await stopAgent();
-                if (!stopped) {
-                  // stopAgent() intentionally leaves agentRunning true on a
-                  // failed cancel (so Stop can be retried) — surface the
-                  // failure in the log instead of silently doing nothing.
-                  appendAgentEntry({
-                    id: generateEntryId(),
-                    kind: "error",
-                    timestamp: currentTimestamp(),
-                    text: "Failed to cancel agent — Stop again to retry.",
-                  });
-                }
-              }}
-              outcome={agentOutcome}
-            />
-            <ActivityLog entries={agentEntries} />
-          </CardContent>
-        </Card>
-      )}
 
       {/* Manual Mode Controls — hidden when in Agent mode */}
       {agentMode === "manual" && <>
         {/* Export Recipe Overlay */}
-        {isExportOpen && (
-          <div className="absolute inset-0 z-55 bg-slate-950/90 backdrop-blur-sm flex items-center justify-center p-4 sm:p-6 animate-in fade-in overflow-y-auto">
-            <Card className="w-full max-w-2xl border-electric-blue/30 flex flex-col max-h-[85vh]">
-              <CardHeader
-                title="Export Microsoft Olive Recipe"
-                description="Download your dynamic JSON recipe configuration or copy the schema to run with the MS Olive CLI."
-                badge={
-                  <Button
-                    variant="ghost"
-                    className="h-8 w-8 p-0 hover:bg-slate-800"
-                    onClick={() => setIsExportOpen(false)}
-                  >
-                    <X className="h-4 w-4" />
-                  </Button>
-                }
-              />
-              <CardContent className="flex flex-col gap-4 overflow-hidden flex-1 p-6">
-                <div className="flex-1 min-h-[300px] relative flex flex-col overflow-hidden bg-slate-950 border border-slate-800 rounded-lg">
-                  <div className="flex items-center justify-between px-4 py-2 border-b border-slate-900 bg-slate-900/40">
-                    <div className="flex items-center gap-2">
-                      <FileJson className="h-4 w-4 text-emerald-400" />
-                      <span className="text-sm font-mono text-slate-300">olive_recipe.json</span>
-                    </div>
-                    <span className="text-[11px] bg-emerald-500/10 border border-emerald-500/20 text-emerald-400 px-2 py-0.5 rounded font-mono font-semibold">
-                      VALID OLIVE SCHEMA
-                    </span>
-                  </div>
-                  <textarea
-                    readOnly
-                    className="w-full flex-1 bg-transparent p-4 font-mono text-sm text-emerald-400 focus-visible:outline-none resize-none overflow-y-auto cursor-text"
-                    value={JSON.stringify(recipe, null, 2)}
-                    onClick={(e) => (e.target as HTMLTextAreaElement).select()}
-                  />
-                </div>
-
-                <div className="flex justify-between items-center gap-3 pt-2">
-                  <span className="text-sm text-slate-500 font-mono hidden sm:inline">
-                    Generated dynamic recipe mapping
-                  </span>
-                  <div className="flex items-center gap-3 w-full sm:w-auto justify-end">
-                    <Button variant="outline" className="text-sm h-9" onClick={() => setIsExportOpen(false)}>
-                      Close
-                    </Button>
-                    <Button
-                      variant="outline"
-                      className="text-sm h-9 border-electric-blue/30 text-electric-blue hover:text-white hover:bg-electric-blue/10"
-                      onClick={handleExportCopy}
-                    >
-                      {isExportCopied ? (
-                        <Check className="h-4 w-4 mr-1.5 text-emerald-500" />
-                      ) : (
-                        <Copy className="h-4 w-4 mr-1.5" />
-                      )}
-                      {isExportCopied ? "Copied!" : "Copy to Clipboard"}
-                    </Button>
-                    <Button
-                      variant="default"
-                      className="text-sm h-9 bg-electric-blue hover:bg-electric-blue/90 text-slate-950"
-                      onClick={handleExportDownload}
-                    >
-                      <Download className="h-4 w-4 mr-1.5" /> Save File (.json)
-                    </Button>
-                  </div>
-                </div>
-              </CardContent>
-            </Card>
-          </div>
+        {recipeViewState.isExportOpen && (
+          <ExportRecipeOverlay
+            open={recipeViewState.isExportOpen}
+            onClose={() => recipeViewState.setIsExportOpen(false)}
+            recipe={recipe}
+            isCopied={recipeViewState.isExportCopied}
+            onCopy={recipeViewState.handleExportCopy}
+            onDownload={recipeViewState.handleExportDownload}
+          />
         )}
 
         {/* OWR Export Bundle Overlay */}
         <OwrExportOverlay
-          open={isOwrExportOpen}
-          onClose={() => setIsOwrExportOpen(false)}
-          configs={owrConfigs}
-          platform={owrPlatform}
-          onPlatformChange={setOwrPlatform}
-          selectedFile={owrSelectedFile}
-          onFileSelect={setOwrSelectedFile}
-          threads={owrThreads}
-          onThreadsChange={setOwrThreads}
-          vramMode={owrVramMode}
-          onVramModeChange={setOwrVramMode}
-          onDownloadBundle={handleDownloadOwrBundle}
-          isDownloading={isOwrDownloading}
-          downloadError={owrDownloadError}
+          open={owrExport.isOwrExportOpen}
+          onClose={() => owrExport.setIsOwrExportOpen(false)}
+          configs={owrExport.owrConfigs}
+          platform={owrExport.owrPlatform}
+          onPlatformChange={owrExport.setOwrPlatform}
+          selectedFile={owrExport.owrSelectedFile}
+          onFileSelect={owrExport.setOwrSelectedFile}
+          threads={owrExport.owrThreads}
+          onThreadsChange={owrExport.setOwrThreads}
+          vramMode={owrExport.owrVramMode}
+          onVramModeChange={owrExport.setOwrVramMode}
+          onDownloadBundle={owrExport.handleDownloadOwrBundle}
+          isDownloading={owrExport.isOwrDownloading}
+          downloadError={owrExport.owrDownloadError}
         />
 
         {/* Recipe Preview */}
-        <Card
-          className={cn(
-            "flex flex-col overflow-hidden",
-            recipeView === "graph" ? "min-h-[340px] wide:min-h-[380px]" : "min-h-[340px]",
-          )}
-        >
-          <CardHeader
-            className="p-3 pb-2"
-            title="Olive Recipe Definition"
-            description={
-              recipeView === "graph"
-                ? undefined
-                : "The exact JSON schema that will be sent to the Olive Engine."
-            }
-            badge={
-              <div className="flex flex-wrap items-center gap-2">
-                <div
-                  className="flex bg-slate-900 border border-slate-800 rounded p-0.5"
-                  role="group"
-                  aria-label="Recipe view"
-                >
-                  <button
-                    type="button"
-                    aria-pressed={recipeView === "graph"}
-                    onClick={() => setRecipeView("graph")}
-                    className={`px-2.5 py-1 text-xs font-semibold rounded transition-all flex items-center gap-1 cursor-pointer ${recipeView === "graph"
-                      ? "bg-electric-blue text-slate-950"
-                      : "text-slate-400 hover:text-slate-200"
-                      }`}
-                  >
-                    <Workflow className="h-3 w-3" /> Graph Flow
-                  </button>
-                  <button
-                    type="button"
-                    aria-pressed={recipeView === "json"}
-                    onClick={() => setRecipeView("json")}
-                    className={`px-2.5 py-1 text-xs font-semibold rounded transition-all flex items-center gap-1 cursor-pointer ${recipeView === "json"
-                      ? "bg-electric-blue text-slate-950"
-                      : "text-slate-400 hover:text-slate-200"
-                      }`}
-                  >
-                    <Code className="h-3 w-3" /> JSON Code
-                  </button>
-                </div>
-                <Button
-                  variant="outline"
-                  className="h-8 px-3 text-sm border-electric-blue/30 text-electric-blue hover:text-white hover:bg-electric-blue/10"
-                  onClick={() => setIsExportOpen(true)}
-                >
-                  <Download className="h-3.5 w-3.5 mr-1.5" /> Export Recipe
-                </Button>
-                <div className="relative" ref={moreToolsContainerRef}>
-                  <Button
-                    ref={moreToolsTriggerRef}
-                    variant="outline"
-                    className="h-8 px-2.5 text-sm border-slate-700 text-slate-300 hover:border-slate-500"
-                    aria-expanded={moreToolsOpen}
-                    aria-haspopup="menu"
-                    onClick={() => setMoreToolsOpen((open) => !open)}
-                  >
-                    <MoreHorizontal className="h-3.5 w-3.5 mr-1" /> More
-                  </Button>
-                  {moreToolsOpen && (
-                    <div
-                      role="menu"
-                      className="absolute right-0 z-20 mt-1 min-w-[180px] rounded-lg border border-slate-800 bg-slate-950 p-1 shadow-xl"
-                    >
-                      <button
-                        type="button"
-                        role="menuitem"
-                        className="flex w-full items-center gap-2 rounded-md px-2.5 py-2 text-left text-xs text-slate-300 hover:bg-slate-900 cursor-pointer"
-                        onClick={() => {
-                          setIsHistoryOpen(true);
-                          setMoreToolsOpen(false);
-                        }}
-                      >
-                        <History className="h-3 w-3" /> Run History
-                      </button>
-                      <button
-                        type="button"
-                        role="menuitem"
-                        className="flex w-full items-center gap-2 rounded-md px-2.5 py-2 text-left text-xs text-slate-300 hover:bg-slate-900 cursor-pointer"
-                        onClick={() => {
-                          setIsOwrExportOpen(true);
-                          setMoreToolsOpen(false);
-                        }}
-                      >
-                        <Globe className="h-3 w-3" /> Export for OWR
-                      </button>
-                    </div>
-                  )}
-                </div>
-              </div>
-            }
-          />
-          {(["graph", "json"] as const).map((view) => {
-            if (!visitedRecipeViews.has(view)) return null;
-            const isActive = recipeView === view;
-            return (
-              <CardContent
-                key={view}
-                className={cn(
-                  "flex-1 overflow-hidden p-0",
-                  view === "graph" ? "min-h-[340px]" : "min-h-[340px]",
-                  isActive ? "block" : "hidden",
-                )}
-              >
-                {view === "graph" && (
-                  <Suspense fallback={<LoadingFallback label="Loading graph editor..." minH="340px" />}>
-                    <RecipeGraphView state={state} setState={setState} />
-                  </Suspense>
-                )}
-                {view === "json" && (
-                  <div className="overflow-auto bg-slate-950 p-4 m-6 mt-0 rounded-lg border border-slate-800 min-h-[360px]">
-                    <pre className="text-sm font-mono text-emerald-400">{JSON.stringify(recipe, null, 2)}</pre>
-                  </div>
-                )}
-              </CardContent>
-            );
-          })}
-        </Card>
+        <RecipePreviewCard
+          recipe={recipe}
+          state={state}
+          setState={setState}
+          recipeView={recipeViewState.recipeView}
+          setRecipeView={recipeViewState.setRecipeView}
+          visitedRecipeViews={recipeViewState.visitedRecipeViews}
+          onExportRecipe={() => recipeViewState.setIsExportOpen(true)}
+          moreToolsOpen={recipeViewState.moreToolsOpen}
+          setMoreToolsOpen={recipeViewState.setMoreToolsOpen}
+          moreToolsContainerRef={recipeViewState.moreToolsContainerRef}
+          moreToolsTriggerRef={recipeViewState.moreToolsTriggerRef}
+          onOpenHistory={() => setIsHistoryOpen(true)}
+          onOpenOwrExport={() => owrExport.setIsOwrExportOpen(true)}
+        />
 
         {/* Active Draft — execution controls + live log in one card */}
-        <Card className="border-slate-800 bg-slate-900/40">
-          <CardHeader
-            title="Active Draft"
-            description={
-              executionStatus === "running"
-                ? "Olive is running. Streaming optimization logs."
-                : executionStatus === "completed"
-                  ? `Run completed (exit 0)`
-                  : executionStatus === "failed"
-                    ? `Run failed (exit ${executionExitCode ?? "?"})`
-                    : "Review recipe above, then execute live or add to batch queue."
-            }
-            badge={
-              <div className="flex items-center gap-2 flex-wrap">
-                {executionStatus === "running" && (
-                  <span className="flex items-center gap-1.5 text-sm font-mono bg-electric-blue/10 text-electric-blue border border-electric-blue/30 px-2.5 py-1 rounded">
-                    <RefreshCw className="h-3 w-3 animate-spin" /> Running
-                  </span>
-                )}
-                {executionStatus === "completed" && (
-                  <>
-                    <span className="flex items-center gap-1.5 text-sm font-mono bg-emerald-500/10 text-emerald-400 border border-emerald-500/30 px-2.5 py-1 rounded">
-                      <CheckCircle2 className="h-3 w-3" /> Done
-                    </span>
-                    <Button
-                      variant="outline"
-                      className="h-8 px-2.5 text-sm border-electric-blue/40 text-electric-blue hover:bg-electric-blue/10"
-                      onClick={() => {
-                        setPlaygroundSubView("browser-test");
-                        navigatePipeline("playground");
-                      }}
-                    >
-                      Test in Playground →
-                    </Button>
-                  </>
-                )}
-                {executionStatus === "failed" && (
-                  <span className="flex items-center gap-1.5 text-sm font-mono bg-red-500/10 text-red-400 border border-red-500/30 px-2.5 py-1 rounded">
-                    <AlertCircle className="h-3 w-3" /> Failed
-                  </span>
-                )}
-                <Button
-                  variant="ghost"
-                  className="h-8 px-2.5 text-sm text-slate-400 hover:text-electric-blue"
-                  onClick={() => onOpenAiAudit?.()}
-                >
-                  Review with Assistant
-                </Button>
-              </div>
-            }
-          />
-          <CardContent className="flex flex-col gap-4 p-4">
-            <VramEstimateBanner state={state} compact />
-            {schemaErrors.length > 0 && (
-              <div className="rounded-lg border border-rose-500/30 bg-rose-950/20 p-3 space-y-2">
-                {schemaErrors.map((error) => (
-                  <div key={error} className="flex items-start gap-2">
-                    <AlertCircle className="h-4 w-4 text-rose-400 shrink-0 mt-0.5" />
-                    <p className="text-xs text-rose-200 leading-relaxed">{error}</p>
-                  </div>
-                ))}
-              </div>
-            )}
-            {advisories.length > 0 && (
-              <div className="rounded-lg border border-slate-800 bg-slate-950/60 p-3 space-y-2">
-                {advisories.map((issue) => (
-                  <div key={issue.id} className="flex items-start gap-2">
-                    <AlertTriangle className="h-4 w-4 text-amber-400 shrink-0 mt-0.5" />
-                    <div className="min-w-0">
-                      <p className="text-sm font-semibold text-amber-300">{issue.title}</p>
-                      <p className="text-xs text-slate-400 leading-relaxed">{issue.description}</p>
-                    </div>
-                  </div>
-                ))}
-              </div>
-            )}
-            <div className="flex justify-between items-center gap-3 flex-wrap sm:flex-nowrap">
-              <div className="flex items-center gap-2">
-                {validationTone === "success" ? (
-                  <CheckCircle2 className="h-4 w-4 text-emerald-500" />
-                ) : validationTone === "warning" ? (
-                  <AlertTriangle className="h-4 w-4 text-amber-400" />
-                ) : (
-                  <AlertCircle className="h-4 w-4 text-rose-400" />
-                )}
-                <span
-                  className={`text-sm sm:text-sm font-medium ${validationTone === "success"
-                    ? "text-emerald-400"
-                    : validationTone === "warning"
-                      ? "text-amber-300"
-                      : "text-rose-300"
-                    }`}
-                >
-                  {validationLabel}
-                </span>
-              </div>
-              <div className="flex items-center gap-2 ml-auto">
-                {isRunning && (
-                  <Button
-                    variant="outline"
-                    onClick={handleCancelJob}
-                    className="h-9 px-3 text-sm border-rose-500/40 text-rose-400 hover:bg-rose-500/10 hover:border-rose-500 cursor-pointer"
-                  >
-                    <Square className="h-3.5 w-3.5 mr-1.5 fill-rose-400 text-rose-400" /> Cancel Run
-                  </Button>
-                )}
-                {justQueued ? (
-                  <span className="text-sm text-electric-blue font-semibold font-mono mr-2">Queued</span>
-                ) : (
-                  <Button
-                    variant="outline"
-                    className="h-9 px-3 text-sm border-dashed border-slate-700 hover:border-electric-blue hover:text-electric-blue disabled:opacity-40"
-                    onClick={handleQueueJob}
-                    disabled={!isRunnable}
-                  >
-                    + Queue
-                  </Button>
-                )}
-                <Button
-                  variant="success"
-                  onClick={handleExecuteLive}
-                  disabled={isRunning || !isRunnable}
-                  className="h-9 text-sm"
-                >
-                  {isRunning ? (
-                    <>
-                      <RefreshCw className="h-3.5 w-3.5 mr-1.5 animate-spin" /> Olive running...
-                    </>
-                  ) : (
-                    <>
-                      <Play className="h-3.5 w-3.5 mr-1.5" fill="currentColor" /> Execute Live
-                    </>
-                  )}
-                </Button>
-              </div>
-            </div>
-            {/* GPU metrics live bar */}
-            {isRunning && gpuMetrics && <GpuMetricsBar metrics={gpuMetrics} />}
-            {/* Log panel with selection, manual diagnosis, and history sidebar */}
-            <div className="flex gap-0 rounded-md border border-slate-800 overflow-hidden">
-              <div className="flex-1 space-y-1.5 min-w-0">
-                {executionLogs.length > 0 && (
-                  <div className="flex items-center justify-between gap-2 px-1">
-                    <div className="flex items-center gap-2">
-                      <span className="text-xs text-slate-400 font-mono">
-                        {selectedLogIndices.size > 0
-                          ? `${selectedLogIndices.size} line${selectedLogIndices.size > 1 ? "s" : ""} selected`
-                          : `${executionLogs.length} lines`}
-                      </span>
-                      <span className="text-xs text-slate-400 hidden sm:inline">
-                        Click to select · Shift+click for range · Ctrl/Cmd+click for multi
-                      </span>
-                    </div>
-                    <div className="flex items-center gap-1.5">
-                      <button
-                        type="button"
-                        onClick={handleDiagnose}
-                        disabled={isDiagnosing || executionLogs.length === 0}
-                        title={
-                          selectedLogIndices.size > 0
-                            ? `Diagnose ${selectedLogIndices.size} selected line(s)`
-                            : "Diagnose full log (error lines are auto-selected on failure)"
-                        }
-                        className="flex items-center gap-1 px-2 py-1 text-xs font-semibold rounded border border-electric-blue/30 bg-electric-blue/10 text-electric-blue hover:bg-electric-blue/20 hover:border-electric-blue/50 transition-all cursor-pointer disabled:opacity-50"
-                      >
-                        <Wrench className="h-3 w-3" />{" "}
-                        {selectedLogIndices.size > 0 ? `Diagnose (${selectedLogIndices.size})` : "Diagnose"}
-                      </button>
-                      {executionStatus === "failed" && (
-                        <button
-                          type="button"
-                          onClick={() => {
-                            setReportArea("execution-batch");
-                            setReportDescription(
-                              `Execution failed with exit code ${executionExitCode ?? "?"}.\n\nRecent logs:\n${executionLogs.slice(-20).join("\n")}`,
-                            );
-                            setIsReportOpen(true);
-                          }}
-                          title="Send feedback"
-                          className="flex items-center gap-1 px-2 py-1 text-xs font-semibold rounded border border-amber-500/30 bg-amber-500/10 text-amber-400 hover:bg-amber-500/20 hover:border-amber-500/50 transition-all cursor-pointer"
-                        >
-                          <Bug className="h-3 w-3" /> Send feedback
-                        </button>
-                      )}
-                      {executionStatus === "failed" &&
-                        state.ihvProvider === "QNNExecutionProvider" &&
-                        qnnExplicitRetryProviders().map((provider) => (
-                          <button
-                            key={provider}
-                            type="button"
-                            onClick={() => {
-                              const patch = prepareProviderChange(state, provider, hardwareProbe, {
-                                skipHardwareBlock: true,
-                              });
-                              setState(patch ?? { ihvProvider: provider });
-                              setExecutionLogs((prev) => [
-                                ...prev,
-                                `[INFO] Switched target to ${provider} (explicit retry, QNN does not auto-fallback). Rebuild/refresh the recipe, then Execute Live again.`,
-                              ]);
-                            }}
-                            title={`Explicit retry with ${provider} (no automatic EP fallback)`}
-                            className="flex items-center gap-1 px-2 py-1 text-xs font-semibold rounded border border-slate-600/50 bg-slate-800/60 text-slate-300 hover:bg-slate-700/60 transition-all cursor-pointer"
-                          >
-                            Retry with {provider === "DmlExecutionProvider" ? "DirectML" : "CPU"}
-                          </button>
-                        ))}
-                    </div>
-                  </div>
-                )}
-                <div
-                  data-testid="execution-log-panel"
-                  className="bg-slate-950 border border-slate-800 rounded-md p-4 font-mono text-sm text-emerald-400 space-y-0.5 h-[220px] overflow-y-auto"
-                >
-                  {executionLogs.length === 0 ? (
-                    <p className="text-slate-500 italic">
-                      Ready. Click &quot;Execute Live&quot; to begin an Olive optimization run.
-                    </p>
-                  ) : (
-                    executionLogs.map((line, i) => {
-                      const isSelected = selectedLogIndices.has(i);
-                      const lineClass = line.includes("[ERROR]")
-                        ? "text-red-400"
-                        : line.includes("[WARN]")
-                          ? "text-amber-300"
-                          : line.includes("[SETUP]")
-                            ? "text-amber-400"
-                            : line.includes("[DONE]") || line.includes("[info] Job cancelled")
-                              ? "text-emerald-300 font-bold"
-                              : "text-emerald-400";
-                      return (
-                        <p
-                          key={i}
-                          onClick={(e) => handleLogLineClick(i, e)}
-                          className={`${lineClass} cursor-pointer rounded px-1 -mx-1 transition-colors ${isSelected
-                            ? "bg-electric-blue/15 ring-1 ring-electric-blue/30"
-                            : "hover:bg-slate-800/50"
-                            }`}
-                        >
-                          {line}
-                        </p>
-                      );
-                    })
-                  )}
-                </div>
-              </div>
-
-              {/* Diagnosis history sidebar */}
-              <DiagnosisHistory
-                entries={diagnosisHistory}
-                activeIndex={activeHistoryIndex}
-                onSelect={handleSelectHistory}
-                onClear={handleClearHistory}
-              />
-            </div>
-
-            {/* MCP Diagnostic & Auto-Fix Card (matched_entry from MCP/local parsers enables thumbs) */}
-            {executionStatus === "failed" && (
-              <LazyMCPDiagnosticCard
-                diagnostic={displayedDiagnostic}
-                isDiagnosing={isDiagnosing}
-                fixApplied={displayedFixApplied}
-                onApplyFix={handleApplyMcpFix}
-                onRunDiagnosis={handleDiagnose}
-                error={diagnoseError}
-                onFeedbackSubmitted={handleFeedbackSubmitted}
-              />
-            )}
-          </CardContent>
-        </Card>
-
-        {/* History & Side-by-Side Comparison Modal */}
-        <JobHistoryModal
-          isOpen={isHistoryOpen}
-          onClose={() => setIsHistoryOpen(false)}
-          onSelectRecipe={(recipeJsonStr) => {
-            try {
-              const parsed = JSON.parse(recipeJsonStr);
-              // Optionally update UI state if needed
-              setExecutionLogs([
-                `[INFO] Loaded recipe from history (${parsed.input_model?.type || "Olive recipe"})`,
-              ]);
-            } catch {
-              /* ignore */
-            }
-          }}
-        />
-
-        {/* Report Issue Modal */}
-        <ReportIssueModal
-          open={isReportOpen}
-          onClose={() => {
-            setIsReportOpen(false);
-            setReportArea(undefined);
-            setReportDescription("");
-          }}
+        <ManualExecutionControls
           state={state}
-          hardwareProbe={hardwareProbe}
-          executionLogs={executionLogs}
-          mcpDiagnostic={mcpDiagnostic}
-          defaultArea={reportArea}
-          defaultDescription={reportDescription}
-        />
+          executionStatus={executionStatus}
+          executionExitCode={executionExitCode}
+          isRunning={isRunning}
+          validationLabel={validationLabel}
+          validationTone={validationTone}
+          schemaErrors={schemaErrors}
+          advisories={advisories}
+          isRunnable={isRunnable}
+          justQueued={justQueued}
+          gpuMetrics={gpuMetrics}
+          onQueueJob={handleQueueJob}
+          onExecuteLive={handleExecuteLive}
+          onCancelJob={handleCancelJob}
+          onOpenAiAudit={onOpenAiAudit}
+          onTestInPlayground={() => {
+            setPlaygroundSubView("browser-test");
+            navigatePipeline("playground");
+          }}
+        >
+          <ExecutionLogPanel
+            executionLogs={executionLogs}
+            executionStatus={executionStatus}
+            selectedLogIndices={selectedLogIndices}
+            handleLogLineClick={handleLogLineClick}
+            isDiagnosing={diagnosis.isDiagnosing}
+            handleDiagnose={diagnosis.handleDiagnose}
+            showQnnRetry={
+              executionStatus === "failed" && state.ihvProvider === "QNNExecutionProvider"
+            }
+            onRetryProvider={handleRetryProvider}
+            onSendFeedback={() => {
+              setReportArea("execution-batch");
+              setReportDescription(
+                `Execution failed with exit code ${executionExitCode ?? "?"}.\n\nRecent logs:\n${executionLogs.slice(-20).join("\n")}`,
+              );
+              setIsReportOpen(true);
+            }}
+            diagnosisHistory={diagnosis.diagnosisHistory}
+            activeHistoryIndex={diagnosis.activeHistoryIndex}
+            onSelectHistory={diagnosis.handleSelectHistory}
+            onClearHistory={diagnosis.handleClearHistory}
+          />
+
+          {/* MCP Diagnostic & Auto-Fix Card (matched_entry from MCP/local parsers enables thumbs) */}
+          {executionStatus === "failed" && (
+            <LazyMCPDiagnosticCard
+              diagnostic={diagnosis.displayedDiagnostic}
+              isDiagnosing={diagnosis.isDiagnosing}
+              fixApplied={diagnosis.displayedFixApplied}
+              onApplyFix={diagnosis.handleApplyMcpFix}
+              onRunDiagnosis={diagnosis.handleDiagnose}
+              error={diagnosis.diagnoseError}
+              onFeedbackSubmitted={diagnosis.handleFeedbackSubmitted}
+            />
+          )}
+        </ManualExecutionControls>
       </>}
+
+      {/* History & Side-by-Side Comparison Modal */}
+      <JobHistoryModal
+        isOpen={isHistoryOpen}
+        onClose={() => setIsHistoryOpen(false)}
+        onSelectRecipe={(recipeJsonStr) => {
+          try {
+            const parsed = JSON.parse(recipeJsonStr);
+            // Optionally update UI state if needed
+            setExecutionLogs([
+              `[INFO] Loaded recipe from history (${parsed.input_model?.type || "Olive recipe"})`,
+            ]);
+          } catch {
+            /* ignore */
+          }
+        }}
+      />
+
+      {/* Report Issue Modal */}
+      <ReportIssueModal
+        open={isReportOpen}
+        onClose={() => {
+          setIsReportOpen(false);
+          setReportArea(undefined);
+          setReportDescription("");
+        }}
+        state={state}
+        hardwareProbe={hardwareProbe}
+        executionLogs={executionLogs}
+        mcpDiagnostic={diagnosis.mcpDiagnostic}
+        defaultArea={reportArea}
+        defaultDescription={reportDescription}
+      />
     </div>
   );
 }

--- a/src/components/features/execute/ExportRecipeOverlay.tsx
+++ b/src/components/features/execute/ExportRecipeOverlay.tsx
@@ -1,0 +1,96 @@
+import { Button } from "@/components/ui/Button";
+import { Card, CardContent, CardHeader } from "@/components/ui/Card";
+import { X, FileJson, Check, Copy, Download } from "lucide-react";
+
+export interface ExportRecipeOverlayProps {
+  open: boolean;
+  onClose: () => void;
+  recipe: Record<string, unknown>;
+  isCopied: boolean;
+  onCopy: () => void;
+  onDownload: () => void;
+}
+
+/**
+ * Full-screen overlay showing the generated Olive recipe JSON with copy and
+ * download actions. Rendered on top of the manual execution workspace.
+ */
+export function ExportRecipeOverlay({
+  open,
+  onClose,
+  recipe,
+  isCopied,
+  onCopy,
+  onDownload,
+}: ExportRecipeOverlayProps) {
+  if (!open) return null;
+
+  return (
+    <div className="absolute inset-0 z-55 bg-slate-950/90 backdrop-blur-sm flex items-center justify-center p-4 sm:p-6 animate-in fade-in overflow-y-auto">
+      <Card className="w-full max-w-2xl border-electric-blue/30 flex flex-col max-h-[85vh]">
+        <CardHeader
+          title="Export Microsoft Olive Recipe"
+          description="Download your dynamic JSON recipe configuration or copy the schema to run with the MS Olive CLI."
+          badge={
+            <Button
+              variant="ghost"
+              className="h-8 w-8 p-0 hover:bg-slate-800"
+              onClick={onClose}
+            >
+              <X className="h-4 w-4" />
+            </Button>
+          }
+        />
+        <CardContent className="flex flex-col gap-4 overflow-hidden flex-1 p-6">
+          <div className="flex-1 min-h-[300px] relative flex flex-col overflow-hidden bg-slate-950 border border-slate-800 rounded-lg">
+            <div className="flex items-center justify-between px-4 py-2 border-b border-slate-900 bg-slate-900/40">
+              <div className="flex items-center gap-2">
+                <FileJson className="h-4 w-4 text-emerald-400" />
+                <span className="text-sm font-mono text-slate-300">olive_recipe.json</span>
+              </div>
+              <span className="text-[11px] bg-emerald-500/10 border border-emerald-500/20 text-emerald-400 px-2 py-0.5 rounded font-mono font-semibold">
+                VALID OLIVE SCHEMA
+              </span>
+            </div>
+            <textarea
+              readOnly
+              className="w-full flex-1 bg-transparent p-4 font-mono text-sm text-emerald-400 focus-visible:outline-none resize-none overflow-y-auto cursor-text"
+              value={JSON.stringify(recipe, null, 2)}
+              onClick={(e) => (e.target as HTMLTextAreaElement).select()}
+            />
+          </div>
+
+          <div className="flex justify-between items-center gap-3 pt-2">
+            <span className="text-sm text-slate-500 font-mono hidden sm:inline">
+              Generated dynamic recipe mapping
+            </span>
+            <div className="flex items-center gap-3 w-full sm:w-auto justify-end">
+              <Button variant="outline" className="text-sm h-9" onClick={onClose}>
+                Close
+              </Button>
+              <Button
+                variant="outline"
+                className="text-sm h-9 border-electric-blue/30 text-electric-blue hover:text-white hover:bg-electric-blue/10"
+                onClick={onCopy}
+              >
+                {isCopied ? (
+                  <Check className="h-4 w-4 mr-1.5 text-emerald-500" />
+                ) : (
+                  <Copy className="h-4 w-4 mr-1.5" />
+                )}
+                {isCopied ? "Copied!" : "Copy to Clipboard"}
+              </Button>
+              <Button
+                variant="default"
+                className="text-sm h-9 bg-electric-blue hover:bg-electric-blue/90 text-slate-950"
+                onClick={onDownload}
+              >
+                <Download className="h-4 w-4 mr-1.5" /> Save File (.json)
+              </Button>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/components/features/execute/ManualExecutionControls.tsx
+++ b/src/components/features/execute/ManualExecutionControls.tsx
@@ -1,0 +1,204 @@
+import type { ReactNode } from "react";
+import { Button } from "@/components/ui/Button";
+import { Card, CardContent, CardHeader } from "@/components/ui/Card";
+import { type UIState } from "@/types";
+import type { PipelineIssue } from "@/lib/pipelineValidation";
+import { VramEstimateBanner } from "@/components/features/VramEstimateBanner";
+import { GpuMetricsBar } from "@/components/features/execute/GpuMetricsBar";
+import type { GpuMetrics } from "@/lib/gpuMetrics";
+import {
+  RefreshCw,
+  CheckCircle2,
+  AlertCircle,
+  AlertTriangle,
+  Square,
+  Play,
+} from "lucide-react";
+
+export type ExecutionStatus = "idle" | "running" | "completed" | "failed" | "cancelled";
+
+export interface ManualExecutionControlsProps {
+  state: UIState;
+  executionStatus: ExecutionStatus;
+  executionExitCode: number | null;
+  isRunning: boolean;
+  validationLabel: string;
+  validationTone: "success" | "warning" | "error";
+  schemaErrors: string[];
+  advisories: PipelineIssue[];
+  isRunnable: boolean;
+  justQueued: boolean;
+  gpuMetrics: GpuMetrics | null;
+  onQueueJob: () => void;
+  onExecuteLive: () => void;
+  onCancelJob: () => void;
+  onOpenAiAudit?: () => void;
+  onTestInPlayground: () => void;
+  children?: ReactNode;
+}
+
+/**
+ * Active Draft card: status badge, VRAM estimate, schema/advisory issues,
+ * validation label, and the execute/cancel/queue controls. Receives the log
+ * panel and MCP diagnostic card as children so they stay inside the same card.
+ */
+export function ManualExecutionControls({
+  state,
+  executionStatus,
+  executionExitCode,
+  isRunning,
+  validationLabel,
+  validationTone,
+  schemaErrors,
+  advisories,
+  isRunnable,
+  justQueued,
+  gpuMetrics,
+  onQueueJob,
+  onExecuteLive,
+  onCancelJob,
+  onOpenAiAudit,
+  onTestInPlayground,
+  children,
+}: ManualExecutionControlsProps) {
+  return (
+    <Card className="border-slate-800 bg-slate-900/40">
+      <CardHeader
+        title="Active Draft"
+        description={
+          executionStatus === "running"
+            ? "Olive is running. Streaming optimization logs."
+            : executionStatus === "completed"
+              ? `Run completed (exit 0)`
+              : executionStatus === "failed"
+                ? `Run failed (exit ${executionExitCode ?? "?"})`
+                : "Review recipe above, then execute live or add to batch queue."
+        }
+        badge={
+          <div className="flex items-center gap-2 flex-wrap">
+            {executionStatus === "running" && (
+              <span className="flex items-center gap-1.5 text-sm font-mono bg-electric-blue/10 text-electric-blue border border-electric-blue/30 px-2.5 py-1 rounded">
+                <RefreshCw className="h-3 w-3 animate-spin" /> Running
+              </span>
+            )}
+            {executionStatus === "completed" && (
+              <>
+                <span className="flex items-center gap-1.5 text-sm font-mono bg-emerald-500/10 text-emerald-400 border border-emerald-500/30 px-2.5 py-1 rounded">
+                  <CheckCircle2 className="h-3 w-3" /> Done
+                </span>
+                <Button
+                  variant="outline"
+                  className="h-8 px-2.5 text-sm border-electric-blue/40 text-electric-blue hover:bg-electric-blue/10"
+                  onClick={onTestInPlayground}
+                >
+                  Test in Playground →
+                </Button>
+              </>
+            )}
+            {executionStatus === "failed" && (
+              <span className="flex items-center gap-1.5 text-sm font-mono bg-red-500/10 text-red-400 border border-red-500/30 px-2.5 py-1 rounded">
+                <AlertCircle className="h-3 w-3" /> Failed
+              </span>
+            )}
+            <Button
+              variant="ghost"
+              className="h-8 px-2.5 text-sm text-slate-400 hover:text-electric-blue"
+              onClick={() => onOpenAiAudit?.()}
+            >
+              Review with Assistant
+            </Button>
+          </div>
+        }
+      />
+      <CardContent className="flex flex-col gap-4 p-4">
+        <VramEstimateBanner state={state} compact />
+        {schemaErrors.length > 0 && (
+          <div className="rounded-lg border border-rose-500/30 bg-rose-950/20 p-3 space-y-2">
+            {schemaErrors.map((error) => (
+              <div key={error} className="flex items-start gap-2">
+                <AlertCircle className="h-4 w-4 text-rose-400 shrink-0 mt-0.5" />
+                <p className="text-xs text-rose-200 leading-relaxed">{error}</p>
+              </div>
+            ))}
+          </div>
+        )}
+        {advisories.length > 0 && (
+          <div className="rounded-lg border border-slate-800 bg-slate-950/60 p-3 space-y-2">
+            {advisories.map((issue) => (
+              <div key={issue.id} className="flex items-start gap-2">
+                <AlertTriangle className="h-4 w-4 text-amber-400 shrink-0 mt-0.5" />
+                <div className="min-w-0">
+                  <p className="text-sm font-semibold text-amber-300">{issue.title}</p>
+                  <p className="text-xs text-slate-400 leading-relaxed">{issue.description}</p>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+        <div className="flex justify-between items-center gap-3 flex-wrap sm:flex-nowrap">
+          <div className="flex items-center gap-2">
+            {validationTone === "success" ? (
+              <CheckCircle2 className="h-4 w-4 text-emerald-500" />
+            ) : validationTone === "warning" ? (
+              <AlertTriangle className="h-4 w-4 text-amber-400" />
+            ) : (
+              <AlertCircle className="h-4 w-4 text-rose-400" />
+            )}
+            <span
+              className={`text-sm sm:text-sm font-medium ${validationTone === "success"
+                ? "text-emerald-400"
+                : validationTone === "warning"
+                  ? "text-amber-300"
+                  : "text-rose-300"
+                }`}
+            >
+              {validationLabel}
+            </span>
+          </div>
+          <div className="flex items-center gap-2 ml-auto">
+            {isRunning && (
+              <Button
+                variant="outline"
+                onClick={onCancelJob}
+                className="h-9 px-3 text-sm border-rose-500/40 text-rose-400 hover:bg-rose-500/10 hover:border-rose-500 cursor-pointer"
+              >
+                <Square className="h-3.5 w-3.5 mr-1.5 fill-rose-400 text-rose-400" /> Cancel Run
+              </Button>
+            )}
+            {justQueued ? (
+              <span className="text-sm text-electric-blue font-semibold font-mono mr-2">Queued</span>
+            ) : (
+              <Button
+                variant="outline"
+                className="h-9 px-3 text-sm border-dashed border-slate-700 hover:border-electric-blue hover:text-electric-blue disabled:opacity-40"
+                onClick={onQueueJob}
+                disabled={!isRunnable}
+              >
+                + Queue
+              </Button>
+            )}
+            <Button
+              variant="success"
+              onClick={onExecuteLive}
+              disabled={isRunning || !isRunnable}
+              className="h-9 text-sm"
+            >
+              {isRunning ? (
+                <>
+                  <RefreshCw className="h-3.5 w-3.5 mr-1.5 animate-spin" /> Olive running...
+                </>
+              ) : (
+                <>
+                  <Play className="h-3.5 w-3.5 mr-1.5" fill="currentColor" /> Execute Live
+                </>
+              )}
+            </Button>
+          </div>
+        </div>
+        {/* GPU metrics live bar */}
+        {isRunning && gpuMetrics && <GpuMetricsBar metrics={gpuMetrics} />}
+        {children}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/features/execute/ManualExecutionControls.tsx
+++ b/src/components/features/execute/ManualExecutionControls.tsx
@@ -37,6 +37,179 @@ export interface ManualExecutionControlsProps {
   children?: ReactNode;
 }
 
+function getExecutionDescription(status: ExecutionStatus, exitCode: number | null) {
+  switch (status) {
+    case "running":
+      return "Olive is running. Streaming optimization logs.";
+    case "completed":
+      return "Run completed (exit 0)";
+    case "failed":
+      return `Run failed (exit ${exitCode ?? "?"})`;
+    default:
+      return "Review recipe above, then execute live or add to batch queue.";
+  }
+}
+
+function ExecutionStatusBadge({
+  executionStatus,
+  onOpenAiAudit,
+  onTestInPlayground,
+}: Pick<ManualExecutionControlsProps, "executionStatus" | "onOpenAiAudit" | "onTestInPlayground">) {
+  return (
+    <div className="flex items-center gap-2 flex-wrap">
+      {executionStatus === "running" && (
+        <span className="flex items-center gap-1.5 text-sm font-mono bg-electric-blue/10 text-electric-blue border border-electric-blue/30 px-2.5 py-1 rounded">
+          <RefreshCw className="h-3 w-3 animate-spin" /> Running
+        </span>
+      )}
+      {executionStatus === "completed" && (
+        <>
+          <span className="flex items-center gap-1.5 text-sm font-mono bg-emerald-500/10 text-emerald-400 border border-emerald-500/30 px-2.5 py-1 rounded">
+            <CheckCircle2 className="h-3 w-3" /> Done
+          </span>
+          <Button
+            variant="outline"
+            className="h-8 px-2.5 text-sm border-electric-blue/40 text-electric-blue hover:bg-electric-blue/10"
+            onClick={onTestInPlayground}
+          >
+            Test in Playground →
+          </Button>
+        </>
+      )}
+      {executionStatus === "failed" && (
+        <span className="flex items-center gap-1.5 text-sm font-mono bg-red-500/10 text-red-400 border border-red-500/30 px-2.5 py-1 rounded">
+          <AlertCircle className="h-3 w-3" /> Failed
+        </span>
+      )}
+      <Button
+        variant="ghost"
+        className="h-8 px-2.5 text-sm text-slate-400 hover:text-electric-blue"
+        onClick={() => onOpenAiAudit?.()}
+      >
+        Review with Assistant
+      </Button>
+    </div>
+  );
+}
+
+function RecipeIssues({
+  schemaErrors,
+  advisories,
+}: Pick<ManualExecutionControlsProps, "schemaErrors" | "advisories">) {
+  return (
+    <>
+      {schemaErrors.length > 0 && (
+        <div className="rounded-lg border border-rose-500/30 bg-rose-950/20 p-3 space-y-2">
+          {schemaErrors.map((error) => (
+            <div key={error} className="flex items-start gap-2">
+              <AlertCircle className="h-4 w-4 text-rose-400 shrink-0 mt-0.5" />
+              <p className="text-xs text-rose-200 leading-relaxed">{error}</p>
+            </div>
+          ))}
+        </div>
+      )}
+      {advisories.length > 0 && (
+        <div className="rounded-lg border border-slate-800 bg-slate-950/60 p-3 space-y-2">
+          {advisories.map((issue) => (
+            <div key={issue.id} className="flex items-start gap-2">
+              <AlertTriangle className="h-4 w-4 text-amber-400 shrink-0 mt-0.5" />
+              <div className="min-w-0">
+                <p className="text-sm font-semibold text-amber-300">{issue.title}</p>
+                <p className="text-xs text-slate-400 leading-relaxed">{issue.description}</p>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </>
+  );
+}
+
+function ValidationSummary({
+  validationLabel,
+  validationTone,
+}: Pick<ManualExecutionControlsProps, "validationLabel" | "validationTone">) {
+  const Icon =
+    validationTone === "success"
+      ? CheckCircle2
+      : validationTone === "warning"
+        ? AlertTriangle
+        : AlertCircle;
+  const color =
+    validationTone === "success"
+      ? "text-emerald-400"
+      : validationTone === "warning"
+        ? "text-amber-300"
+        : "text-rose-300";
+  const iconColor =
+    validationTone === "success"
+      ? "text-emerald-500"
+      : validationTone === "warning"
+        ? "text-amber-400"
+        : "text-rose-400";
+
+  return (
+    <div className="flex items-center gap-2">
+      <Icon className={`h-4 w-4 ${iconColor}`} />
+      <span className={`text-sm sm:text-sm font-medium ${color}`}>{validationLabel}</span>
+    </div>
+  );
+}
+
+function ExecutionActions({
+  isRunning,
+  isRunnable,
+  justQueued,
+  onCancelJob,
+  onQueueJob,
+  onExecuteLive,
+}: Pick<
+  ManualExecutionControlsProps,
+  "isRunning" | "isRunnable" | "justQueued" | "onCancelJob" | "onQueueJob" | "onExecuteLive"
+>) {
+  return (
+    <div className="flex items-center gap-2 ml-auto">
+      {isRunning && (
+        <Button
+          variant="outline"
+          onClick={onCancelJob}
+          className="h-9 px-3 text-sm border-rose-500/40 text-rose-400 hover:bg-rose-500/10 hover:border-rose-500 cursor-pointer"
+        >
+          <Square className="h-3.5 w-3.5 mr-1.5 fill-rose-400 text-rose-400" /> Cancel Run
+        </Button>
+      )}
+      {justQueued ? (
+        <span className="text-sm text-electric-blue font-semibold font-mono mr-2">Queued</span>
+      ) : (
+        <Button
+          variant="outline"
+          className="h-9 px-3 text-sm border-dashed border-slate-700 hover:border-electric-blue hover:text-electric-blue disabled:opacity-40"
+          onClick={onQueueJob}
+          disabled={!isRunnable}
+        >
+          + Queue
+        </Button>
+      )}
+      <Button
+        variant="success"
+        onClick={onExecuteLive}
+        disabled={isRunning || !isRunnable}
+        className="h-9 text-sm"
+      >
+        {isRunning ? (
+          <>
+            <RefreshCw className="h-3.5 w-3.5 mr-1.5 animate-spin" /> Olive running...
+          </>
+        ) : (
+          <>
+            <Play className="h-3.5 w-3.5 mr-1.5" fill="currentColor" /> Execute Live
+          </>
+        )}
+      </Button>
+    </div>
+  );
+}
+
 /**
  * Active Draft card: status badge, VRAM estimate, schema/advisory issues,
  * validation label, and the execute/cancel/queue controls. Receives the log
@@ -65,135 +238,28 @@ export function ManualExecutionControls({
     <Card className="border-slate-800 bg-slate-900/40">
       <CardHeader
         title="Active Draft"
-        description={
-          executionStatus === "running"
-            ? "Olive is running. Streaming optimization logs."
-            : executionStatus === "completed"
-              ? `Run completed (exit 0)`
-              : executionStatus === "failed"
-                ? `Run failed (exit ${executionExitCode ?? "?"})`
-                : "Review recipe above, then execute live or add to batch queue."
-        }
+        description={getExecutionDescription(executionStatus, executionExitCode)}
         badge={
-          <div className="flex items-center gap-2 flex-wrap">
-            {executionStatus === "running" && (
-              <span className="flex items-center gap-1.5 text-sm font-mono bg-electric-blue/10 text-electric-blue border border-electric-blue/30 px-2.5 py-1 rounded">
-                <RefreshCw className="h-3 w-3 animate-spin" /> Running
-              </span>
-            )}
-            {executionStatus === "completed" && (
-              <>
-                <span className="flex items-center gap-1.5 text-sm font-mono bg-emerald-500/10 text-emerald-400 border border-emerald-500/30 px-2.5 py-1 rounded">
-                  <CheckCircle2 className="h-3 w-3" /> Done
-                </span>
-                <Button
-                  variant="outline"
-                  className="h-8 px-2.5 text-sm border-electric-blue/40 text-electric-blue hover:bg-electric-blue/10"
-                  onClick={onTestInPlayground}
-                >
-                  Test in Playground →
-                </Button>
-              </>
-            )}
-            {executionStatus === "failed" && (
-              <span className="flex items-center gap-1.5 text-sm font-mono bg-red-500/10 text-red-400 border border-red-500/30 px-2.5 py-1 rounded">
-                <AlertCircle className="h-3 w-3" /> Failed
-              </span>
-            )}
-            <Button
-              variant="ghost"
-              className="h-8 px-2.5 text-sm text-slate-400 hover:text-electric-blue"
-              onClick={() => onOpenAiAudit?.()}
-            >
-              Review with Assistant
-            </Button>
-          </div>
+          <ExecutionStatusBadge
+            executionStatus={executionStatus}
+            onOpenAiAudit={onOpenAiAudit}
+            onTestInPlayground={onTestInPlayground}
+          />
         }
       />
       <CardContent className="flex flex-col gap-4 p-4">
         <VramEstimateBanner state={state} compact />
-        {schemaErrors.length > 0 && (
-          <div className="rounded-lg border border-rose-500/30 bg-rose-950/20 p-3 space-y-2">
-            {schemaErrors.map((error) => (
-              <div key={error} className="flex items-start gap-2">
-                <AlertCircle className="h-4 w-4 text-rose-400 shrink-0 mt-0.5" />
-                <p className="text-xs text-rose-200 leading-relaxed">{error}</p>
-              </div>
-            ))}
-          </div>
-        )}
-        {advisories.length > 0 && (
-          <div className="rounded-lg border border-slate-800 bg-slate-950/60 p-3 space-y-2">
-            {advisories.map((issue) => (
-              <div key={issue.id} className="flex items-start gap-2">
-                <AlertTriangle className="h-4 w-4 text-amber-400 shrink-0 mt-0.5" />
-                <div className="min-w-0">
-                  <p className="text-sm font-semibold text-amber-300">{issue.title}</p>
-                  <p className="text-xs text-slate-400 leading-relaxed">{issue.description}</p>
-                </div>
-              </div>
-            ))}
-          </div>
-        )}
+        <RecipeIssues schemaErrors={schemaErrors} advisories={advisories} />
         <div className="flex justify-between items-center gap-3 flex-wrap sm:flex-nowrap">
-          <div className="flex items-center gap-2">
-            {validationTone === "success" ? (
-              <CheckCircle2 className="h-4 w-4 text-emerald-500" />
-            ) : validationTone === "warning" ? (
-              <AlertTriangle className="h-4 w-4 text-amber-400" />
-            ) : (
-              <AlertCircle className="h-4 w-4 text-rose-400" />
-            )}
-            <span
-              className={`text-sm sm:text-sm font-medium ${validationTone === "success"
-                ? "text-emerald-400"
-                : validationTone === "warning"
-                  ? "text-amber-300"
-                  : "text-rose-300"
-                }`}
-            >
-              {validationLabel}
-            </span>
-          </div>
-          <div className="flex items-center gap-2 ml-auto">
-            {isRunning && (
-              <Button
-                variant="outline"
-                onClick={onCancelJob}
-                className="h-9 px-3 text-sm border-rose-500/40 text-rose-400 hover:bg-rose-500/10 hover:border-rose-500 cursor-pointer"
-              >
-                <Square className="h-3.5 w-3.5 mr-1.5 fill-rose-400 text-rose-400" /> Cancel Run
-              </Button>
-            )}
-            {justQueued ? (
-              <span className="text-sm text-electric-blue font-semibold font-mono mr-2">Queued</span>
-            ) : (
-              <Button
-                variant="outline"
-                className="h-9 px-3 text-sm border-dashed border-slate-700 hover:border-electric-blue hover:text-electric-blue disabled:opacity-40"
-                onClick={onQueueJob}
-                disabled={!isRunnable}
-              >
-                + Queue
-              </Button>
-            )}
-            <Button
-              variant="success"
-              onClick={onExecuteLive}
-              disabled={isRunning || !isRunnable}
-              className="h-9 text-sm"
-            >
-              {isRunning ? (
-                <>
-                  <RefreshCw className="h-3.5 w-3.5 mr-1.5 animate-spin" /> Olive running...
-                </>
-              ) : (
-                <>
-                  <Play className="h-3.5 w-3.5 mr-1.5" fill="currentColor" /> Execute Live
-                </>
-              )}
-            </Button>
-          </div>
+          <ValidationSummary validationLabel={validationLabel} validationTone={validationTone} />
+          <ExecutionActions
+            isRunning={isRunning}
+            isRunnable={isRunnable}
+            justQueued={justQueued}
+            onCancelJob={onCancelJob}
+            onQueueJob={onQueueJob}
+            onExecuteLive={onExecuteLive}
+          />
         </div>
         {/* GPU metrics live bar */}
         {isRunning && gpuMetrics && <GpuMetricsBar metrics={gpuMetrics} />}

--- a/src/components/features/execute/RecipePreviewCard.tsx
+++ b/src/components/features/execute/RecipePreviewCard.tsx
@@ -1,0 +1,188 @@
+import { Suspense, lazy } from "react";
+import { Button } from "@/components/ui/Button";
+import { Card, CardContent, CardHeader } from "@/components/ui/Card";
+import { type UIState } from "@/types";
+import { cn } from "@/lib/utils";
+import {
+  Workflow,
+  Code,
+  Download,
+  MoreHorizontal,
+  History,
+  Globe,
+  RefreshCw,
+} from "lucide-react";
+import type { RecipeViewMode } from "./useRecipeView";
+
+const RecipeGraphView = lazy(() => import("./recipe-graph/RecipeGraphView").then((m) => ({ default: m.RecipeGraphView })));
+
+export interface RecipePreviewCardProps {
+  recipe: Record<string, unknown>;
+  state: UIState;
+  setState: (s: Partial<UIState>) => void;
+  recipeView: RecipeViewMode;
+  setRecipeView: (view: RecipeViewMode) => void;
+  visitedRecipeViews: Set<string>;
+  onExportRecipe: () => void;
+  moreToolsOpen: boolean;
+  setMoreToolsOpen: (open: boolean | ((prev: boolean) => boolean)) => void;
+  moreToolsContainerRef: React.RefObject<HTMLDivElement | null>;
+  moreToolsTriggerRef: React.RefObject<HTMLButtonElement | null>;
+  onOpenHistory: () => void;
+  onOpenOwrExport: () => void;
+}
+
+function LoadingFallback({ label, minH }: { label: string; minH?: string }) {
+  return (
+    <div className="flex items-center justify-center w-full" style={minH ? { minHeight: minH } : undefined}>
+      <div className="flex flex-col items-center gap-3 py-16">
+        <RefreshCw className="h-5 w-5 text-electric-blue animate-spin" />
+        <p className="text-sm text-slate-500">{label}</p>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Renders the Olive recipe definition preview with graph/json view toggle,
+ * export actions, and the "More" tools menu.
+ */
+export function RecipePreviewCard({
+  recipe,
+  state,
+  setState,
+  recipeView,
+  setRecipeView,
+  visitedRecipeViews,
+  onExportRecipe,
+  moreToolsOpen,
+  setMoreToolsOpen,
+  moreToolsContainerRef,
+  moreToolsTriggerRef,
+  onOpenHistory,
+  onOpenOwrExport,
+}: RecipePreviewCardProps) {
+  return (
+    <Card
+      className={cn(
+        "flex flex-col overflow-hidden",
+        recipeView === "graph" ? "min-h-[340px] wide:min-h-[380px]" : "min-h-[340px]",
+      )}
+    >
+      <CardHeader
+        className="p-3 pb-2"
+        title="Olive Recipe Definition"
+        description={
+          recipeView === "graph"
+            ? undefined
+            : "The exact JSON schema that will be sent to the Olive Engine."
+        }
+        badge={
+          <div className="flex flex-wrap items-center gap-2">
+            <div
+              className="flex bg-slate-900 border border-slate-800 rounded p-0.5"
+              role="group"
+              aria-label="Recipe view"
+            >
+              <button
+                type="button"
+                aria-pressed={recipeView === "graph"}
+                onClick={() => setRecipeView("graph")}
+                className={`px-2.5 py-1 text-xs font-semibold rounded transition-all flex items-center gap-1 cursor-pointer ${recipeView === "graph"
+                  ? "bg-electric-blue text-slate-950"
+                  : "text-slate-400 hover:text-slate-200"
+                  }`}
+              >
+                <Workflow className="h-3 w-3" /> Graph Flow
+              </button>
+              <button
+                type="button"
+                aria-pressed={recipeView === "json"}
+                onClick={() => setRecipeView("json")}
+                className={`px-2.5 py-1 text-xs font-semibold rounded transition-all flex items-center gap-1 cursor-pointer ${recipeView === "json"
+                  ? "bg-electric-blue text-slate-950"
+                  : "text-slate-400 hover:text-slate-200"
+                  }`}
+              >
+                <Code className="h-3 w-3" /> JSON Code
+              </button>
+            </div>
+            <Button
+              variant="outline"
+              className="h-8 px-3 text-sm border-electric-blue/30 text-electric-blue hover:text-white hover:bg-electric-blue/10"
+              onClick={onExportRecipe}
+            >
+              <Download className="h-3.5 w-3.5 mr-1.5" /> Export Recipe
+            </Button>
+            <div className="relative" ref={moreToolsContainerRef}>
+              <Button
+                ref={moreToolsTriggerRef}
+                variant="outline"
+                className="h-8 px-2.5 text-sm border-slate-700 text-slate-300 hover:border-slate-500"
+                aria-expanded={moreToolsOpen}
+                aria-haspopup="menu"
+                onClick={() => setMoreToolsOpen((open) => !open)}
+              >
+                <MoreHorizontal className="h-3.5 w-3.5 mr-1" /> More
+              </Button>
+              {moreToolsOpen && (
+                <div
+                  role="menu"
+                  className="absolute right-0 z-20 mt-1 min-w-[180px] rounded-lg border border-slate-800 bg-slate-950 p-1 shadow-xl"
+                >
+                  <button
+                    type="button"
+                    role="menuitem"
+                    className="flex w-full items-center gap-2 rounded-md px-2.5 py-2 text-left text-xs text-slate-300 hover:bg-slate-900 cursor-pointer"
+                    onClick={() => {
+                      onOpenHistory();
+                      setMoreToolsOpen(false);
+                    }}
+                  >
+                    <History className="h-3 w-3" /> Run History
+                  </button>
+                  <button
+                    type="button"
+                    role="menuitem"
+                    className="flex w-full items-center gap-2 rounded-md px-2.5 py-2 text-left text-xs text-slate-300 hover:bg-slate-900 cursor-pointer"
+                    onClick={() => {
+                      onOpenOwrExport();
+                      setMoreToolsOpen(false);
+                    }}
+                  >
+                    <Globe className="h-3 w-3" /> Export for OWR
+                  </button>
+                </div>
+              )}
+            </div>
+          </div>
+        }
+      />
+      {(["graph", "json"] as const).map((view) => {
+        if (!visitedRecipeViews.has(view)) return null;
+        const isActive = recipeView === view;
+        return (
+          <CardContent
+            key={view}
+            className={cn(
+              "flex-1 overflow-hidden p-0",
+              view === "graph" ? "min-h-[340px]" : "min-h-[340px]",
+              isActive ? "block" : "hidden",
+            )}
+          >
+            {view === "graph" && (
+              <Suspense fallback={<LoadingFallback label="Loading graph editor..." minH="340px" />}>
+                <RecipeGraphView state={state} setState={setState} />
+              </Suspense>
+            )}
+            {view === "json" && (
+              <div className="overflow-auto bg-slate-950 p-4 m-6 mt-0 rounded-lg border border-slate-800 min-h-[360px]">
+                <pre className="text-sm font-mono text-emerald-400">{JSON.stringify(recipe, null, 2)}</pre>
+              </div>
+            )}
+          </CardContent>
+        );
+      })}
+    </Card>
+  );
+}

--- a/src/components/features/execute/executionJobUtils.test.ts
+++ b/src/components/features/execute/executionJobUtils.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { createMockUIState } from "../__tests__/testUtils";
+import {
+  buildQueuedBatchJob,
+  describeAppliedMcpPatches,
+  resolveQueuedModelIdentifier,
+} from "./executionJobUtils";
+import { DEFAULT_PASSES } from "@/lib/defaultPasses";
+
+describe("buildQueuedBatchJob", () => {
+  it("builds a queued snapshot with a model identifier and active pass names", () => {
+    const state = createMockUIState({
+      passes: { ...DEFAULT_PASSES, conversion: true, quantization: true, pruning: false },
+    });
+    const job = buildQueuedBatchJob(state);
+    expect(job.status).toBe("queued");
+    expect(job.modelSource).toBe("huggingface");
+    expect(job.provider).toBe("CPUExecutionProvider");
+    expect(job.modelIdentifier).toBe("meta-llama/Meta-Llama-3-8B");
+    expect(job.passes).toEqual(["Conversion (ONNX)", "Quantization (int8)"]);
+    expect(job.progress).toBe(0);
+    expect(job.progressKnown).toBe(true);
+    expect(job.recipeJson).toContain("Meta-Llama-3-8B");
+    expect(job.logs.length).toBeGreaterThan(0);
+  });
+
+  it("falls back to a baseline export label when no pass is active", () => {
+    const state = createMockUIState({
+      passes: { ...DEFAULT_PASSES, conversion: false, quantization: false, pruning: false },
+    });
+    expect(buildQueuedBatchJob(state).passes).toEqual(["Default Baseline Export"]);
+  });
+
+  it("resolves the Offline Weights Folder identifier for local sources", () => {
+    const state = createMockUIState({ modelSource: "local", localFiles: [{ name: "model.bin", size: 1 }] });
+    expect(resolveQueuedModelIdentifier(state)).toBe("Offline Weights Folder");
+  });
+});
+
+describe("describeAppliedMcpPatches", () => {
+  const state = createMockUIState();
+
+  it("lists cacheDir, overrides, and changed passes", () => {
+    const parts = describeAppliedMcpPatches(
+      { cacheDir: "/tmp/cache", passes: { quantization: true, pruning: true }, passRecipeOverrides: { opt: {} } },
+      state.passes,
+      [],
+    );
+    expect(parts).toContain("cacheDir=/tmp/cache");
+    expect(parts).toContain("passOverrides=opt");
+    expect(parts).toContain("quantization=true");
+    expect(parts).toContain("pruning=true");
+  });
+
+  it("appends applied quirks", () => {
+    expect(describeAppliedMcpPatches({}, state.passes, ["external-data"])).toEqual([
+      "quirks=external-data",
+    ]);
+  });
+
+  it("returns an empty list when nothing was applied", () => {
+    expect(describeAppliedMcpPatches({}, state.passes, [])).toEqual([]);
+  });
+});

--- a/src/components/features/execute/executionJobUtils.ts
+++ b/src/components/features/execute/executionJobUtils.ts
@@ -1,0 +1,68 @@
+import { type UIState, type BatchJob } from "@/types";
+import { buildRecipeJsonFromState } from "@/lib/recipePipeline";
+
+/**
+ * Returns the display names of active passes in the given state, falling back
+ * to a default baseline export label when no pass is enabled.
+ */
+export function collectActivePassNames(passes: UIState["passes"]): string[] {
+  const names: string[] = [];
+  if (passes.conversion) {
+    names.push(`Conversion (${passes.conversionFormat === "onnx" ? "ONNX" : "OpenVINO"})`);
+  }
+  if (passes.quantization) names.push(`Quantization (${passes.quantPrecision})`);
+  if (passes.pruning) names.push(`Pruning (${passes.pruningMethod})`);
+  if (passes.onnxTransforms) names.push("ORT Transforms");
+  return names.length > 0 ? names : ["Default Baseline Export"];
+}
+
+/** Resolves a human-readable model identifier for the active model source. */
+export function resolveQueuedModelIdentifier(state: UIState): string {
+  if (state.modelSource === "huggingface") return state.hfModelId || "unspecified-hf-model";
+  if (state.modelSource === "azure") return state.azureModelPath || "AzureML Asset Container";
+  return "Offline Weights Folder";
+}
+
+/** Builds a queued batch job snapshot from the current pipeline state. */
+export function buildQueuedBatchJob(state: UIState): BatchJob {
+  const mid = resolveQueuedModelIdentifier(state);
+  const activePassesNames = collectActivePassNames(state.passes);
+  const jobName = `Staged: ${mid.split("/").pop()} - ${state.ihvProvider.replace("ExecutionProvider", "")}`;
+  return {
+    id: "job-" + Date.now(),
+    name: jobName,
+    modelSource: state.modelSource,
+    modelIdentifier: mid,
+    provider: state.ihvProvider,
+    passes: activePassesNames,
+    recipeJson: buildRecipeJsonFromState(state),
+    status: "queued",
+    progress: 0,
+    progressKnown: true,
+    logs: ["Job created from active template configuration. Awaiting queue start."],
+  };
+}
+
+/**
+ * Summarizes MCP-applied UI patches and quirks into log-friendly strings so
+ * users can see exactly what the "Apply Fix" flow changed.
+ */
+export function describeAppliedMcpPatches(
+  patches: { cacheDir?: string; passRecipeOverrides?: Record<string, unknown>; passes?: Partial<UIState["passes"]> },
+  statePasses: UIState["passes"],
+  appliedQuirks: string[],
+): string[] {
+  const appliedParts: string[] = [];
+  if (patches.cacheDir) appliedParts.push(`cacheDir=${patches.cacheDir}`);
+  if (patches.passRecipeOverrides) {
+    appliedParts.push(`passOverrides=${Object.keys(patches.passRecipeOverrides).join("+")}`);
+  }
+  if (patches.passes) {
+    const changed = Object.entries(patches.passes)
+      .filter(([k, v]) => (statePasses as Record<string, unknown>)[k] !== v)
+      .map(([k, v]) => `${k}=${JSON.stringify(v)}`);
+    if (changed.length) appliedParts.push(...changed.slice(0, 8));
+  }
+  if (appliedQuirks.length) appliedParts.push(`quirks=${appliedQuirks.join("+")}`);
+  return appliedParts;
+}

--- a/src/components/features/execute/recipe-graph/RecipeValidationPanel.tsx
+++ b/src/components/features/execute/recipe-graph/RecipeValidationPanel.tsx
@@ -50,6 +50,7 @@ function getHardwareTargetFromProvider(provider: IHVProvider): string {
     case "CPUExecutionProvider":
       return "Intel Core i9 CPU";
     case "QNNExecutionProvider":
+    case "QnnAbiExecutionProvider":
       return "Qualcomm Snapdragon NPU";
     case "ROCMExecutionProvider":
       return "AMD MI300X / ROCm";
@@ -69,8 +70,6 @@ function getHardwareTargetFromProvider(provider: IHVProvider): string {
       return "XNNPACK (Mobile)";
     case "WasmExecutionProvider":
       return "WASM (Browser)";
-    case "QnnAbiExecutionProvider":
-      return "QNN ABI";
     default: {
       const _exhaustive: never = provider;
       return _exhaustive;

--- a/src/components/features/execute/useDiagnosis.ts
+++ b/src/components/features/execute/useDiagnosis.ts
@@ -201,8 +201,12 @@ export function useDiagnosis({
         logSnippet: executionLogs.slice(-20).join("\n"),
         fixApplied: false,
       };
-      setDiagnosisHistory((prev) => [entry, ...prev].slice(0, 50));
-      setActiveHistoryIndex(0);
+      prevDiagnosticRef.current = mcpDiagnostic;
+      queueMicrotask(() => {
+        setDiagnosisHistory((prev) => [entry, ...prev].slice(0, 50));
+        setActiveHistoryIndex(0);
+      });
+      return;
     }
     prevDiagnosticRef.current = mcpDiagnostic;
   }, [mcpDiagnostic, executionLogs]);

--- a/src/components/features/execute/useDiagnosis.ts
+++ b/src/components/features/execute/useDiagnosis.ts
@@ -1,0 +1,225 @@
+import { useState, useEffect, useRef, type Dispatch, type SetStateAction } from "react";
+import { type UIState, type McpTroubleshootFeedbackRating } from "@/types";
+import { useMcpDiagnosticKeyed } from "@/lib/hooks/useMcpDiagnostic";
+import { applyMcpDiagnosticToUiState, canApplyMcpDiagnostic } from "@/lib/mcpConfigMapping";
+import { isStudioHfTaskSpeechFix, isFailureLine, expandLogSelection } from "@/lib/logFailurePatterns";
+import { describeAppliedMcpPatches } from "./executionJobUtils";
+import { type DiagnosisEntry } from "./DiagnosisHistory";
+
+export interface UseDiagnosisOptions {
+  state: UIState;
+  setState: (s: Partial<UIState>) => void;
+  executionLogs: string[];
+  setExecutionLogs: Dispatch<SetStateAction<string[]>>;
+  executionStatus: "idle" | "running" | "completed" | "failed" | "cancelled";
+  selectedLogIndices: Set<number>;
+  mcpFixApplied: string;
+  setMcpFixApplied: (value: string) => void;
+}
+
+export interface UseDiagnosisReturn {
+  diagnosisHistory: DiagnosisEntry[];
+  activeHistoryIndex: number;
+  mcpDiagnostic: ReturnType<typeof useMcpDiagnosticKeyed>["diagnostics"]["current"] | null;
+  isDiagnosing: boolean;
+  diagnoseError: string | null;
+  viewingHistoricalDiagnosis: boolean;
+  displayedDiagnostic: ReturnType<typeof useMcpDiagnosticKeyed>["diagnostics"]["current"] | null;
+  displayedFixApplied: string;
+  handleDiagnose: () => void;
+  handleApplyMcpFix: () => void;
+  handleSelectHistory: (index: number) => void;
+  handleClearHistory: () => void;
+  handleFeedbackSubmitted: (payload: {
+    matched_entry: string;
+    rating: McpTroubleshootFeedbackRating;
+  }) => void;
+}
+
+/**
+ * Manages the MCP diagnostic lifecycle: keyed diagnostics, manual and
+ * auto-diagnose, apply-fix mapping, and diagnosis history.
+ */
+export function useDiagnosis({
+  state,
+  setState,
+  executionLogs,
+  setExecutionLogs,
+  executionStatus,
+  selectedLogIndices,
+  mcpFixApplied,
+  setMcpFixApplied,
+}: UseDiagnosisOptions): UseDiagnosisReturn {
+  const {
+    fetchKeyedDiagnostic,
+    diagnostics: keyedDiagnostics,
+    diagnosingKeys,
+    errors: diagnoseErrors,
+  } = useMcpDiagnosticKeyed();
+  const mcpDiagnostic = keyedDiagnostics["current"] ?? null;
+  const isDiagnosing = diagnosingKeys?.["current"] ?? false;
+  const diagnoseError = diagnoseErrors?.["current"] ?? null;
+
+  const [diagnosisHistory, setDiagnosisHistory] = useState<DiagnosisEntry[]>([]);
+  const [activeHistoryIndex, setActiveHistoryIndex] = useState(-1);
+
+  const viewingHistoricalDiagnosis =
+    activeHistoryIndex >= 0 && activeHistoryIndex < diagnosisHistory.length;
+  const displayedDiagnostic = viewingHistoricalDiagnosis
+    ? diagnosisHistory[activeHistoryIndex]!.diagnostic
+    : mcpDiagnostic;
+  const displayedFixApplied = viewingHistoricalDiagnosis
+    ? diagnosisHistory[activeHistoryIndex]!.fixApplied
+      ? "applied"
+      : ""
+    : mcpFixApplied;
+
+  /** Card self-submits feedback; parent hook is optional analytics / future history annotation. */
+  const handleFeedbackSubmitted = (payload: {
+    matched_entry: string;
+    rating: McpTroubleshootFeedbackRating;
+  }) => {
+    // No UI mutation — diagnosis display and history stay as-is after thumbs.
+    void payload.matched_entry;
+  };
+
+  const handleApplyMcpFix = () => {
+    if (!displayedDiagnostic || !canApplyMcpDiagnostic(displayedDiagnostic)) {
+      setExecutionLogs((prev) => [
+        ...prev,
+        "[MCP FIX] Nothing auto-applyable. Follow Recommended Fix / Known Quirks manually.",
+      ]);
+      return;
+    }
+
+    if (isStudioHfTaskSpeechFix(displayedDiagnostic)) {
+      setState({ hfTask: "automatic-speech-recognition" });
+      setExecutionLogs((prev) => [
+        ...prev,
+        "[FIX] Hugging Face task corrected to `automatic-speech-recognition` for Whisper. Rebuild/refresh the recipe, then run Execute Live again.",
+      ]);
+      setMcpFixApplied("applied");
+      // Mark the history row that matches the applied diagnostic (live = index 0).
+      const historyIdx = viewingHistoricalDiagnosis ? activeHistoryIndex : 0;
+      if (historyIdx >= 0 && historyIdx < diagnosisHistory.length) {
+        setDiagnosisHistory((prev) =>
+          prev.map((entry, idx) => (idx === historyIdx ? { ...entry, fixApplied: true } : entry)),
+        );
+      }
+      return;
+    }
+
+    const {
+      patches,
+      logs,
+      appliedQuirks,
+      notedQuirks: _notedQuirks,
+    } = applyMcpDiagnosticToUiState(displayedDiagnostic, state.passes, state.passRecipeOverrides);
+
+    const hasPatches = Object.keys(patches).length > 0;
+    if (!hasPatches && logs.length === 0) {
+      setExecutionLogs((prev) => [
+        ...prev,
+        "[MCP FIX] Could not map this diagnostic to UI/recipe fields. See Recommended Fix and Known Quirks.",
+      ]);
+      return;
+    }
+
+    if (hasPatches) {
+      setState(patches);
+    }
+
+    const appliedParts = describeAppliedMcpPatches(patches, state.passes, appliedQuirks);
+
+    setExecutionLogs((prev) => [
+      ...prev,
+      ...logs,
+      hasPatches
+        ? `[MCP FIX] Applied config + quirks: ${appliedParts.join(", ") || Object.keys(patches).join(", ")}. Re-run Execute (recipe order: Convert → Optimize → Quantize).`
+        : "[MCP FIX] Logged notes only. No UI fields changed.",
+    ]);
+    // Gate success UI state on actual applied quirks/patches only, not noted quirks
+    const applied = hasPatches || appliedQuirks.length > 0;
+    setMcpFixApplied(applied ? "applied" : "");
+    if (applied) {
+      const historyIdx = viewingHistoricalDiagnosis ? activeHistoryIndex : 0;
+      if (historyIdx >= 0 && historyIdx < diagnosisHistory.length) {
+        setDiagnosisHistory((prev) =>
+          prev.map((entry, idx) => (idx === historyIdx ? { ...entry, fixApplied: true } : entry)),
+        );
+      }
+    }
+  };
+
+  const handleSelectHistory = (index: number) => {
+    setActiveHistoryIndex(index);
+  };
+
+  const handleClearHistory = () => {
+    setDiagnosisHistory([]);
+    setActiveHistoryIndex(-1);
+  };
+
+  /** Prefer selected lines when present; expand traceback context; else full log. */
+  const handleDiagnose = () => {
+    if (executionLogs.length === 0) return;
+    setMcpFixApplied("");
+    const logs =
+      selectedLogIndices.size > 0
+        ? expandLogSelection(executionLogs, Array.from(selectedLogIndices))
+        : executionLogs;
+    void fetchKeyedDiagnostic("current", logs);
+  };
+
+  // Auto-diagnose once when a run fails (same pattern as BatchProcessingPanel).
+  const autoDiagnoseRef = useRef(false);
+  useEffect(() => {
+    if (executionStatus === "failed" && executionLogs.length > 0 && !autoDiagnoseRef.current) {
+      autoDiagnoseRef.current = true;
+      const errorIndices: number[] = [];
+      for (let i = 0; i < executionLogs.length; i++) {
+        if (isFailureLine(executionLogs[i]!)) {
+          errorIndices.push(i);
+        }
+      }
+      const logs = errorIndices.length > 0 ? expandLogSelection(executionLogs, errorIndices) : executionLogs;
+      void fetchKeyedDiagnostic("current", logs);
+    }
+    if (executionStatus !== "failed") {
+      autoDiagnoseRef.current = false;
+    }
+  }, [executionStatus, executionLogs, fetchKeyedDiagnostic]);
+
+  // Auto-save completed diagnoses to history
+  const prevDiagnosticRef = useRef(mcpDiagnostic);
+  useEffect(() => {
+    if (mcpDiagnostic && mcpDiagnostic !== prevDiagnosticRef.current) {
+      const entry: DiagnosisEntry = {
+        id: `diag-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`,
+        timestamp: Date.now(),
+        diagnostic: mcpDiagnostic,
+        logSnippet: executionLogs.slice(-20).join("\n"),
+        fixApplied: false,
+      };
+      setDiagnosisHistory((prev) => [entry, ...prev].slice(0, 50));
+      setActiveHistoryIndex(0);
+    }
+    prevDiagnosticRef.current = mcpDiagnostic;
+  }, [mcpDiagnostic, executionLogs]);
+
+  return {
+    diagnosisHistory,
+    activeHistoryIndex,
+    mcpDiagnostic,
+    isDiagnosing,
+    diagnoseError,
+    viewingHistoricalDiagnosis,
+    displayedDiagnostic,
+    displayedFixApplied,
+    handleDiagnose,
+    handleApplyMcpFix,
+    handleSelectHistory,
+    handleClearHistory,
+    handleFeedbackSubmitted,
+  };
+}

--- a/src/components/features/execute/useOwrExport.ts
+++ b/src/components/features/execute/useOwrExport.ts
@@ -1,0 +1,148 @@
+import { useState, useMemo } from "react";
+import { type UIState } from "@/types";
+import { buildOwrConfigs } from "@/lib/owrExportConfigs";
+import type { OwrExportConfigs } from "./OwrExportOverlay";
+
+export type OwrPlatform = "web" | "mobile";
+export type OwrVramMode = "performance" | "memory";
+export type OwrSelectedFile = "ort_config.json" | "onnx_model_manifest.json" | "web_init.js" | "mobile_init.kt";
+
+export interface UseOwrExportOptions {
+  state: UIState;
+}
+
+export interface UseOwrExportReturn {
+  isOwrExportOpen: boolean;
+  setIsOwrExportOpen: (open: boolean) => void;
+  owrConfigs: OwrExportConfigs;
+  owrPlatform: OwrPlatform;
+  setOwrPlatform: (platform: OwrPlatform) => void;
+  owrSelectedFile: OwrSelectedFile;
+  setOwrSelectedFile: (file: OwrSelectedFile) => void;
+  owrThreads: string;
+  setOwrThreads: (threads: string) => void;
+  owrVramMode: OwrVramMode;
+  setOwrVramMode: (mode: OwrVramMode) => void;
+  owrDownloadError: string | null;
+  isOwrDownloading: boolean;
+  handleDownloadOwrBundle: () => Promise<void>;
+}
+
+/**
+ * Owns the ONNX Runtime Web/Mobile (OWR) export overlay state, config building,
+ * and bundle download logic.
+ */
+export function useOwrExport({ state }: UseOwrExportOptions): UseOwrExportReturn {
+  const [isOwrExportOpen, setIsOwrExportOpen] = useState(false);
+  const [owrPlatform, setOwrPlatform] = useState<OwrPlatform>("web");
+  const [owrThreads, setOwrThreads] = useState("4");
+  const [owrVramMode, setOwrVramMode] = useState<OwrVramMode>("performance");
+  const [owrSelectedFile, setOwrSelectedFile] = useState<OwrSelectedFile>("ort_config.json");
+  const [owrDownloadError, setOwrDownloadError] = useState<string | null>(null);
+  const [isOwrDownloading, setIsOwrDownloading] = useState(false);
+
+  const owrConfigs = useMemo(
+    () =>
+      buildOwrConfigs({
+        state,
+        platform: owrPlatform,
+        threads: owrThreads,
+        vramMode: owrVramMode,
+      }),
+    [state, owrPlatform, owrThreads, owrVramMode],
+  );
+
+  const handleDownloadOwrBundle = async () => {
+    if (isOwrDownloading) return;
+    setIsOwrDownloading(true);
+    try {
+      setOwrDownloadError(null);
+      const { ortConfig, manifestConfig, webInitCode, mobileInitCode } = owrConfigs;
+      const rawModelId = state.hfModelId || (state.localFiles && state.localFiles[0]?.name) || "model";
+      const modelName = rawModelId.split("/").pop() || "model";
+
+      let zipData: Uint8Array;
+      let zipSync: typeof import("fflate").zipSync;
+      let strToU8: typeof import("fflate").strToU8;
+      try {
+        ({ zipSync, strToU8 } = await import("fflate"));
+      } catch (e) {
+        console.error("Failed to load ZIP module", e);
+        setOwrDownloadError("Couldn't load the ZIP module. Check your connection and try again.");
+        return;
+      }
+
+      try {
+        const files: Record<string, Uint8Array> = {};
+        files["ort_config.json"] = strToU8(JSON.stringify(ortConfig, null, 2));
+        files["onnx_model_manifest.json"] = strToU8(JSON.stringify(manifestConfig, null, 2));
+
+        if (owrPlatform === "web") {
+          files["web_init.js"] = strToU8(webInitCode);
+        } else {
+          files["mobile_init.kt"] = strToU8(mobileInitCode);
+        }
+
+        const readme = `ONNX Runtime Web/Mobile (OWR) Deployment Bundle
+  ==================================================
+  Created: ${new Date().toLocaleString()}
+  Target Environment: ONNX Runtime ${owrPlatform === "web" ? "Web (WebGPU/WASM)" : "Mobile (Android/iOS)"}
+  Optimized Model: ${modelName}
+
+  Contents of this bundle:
+  1. onnx_model_manifest.json - Full optimization and pipeline conversion audit trail from MS Olive.
+  2. ort_config.json - Direct configuration rules for loading the model session dynamically.
+  3. ${owrPlatform === "web" ? "web_init.js" : "mobile_init.kt"} - Boilerplate initialization and execution patterns.
+
+  Deployment Steps:
+  ${owrPlatform === "web"
+            ? "- Place the optimized model file (model.onnx) in your public asset folder.\\n- Install 'onnxruntime-web' dependency using pnpm.\\n- Import and invoke your customized initializeOrtSession() function. "
+            : "- Place the compiled ORT flatbuffer file (model.ort) under your Android App's 'src/main/assets' directory.\\n- Implement 'ai.onnxruntime:onnxruntime-android' via gradle.\\n- Wire up your OnnxModelExecutor wrapper inside Activities/Handlers."
+          }
+  `;
+        files["README.txt"] = strToU8(readme);
+
+        zipData = zipSync(files);
+      } catch (e) {
+        console.error("Archive generation failed", e);
+        setOwrDownloadError("Failed to create the ZIP archive. Check the browser console for details.");
+        return;
+      }
+
+      try {
+        const content = new Blob([zipData as unknown as ArrayBuffer], { type: "application/zip" });
+        const url = URL.createObjectURL(content);
+        const link = document.createElement("a");
+        link.href = url;
+        const modelCleanName = modelName.replace(/[^a-z0-9_-]/gi, "_").toLowerCase();
+        link.download = `owr_bundle_${owrPlatform}_${modelCleanName}.zip`;
+        document.body.appendChild(link);
+        link.click();
+        document.body.removeChild(link);
+        URL.revokeObjectURL(url);
+      } catch (e) {
+        console.error("ZIP Generation failed", e);
+        setOwrDownloadError("ZIP generation failed. Try again, or check the browser console for details.");
+      }
+    } finally {
+      setIsOwrDownloading(false);
+    }
+  };
+
+  return {
+    isOwrExportOpen,
+    setIsOwrExportOpen,
+    owrConfigs,
+    owrPlatform,
+    setOwrPlatform,
+    owrSelectedFile,
+    setOwrSelectedFile,
+    owrThreads,
+    setOwrThreads,
+    owrVramMode,
+    setOwrVramMode,
+    owrDownloadError,
+    isOwrDownloading,
+    handleDownloadOwrBundle,
+  };
+}

--- a/src/components/features/execute/useRecipeView.ts
+++ b/src/components/features/execute/useRecipeView.ts
@@ -1,0 +1,122 @@
+import { useEffect, useRef, useState, useTransition } from "react";
+import { type UIState } from "@/types";
+import { buildRecipeJsonFromState } from "@/lib/recipePipeline";
+
+export type RecipeViewMode = "graph" | "json";
+
+export interface UseRecipeViewOptions {
+  state: UIState;
+}
+
+export interface UseRecipeViewReturn {
+  recipeView: RecipeViewMode;
+  setRecipeView: (view: RecipeViewMode) => void;
+  visitedRecipeViews: Set<string>;
+  moreToolsOpen: boolean;
+  setMoreToolsOpen: (open: boolean | ((prev: boolean) => boolean)) => void;
+  moreToolsContainerRef: React.RefObject<HTMLDivElement | null>;
+  moreToolsTriggerRef: React.RefObject<HTMLButtonElement | null>;
+  isExportOpen: boolean;
+  setIsExportOpen: (open: boolean) => void;
+  isExportCopied: boolean;
+  handleExportCopy: () => void;
+  handleExportDownload: () => void;
+}
+
+/**
+ * Owns recipe preview view state (graph/json, lazy-mount tracking), the
+ * "More" tools menu (open state + click-outside/Escape handling), and the
+ * export recipe overlay state (open/copied + copy/download actions).
+ */
+export function useRecipeView({ state }: UseRecipeViewOptions): UseRecipeViewReturn {
+  const [recipeView, setRecipeViewRaw] = useState<RecipeViewMode>("graph");
+  const [visitedRecipeViews, setVisitedRecipeViews] = useState<Set<string>>(new Set(["graph"]));
+  const [, startRecipeTransition] = useTransition();
+  const setRecipeView = (view: RecipeViewMode) => {
+    startRecipeTransition(() => {
+      setRecipeViewRaw(view);
+      setVisitedRecipeViews((prev) => {
+        if (prev.has(view)) return prev;
+        return new Set(prev).add(view);
+      });
+    });
+  };
+
+  const [moreToolsOpen, setMoreToolsOpen] = useState(false);
+  const moreToolsContainerRef = useRef<HTMLDivElement | null>(null);
+  const moreToolsTriggerRef = useRef<HTMLButtonElement | null>(null);
+
+  useEffect(() => {
+    if (!moreToolsOpen) return;
+    const handlePointerDown = (event: MouseEvent) => {
+      const target = event.target as Node | null;
+      if (target && moreToolsContainerRef.current?.contains(target)) return;
+      setMoreToolsOpen(false);
+    };
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== "Escape") return;
+      setMoreToolsOpen(false);
+      moreToolsTriggerRef.current?.focus();
+    };
+    document.addEventListener("mousedown", handlePointerDown);
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("mousedown", handlePointerDown);
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [moreToolsOpen]);
+
+  const [isExportOpen, setIsExportOpen] = useState(false);
+  const [isExportCopied, setIsExportCopied] = useState(false);
+  const exportCopiedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (exportCopiedTimerRef.current) clearTimeout(exportCopiedTimerRef.current);
+    };
+  }, []);
+
+  const handleExportCopy = () => {
+    // Rebuild from live state — the displayed (deferred) recipe may lag the latest keystroke.
+    void navigator.clipboard
+      .writeText(buildRecipeJsonFromState(state))
+      .then(() => {
+        setIsExportCopied(true);
+        if (exportCopiedTimerRef.current) clearTimeout(exportCopiedTimerRef.current);
+        exportCopiedTimerRef.current = setTimeout(() => setIsExportCopied(false), 2000);
+      })
+      .catch(() => {});
+  };
+
+  const handleExportDownload = () => {
+    // Rebuild from live state — the displayed (deferred) recipe may lag the latest keystroke.
+    const jsonString = buildRecipeJsonFromState(state);
+    const blob = new Blob([jsonString], { type: "application/json" });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    const modelCleanName = (state.hfModelId || (state.localFiles && state.localFiles[0]?.name) || "model")
+      .replace(/[^a-z0-9_-]/gi, "_")
+      .toLowerCase();
+    link.href = url;
+    link.download = `olive_recipe_${modelCleanName}.json`;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+  };
+
+  return {
+    recipeView,
+    setRecipeView,
+    visitedRecipeViews,
+    moreToolsOpen,
+    setMoreToolsOpen,
+    moreToolsContainerRef,
+    moreToolsTriggerRef,
+    isExportOpen,
+    setIsExportOpen,
+    isExportCopied,
+    handleExportCopy,
+    handleExportDownload,
+  };
+}


### PR DESCRIPTION
Splits the ~1370-line `ExecutionWorkspace` orchestrator into feature-focused, colocated files per the CodeRabbit plan in issue #304, extended to cover the agent-mode section that landed with #285.

**Hooks / pure utils (Phase 1)**
- `executionJobUtils`: `collectActivePassNames`, `resolveQueuedModelIdentifier`, `buildQueuedBatchJob`, `describeAppliedMcpPatches` (+ unit tests)
- `useDiagnosis`: MCP diagnostic lifecycle, keyed diagnostics, diagnosis history, apply-fix mapping
- `useOwrExport`: OWR export overlay state + bundle download (dynamic `fflate` zip)
- `useRecipeView`: graph/json view state, More menu (click-outside/Escape), export overlay copy/download

**Presentational components (Phase 2)**
- `ExportRecipeOverlay`, `RecipePreviewCard`, `ExecutionLogPanel`, `ManualExecutionControls`, `AgentModeSection`

**Orchestrator (Phase 3)**
- `ExecutionWorkspace.tsx` is now a thin orchestrator wiring hooks + presentational sections.

**Design choices (per plan)**
- Direct type imports from leaf components — no `types.ts` (no cycle).
- No barrel file.
- `useAutoClearError` stays in the orchestrator (not moved into `useDiagnosis`): `useOliveStream` needs `setMcpFixApplied`, which would otherwise create a hook-call-order cycle.
- Log-line selection state stays in the orchestrator (shared between the log panel and `useDiagnosis.handleDiagnose`).

**Verification**
- `tsc --noEmit` clean
- `eslint --max-warnings 0` clean on execute folder
- Component suite: 292/292 pass — existing `ExecutionWorkspace.test.tsx` unchanged

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tonythethompson/Olive-Studio/pull/320?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

