### PR TITLE
Enhance knowledge refresh process and close review gaps

### DIFF
--- a/docs/REACT_BEST_PRACTICES.md
+++ b/docs/REACT_BEST_PRACTICES.md
@@ -3765,7 +3765,7 @@ Linux/macOS:
 - `olive_mcp_server/` - installable Python package
 - `olive_mcp_server/tools/` - 12 MCP tool implementations
 - `olive_mcp_server/knowledge_base/` - JSON catalogs for passes, hardware profiles, troubleshooting, quirks, and compatibility
-- `olive_mcp_server/fetchers/` - stubs for live knowledge-base updates
+- `olive_mcp_server/fetchers/` - source-backed fetchers for live knowledge-base updates
 - `scripts/` - helper scripts for expanding or updating the knowledge base
 - `tests/` - unit and integration tests
 

--- a/olive-mcp-server/README.md
+++ b/olive-mcp-server/README.md
@@ -295,11 +295,17 @@ disables Apply Fix and shows guidance only. Thumbs feedback appears only when
 ## Fetchers and update mechanism
 
 Live fetchers use `requests` and `BeautifulSoup` to pull fresh guidance from
-external sources:
+external sources. Olive docs cover the core landing, getting-started, how-to,
+pass/configuration, options, CLI, quantization, IHV integration, and model
+compression pages; ONNX Runtime coverage includes CUDA, TensorRT, CoreML, QNN,
+OpenVINO, DirectML, and the overview (CPU is documented by the overview).
 
 - `fetchers/official_docs_fetcher.py` - <https://microsoft.github.io/Olive/>
 - `fetchers/github_scraper.py` - microsoft/Olive releases and issues
 - `fetchers/onnx_runtime_fetcher.py` - ONNX Runtime execution-provider docs
+
+Set `GITHUB_TOKEN` or `GH_TOKEN` when refreshing to increase GitHub API rate
+limits; unauthenticated refreshes remain supported.
 
 Update scripts:
 

--- a/olive-mcp-server/README.md
+++ b/olive-mcp-server/README.md
@@ -295,10 +295,12 @@ disables Apply Fix and shows guidance only. Thumbs feedback appears only when
 ## Fetchers and update mechanism
 
 Live fetchers use `requests` and `BeautifulSoup` to pull fresh guidance from
-external sources. Olive docs cover the core landing, getting-started, how-to,
-pass/configuration, options, CLI, quantization, IHV integration, and model
-compression pages; ONNX Runtime coverage includes CUDA, TensorRT, CoreML, QNN,
-OpenVINO, DirectML, and the overview (CPU is documented by the overview).
+external sources. The default Olive docs refresh covers the landing,
+why-Olive, getting-started, how-to, pass/configuration, options, quantization,
+and IHV integration pages. Additional aliases include the CLI and
+model-compression pages. ONNX Runtime coverage includes CUDA, TensorRT,
+CoreML, QNN, OpenVINO, DirectML, and the overview (CPU is documented by the
+overview).
 
 - `fetchers/official_docs_fetcher.py` - <https://microsoft.github.io/Olive/>
 - `fetchers/github_scraper.py` - microsoft/Olive releases and issues

--- a/olive-mcp-server/olive_mcp_server/fetchers/_http.py
+++ b/olive-mcp-server/olive_mcp_server/fetchers/_http.py
@@ -1,0 +1,94 @@
+"""Shared HTTP and HTML helpers for knowledge-base fetchers."""
+
+from __future__ import annotations
+
+import time
+from email.utils import parsedate_to_datetime
+from typing import Any
+
+import requests
+from bs4 import BeautifulSoup
+
+from .. import __version__
+
+DEFAULT_TIMEOUT = 15
+_session: requests.Session | None = None
+
+
+def get_session() -> requests.Session:
+    """Return the lazily-created shared HTTP session."""
+    global _session
+    if _session is None:
+        _session = requests.Session()
+        _session.headers.update({
+            "User-Agent": f"olive-mcp-server/{__version__} (knowledge-base refresh)",
+        })
+    return _session
+
+
+def _retry_delay(response: Any, attempt: int) -> float:
+    """Return a bounded delay honoring a server-provided Retry-After."""
+    value = response.headers.get("Retry-After") if hasattr(response, "headers") else None
+    if value:
+        try:
+            return min(float(value), 10.0)
+        except ValueError:
+            try:
+                return min(max((parsedate_to_datetime(value).timestamp() - time.time()), 0), 10.0)
+            except (TypeError, ValueError, OverflowError):
+                pass
+    return min(0.25 * (2**attempt), 4.0)
+
+
+def fetch_html(url: str) -> str:
+    """Fetch HTML with bounded retries for transient responses."""
+    for attempt in range(3):
+        response = get_session().get(url, timeout=DEFAULT_TIMEOUT, allow_redirects=False)
+        if response.status_code in {429, 500, 502, 503, 504} and attempt < 2:
+            time.sleep(_retry_delay(response, attempt))
+            continue
+        response.raise_for_status()
+        location = response.headers.get("Location", "") if hasattr(response, "headers") else ""
+        if response.status_code in {301, 302, 303, 307, 308} and location:
+            raise requests.HTTPError(f"HTML request redirected unexpectedly to {location}")
+        content_type = response.headers.get("Content-Type", "") if hasattr(response, "headers") else ""
+        if content_type and "html" not in content_type.lower():
+            raise requests.RequestException(f"Expected HTML response, got {content_type}")
+        return response.text
+    raise requests.RequestException(f"HTTP request failed after retries: {url}")
+
+
+def markdown_from_html(html: str) -> str:
+    """Convert documentation HTML into headings, prose, lists, and code fences."""
+    soup = BeautifulSoup(html, "html.parser")
+    main = soup.find("main") or soup.find(attrs={"role": "main"}) or soup.find("article") or soup
+    for tag in main.find_all(["script", "style", "nav", "header", "footer", "form"]):
+        tag.decompose()
+    def is_sidebar(node: Any) -> bool:
+        classes = " ".join(node.get("class", [])).lower()
+        identifier = str(node.get("id", "")).lower()
+        return node.name in {"aside", "div", "section"} and any(
+            token in f"{classes} {identifier}"
+            for token in ("sidebar", "toc", "table-of-contents")
+        )
+
+    for tag in main.find_all(is_sidebar):
+        tag.decompose()
+
+    lines: list[str] = []
+    for elem in main.find_all(["h1", "h2", "h3", "h4", "h5", "h6", "p", "li", "pre"]):
+        if elem.name == "pre":
+            text = elem.get_text("\n", strip=True)
+            if text:
+                lines.append(f"```\n{text}\n```")
+            continue
+        text = elem.get_text(" ", strip=True)
+        if not text:
+            continue
+        if elem.name.startswith("h"):
+            lines.append(f"{'#' * int(elem.name[1])} {text}")
+        elif elem.name == "li":
+            lines.append(f"- {text}")
+        else:
+            lines.append(text)
+    return "\n\n".join(lines)

--- a/olive-mcp-server/olive_mcp_server/fetchers/_http.py
+++ b/olive-mcp-server/olive_mcp_server/fetchers/_http.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import time
 from email.utils import parsedate_to_datetime
 from typing import Any
+from urllib.parse import urljoin, urlparse
 
 import requests
 from bs4 import BeautifulSoup
@@ -42,19 +43,58 @@ def _retry_delay(response: Any, attempt: int) -> float:
 
 def fetch_html(url: str) -> str:
     """Fetch HTML with bounded retries for transient responses."""
+    current_url = url
+    origin_host = urlparse(url).netloc
     for attempt in range(3):
-        response = get_session().get(url, timeout=DEFAULT_TIMEOUT, allow_redirects=False)
+        response = get_session().get(current_url, timeout=DEFAULT_TIMEOUT, allow_redirects=False)
         if response.status_code in {429, 500, 502, 503, 504} and attempt < 2:
             time.sleep(_retry_delay(response, attempt))
             continue
-        response.raise_for_status()
         location = response.headers.get("Location", "") if hasattr(response, "headers") else ""
         if response.status_code in {301, 302, 303, 307, 308} and location:
-            raise requests.HTTPError(f"HTML request redirected unexpectedly to {location}")
+            if attempt >= 2:
+                raise requests.TooManyRedirects(f"Too many redirects fetching {url}")
+            current_url = urljoin(current_url, location)
+            if urlparse(current_url).netloc != origin_host:
+                raise requests.RequestException(f"HTML request redirected to another host: {current_url}")
+            continue
+        response.raise_for_status()
         content_type = response.headers.get("Content-Type", "") if hasattr(response, "headers") else ""
-        if content_type and "html" not in content_type.lower():
+        if content_type and "html" not in content_type.lower() and "text/plain" not in content_type.lower():
             raise requests.RequestException(f"Expected HTML response, got {content_type}")
         return response.text
+    raise requests.RequestException(f"HTTP request failed after retries: {url}")
+
+
+def fetch_json(
+    url: str,
+    *,
+    params: dict[str, Any] | None = None,
+    headers: dict[str, str] | None = None,
+) -> requests.Response:
+    """Fetch a JSON API response through the shared session."""
+    current_url = url
+    origin_host = urlparse(url).netloc
+    for attempt in range(3):
+        response = get_session().get(
+            current_url,
+            params=params,
+            headers=headers,
+            timeout=DEFAULT_TIMEOUT,
+            allow_redirects=False,
+        )
+        if response.status_code in {429, 500, 502, 503, 504} and attempt < 2:
+            time.sleep(_retry_delay(response, attempt))
+            continue
+        location = response.headers.get("Location", "") if hasattr(response, "headers") else ""
+        if response.status_code in {301, 302, 303, 307, 308} and location:
+            if attempt >= 2:
+                raise requests.TooManyRedirects(f"Too many redirects fetching {url}")
+            current_url = urljoin(current_url, location)
+            if urlparse(current_url).netloc != origin_host:
+                raise requests.RequestException(f"JSON request redirected to another host: {current_url}")
+            continue
+        return response
     raise requests.RequestException(f"HTTP request failed after retries: {url}")
 
 

--- a/olive-mcp-server/olive_mcp_server/fetchers/_http.py
+++ b/olive-mcp-server/olive_mcp_server/fetchers/_http.py
@@ -13,6 +13,10 @@ from bs4 import BeautifulSoup
 from .. import __version__
 
 DEFAULT_TIMEOUT = 15
+MAX_ATTEMPTS = 3
+MAX_REDIRECTS = 5
+RETRY_STATUS = {429, 500, 502, 503, 504}
+REDIRECT_STATUS = {301, 302, 303, 307, 308}
 _session: requests.Session | None = None
 
 
@@ -41,29 +45,55 @@ def _retry_delay(response: Any, attempt: int) -> float:
     return min(0.25 * (2**attempt), 4.0)
 
 
-def fetch_html(url: str) -> str:
-    """Fetch HTML with bounded retries for transient responses."""
+def _request(
+    url: str,
+    *,
+    kind: str,
+    params: dict[str, Any] | None = None,
+    headers: dict[str, str] | None = None,
+) -> requests.Response:
+    """Fetch a URL, retrying transient responses and following same-host redirects.
+
+    Retry attempts and redirect hops have independent budgets: a slow upstream that
+    also redirects should not exhaust the redirect allowance.
+    """
     current_url = url
     origin_host = urlparse(url).netloc
-    for attempt in range(3):
-        response = get_session().get(current_url, timeout=DEFAULT_TIMEOUT, allow_redirects=False)
-        if response.status_code in {429, 500, 502, 503, 504} and attempt < 2:
+    attempt = 0
+    redirects = 0
+    while True:
+        response = get_session().get(
+            current_url,
+            params=params,
+            headers=headers,
+            timeout=DEFAULT_TIMEOUT,
+            allow_redirects=False,
+        )
+        if response.status_code in RETRY_STATUS and attempt < MAX_ATTEMPTS - 1:
             time.sleep(_retry_delay(response, attempt))
+            attempt += 1
             continue
         location = response.headers.get("Location", "") if hasattr(response, "headers") else ""
-        if response.status_code in {301, 302, 303, 307, 308} and location:
-            if attempt >= 2:
+        if response.status_code in REDIRECT_STATUS and location:
+            if redirects >= MAX_REDIRECTS:
                 raise requests.TooManyRedirects(f"Too many redirects fetching {url}")
+            redirects += 1
+            attempt = 0
             current_url = urljoin(current_url, location)
             if urlparse(current_url).netloc != origin_host:
-                raise requests.RequestException(f"HTML request redirected to another host: {current_url}")
+                raise requests.RequestException(f"{kind} request redirected to another host: {current_url}")
             continue
-        response.raise_for_status()
-        content_type = response.headers.get("Content-Type", "") if hasattr(response, "headers") else ""
-        if content_type and "html" not in content_type.lower() and "text/plain" not in content_type.lower():
-            raise requests.RequestException(f"Expected HTML response, got {content_type}")
-        return response.text
-    raise requests.RequestException(f"HTTP request failed after retries: {url}")
+        return response
+
+
+def fetch_html(url: str) -> str:
+    """Fetch HTML with bounded retries for transient responses."""
+    response = _request(url, kind="HTML")
+    response.raise_for_status()
+    content_type = response.headers.get("Content-Type", "") if hasattr(response, "headers") else ""
+    if content_type and "html" not in content_type.lower() and "text/plain" not in content_type.lower():
+        raise requests.RequestException(f"Expected HTML response, got {content_type}")
+    return response.text
 
 
 def fetch_json(
@@ -73,29 +103,7 @@ def fetch_json(
     headers: dict[str, str] | None = None,
 ) -> requests.Response:
     """Fetch a JSON API response through the shared session."""
-    current_url = url
-    origin_host = urlparse(url).netloc
-    for attempt in range(3):
-        response = get_session().get(
-            current_url,
-            params=params,
-            headers=headers,
-            timeout=DEFAULT_TIMEOUT,
-            allow_redirects=False,
-        )
-        if response.status_code in {429, 500, 502, 503, 504} and attempt < 2:
-            time.sleep(_retry_delay(response, attempt))
-            continue
-        location = response.headers.get("Location", "") if hasattr(response, "headers") else ""
-        if response.status_code in {301, 302, 303, 307, 308} and location:
-            if attempt >= 2:
-                raise requests.TooManyRedirects(f"Too many redirects fetching {url}")
-            current_url = urljoin(current_url, location)
-            if urlparse(current_url).netloc != origin_host:
-                raise requests.RequestException(f"JSON request redirected to another host: {current_url}")
-            continue
-        return response
-    raise requests.RequestException(f"HTTP request failed after retries: {url}")
+    return _request(url, kind="JSON", params=params, headers=headers)
 
 
 def markdown_from_html(html: str) -> str:

--- a/olive-mcp-server/olive_mcp_server/fetchers/github_scraper.py
+++ b/olive-mcp-server/olive_mcp_server/fetchers/github_scraper.py
@@ -7,6 +7,8 @@ from typing import Any
 
 import requests
 
+from ._http import fetch_json
+
 REPO = "microsoft/Olive"
 RELEASES_URL = f"https://api.github.com/repos/{REPO}/releases"
 ISSUES_URL = f"https://api.github.com/repos/{REPO}/issues"
@@ -80,7 +82,7 @@ def fetch_github_issues(labels: list[str] | None = None, max_results: int = 50) 
             params["labels"] = ",".join(labels)
         for page in range(1, 4):
             params["page"] = page
-            issues_response = requests.get(ISSUES_URL, params=params, headers=headers, timeout=15)
+            issues_response = fetch_json(ISSUES_URL, params=params, headers=headers)
             _request_error(issues_response)
             raw_batch = issues_response.json()
             batch = [item for item in raw_batch if "pull_request" not in item]
@@ -92,8 +94,8 @@ def fetch_github_issues(labels: list[str] | None = None, max_results: int = 50) 
         errors["issues_error"] = str(exc)
 
     try:
-        releases_response = requests.get(
-            RELEASES_URL, params={"per_page": 5}, headers=headers, timeout=15
+        releases_response = fetch_json(
+            RELEASES_URL, params={"per_page": 5}, headers=headers
         )
         _request_error(releases_response)
         releases = releases_response.json()[:5]

--- a/olive-mcp-server/olive_mcp_server/fetchers/github_scraper.py
+++ b/olive-mcp-server/olive_mcp_server/fetchers/github_scraper.py
@@ -43,7 +43,6 @@ def _headers() -> dict[str, str]:
     token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
     if token:
         headers["Authorization"] = f"Bearer {token}"
-    return headers
 
 
 def _request_error(response: requests.Response) -> None:

--- a/olive-mcp-server/olive_mcp_server/fetchers/github_scraper.py
+++ b/olive-mcp-server/olive_mcp_server/fetchers/github_scraper.py
@@ -1,5 +1,8 @@
 """Fetcher for Olive GitHub releases and issues."""
 
+from __future__ import annotations
+
+import os
 from typing import Any
 
 import requests
@@ -21,7 +24,30 @@ def _release_to_text(release: dict[str, Any]) -> str:
     name = release.get("name", "")
     tag = release.get("tag_name", "")
     body = release.get("body") or ""
-    return f"## {name} ({tag})\n{body}"
+    flags = []
+    if release.get("prerelease"):
+        flags.append("prerelease")
+    if release.get("draft"):
+        flags.append("draft")
+    suffix = f" [{' / '.join(flags)}]" if flags else ""
+    return f"## {name} ({tag}){suffix}\n{body}"
+
+
+def _headers() -> dict[str, str]:
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    return headers
+
+
+def _request_error(response: requests.Response) -> None:
+    if response.status_code in {403, 429} and response.headers.get("x-ratelimit-remaining") == "0":
+        raise requests.HTTPError("GitHub API rate limit exhausted (x-ratelimit-remaining: 0)")
+    response.raise_for_status()
 
 
 def fetch_github_issues(labels: list[str] | None = None, max_results: int = 50) -> dict[str, Any]:
@@ -41,27 +67,54 @@ def fetch_github_issues(labels: list[str] | None = None, max_results: int = 50) 
         "max_results": max_results,
     }
 
+    errors: dict[str, str] = {}
+    issues: list[dict[str, Any]] = []
+    releases: list[dict[str, Any]] = []
+    headers = _headers()
     try:
-        params: dict[str, str | int] = {"state": "open", "per_page": max_results}
+        per_page = min(max(max_results, 1), 100)
+        params: dict[str, str | int] = {
+            "state": "open", "sort": "updated", "direction": "desc", "per_page": per_page,
+        }
         if labels:
             params["labels"] = ",".join(labels)
-
-        issues_response = requests.get(ISSUES_URL, params=params, timeout=30)
-        issues_response.raise_for_status()
-        issues = issues_response.json()
-
-        releases_response = requests.get(f"{RELEASES_URL}?per_page=5", timeout=30)
-        releases_response.raise_for_status()
-        releases = releases_response.json()
-
-        sections = ["# Recent Releases"]
-        sections.extend(_release_to_text(r) for r in releases[:5])
-        sections.append("# Open Issues")
-        sections.extend(_issue_to_text(i) for i in issues[:max_results])
-
-        result["content"] = "\n\n".join(sections)
+        for page in range(1, 4):
+            params["page"] = page
+            issues_response = requests.get(ISSUES_URL, params=params, headers=headers, timeout=15)
+            _request_error(issues_response)
+            raw_batch = issues_response.json()
+            batch = [item for item in raw_batch if "pull_request" not in item]
+            issues.extend(batch)
+            if len(issues) >= max_results or len(raw_batch) < per_page:
+                break
+        issues = issues[:max_results]
     except Exception as exc:  # noqa: BLE001
-        result["status"] = "error"
-        result["error"] = str(exc)
+        errors["issues_error"] = str(exc)
+
+    try:
+        releases_response = requests.get(
+            RELEASES_URL, params={"per_page": 5}, headers=headers, timeout=15
+        )
+        _request_error(releases_response)
+        releases = releases_response.json()[:5]
+    except Exception as exc:  # noqa: BLE001
+        errors["releases_error"] = str(exc)
+
+    sections = ["# Recent Releases"]
+    sections.extend(_release_to_text(r) for r in releases)
+    sections.append("# Open Issues")
+    sections.extend(_issue_to_text(i) for i in issues)
+    result["content"] = "\n\n".join(sections)
+    stamps = [
+        item["updated_at"] for item in issues if isinstance(item.get("updated_at"), str)
+    ]
+    stamps.extend(
+        item["published_at"] for item in releases if isinstance(item.get("published_at"), str)
+    )
+    if stamps:
+        result["source_timestamp"] = max(stamps)
+    if errors:
+        result.update(errors)
+        result["status"] = "error" if len(errors) == 2 else "partial"
 
     return result

--- a/olive-mcp-server/olive_mcp_server/fetchers/github_scraper.py
+++ b/olive-mcp-server/olive_mcp_server/fetchers/github_scraper.py
@@ -43,6 +43,7 @@ def _headers() -> dict[str, str]:
     token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
     if token:
         headers["Authorization"] = f"Bearer {token}"
+    return headers
 
 
 def _request_error(response: requests.Response) -> None:

--- a/olive-mcp-server/olive_mcp_server/fetchers/official_docs_fetcher.py
+++ b/olive-mcp-server/olive_mcp_server/fetchers/official_docs_fetcher.py
@@ -2,39 +2,36 @@
 
 from typing import Any
 
-import requests
-from bs4 import BeautifulSoup
+from ._http import fetch_html, markdown_from_html
 
 # SOURCE: https://microsoft.github.io/Olive/
 OFFICIAL_DOCS_URL = "https://microsoft.github.io/Olive/"
-
-
-def _markdown_from_html(html: str) -> str:
-    """Convert an HTML page to a simple Markdown string for downstream parsing."""
-    soup = BeautifulSoup(html, "html.parser")
-    for tag in soup(["script", "style", "nav", "footer", "header"]):
-        tag.decompose()
-
-    lines: list[str] = []
-    for elem in soup.find_all(["h1", "h2", "h3", "h4", "h5", "h6", "p", "li"]):
-        text = elem.get_text(strip=True)
-        if not text:
-            continue
-        if elem.name in ("h1", "h2", "h3", "h4", "h5", "h6"):
-            level = int(elem.name[1])
-            lines.append(f"{'#' * level} {text}")
-        elif elem.name == "li":
-            lines.append(f"- {text}")
-        else:
-            lines.append(text)
-    return "\n\n".join(lines)
+PAGE_PATHS = {
+    "index": "index.html",
+    "why-olive": "why-olive.html",
+    "getting-started": "getting-started/getting-started.html",
+    "how-to": "how-to/index.html",
+    "passes": "reference/pass.html",
+    "tutorials": "how-to/index.html",
+    "pass-configuration": "how-to/configure-workflows/pass-configuration.html",
+    "options": "reference/options.html",
+    "cli": "reference/cli.html",
+    "quantization": "features/quantization.html",
+    "ihv-integration": "features/ihv-integration/index.html",
+    "model-compression": "features/model-compression.html",
+}
 
 
 def _try_fetch(url: str) -> str:
     """Fetch a URL and return its Markdown content, raising on failure."""
-    response = requests.get(url, timeout=30)
-    response.raise_for_status()
-    return _markdown_from_html(response.text)
+    return markdown_from_html(fetch_html(url))
+
+
+def _candidates(page: str) -> list[str]:
+    if page in PAGE_PATHS:
+        return [f"{OFFICIAL_DOCS_URL}{PAGE_PATHS[page]}"]
+    paths = [page, f"{page}.html", f"{page}/", f"{page}/index.html"]
+    return list(dict.fromkeys(f"{OFFICIAL_DOCS_URL}{path}" for path in paths))
 
 
 def fetch_official_docs(pages: list[str] | None = None) -> dict[str, Any]:
@@ -46,23 +43,24 @@ def fetch_official_docs(pages: list[str] | None = None) -> dict[str, Any]:
     Returns:
         Dict mapping page path to Markdown content or error info.
     """
-    target_pages = pages if pages is not None else ["index", "passes", "tutorials"]
+    target_pages = pages if pages is not None else [
+        "index", "why-olive", "getting-started", "how-to", "passes",
+        "pass-configuration", "options", "quantization", "ihv-integration",
+    ]
     result: dict[str, Any] = {
         "status": "ok",
         "source": OFFICIAL_DOCS_URL,
         "pages": {},
+        "sources": {},
     }
 
     for page in target_pages:
-        candidates = [
-            f"{OFFICIAL_DOCS_URL}{page}/",
-            f"{OFFICIAL_DOCS_URL}{page}.html",
-            f"{OFFICIAL_DOCS_URL}{page}",
-        ]
+        candidates = _candidates(page)
         last_error = "No URL candidates tried"
         for url in candidates:
             try:
                 result["pages"][page] = _try_fetch(url)
+                result["sources"][page] = url
                 break
             except Exception as exc:  # noqa: BLE001
                 last_error = str(exc)

--- a/olive-mcp-server/olive_mcp_server/fetchers/onnx_runtime_fetcher.py
+++ b/olive-mcp-server/olive_mcp_server/fetchers/onnx_runtime_fetcher.py
@@ -2,31 +2,17 @@
 
 from typing import Any
 
-import requests
-from bs4 import BeautifulSoup
+from ._http import fetch_html, markdown_from_html
 
 ONNX_RUNTIME_EP_URL = "https://onnxruntime.ai/docs/execution-providers/"
-
-
-def _markdown_from_html(html: str) -> str:
-    """Convert an HTML page to a simple Markdown string for downstream parsing."""
-    soup = BeautifulSoup(html, "html.parser")
-    for tag in soup(["script", "style", "nav", "footer", "header"]):
-        tag.decompose()
-
-    lines: list[str] = []
-    for elem in soup.find_all(["h1", "h2", "h3", "h4", "h5", "h6", "p", "li"]):
-        text = elem.get_text(strip=True)
-        if not text:
-            continue
-        if elem.name in ("h1", "h2", "h3", "h4", "h5", "h6"):
-            level = int(elem.name[1])
-            lines.append(f"{'#' * level} {text}")
-        elif elem.name == "li":
-            lines.append(f"- {text}")
-        else:
-            lines.append(text)
-    return "\n\n".join(lines)
+EP_SLUGS = {
+    "CUDAExecutionProvider": "CUDA",
+    "TensorRTExecutionProvider": "TensorRT",
+    "CoreMLExecutionProvider": "CoreML",
+    "QNNExecutionProvider": "QNN",
+    "OpenVINOExecutionProvider": "OpenVINO",
+    "DirectMLExecutionProvider": "DirectML",
+}
 
 
 def fetch_onnx_runtime_docs(execution_providers: list[str] | None = None) -> dict[str, Any]:
@@ -41,34 +27,34 @@ def fetch_onnx_runtime_docs(execution_providers: list[str] | None = None) -> dic
     eps = execution_providers if execution_providers is not None else [
         "CPUExecutionProvider",
         "CUDAExecutionProvider",
-        "TensorrtExecutionProvider",
+        "TensorRTExecutionProvider",
         "CoreMLExecutionProvider",
         "QNNExecutionProvider",
         "OpenVINOExecutionProvider",
+        "DirectMLExecutionProvider",
     ]
     result: dict[str, Any] = {
         "status": "ok",
         "source": ONNX_RUNTIME_EP_URL,
         "pages": {},
+        "sources": {},
     }
 
-    # ONNX Runtime doc slugs use the EP name without the "ExecutionProvider"
-    # suffix and lowercased, e.g. "CUDA-ExecutionProvider".
-    def _slug(ep: str) -> str:
-        return ep.replace("ExecutionProvider", "").lower()
-
     for ep in eps:
-        candidates = [
-            f"{ONNX_RUNTIME_EP_URL}{_slug(ep)}-ExecutionProvider.html",
-            f"{ONNX_RUNTIME_EP_URL}{_slug(ep)}-executionprovider.html",
-            f"{ONNX_RUNTIME_EP_URL}{_slug(ep)}-ExecutionProvider/",
-        ]
+        if ep == "CPUExecutionProvider":
+            result["pages"][ep] = (
+                "# CPUExecutionProvider\n"
+                "CPUExecutionProvider is documented by the ONNX Runtime execution-provider overview."
+            )
+            result["sources"][ep] = ONNX_RUNTIME_EP_URL
+            continue
+        slug = EP_SLUGS.get(ep, ep.removesuffix("ExecutionProvider"))
+        candidates = [f"{ONNX_RUNTIME_EP_URL}{slug}-ExecutionProvider.html"]
         last_error = "No URL candidates tried"
         for url in candidates:
             try:
-                response = requests.get(url, timeout=30)
-                response.raise_for_status()
-                result["pages"][ep] = _markdown_from_html(response.text)
+                result["pages"][ep] = markdown_from_html(fetch_html(url))
+                result["sources"][ep] = url
                 break
             except Exception as exc:  # noqa: BLE001
                 last_error = str(exc)
@@ -78,9 +64,8 @@ def fetch_onnx_runtime_docs(execution_providers: list[str] | None = None) -> dic
 
     # Always fetch the main landing page as a fallback/aggregate source.
     try:
-        main_response = requests.get(ONNX_RUNTIME_EP_URL, timeout=30)
-        main_response.raise_for_status()
-        result["overview"] = _markdown_from_html(main_response.text)
+        result["overview"] = markdown_from_html(fetch_html(ONNX_RUNTIME_EP_URL))
+        result["sources"]["overview"] = ONNX_RUNTIME_EP_URL
     except Exception as exc:  # noqa: BLE001
         result["overview_error"] = str(exc)
         result["status"] = "partial"

--- a/olive-mcp-server/olive_mcp_server/fetchers/onnx_runtime_fetcher.py
+++ b/olive-mcp-server/olive_mcp_server/fetchers/onnx_runtime_fetcher.py
@@ -13,6 +13,7 @@ EP_SLUGS = {
     "OpenVINOExecutionProvider": "OpenVINO",
     "DirectMLExecutionProvider": "DirectML",
 }
+_EP_SLUGS_NORMALIZED = {key.lower(): value for key, value in EP_SLUGS.items()}
 
 
 def fetch_onnx_runtime_docs(execution_providers: list[str] | None = None) -> dict[str, Any]:
@@ -27,7 +28,7 @@ def fetch_onnx_runtime_docs(execution_providers: list[str] | None = None) -> dic
     eps = execution_providers if execution_providers is not None else [
         "CPUExecutionProvider",
         "CUDAExecutionProvider",
-        "TensorRTExecutionProvider",
+        "TensorrtExecutionProvider",
         "CoreMLExecutionProvider",
         "QNNExecutionProvider",
         "OpenVINOExecutionProvider",
@@ -41,14 +42,13 @@ def fetch_onnx_runtime_docs(execution_providers: list[str] | None = None) -> dic
     }
 
     for ep in eps:
-        if ep == "CPUExecutionProvider":
-            result["pages"][ep] = (
-                "# CPUExecutionProvider\n"
+        if ep.lower() == "cpuexecutionprovider":
+            result.setdefault("informational", {})[ep] = (
                 "CPUExecutionProvider is documented by the ONNX Runtime execution-provider overview."
             )
             result["sources"][ep] = ONNX_RUNTIME_EP_URL
             continue
-        slug = EP_SLUGS.get(ep, ep.removesuffix("ExecutionProvider"))
+        slug = _EP_SLUGS_NORMALIZED.get(ep.lower(), ep.removesuffix("ExecutionProvider"))
         candidates = [f"{ONNX_RUNTIME_EP_URL}{slug}-ExecutionProvider.html"]
         last_error = "No URL candidates tried"
         for url in candidates:

--- a/olive-mcp-server/scripts/update_kb.py
+++ b/olive-mcp-server/scripts/update_kb.py
@@ -98,13 +98,14 @@ def _coalesce_text(data: Any) -> str:
     if isinstance(data, dict):
         if isinstance(data.get("content"), str):
             return data["content"]
+        parts: list[str] = []
         pages = data.get("pages", {})
         if isinstance(pages, dict):
-            parts = [v for v in pages.values() if isinstance(v, str)]
-            if parts:
-                return "\n\n".join(parts)
-        if isinstance(data.get("overview"), str):
-            return data["overview"]
+            parts.extend(v for v in pages.values() if isinstance(v, str))
+        overview = data.get("overview")
+        if isinstance(overview, str) and overview:
+            parts.append(overview)
+        return "\n\n".join(parts)
     return ""
 
 

--- a/olive-mcp-server/scripts/update_kb.py
+++ b/olive-mcp-server/scripts/update_kb.py
@@ -258,9 +258,10 @@ def _merge_refresh_metadata(
     }
 
 
-def main() -> None:
+def main(kb_dir: Path | None = None) -> None:
     """Fetch external sources, parse them, and write freshness reports."""
-    kb_dir = Path(__file__).parent.parent / "olive_mcp_server" / "knowledge_base"
+    if kb_dir is None:
+        kb_dir = Path(__file__).parent.parent / "olive_mcp_server" / "knowledge_base"
     kb_dir.mkdir(parents=True, exist_ok=True)
 
     generator_version = _generator_version()
@@ -306,6 +307,8 @@ def main() -> None:
     }
 
     changed_files: list[str] = []
+    metadata_path = kb_dir / REFRESH_METADATA_NAME
+    existing_meta = _load_refresh_metadata(metadata_path)
 
     update_report_path = kb_dir / "update_report.json"
     if _write_json_if_changed(update_report_path, report):
@@ -323,12 +326,13 @@ def main() -> None:
         "generator_version": generator_version,
         "source_timestamp": source_ts,
         "source_fingerprint": source_fingerprint,
-        "changed_files": list(changed_files),
+        "changed_files": list(
+            changed_files
+            or ((existing_meta.get("runs", {}).get(GENERATOR_NAME, {}) or {}).get("changed_files") or [])
+        ),
         "success": success,
     }
 
-    metadata_path = kb_dir / REFRESH_METADATA_NAME
-    existing_meta = _load_refresh_metadata(metadata_path)
     metadata = _merge_refresh_metadata(
         existing_meta,
         run_meta=run_meta,

--- a/olive-mcp-server/scripts/update_kb.py
+++ b/olive-mcp-server/scripts/update_kb.py
@@ -326,10 +326,7 @@ def main(kb_dir: Path | None = None) -> None:
         "generator_version": generator_version,
         "source_timestamp": source_ts,
         "source_fingerprint": source_fingerprint,
-        "changed_files": list(
-            changed_files
-            or ((existing_meta.get("runs", {}).get(GENERATOR_NAME, {}) or {}).get("changed_files") or [])
-        ),
+        "changed_files": list(changed_files),
         "success": success,
     }
 

--- a/olive-mcp-server/tests/test_fetchers.py
+++ b/olive-mcp-server/tests/test_fetchers.py
@@ -2,18 +2,18 @@
 
 from __future__ import annotations
 
-from collections import defaultdict
-
+import pytest
 from olive_mcp_server.fetchers import github_scraper
+from olive_mcp_server.fetchers import _http
 from olive_mcp_server.fetchers import official_docs_fetcher as docs
 from olive_mcp_server.fetchers import onnx_runtime_fetcher as ort
 
 
 class Response:
-    def __init__(self, text: str = "", status_code: int = 200, payload=None):
+    def __init__(self, text: str = "", status_code: int = 200, payload=None, headers=None):
         self.text = text
         self.status_code = status_code
-        self.headers = {"Content-Type": "text/html"}
+        self.headers = headers or {"Content-Type": "text/html"}
         self._payload = payload
 
     def raise_for_status(self):
@@ -68,6 +68,23 @@ def test_official_docs_unknown_falls_back(monkeypatch):
     assert session.urls == ["https://microsoft.github.io/Olive/custom", url]
 
 
+def test_official_docs_failures_set_partial_and_error(monkeypatch):
+    session = Session({
+        "https://microsoft.github.io/Olive/index.html": [Response(status_code=404)],
+        "https://microsoft.github.io/Olive/why-olive.html": [Response(HTML)],
+    })
+    monkeypatch.setattr("olive_mcp_server.fetchers._http.get_session", lambda: session)
+    one_failed = docs.fetch_official_docs(pages=["index", "why-olive"])
+    assert one_failed["status"] == "partial"
+    assert isinstance(one_failed["pages"]["index"], dict)
+    failed_session = Session({
+        "https://microsoft.github.io/Olive/index.html": [Response(status_code=404)],
+    })
+    monkeypatch.setattr("olive_mcp_server.fetchers._http.get_session", lambda: failed_session)
+    all_failed = docs.fetch_official_docs(pages=["index"])
+    assert all_failed["status"] == "error"
+
+
 def test_ort_uses_case_sensitive_slugs_and_cpu_overview(monkeypatch):
     urls = {
         "https://onnxruntime.ai/docs/execution-providers/CUDA-ExecutionProvider.html": [Response(HTML)],
@@ -77,8 +94,51 @@ def test_ort_uses_case_sensitive_slugs_and_cpu_overview(monkeypatch):
     monkeypatch.setattr("olive_mcp_server.fetchers._http.get_session", lambda: session)
     result = ort.fetch_onnx_runtime_docs(["CUDAExecutionProvider", "CPUExecutionProvider"])
     assert result["status"] == "ok"
-    assert "cuda-executionprovider" not in session.urls
-    assert result["pages"]["CPUExecutionProvider"].startswith("# CPU")
+    assert not any("cuda-executionprovider" in url for url in session.urls)
+    assert "CPUExecutionProvider" not in result["pages"]
+    assert result["informational"]["CPUExecutionProvider"]
+
+
+def test_ort_overview_failure_is_partial(monkeypatch):
+    session = Session({
+        "https://onnxruntime.ai/docs/execution-providers/CUDA-ExecutionProvider.html": [Response(HTML)],
+        "https://onnxruntime.ai/docs/execution-providers/": [Response(status_code=503)],
+    })
+    monkeypatch.setattr("olive_mcp_server.fetchers._http.get_session", lambda: session)
+    result = ort.fetch_onnx_runtime_docs(["CUDAExecutionProvider"])
+    assert result["status"] == "partial"
+    assert "overview_error" in result
+
+
+def test_http_retries_503_and_honors_retry_after(monkeypatch):
+    response = Response(HTML, status_code=503, headers={"Content-Type": "text/html", "Retry-After": "7"})
+    session = Session({"https://example.test/page": [response, Response(HTML)]})
+    delays = []
+    monkeypatch.setattr(_http, "get_session", lambda: session)
+    monkeypatch.setattr(_http.time, "sleep", delays.append)
+    assert _http.fetch_html("https://example.test/page")
+    assert delays == [7.0]
+
+
+def test_http_follows_same_host_redirect_and_rejects_cross_host(monkeypatch):
+    session = Session({
+        "https://example.test/page": [
+            Response(status_code=302, headers={"Location": "/final"}),
+        ],
+        "https://example.test/final": [Response(HTML)],
+    })
+    monkeypatch.setattr(_http, "get_session", lambda: session)
+    assert _http.fetch_html("https://example.test/page")
+    assert session.urls == ["https://example.test/page", "https://example.test/final"]
+
+    cross_host = Session({
+        "https://example.test/page": [
+            Response(status_code=302, headers={"Location": "https://other.test/final"}),
+        ],
+    })
+    monkeypatch.setattr(_http, "get_session", lambda: cross_host)
+    with pytest.raises(Exception, match="another host"):
+        _http.fetch_html("https://example.test/page")
 
 
 def test_github_filters_prs_and_paginates(monkeypatch):
@@ -91,7 +151,7 @@ def test_github_filters_prs_and_paginates(monkeypatch):
         [{"number": 3, "title": "issue 2", "updated_at": "2024-02-01T00:00:00Z"}],
     ]
 
-    def get(url, **kwargs):
+    def get(self, url, **kwargs):
         calls.append((url, kwargs))
         if url == github_scraper.ISSUES_URL:
             payload = issue_pages.pop(0)
@@ -101,9 +161,59 @@ def test_github_filters_prs_and_paginates(monkeypatch):
 
     monkeypatch.delenv("GITHUB_TOKEN", raising=False)
     monkeypatch.delenv("GH_TOKEN", raising=False)
-    monkeypatch.setattr(github_scraper.requests, "get", get)
+    session = type("Session", (), {"get": get})()
+    monkeypatch.setattr("olive_mcp_server.fetchers._http.get_session", lambda: session)
     result = github_scraper.fetch_github_issues(max_results=2)
-    assert "# 2 pr" not in result["content"]
+    assert "## #2 pr" not in result["content"]
     assert "## #3 issue 2" in result["content"]
     assert result["source_timestamp"] == "2024-03-01T00:00:00Z"
     assert "Authorization" not in calls[0][1]["headers"]
+
+
+@pytest.mark.parametrize("variable", ["GITHUB_TOKEN", "GH_TOKEN"])
+def test_github_auth_header_is_optional_and_token_is_not_returned(monkeypatch, variable):
+    token = "test-secret-token"
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.delenv("GH_TOKEN", raising=False)
+    monkeypatch.setenv(variable, token)
+    calls = []
+
+    def get(self, url, **kwargs):
+        calls.append(kwargs)
+        return Response(payload=[])
+
+    session = type("Session", (), {"get": get})()
+    monkeypatch.setattr("olive_mcp_server.fetchers._http.get_session", lambda: session)
+    result = github_scraper.fetch_github_issues(max_results=1)
+    assert calls[0]["headers"]["Authorization"] == f"Bearer {token}"
+    assert token not in repr(result)
+
+
+def test_github_rate_limit_is_error(monkeypatch):
+    response = Response(
+        status_code=403,
+        headers={"x-ratelimit-remaining": "0", "Content-Type": "application/json"},
+    )
+    session = type("Session", (), {"get": lambda self, *args, **kwargs: response})()
+    monkeypatch.setattr("olive_mcp_server.fetchers._http.get_session", lambda: session)
+    result = github_scraper.fetch_github_issues()
+    assert result["status"] == "error"
+    assert "rate limit" in result["issues_error"].lower()
+    assert "rate limit" in result["releases_error"].lower()
+
+
+def test_github_releases_failure_keeps_issues(monkeypatch):
+    calls = []
+
+    def get(self, url, **kwargs):
+        calls.append(url)
+        if url == github_scraper.ISSUES_URL:
+            return Response(payload=[{"number": 4, "title": "kept"}])
+        return Response(status_code=500, headers={"Content-Type": "application/json"})
+
+    session = type("Session", (), {"get": get})()
+    monkeypatch.setattr("olive_mcp_server.fetchers._http.get_session", lambda: session)
+    result = github_scraper.fetch_github_issues(max_results=1)
+    assert result["status"] == "partial"
+    assert "## #4 kept" in result["content"]
+    assert "releases_error" in result

--- a/olive-mcp-server/tests/test_fetchers.py
+++ b/olive-mcp-server/tests/test_fetchers.py
@@ -1,0 +1,109 @@
+"""Mocked HTTP tests for knowledge-base fetchers."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+
+from olive_mcp_server.fetchers import github_scraper
+from olive_mcp_server.fetchers import official_docs_fetcher as docs
+from olive_mcp_server.fetchers import onnx_runtime_fetcher as ort
+
+
+class Response:
+    def __init__(self, text: str = "", status_code: int = 200, payload=None):
+        self.text = text
+        self.status_code = status_code
+        self.headers = {"Content-Type": "text/html"}
+        self._payload = payload
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise RuntimeError(f"HTTP {self.status_code}")
+
+    def json(self):
+        return self._payload
+
+
+class Session:
+    def __init__(self, responses):
+        self.responses = responses
+        self.urls = []
+
+    def get(self, url, **kwargs):
+        self.urls.append(url)
+        return self.responses[url].pop(0)
+
+
+HTML = """
+<html><body><nav>bad nav</nav><main><h1>Title</h1>
+<aside class="sidebar">bad sidebar</aside><p>Text</p><ul><li>one</li></ul>
+<pre>key: value</pre></main></body></html>
+"""
+
+
+def test_official_docs_resolution_and_markdown(monkeypatch):
+    session = Session({
+        "https://microsoft.github.io/Olive/index.html": [Response(HTML)],
+    })
+    monkeypatch.setattr("olive_mcp_server.fetchers._http.get_session", lambda: session)
+    result = docs.fetch_official_docs(pages=["index"])
+    assert result["status"] == "ok"
+    assert session.urls == ["https://microsoft.github.io/Olive/index.html"]
+    assert "# Title" in result["pages"]["index"]
+    assert "- one" in result["pages"]["index"]
+    assert "```" in result["pages"]["index"]
+    assert "bad nav" not in result["pages"]["index"]
+    assert result["sources"]["index"].endswith("index.html")
+
+
+def test_official_docs_unknown_falls_back(monkeypatch):
+    url = "https://microsoft.github.io/Olive/custom.html"
+    session = Session({
+        "https://microsoft.github.io/Olive/custom": [Response(status_code=404)],
+        url: [Response(HTML)],
+    })
+    monkeypatch.setattr("olive_mcp_server.fetchers._http.get_session", lambda: session)
+    result = docs.fetch_official_docs(pages=["custom"])
+    assert result["status"] == "ok"
+    assert session.urls == ["https://microsoft.github.io/Olive/custom", url]
+
+
+def test_ort_uses_case_sensitive_slugs_and_cpu_overview(monkeypatch):
+    urls = {
+        "https://onnxruntime.ai/docs/execution-providers/CUDA-ExecutionProvider.html": [Response(HTML)],
+        "https://onnxruntime.ai/docs/execution-providers/": [Response(HTML)],
+    }
+    session = Session(urls)
+    monkeypatch.setattr("olive_mcp_server.fetchers._http.get_session", lambda: session)
+    result = ort.fetch_onnx_runtime_docs(["CUDAExecutionProvider", "CPUExecutionProvider"])
+    assert result["status"] == "ok"
+    assert "cuda-executionprovider" not in session.urls
+    assert result["pages"]["CPUExecutionProvider"].startswith("# CPU")
+
+
+def test_github_filters_prs_and_paginates(monkeypatch):
+    calls = []
+    issue_pages = [
+        [
+            {"number": 1, "title": "issue", "updated_at": "2024-01-01T00:00:00Z"},
+            {"number": 2, "pull_request": {}, "title": "pr"},
+        ],
+        [{"number": 3, "title": "issue 2", "updated_at": "2024-02-01T00:00:00Z"}],
+    ]
+
+    def get(url, **kwargs):
+        calls.append((url, kwargs))
+        if url == github_scraper.ISSUES_URL:
+            payload = issue_pages.pop(0)
+        else:
+            payload = [{"name": "release", "published_at": "2024-03-01T00:00:00Z"}]
+        return Response(payload=payload)
+
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.delenv("GH_TOKEN", raising=False)
+    monkeypatch.setattr(github_scraper.requests, "get", get)
+    result = github_scraper.fetch_github_issues(max_results=2)
+    assert "# 2 pr" not in result["content"]
+    assert "## #3 issue 2" in result["content"]
+    assert result["source_timestamp"] == "2024-03-01T00:00:00Z"
+    assert "Authorization" not in calls[0][1]["headers"]

--- a/olive-mcp-server/tests/test_fetchers.py
+++ b/olive-mcp-server/tests/test_fetchers.py
@@ -141,6 +141,20 @@ def test_http_follows_same_host_redirect_and_rejects_cross_host(monkeypatch):
         _http.fetch_html("https://example.test/page")
 
 
+def test_http_retry_budget_does_not_consume_redirect_budget(monkeypatch):
+    session = Session({
+        "https://example.test/page": [
+            Response(status_code=503),
+            Response(status_code=503),
+            Response(status_code=302, headers={"Location": "/final"}),
+        ],
+        "https://example.test/final": [Response(status_code=503), Response(HTML)],
+    })
+    monkeypatch.setattr(_http, "get_session", lambda: session)
+    monkeypatch.setattr(_http.time, "sleep", lambda _seconds: None)
+    assert _http.fetch_html("https://example.test/page")
+
+
 def test_github_filters_prs_and_paginates(monkeypatch):
     calls = []
     issue_pages = [

--- a/olive-mcp-server/tests/test_update_kb_refresh.py
+++ b/olive-mcp-server/tests/test_update_kb_refresh.py
@@ -1,0 +1,52 @@
+"""Determinism and failure tests for the KB refresh script."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+
+def _load_script():
+    path = Path(__file__).parents[1] / "scripts" / "update_kb.py"
+    spec = importlib.util.spec_from_file_location("update_kb_test_module", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_refresh_is_deterministic_and_preserves_candidates(monkeypatch, tmp_path):
+    update_kb = _load_script()
+    payloads = {
+        "docs": {"status": "ok", "pages": {"index": "# Docs\n\n- documented option."}},
+        "github": {
+            "status": "ok", "content": "# Open Issues\n\n- deprecated API.",
+            "source_timestamp": "2024-01-01T00:00:00Z",
+        },
+        "ort": {"status": "ok", "pages": {"CUDA": "## CUDA\n\n- use it."}},
+    }
+    monkeypatch.setattr(update_kb, "fetch_official_docs", lambda: payloads["docs"])
+    monkeypatch.setattr(update_kb, "fetch_github_issues", lambda: payloads["github"])
+    monkeypatch.setattr(update_kb, "fetch_onnx_runtime_docs", lambda: payloads["ort"])
+    update_kb.main(tmp_path)
+    first = {p.name: p.read_bytes() for p in tmp_path.glob("*.json")}
+    update_kb.main(tmp_path)
+    second = {p.name: p.read_bytes() for p in tmp_path.glob("*.json")}
+    assert first == second
+    candidates = json.loads((tmp_path / "candidate_quirks.json").read_text())
+    assert candidates and {"category", "title", "description", "source"} <= candidates[0].keys()
+    report = json.loads((tmp_path / "update_report.json").read_text())
+    assert report["deprecations"]
+
+
+def test_refresh_error_exits(tmp_path, monkeypatch):
+    update_kb = _load_script()
+    monkeypatch.setattr(update_kb, "fetch_official_docs", lambda: {"status": "error"})
+    monkeypatch.setattr(update_kb, "fetch_github_issues", lambda: {"status": "ok", "content": ""})
+    monkeypatch.setattr(update_kb, "fetch_onnx_runtime_docs", lambda: {"status": "ok", "pages": {}})
+    with pytest.raises(SystemExit) as exc:
+        update_kb.main(tmp_path)
+    assert exc.value.code == 1
+    assert json.loads((tmp_path / "update_report.json").read_text())["success"] is False

--- a/olive-mcp-server/tests/test_update_kb_refresh.py
+++ b/olive-mcp-server/tests/test_update_kb_refresh.py
@@ -34,7 +34,15 @@ def test_refresh_is_deterministic_and_preserves_candidates(monkeypatch, tmp_path
     first = {p.name: p.read_bytes() for p in tmp_path.glob("*.json")}
     update_kb.main(tmp_path)
     second = {p.name: p.read_bytes() for p in tmp_path.glob("*.json")}
-    assert first == second
+    assert first["update_report.json"] == second["update_report.json"]
+    assert first["candidate_quirks.json"] == second["candidate_quirks.json"]
+    first_report = json.loads(first["update_report.json"])
+    second_report = json.loads(second["update_report.json"])
+    assert first_report["source_fingerprint"] == second_report["source_fingerprint"]
+    assert first_report["source_timestamp"] == second_report["source_timestamp"]
+    first_meta = json.loads(first["refresh_metadata.json"])
+    second_meta = json.loads(second["refresh_metadata.json"])
+    assert second_meta["runs"]["update_kb"]["changed_files"] == []
     candidates = json.loads((tmp_path / "candidate_quirks.json").read_text())
     assert candidates and {"category", "title", "description", "source"} <= candidates[0].keys()
     report = json.loads((tmp_path / "update_report.json").read_text())

--- a/olive-mcp-server/tests/test_update_kb_refresh.py
+++ b/olive-mcp-server/tests/test_update_kb_refresh.py
@@ -49,6 +49,26 @@ def test_refresh_is_deterministic_and_preserves_candidates(monkeypatch, tmp_path
     assert report["deprecations"]
 
 
+def test_ort_overview_is_parsed_alongside_pages(monkeypatch, tmp_path):
+    update_kb = _load_script()
+    monkeypatch.setattr(update_kb, "fetch_official_docs", lambda: {"status": "ok", "pages": {}})
+    monkeypatch.setattr(update_kb, "fetch_github_issues", lambda: {"status": "ok", "content": ""})
+    monkeypatch.setattr(
+        update_kb,
+        "fetch_onnx_runtime_docs",
+        lambda: {
+            "status": "ok",
+            "pages": {"CUDA": "## CUDA\n\n- use it."},
+            "overview": "## Overview\n\n- CPU runs everywhere.",
+        },
+    )
+    update_kb.main(tmp_path)
+    parsed = json.loads((tmp_path / "update_report.json").read_text())["parsed"]
+    headings = parsed["onnx_runtime"]["headings"]
+    assert "CUDA" in headings
+    assert "Overview" in headings
+
+
 def test_refresh_error_exits(tmp_path, monkeypatch):
     update_kb = _load_script()
     monkeypatch.setattr(update_kb, "fetch_official_docs", lambda: {"status": "error"})


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Unifies and hardens knowledge refresh fetchers, expands docs coverage, and fixes GitHub auth/PR filtering. Previously each fetcher made ad‑hoc requests and GitHub content sometimes included PRs; now fetchers share resilient HTTP and Markdown parsing, and the GitHub digest paginates, excludes PRs, and correctly sends headers/tokens.

- Shared helpers in `olive_mcp_server.fetchers._http`: session with UA, bounded retries honoring Retry-After, separate retry/redirect budgets, same-host-only redirects, `fetch_html`/`fetch_json`, and `markdown_from_html` that drops nav/sidebars and preserves code fences.
- Official docs fetcher (`official_docs_fetcher`): adds landing, why‑Olive, getting‑started, how‑to, passes, pass‑configuration, options, quantization, and IHV integration (aliases include CLI/model‑compression); returns a `sources` map; marks `partial` on per‑page failures.
- ONNX Runtime fetcher (`onnx_runtime_fetcher`): adds DirectML, fixes case‑sensitive slugs, treats `CPUExecutionProvider` as covered by the overview, returns `sources`, always parses the overview and sets `partial` on overview failure.
- GitHub scraper (`github_scraper`): paginates, filters out PRs, annotates releases with draft/prerelease, sets `source_timestamp`, surfaces rate‑limit errors, and supports optional `GITHUB_TOKEN`/`GH_TOKEN`. Sends `Accept` and API version headers; fixes `_headers()` to return the header dict so auth actually applies.
- Update script/tests: `scripts/update_kb.main(kb_dir=None)` accepts an optional output dir and preserves existing metadata; `_coalesce_text` concatenates page content with the ORT overview; new tests cover Retry‑After, same‑host redirects, separate retry/redirect budgets, GitHub pagination/auth/rate limits, determinism, and failure exits.

<sup>Written for commit 2860cc44c713a06a35d227f532a1d12db4a4720a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tonythethompson/Olive-Studio/pull/326?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

