### PR TITLE
chore(olive-mcp-server): enable ruff ANN rules on the shipped package

### DIFF
--- a/olive-mcp-server/olive_mcp_server/mcp_server.py
+++ b/olive-mcp-server/olive_mcp_server/mcp_server.py
@@ -14,6 +14,7 @@ import importlib
 import logging
 import os
 import sys
+from collections.abc import Callable, Iterator
 from typing import Any
 
 logger = logging.getLogger(__name__)
@@ -122,7 +123,7 @@ _mcp_instance: Any | None = None
 _resolved_tools: dict[str, Any] = {}
 
 
-def _resolve_tool(name: str):
+def _resolve_tool(name: str) -> Callable[..., Any] | None:
     """Resolve and cache a registered tool by name.
 
     Parameters:
@@ -157,7 +158,7 @@ def _resolve_tool(name: str):
     return fn
 
 
-def call_tool(name: str, args: dict | None = None):
+def call_tool(name: str, args: dict | None = None) -> Any:
     """
     Invoke a registered tool with the supplied arguments.
 
@@ -178,7 +179,7 @@ def call_tool(name: str, args: dict | None = None):
         return {"error": f"Invalid arguments for {name}: {exc}"}
 
 
-def _iter_tools():
+def _iter_tools() -> Iterator[Callable[..., Any]]:
     """Lazily resolve and yield all registered tool functions."""
     for name in _TOOL_IMPORTS:
         fn = _resolve_tool(name)
@@ -186,7 +187,7 @@ def _iter_tools():
             yield fn
 
 
-def _build_mcp():
+def _build_mcp() -> Any:
     """Create the FastMCP server (requires the optional ``mcp`` package)."""
     from mcp.server.fastmcp import FastMCP
 
@@ -196,7 +197,7 @@ def _build_mcp():
     return instance
 
 
-def __getattr__(name: str):
+def __getattr__(name: str) -> Any:
     """
     Lazily provides the module's `mcp` and `TOOLS` attributes.
 

--- a/olive-mcp-server/olive_mcp_server/tools/docs_search.py
+++ b/olive-mcp-server/olive_mcp_server/tools/docs_search.py
@@ -11,6 +11,8 @@ import logging
 import re
 import threading
 import time
+from collections.abc import Iterator
+from pathlib import Path
 from typing import Any
 
 import numpy as np
@@ -77,7 +79,7 @@ def _flatten(obj: Any, prefix: str = "") -> list[tuple[str, str]]:
     return results
 
 
-def _iter_kb_json_files():
+def _iter_kb_json_files() -> Iterator[Path]:
     """Yield searchable KB JSON paths in a stable, sorted order.
 
     ``Path.glob`` order is OS-dependent; indexing and content hashing must

--- a/olive-mcp-server/olive_mcp_server/tools/embeddings.py
+++ b/olive-mcp-server/olive_mcp_server/tools/embeddings.py
@@ -13,9 +13,12 @@ from __future__ import annotations
 
 import threading
 from collections.abc import Iterable, Sequence
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
+
+if TYPE_CHECKING:
+    from sentence_transformers import SentenceTransformer
 
 MODEL_NAME = "BAAI/bge-small-en-v1.5"
 EMBEDDING_DIM = 384
@@ -27,7 +30,7 @@ _model = None
 _model_lock = threading.Lock()
 
 
-def _get_model():
+def _get_model() -> SentenceTransformer | None:
     """Thread-safe lazy singleton for SentenceTransformer (CPU-only)."""
     global _model
     if _model is not None:

--- a/olive-mcp-server/olive_mcp_server/tools/studio_loopback.py
+++ b/olive-mcp-server/olive_mcp_server/tools/studio_loopback.py
@@ -23,7 +23,7 @@ _LOOPBACK_HOSTNAMES = frozenset({"localhost", "127.0.0.1", "::1"})
 class _NoRedirect(HTTPRedirectHandler):
     """Refuse redirects so a loopback URL cannot bounce off-host (SSRF)."""
 
-    def redirect_request(self, req, fp, code, msg, headers, newurl):  # noqa: ANN001
+    def redirect_request(self, req, fp, code, msg, headers, newurl) -> None:  # noqa: ANN001
         return None
 
 

--- a/olive-mcp-server/pyproject.toml
+++ b/olive-mcp-server/pyproject.toml
@@ -72,12 +72,16 @@ target-version = "py310"
 # pycodestyle (E/W) + pyflakes (F) + isort (I) + pyupgrade (UP) + bugbear (B) + simplify (SIM).
 # E501 is enforced; long lines were reflowed. `scripts/expand_kb.py` is exempt
 # (per-file ignore below) because it embeds long prose KB-data string literals.
-select = ["E", "W", "F", "I", "UP", "B", "SIM"]
-ignore = ["SIM102", "SIM103", "SIM105", "SIM108"]
+select = ["ANN", "E", "W", "F", "I", "UP", "B", "SIM"]
+# ANN401 (Any) excluded: this tool passes around JSON/dicts intentionally.
+ignore = ["ANN401", "SIM102", "SIM103", "SIM105", "SIM108"]
 
 [tool.ruff.lint.per-file-ignores]
-# S106: Suppress "possible hardcoded password" for pass_name keyword argument in tests
-"tests/**" = ["S106"]
+# S106: Suppress "possible hardcoded password" for pass_name keyword argument in tests.
+# ANN: test functions/fixtures legitimately omit annotations.
+"tests/**" = ["S106", "ANN"]
+# scripts are dev tooling; annotations optional there.
+"scripts/**" = ["ANN"]
 # expand_kb.py embeds long prose KB-data string literals; wrapping them across many
 # lines would harm readability (the data is authored as one phrase per entry).
 "scripts/expand_kb.py" = ["E501"]


### PR DESCRIPTION
## Summary

Stacked on top of #345 (the ruff lint+format CI gate). Enforces type-annotation presence (`ANN001/002/003/201/202/204`) on the shipped `olive_mcp_server/` package.

`ANN401` (any-type) is excluded globally — this tool intentionally passes JSON/dicts around. `tests/` and `scripts/` are exempted (annotations optional there).

## Changes

The package was already ~fully annotated; only **8 return annotations** were missing:

- `mcp_server.py`
  - `_resolve_tool -> Callable[..., Any] | None`
  - `call_tool -> Any`
  - `_iter_tools -> Iterator[Callable[..., Any]]`
  - `_build_mcp -> Any`
  - `__getattr__ -> Any`
  - (added `from collections.abc import Callable, Iterator`)
- `tools/docs_search.py`: `_iter_kb_json_files -> Iterator[Path]` (added `Iterator`, `Path` imports)
- `tools/embeddings.py`: `_get_model -> SentenceTransformer | None` (added `TYPE_CHECKING` import so the runtime import stays lazy)
- `tools/studio_loopback.py`: `redirect_request -> None` (override; `# noqa: ANN001` kept for the parent-matching args)

### Config (`pyproject.toml`)
- `select` adds `"ANN"`
- `ignore` adds `"ANN401"`
- `per-file-ignores`: `tests/**` += `["ANN"]`, `scripts/**` = `["ANN"]`

## Verification
- `ruff check .` → All checks passed (ANN active; 29 `ANN401` `Any` usages correctly ignored)
- `ruff check olive_mcp_server` (config-driven) → clean
- `ruff format --check .` → 89 files already formatted
- `pytest` → 689 passed, 1 skipped, **0 failed**
- native MCP smoke → PASS

## Stacking note

This PR targets `chore/olive-mcp-server-ruff-ci-gate` (base = that branch), not `main`, because it depends on the ruff config introduced in #345. Re-target to `main` after #345 merges.

Follow-up candidates (not in this PR): `ANN401` could be selectively re-enabled in narrow modules later; the 4 ignored SIM refactor rules remain deferred.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tonythethompson/Olive-Studio/pull/347?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

