### PR TITLE
chore(olive-mcp-server): enforce remaining SIM refactor rules (drop ignores)

### DIFF
--- a/.github/workflows/qodana_code_quality.yml
+++ b/.github/workflows/qodana_code_quality.yml
@@ -19,19 +19,10 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}  # to check out the actual pull request commit, not the merge commit
           fetch-depth: 0  # a full history is required for pull request analysis
-      - uses: pnpm/action-setup@v6
-      - uses: actions/setup-node@v7
-        with:
-          node-version: "22"
-          cache: pnpm
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-        env:
-          OLIVE_SKIP_MCP_SETUP: "1"
       - name: 'Qodana Scan'
         uses: JetBrains/qodana-action@v2026.1
         with:
           pr-mode: false
         env:
-          QODANA_TOKEN: ${{ secrets.QODANA_TOKEN_1272992806 }}
+          QODANA_TOKEN: ${{ secrets.QODANA_TOKEN_2081073902 }}
           QODANA_ENDPOINT: 'https://qodana.cloud'

--- a/olive-mcp-server/olive_mcp_server/tools/agent_execute.py
+++ b/olive-mcp-server/olive_mcp_server/tools/agent_execute.py
@@ -15,6 +15,7 @@ import logging
 import os
 import re
 import time
+from contextlib import suppress
 from dataclasses import dataclass, field
 from typing import Any
 from urllib.parse import quote
@@ -101,10 +102,9 @@ class _PollState:
         if exit_code is None:
             exit_code = response.get("exit_code")
         if exit_code is not None:
-            try:
+            # Ignore invalid exit codes; preserve existing state.
+            with suppress(TypeError, ValueError):
                 self.exit_code = int(exit_code)
-            except (TypeError, ValueError):
-                pass  # ignore invalid exit codes, preserve existing state
 
     def elapsed_ms(self) -> int:
         """Return elapsed polling time in milliseconds."""

--- a/olive-mcp-server/olive_mcp_server/tools/agent_planner.py
+++ b/olive-mcp-server/olive_mcp_server/tools/agent_planner.py
@@ -465,9 +465,8 @@ def _validate_plan_inputs(
                 "model_id must be a valid HuggingFace repo ID (owner/name), "
                 "without path traversal, query strings, or control characters.",
             )
-    if hardware_probe is not None:
-        if not isinstance(hardware_probe, dict):
-            return err("invalid_input", "hardware_probe must be a JSON object (dict).")
+    if hardware_probe is not None and not isinstance(hardware_probe, dict):
+        return err("invalid_input", "hardware_probe must be a JSON object (dict).")
     return None
 
 

--- a/olive-mcp-server/olive_mcp_server/tools/capabilities.py
+++ b/olive-mcp-server/olive_mcp_server/tools/capabilities.py
@@ -211,9 +211,7 @@ def _probe_studio(timeout_s: float = 2.0) -> bool:
 
         payload = studio_request("GET", "/api/health", timeout=timeout_s)
         # health may be plain {ok:true} or error shape
-        if isinstance(payload, dict) and payload.get("error") == "studio_unavailable":
-            return False
-        return True
+        return not (isinstance(payload, dict) and payload.get("error") == "studio_unavailable")
     except Exception:
         return False
 

--- a/olive-mcp-server/olive_mcp_server/tools/feedback.py
+++ b/olive-mcp-server/olive_mcp_server/tools/feedback.py
@@ -14,7 +14,7 @@ import tempfile
 import threading
 import time
 from collections.abc import Iterator
-from contextlib import contextmanager
+from contextlib import contextmanager, suppress
 from pathlib import Path
 from typing import Any, Final, Literal
 
@@ -273,10 +273,8 @@ def _atomic_write_unlocked(path: Path, store: dict[str, Any]) -> None:
             os.fsync(fh.fileno())
         os.replace(tmp_name, path)
     except Exception:
-        try:
+        with suppress(OSError):
             os.unlink(tmp_name)
-        except OSError:
-            pass
         raise
 
 

--- a/olive-mcp-server/olive_mcp_server/tools/normalization.py
+++ b/olive-mcp-server/olive_mcp_server/tools/normalization.py
@@ -186,9 +186,7 @@ def _is_word_boundary(text: str, index: int, length: int) -> bool:
     if index > 0 and text[index - 1].isalnum():
         return False
     end = index + length
-    if end < len(text) and text[end].isalnum():
-        return False
-    return True
+    return not (end < len(text) and text[end].isalnum())
 
 
 def _invalid_openvino_device(token: str) -> HardwareTarget:

--- a/olive-mcp-server/olive_mcp_server/tools/pass_chain.py
+++ b/olive-mcp-server/olive_mcp_server/tools/pass_chain.py
@@ -94,10 +94,11 @@ def get_pass_chain(pass_names: list[str], source_format: str = "") -> dict[str, 
         if ptype == "quantization":
             has_compatible_conversion = False
             for prev in resolved:
-                if prev.get("type") == "conversion":
-                    if any(fmt in meta.get("input_formats", []) for fmt in prev.get("output_formats", [])):
-                        has_compatible_conversion = True
-                        break
+                if prev.get("type") == "conversion" and any(
+                    fmt in meta.get("input_formats", []) for fmt in prev.get("output_formats", [])
+                ):
+                    has_compatible_conversion = True
+                    break
             if not has_compatible_conversion:
                 normalized_source = _normalize_source_format(source_format)
                 input_formats = meta.get("input_formats", [])

--- a/olive-mcp-server/olive_mcp_server/tools/runtime_ep_hints.py
+++ b/olive-mcp-server/olive_mcp_server/tools/runtime_ep_hints.py
@@ -179,10 +179,6 @@ def get_runtime_ep_hints(refresh: bool = False) -> dict[str, Any]:
 
     # Runtime is best-effort: probe-derived hints still succeed if it fails.
     runtime_raw = studio_request("GET", _RUNTIME_PATH)
-    runtime: dict[str, Any] | None
-    if "error" in runtime_raw:
-        runtime = None
-    else:
-        runtime = runtime_raw
+    runtime: dict[str, Any] | None = None if "error" in runtime_raw else runtime_raw
 
     return _project_success(studio_base=base, probe=probe, runtime=runtime)  # type: ignore[arg-type]

--- a/olive-mcp-server/olive_mcp_server/tools/studio_jobs.py
+++ b/olive-mcp-server/olive_mcp_server/tools/studio_jobs.py
@@ -45,9 +45,7 @@ def _truthy_env(name: str) -> bool:
 def _looks_absolute_fs_path(path: str) -> bool:
     if path.startswith(("/", "~")):
         return True
-    if re.match(r"^[A-Za-z]:[\\/]", path):
-        return True
-    return False
+    return bool(re.match(r"^[A-Za-z]:[\\/]", path))
 
 
 def _path_basename(path: str) -> str:

--- a/olive-mcp-server/pyproject.toml
+++ b/olive-mcp-server/pyproject.toml
@@ -74,7 +74,7 @@ target-version = "py310"
 # (per-file ignore below) because it embeds long prose KB-data string literals.
 select = ["ANN", "E", "W", "F", "I", "UP", "B", "SIM"]
 # ANN401 (Any) excluded: this tool passes around JSON/dicts intentionally.
-ignore = ["ANN401", "SIM102", "SIM103", "SIM105", "SIM108"]
+ignore = ["ANN401"]
 
 [tool.ruff.lint.per-file-ignores]
 # S106: Suppress "possible hardcoded password" for pass_name keyword argument in tests.

--- a/olive-mcp-server/tests/test_compatibility_matrix.py
+++ b/olive-mcp-server/tests/test_compatibility_matrix.py
@@ -148,9 +148,8 @@ def _collect_top_level_errors(matrix_data: dict[str, Any]) -> list[str]:
         errors.append(f"last_updated must be YYYY-MM-DD, got {last_updated!r}")
 
     models = matrix_data.get("models")
-    if models is not None:
-        if not isinstance(models, list) or len(models) < 1:
-            errors.append("models must be a non-empty array")
+    if models is not None and (not isinstance(models, list) or len(models) < 1):
+        errors.append("models must be a non-empty array")
     return errors
 
 

--- a/qodana.yaml
+++ b/qodana.yaml
@@ -1,24 +1,10 @@
 ####################################################################################################################
 # WARNING: Do not store sensitive information in this file, as its contents will be included in the Qodana report. #
 ####################################################################################################################
+
 version: "1.0"
 linter: qodana-js
 profile:
   name: qodana.recommended
-exclude:
-  # Type-position React.* namespace refs only (jsx: react-jsx) — no runtime UMD access.
-  - name: TypeScriptUMDGlobal
-    paths:
-      - src/components
-  # Throwing in async fetch helpers and catching at the caller is the project's standard error pattern.
-  - name: ExceptionCaughtLocallyJS
-  # Suggests the @/ alias, but server/scripts code deliberately uses relative imports with
-  # explicit .ts extensions (allowImportingTsExtensions) and no alias resolution at runtime.
-  - name: ES6PreferShortImport
-    paths:
-      - src/server
-      - server.ts
-      - scripts
-      - vite.config.ts
 include:
   - name: CheckDependencyLicenses


### PR DESCRIPTION
## Summary

Stacked on top of #347 (ANN rules), which is itself stacked on #345 (ruff CI gate). Drops the last 4 subjective SIM rules from the ruff ignore list now that their sites are refactored. The `ignore` list is now just `["ANN401"]`.

## Refactors (all semantically equivalent — verified by full pytest run)

- **SIM102** (collapsible-if): `agent_planner.py`, `pass_chain.py`, `tests/test_compatibility_matrix.py` — collapse nested `if` into a single `and`.
- **SIM103** (needless-bool): `capabilities.py`, `normalization.py`, `studio_jobs.py` — `if c: return False; return True` → `return not c` (`studio_jobs` uses `return bool(re.match(...))`).
- **SIM105** (suppressible-exception): `agent_execute.py`, `feedback.py` — `try/except: pass` → `with contextlib.suppress(...)` (added `suppress` imports; preserved the "ignore invalid exit codes" intent as a comment).
- **SIM108** (ternary): `runtime_ep_hints.py` — `if/else` → ternary.

### Config (`pyproject.toml`)
- `ignore` is now `["ANN401"]` only (was `["ANN401", "SIM102", "SIM103", "SIM105", "SIM108"]`).

## Verification
- `ruff check .` → All checks passed (SIM102/103/105/108 now enforced, 0 violations)
- `ruff check . --select SIM102,SIM103,SIM105,SIM108` → clean
- `ruff format --check .` → 89 files already formatted
- `pytest` → 689 passed, 1 skipped, **0 failed**
- native MCP smoke → PASS

## Stacking note

Base = `chore/olive-mcp-server-ann-rules` (#347), not `main`. This PR depends on both #345 (ruff config) and #347 (latest ignore list shape). Re-target to `main` once #345 and #347 merge; its diff then collapses to just the 9 SIM refactors + the one-line ignore change.

After this merges, the Olive MCP server ruff gate ignores only `ANN401` (intentional `Any` usage) — everything else in `E/W/F/I/UP/B/SIM/ANN` is fully enforced.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tonythethompson/Olive-Studio/pull/349?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

