### PR TITLE
feat(dev): add cross-platform dev server launcher with memory optimiz…

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "scripts": {
     "preinstall": "node -e \"if (!/pnpm/.test(process.env.npm_execpath || \\\"\\\")) { console.error('Use pnpm install, not npm install'); process.exit(1); }\" && node scripts/fix-stale-symlinks.mjs",
     "postinstall": "node scripts/postinstall-mcp-setup.mjs",
-    "dev": "tsx server.ts",
+    "dev": "node scripts/dev.mjs",
     "generate:recipes": "node scripts/generate-olive-recipes-catalog.mjs",
     "build": "vite build && esbuild server.ts --bundle --platform=node --format=esm --packages=external --outfile=dist/server.mjs && node scripts/copy-genai-sidecar.mjs",
     "build:desktop": "vite build && esbuild server.ts --bundle --platform=node --format=esm --ignore-annotations --banner:js=\"import { createRequire as createNodeRequire } from 'node:module'; const require = createNodeRequire(import.meta.url);\" --outfile=dist/server.mjs && node scripts/copy-genai-sidecar.mjs",

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -12,9 +12,9 @@ const serverScript = path.join(root, "server.ts");
 
 const existingOptions = process.env.NODE_OPTIONS || "";
 const memoryOption = "--max-old-space-size=4096";
-const nodeOptions = existingOptions.includes("--max-old-space-size")
-  ? existingOptions
-  : `${existingOptions} ${memoryOption}`.trim();
+// Remove any existing --max-old-space-size setting before appending the enforced 4GB policy
+const cleanedOptions = existingOptions.replace(/--max-old-space-size=\d+/g, "").trim();
+const nodeOptions = `${cleanedOptions} ${memoryOption}`.trim();
 
 const isWin = process.platform === "win32";
 const child = spawn(
@@ -23,7 +23,7 @@ const child = spawn(
   {
     cwd: root,
     stdio: "inherit",
-    shell: isWin,
+    shell: false,
     env: {
       ...process.env,
       NODE_OPTIONS: nodeOptions,
@@ -31,7 +31,18 @@ const child = spawn(
   },
 );
 
+let completed = false;
+
+child.on("error", (err) => {
+  if (completed) return;
+  completed = true;
+  console.error("Failed to start dev server:", err.message);
+  process.exit(1);
+});
+
 child.on("exit", (code, signal) => {
+  if (completed) return;
+  completed = true;
   if (signal) {
     process.kill(process.pid, signal);
   } else {
@@ -39,10 +50,24 @@ child.on("exit", (code, signal) => {
   }
 });
 
+let childExited = false;
+child.on("exit", () => {
+  childExited = true;
+});
+
+const signalHandlers = new Map();
 for (const sig of ["SIGINT", "SIGTERM", "SIGHUP"]) {
-  process.on(sig, () => {
-    if (!child.killed) {
+  const handler = () => {
+    if (!childExited && !child.killed) {
       child.kill(sig);
+    } else if (childExited) {
+      // Remove all signal listeners before re-signaling self
+      for (const [signal, h] of signalHandlers) {
+        process.removeListener(signal, h);
+      }
+      process.kill(process.pid, sig);
     }
-  });
+  };
+  signalHandlers.set(sig, handler);
+  process.on(sig, handler);
 }

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -32,10 +32,20 @@ const child = spawn(
 );
 
 let completed = false;
+let childExited = false;
+
+const signalHandlers = new Map();
+
+const removeSignalListeners = () => {
+  for (const [signal, handler] of signalHandlers) {
+    process.removeListener(signal, handler);
+  }
+};
 
 child.on("error", (err) => {
   if (completed) return;
   completed = true;
+  childExited = true;
   console.error("Failed to start dev server:", err.message);
   process.exit(1);
 });
@@ -43,28 +53,23 @@ child.on("error", (err) => {
 child.on("exit", (code, signal) => {
   if (completed) return;
   completed = true;
+  childExited = true;
   if (signal) {
+    // Remove our handlers first so re-signaling self actually terminates the
+    // launcher instead of being caught by this same handler again.
+    removeSignalListeners();
     process.kill(process.pid, signal);
   } else {
     process.exit(code ?? 0);
   }
 });
 
-let childExited = false;
-child.on("exit", () => {
-  childExited = true;
-});
-
-const signalHandlers = new Map();
 for (const sig of ["SIGINT", "SIGTERM", "SIGHUP"]) {
   const handler = () => {
     if (!childExited && !child.killed) {
       child.kill(sig);
     } else if (childExited) {
-      // Remove all signal listeners before re-signaling self
-      for (const [signal, h] of signalHandlers) {
-        process.removeListener(signal, h);
-      }
+      removeSignalListeners();
       process.kill(process.pid, sig);
     }
   };

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -1,0 +1,48 @@
+#!/usr/bin/env node
+/**
+ * Cross-platform dev server launcher that enforces a 4GB V8 heap size
+ * for the Express + Vite development environment.
+ */
+import { spawn } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const serverScript = path.join(root, "server.ts");
+
+const existingOptions = process.env.NODE_OPTIONS || "";
+const memoryOption = "--max-old-space-size=4096";
+const nodeOptions = existingOptions.includes("--max-old-space-size")
+  ? existingOptions
+  : `${existingOptions} ${memoryOption}`.trim();
+
+const isWin = process.platform === "win32";
+const child = spawn(
+  isWin ? "pnpm.cmd" : "pnpm",
+  ["exec", "tsx", serverScript, ...process.argv.slice(2)],
+  {
+    cwd: root,
+    stdio: "inherit",
+    shell: isWin,
+    env: {
+      ...process.env,
+      NODE_OPTIONS: nodeOptions,
+    },
+  },
+);
+
+child.on("exit", (code, signal) => {
+  if (signal) {
+    process.kill(process.pid, signal);
+  } else {
+    process.exit(code ?? 0);
+  }
+});
+
+for (const sig of ["SIGINT", "SIGTERM", "SIGHUP"]) {
+  process.on(sig, () => {
+    if (!child.killed) {
+      child.kill(sig);
+    }
+  });
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,6 +22,7 @@ import { OLIVE_ASK_AI_CHAT, type AskAiChatDetail } from "@/lib/aiChatBridge";
 import { useHardwareProbe } from "@/lib/hooks/useHardwareProbe";
 import { PipelineStatusSummary } from "@/components/features/pipeline/PipelineStatusSummary";
 import { PipelineSectionGate } from "@/components/features/pipeline/PipelineSectionGate";
+import { ServerConnectionBanner } from "@/components/ServerConnectionBanner";
 
 const BatchProcessingPanel = lazy(() =>
   import("@/components/features/execute/BatchProcessingPanel").then((m) => ({ default: m.BatchProcessingPanel })),
@@ -401,6 +402,7 @@ function Dashboard() {
     <DesktopMinimumViewport>
       <div className="flex flex-col h-screen bg-slate-950 text-slate-300 overflow-hidden font-sans">
         <TitleBar />
+        <ServerConnectionBanner />
         <div className="flex flex-1 min-h-0 overflow-hidden">
           <a
             href="#main"

--- a/src/components/LicenseNotice.tsx
+++ b/src/components/LicenseNotice.tsx
@@ -43,7 +43,9 @@ export function LicenseNotice({ open, onClose }: LicenseNoticeProps) {
             <span className="text-slate-200">Olive Studio</span> is free software licensed under the{" "}
             <button
               type="button"
-              onClick={() => void openExternal(MIT_URL)}
+              onClick={() => void openExternal(MIT_URL).catch((err) => {
+                console.error("Failed to open external URL:", err);
+              })}
               className="text-electric-blue hover:underline cursor-pointer bg-transparent border-none p-0 inline"
             >
               MIT License
@@ -58,7 +60,9 @@ export function LicenseNotice({ open, onClose }: LicenseNoticeProps) {
             Copyright © 2026 Anthony Thompson. Source:{" "}
             <button
               type="button"
-              onClick={() => void openExternal(REPO_URL)}
+              onClick={() => void openExternal(REPO_URL).catch((err) => {
+                console.error("Failed to open external URL:", err);
+              })}
               className="text-electric-blue hover:underline cursor-pointer bg-transparent border-none p-0 inline text-xs"
             >
               GitHub
@@ -66,7 +70,9 @@ export function LicenseNotice({ open, onClose }: LicenseNoticeProps) {
             {" · "}
             <button
               type="button"
-              onClick={() => void openExternal(LICENSE_URL)}
+              onClick={() => void openExternal(LICENSE_URL).catch((err) => {
+                console.error("Failed to open external URL:", err);
+              })}
               className="text-electric-blue hover:underline cursor-pointer bg-transparent border-none p-0 inline text-xs"
             >
               full license text

--- a/src/components/ReportIssueModal.tsx
+++ b/src/components/ReportIssueModal.tsx
@@ -61,6 +61,7 @@ export function ReportIssueModal({
   );
   const [showPreview, setShowPreview] = useState(false);
   const [copied, setCopied] = useState(false);
+  const [openError, setOpenError] = useState<string | null>(null);
 
   // Reset state only when the modal transitions from closed → open.
   // Keeping defaultArea/defaultDescription out of the dep array prevents a
@@ -78,6 +79,7 @@ export function ReportIssueModal({
       setSelectedTelemetry(new Set<TelemetryOptionId>(["platform", "hardware"]));
       setShowPreview(false);
       setCopied(false);
+      setOpenError(null);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps -- intentionally only depend on open
   }, [open]);
@@ -115,11 +117,11 @@ export function ReportIssueModal({
       }),
       frequencyInfo: frequencyInfo
         ? {
-            count: frequencyInfo.count,
-            firstOccurrenceAgo: frequencyInfo.firstOccurrenceAgo,
-            lastOccurrenceAgo: frequencyInfo.lastOccurrenceAgo,
-            frequencyLabel: frequencyInfo.frequencyLabel,
-          }
+          count: frequencyInfo.count,
+          firstOccurrenceAgo: frequencyInfo.firstOccurrenceAgo,
+          lastOccurrenceAgo: frequencyInfo.lastOccurrenceAgo,
+          frequencyLabel: frequencyInfo.frequencyLabel,
+        }
         : null,
     }),
     [category, severity, area, description, selectedTelemetry, state, hardwareProbe, executionLogs, chatLog, frequencyInfo],
@@ -149,16 +151,21 @@ export function ReportIssueModal({
     }
   }, [fullText]);
 
-  const handleOpenGithub = useCallback(() => {
-    if (urlExceededBudget) {
-      // Full prefilled URL was too long: keep complete report on clipboard, open blank form
-      void copyFullText().then(() => {
-        void openExternal(url);
-      });
-      return;
+  const handleOpenGithub = useCallback(async () => {
+    setOpenError(null);
+    try {
+      if (urlExceededBudget) {
+        // Full prefilled URL was too long: keep complete report on clipboard, open blank form
+        await copyFullText();
+        await openExternal(url);
+      } else {
+        await openExternal(url);
+      }
+      onClose();
+    } catch (err) {
+      setOpenError(err instanceof Error ? err.message : "Could not open browser");
     }
-    void openExternal(url);
-  }, [url, urlExceededBudget, copyFullText]);
+  }, [url, urlExceededBudget, copyFullText, onClose]);
 
   const handleCopy = useCallback(() => {
     void copyFullText();
@@ -375,35 +382,40 @@ export function ReportIssueModal({
               to your clipboard so you can paste it into the issue body.
             </p>
           )}
+          {openError && (
+            <p className="text-xs text-red-400 mt-1">
+              {openError}. You can copy the report and open GitHub manually.
+            </p>
+          )}
           <div className="flex items-center justify-between gap-3">
-          <Button variant="outline" onClick={onClose} className="text-sm h-9">
-            Cancel
-          </Button>
-          <div className="flex items-center gap-2">
-            <Button
-              variant="outline"
-              onClick={handleCopy}
-              disabled={!description.trim()}
-              className="text-sm h-9 border-slate-700 text-slate-300 hover:border-slate-500"
-            >
-              {copied ? (
-                <>
-                  <Check className="h-3.5 w-3.5 mr-1.5 text-emerald-400" /> Copied!
-                </>
-              ) : (
-                <>
-                  <Copy className="h-3.5 w-3.5 mr-1.5" /> Copy Report
-                </>
-              )}
+            <Button variant="outline" onClick={onClose} className="text-sm h-9">
+              Cancel
             </Button>
-            <Button
-              onClick={handleOpenGithub}
-              disabled={!description.trim()}
-              className="text-sm h-9 bg-electric-blue hover:bg-electric-blue/90 text-slate-950"
-            >
-              <ExternalLink className="h-3.5 w-3.5 mr-1.5" /> Open GitHub Issue
-            </Button>
-          </div>
+            <div className="flex items-center gap-2">
+              <Button
+                variant="outline"
+                onClick={handleCopy}
+                disabled={!description.trim()}
+                className="text-sm h-9 border-slate-700 text-slate-300 hover:border-slate-500"
+              >
+                {copied ? (
+                  <>
+                    <Check className="h-3.5 w-3.5 mr-1.5 text-emerald-400" /> Copied!
+                  </>
+                ) : (
+                  <>
+                    <Copy className="h-3.5 w-3.5 mr-1.5" /> Copy Report
+                  </>
+                )}
+              </Button>
+              <Button
+                onClick={handleOpenGithub}
+                disabled={!description.trim()}
+                className="text-sm h-9 bg-electric-blue hover:bg-electric-blue/90 text-slate-950"
+              >
+                <ExternalLink className="h-3.5 w-3.5 mr-1.5" /> Open GitHub Issue
+              </Button>
+            </div>
           </div>
         </div>
       </Card>

--- a/src/components/ReportIssueModal.tsx
+++ b/src/components/ReportIssueModal.tsx
@@ -155,9 +155,10 @@ export function ReportIssueModal({
     setOpenError(null);
     try {
       if (urlExceededBudget) {
-        // Full prefilled URL was too long: keep complete report on clipboard, open blank form
-        await copyFullText();
-        await openExternal(url);
+        // Full prefilled URL was too long: start opening URL before clipboard copy to preserve user activation
+        const openPromise = openExternal(url);
+        const copyPromise = copyFullText();
+        await Promise.all([openPromise, copyPromise]);
       } else {
         await openExternal(url);
       }
@@ -383,7 +384,7 @@ export function ReportIssueModal({
             </p>
           )}
           {openError && (
-            <p className="text-xs text-red-400 mt-1">
+            <p className="text-xs text-red-400 mt-1" role="alert">
               {openError}. You can copy the report and open GitHub manually.
             </p>
           )}

--- a/src/components/ServerConnectionBanner.tsx
+++ b/src/components/ServerConnectionBanner.tsx
@@ -1,0 +1,93 @@
+import { useEffect, useState, useCallback, useRef } from "react";
+import { AlertTriangle, RefreshCw } from "lucide-react";
+import { Button } from "@/components/ui/Button";
+
+interface ServerConnectionBannerProps {
+  /** Optional polling interval in ms (default 10000ms). */
+  checkIntervalMs?: number;
+}
+
+export function ServerConnectionBanner({ checkIntervalMs = 10000 }: ServerConnectionBannerProps) {
+  const [isDisconnected, setIsDisconnected] = useState(false);
+  const [isChecking, setIsChecking] = useState(false);
+  const consecutiveFailuresRef = useRef(0);
+
+  const abortControllerRef = useRef<AbortController | null>(null);
+
+  const checkHealth = useCallback(async () => {
+    // Abort any previous in-flight request
+    abortControllerRef.current?.abort();
+    const controller = new AbortController();
+    abortControllerRef.current = controller;
+
+    setIsChecking(true);
+    try {
+      const res = await fetch("/api/health", {
+        signal: AbortSignal.any([controller.signal, AbortSignal.timeout(4000)]),
+      });
+      if (controller.signal.aborted) return;
+      if (res.ok) {
+        consecutiveFailuresRef.current = 0;
+        setIsDisconnected(false);
+      } else {
+        consecutiveFailuresRef.current += 1;
+        if (consecutiveFailuresRef.current >= 2) {
+          setIsDisconnected(true);
+        }
+      }
+    } catch {
+      if (controller.signal.aborted) return;
+      consecutiveFailuresRef.current += 1;
+      if (consecutiveFailuresRef.current >= 2) {
+        setIsDisconnected(true);
+      }
+    } finally {
+      if (!controller.signal.aborted) {
+        setIsChecking(false);
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    // Run an initial health check immediately on mount
+    void checkHealth();
+
+    const interval = window.setInterval(() => {
+      void checkHealth();
+    }, checkIntervalMs);
+
+    return () => {
+      window.clearInterval(interval);
+      // Abort any in-flight fetch on unmount to prevent state updates after cleanup
+      abortControllerRef.current?.abort();
+    };
+  }, [checkHealth, checkIntervalMs]);
+
+  if (!isDisconnected) return null;
+
+  return (
+    <aside
+      aria-label="Server status alert"
+      className="fixed top-0 inset-x-0 z-50 bg-rose-950/90 border-b border-rose-600/50 text-rose-200 px-4 py-2 flex items-center justify-between shadow-lg backdrop-blur-md animate-in slide-in-from-top duration-300"
+    >
+      <div className="flex items-center gap-2.5 min-w-0">
+        <AlertTriangle className="h-4 w-4 text-rose-400 shrink-0 animate-pulse" />
+        <p className="text-xs sm:text-sm font-medium truncate">
+          Backend server disconnected. The Olive Studio service is not responding.
+        </p>
+      </div>
+      <div className="flex items-center gap-2 shrink-0">
+        <Button
+          size="sm"
+          variant="outline"
+          className="h-7 text-xs border-rose-500/40 text-rose-200 hover:bg-rose-900/40 hover:text-white"
+          onClick={() => void checkHealth()}
+          disabled={isChecking}
+        >
+          <RefreshCw className={`h-3 w-3 mr-1.5 ${isChecking ? "animate-spin" : ""}`} />
+          {isChecking ? "Checking…" : "Reconnect"}
+        </Button>
+      </div>
+    </aside>
+  );
+}

--- a/src/components/ServerConnectionBanner.tsx
+++ b/src/components/ServerConnectionBanner.tsx
@@ -50,6 +50,7 @@ export function ServerConnectionBanner({ checkIntervalMs = 10000 }: ServerConnec
 
   useEffect(() => {
     // Run an initial health check immediately on mount
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- intentional: initial health poll on mount
     void checkHealth();
 
     const interval = window.setInterval(() => {
@@ -78,7 +79,6 @@ export function ServerConnectionBanner({ checkIntervalMs = 10000 }: ServerConnec
       </div>
       <div className="flex items-center gap-2 shrink-0">
         <Button
-          size="sm"
           variant="outline"
           className="h-7 text-xs border-rose-500/40 text-rose-200 hover:bg-rose-900/40 hover:text-white"
           onClick={() => void checkHealth()}

--- a/src/components/ServerConnectionBanner.tsx
+++ b/src/components/ServerConnectionBanner.tsx
@@ -68,7 +68,7 @@ export function ServerConnectionBanner({ checkIntervalMs = 10000 }: ServerConnec
   return (
     <aside
       aria-label="Server status alert"
-      className="fixed top-0 inset-x-0 z-50 bg-rose-950/90 border-b border-rose-600/50 text-rose-200 px-4 py-2 flex items-center justify-between shadow-lg backdrop-blur-md animate-in slide-in-from-top duration-300"
+      className="sticky top-0 inset-x-0 z-50 bg-rose-950/90 border-b border-rose-600/50 text-rose-200 px-4 py-2 flex items-center justify-between shadow-lg backdrop-blur-md animate-in slide-in-from-top duration-300"
     >
       <div className="flex items-center gap-2.5 min-w-0">
         <AlertTriangle className="h-4 w-4 text-rose-400 shrink-0 animate-pulse" />

--- a/src/components/features/AgentAccessControls.test.tsx
+++ b/src/components/features/AgentAccessControls.test.tsx
@@ -74,6 +74,65 @@ describe("AgentAccessControls", () => {
     );
   });
 
+  it("drops an older policy update that resolves after a newer refresh", async () => {
+    let resolvePut: (value: unknown) => void = () => {};
+    const putPromise = new Promise((resolve) => {
+      resolvePut = resolve;
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        const method = init?.method ?? "GET";
+        if (url.includes("/api/olive/agent-access") && method === "GET") {
+          return {
+            ok: true,
+            json: async () => ({
+              ok: true,
+              policy: { ...basePolicy, allowJobSubmission: false },
+            }),
+          } as Response;
+        }
+        if (url.includes("/api/olive/agent-access") && method === "PUT") {
+          // The update stays in flight while a refresh starts and finishes.
+          await putPromise;
+          return {
+            ok: true,
+            json: async () => ({
+              ok: true,
+              policy: { ...basePolicy, allowJobSubmission: true },
+            }),
+          } as Response;
+        }
+        return { ok: false, json: async () => ({ error: "not found" }) } as Response;
+      }),
+    );
+
+    render(<AgentAccessControls />);
+    const openBtn = await screen.findByRole("button", { name: /Agent \/ MCP access policy/i });
+    fireEvent.click(openBtn);
+    await waitFor(() => {
+      expect(document.getElementById("agent-access-allowJobSubmission")).toBeTruthy();
+    });
+
+    // Start an update (PUT) that stays pending, then run a refresh that resolves first.
+    const submitToggle = document.getElementById(
+      "agent-access-allowJobSubmission",
+    ) as HTMLInputElement;
+    fireEvent.click(submitToggle);
+    fireEvent.click(screen.getByRole("button", { name: /Refresh agent access policy/i }));
+
+    // The newer refresh (GET) applied allowJobSubmission=false; resolve the stale PUT
+    // afterwards — its result must be dropped, not applied over the refresh.
+    resolvePut(undefined);
+    await waitFor(() => {
+      expect(submitToggle.checked).toBe(false);
+    });
+    // Give any delayed busy-clear a chance to run; the checkbox must stay false.
+    await new Promise((r) => setTimeout(r, 350));
+    expect(submitToggle.checked).toBe(false);
+  });
+
   it("disables child toggles when mcpAccess is off", async () => {
     vi.stubGlobal(
       "fetch",

--- a/src/components/features/AgentAccessControls.tsx
+++ b/src/components/features/AgentAccessControls.tsx
@@ -92,9 +92,26 @@ export const AgentAccessControls = memo(function AgentAccessControls({
   const rootRef = useRef<HTMLDivElement>(null);
   const triggerRef = useRef<HTMLButtonElement>(null);
   const firstToggleRef = useRef<HTMLInputElement | null>(null);
+  const busyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const canMutatePolicy = isBrowserLoopbackHost();
 
+  const clearBusyTimer = useCallback(() => {
+    if (busyTimerRef.current !== null) {
+      clearTimeout(busyTimerRef.current);
+      busyTimerRef.current = null;
+    }
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      clearBusyTimer();
+    };
+  }, [clearBusyTimer]);
+
   const refresh = useCallback(async () => {
+    clearBusyTimer();
+    setBusy(true);
+    setError(null);
     try {
       const res = await fetch("/api/olive/agent-access");
       const data = (await res.json()) as {
@@ -108,8 +125,14 @@ export const AgentAccessControls = memo(function AgentAccessControls({
       setError(null);
     } catch (err: unknown) {
       setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      clearBusyTimer();
+      busyTimerRef.current = setTimeout(() => {
+        setBusy(false);
+        busyTimerRef.current = null;
+      }, 300);
     }
-  }, []);
+  }, [clearBusyTimer]);
 
   useEffect(() => {
     void refresh();
@@ -165,6 +188,7 @@ export const AgentAccessControls = memo(function AgentAccessControls({
       setError("Policy changes require opening Studio on localhost (127.0.0.1).");
       return;
     }
+    clearBusyTimer();
     setBusy(true);
     setMessage(null);
     try {
@@ -186,6 +210,7 @@ export const AgentAccessControls = memo(function AgentAccessControls({
     } catch (err: unknown) {
       setError(err instanceof Error ? err.message : String(err));
     } finally {
+      clearBusyTimer();
       setBusy(false);
     }
   };

--- a/src/components/features/AgentAccessControls.tsx
+++ b/src/components/features/AgentAccessControls.tsx
@@ -102,6 +102,10 @@ export const AgentAccessControls = memo(function AgentAccessControls({
     }
   }, []);
 
+  // Monotonic request generation: only the most recent refresh/update may apply
+  // its result, so a stale GET response cannot overwrite a newer PUT outcome.
+  const requestGenRef = useRef(0);
+
   useEffect(() => {
     return () => {
       clearBusyTimer();
@@ -109,6 +113,7 @@ export const AgentAccessControls = memo(function AgentAccessControls({
   }, [clearBusyTimer]);
 
   const refresh = useCallback(async () => {
+    const gen = ++requestGenRef.current;
     clearBusyTimer();
     setBusy(true);
     setError(null);
@@ -121,16 +126,22 @@ export const AgentAccessControls = memo(function AgentAccessControls({
       };
       if (!res.ok) throw new Error(formatAgentAccessError(res.status, data.error));
       if (!data.policy) throw new Error("Missing policy payload");
-      setPolicy(data.policy);
-      setError(null);
+      if (gen === requestGenRef.current) {
+        setPolicy(data.policy);
+        setError(null);
+      }
     } catch (err: unknown) {
-      setError(err instanceof Error ? err.message : String(err));
+      if (gen === requestGenRef.current) {
+        setError(err instanceof Error ? err.message : String(err));
+      }
     } finally {
-      clearBusyTimer();
-      busyTimerRef.current = setTimeout(() => {
-        setBusy(false);
-        busyTimerRef.current = null;
-      }, 300);
+      if (gen === requestGenRef.current) {
+        clearBusyTimer();
+        busyTimerRef.current = setTimeout(() => {
+          setBusy(false);
+          busyTimerRef.current = null;
+        }, 300);
+      }
     }
   }, [clearBusyTimer]);
 
@@ -188,6 +199,7 @@ export const AgentAccessControls = memo(function AgentAccessControls({
       setError("Policy changes require opening Studio on localhost (127.0.0.1).");
       return;
     }
+    const gen = ++requestGenRef.current;
     clearBusyTimer();
     setBusy(true);
     setMessage(null);
@@ -204,14 +216,20 @@ export const AgentAccessControls = memo(function AgentAccessControls({
       };
       if (!res.ok) throw new Error(formatAgentAccessError(res.status, data.error));
       if (!data.policy) throw new Error("Missing policy payload");
-      setPolicy(data.policy);
-      setMessage("Saved.");
-      setError(null);
+      if (gen === requestGenRef.current) {
+        setPolicy(data.policy);
+        setMessage("Saved.");
+        setError(null);
+      }
     } catch (err: unknown) {
-      setError(err instanceof Error ? err.message : String(err));
+      if (gen === requestGenRef.current) {
+        setError(err instanceof Error ? err.message : String(err));
+      }
     } finally {
-      clearBusyTimer();
-      setBusy(false);
+      if (gen === requestGenRef.current) {
+        clearBusyTimer();
+        setBusy(false);
+      }
     }
   };
 

--- a/src/components/features/assistant/ActionButton.tsx
+++ b/src/components/features/assistant/ActionButton.tsx
@@ -15,7 +15,12 @@ import { useState, useCallback } from "react";
 import { Wrench, Navigation, BookOpen, ExternalLink, AlertTriangle } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { usePipelineState } from "@/lib/stores/pipelineStore";
-import { chatPatchToUiState, sanitizeChatActionPatch } from "@/lib/chatActions";
+import {
+  chatPatchToUiState,
+  sanitizeChatActionPatch,
+  stripGatedFields,
+  confirmGatedPatchFields,
+} from "@/lib/chatActions";
 import { commitUiStateUpdate } from "@/lib/pipelineValidation";
 import { executeNavigateAction } from "@/lib/actionExecutor";
 import type { Action } from "@/lib/types/findingTypes";
@@ -129,7 +134,9 @@ export function ActionButton({
 
     const patch = sanitizeChatActionPatch(action.payload);
     if (!patch) return;
-    const partial = chatPatchToUiState(state, patch);
+    const confirmGated = confirmGatedPatchFields(patch);
+    const appliedPatch = confirmGated ? patch : stripGatedFields(patch);
+    const partial = chatPatchToUiState(state, appliedPatch, { confirmGated });
 
     // Apply the patch through the store (runs commitUiStateUpdate internally).
     setState(partial);

--- a/src/components/features/assistant/AssistantSidebar.tsx
+++ b/src/components/features/assistant/AssistantSidebar.tsx
@@ -8,7 +8,13 @@ import {
   buildChatPresetQueries,
   buildWorkspaceContextSummary,
 } from "@/lib/aiWorkspaceContext";
-import { chatPatchToUiState, sanitizeChatActionPatch, type ChatAction } from "@/lib/chatActions";
+import {
+  chatPatchToUiState,
+  sanitizeChatActionPatch,
+  stripGatedFields,
+  confirmGatedPatchFields,
+  type ChatAction,
+} from "@/lib/chatActions";
 import { Bot, X, MessageSquareCode, Settings2, Shield, Bug } from "lucide-react";
 import { useHardwareProbe } from "@/lib/hooks/useHardwareProbe";
 import { PipelineReview } from "./PipelineReview";
@@ -153,7 +159,9 @@ export function AssistantSidebar({
   const handleApplyChatAction = (messageIndex: number, action: ChatAction) => {
     const patch = sanitizeChatActionPatch(action.patch);
     if (!patch) return;
-    const partial = chatPatchToUiState(state, patch);
+    const confirmGated = confirmGatedPatchFields(patch);
+    const appliedPatch = confirmGated ? patch : stripGatedFields(patch);
+    const partial = chatPatchToUiState(state, appliedPatch, { confirmGated });
     setState(partial);
     chat.markActionApplied(messageIndex, action.id);
     // Route post-patch refresh through PipelineReview's schedulePostPatchRefresh.
@@ -205,7 +213,7 @@ export function AssistantSidebar({
     if (!openToAudit) return;
     // eslint-disable-next-line react-hooks/set-state-in-effect -- intentional: respond to prop change
     setActiveTab("assistant");
-    requestReviewRefresh();
+    requestReviewRefresh({ resetFirst: true });
     onAuditOpened?.();
   }, [openToAudit, requestReviewRefresh]); // eslint-disable-line react-hooks/exhaustive-deps
 
@@ -230,15 +238,17 @@ export function AssistantSidebar({
     return () => window.removeEventListener("keydown", onKeyDown);
   }, [isOpen, isReportOpen, onClose]);
 
+  const normalizedProviderId =
+    normalizeUiProviderId(providers.providerStatus.provider ?? "") ?? providers.providerStatus.provider;
+  const devinMatch =
+    normalizedProviderId === "devin"
+      ? providers.devinModels.find((m) => m.id === providers.providerStatus.model)
+      : undefined;
+  const modelName = devinMatch ? devinMatch.name : providers.providerStatus.model;
+
   const providerLabel =
     providerSource !== "none"
-      ? `${PROVIDER_OPTIONS.find(
-        (p) =>
-          p.id ===
-          (normalizeUiProviderId(providers.providerStatus.provider ?? "") ??
-            providers.providerStatus.provider),
-      )?.name ?? providers.providerStatus.provider
-      } / ${providers.providerStatus.model}`
+      ? `${PROVIDER_OPTIONS.find((p) => p.id === normalizedProviderId)?.name ?? providers.providerStatus.provider} / ${modelName}`
       : "No provider set";
 
   return (
@@ -265,10 +275,13 @@ export function AssistantSidebar({
       >
         <div className="w-full wide:w-[420px] h-full flex flex-col shadow-[-4px_0_24px_rgba(3,7,18,0.25)]">
           {/* Header */}
-          <div className="h-12 flex items-center justify-between px-5 border-b border-slate-800 shrink-0 bg-slate-950/80">
+          <div className="h-12 flex items-center justify-between px-4 border-b border-slate-800 shrink-0 bg-slate-950/80">
             <div className="flex items-center gap-2 min-w-0">
               <Bot className="h-4 w-4 text-electric-blue shrink-0" />
               <span className="text-sm font-medium text-slate-100">Assistant</span>
+              <span className="text-xs text-slate-400 font-mono truncate max-w-[140px]" title={state.ihvProvider}>
+                [{state.ihvProvider.replace("ExecutionProvider", "")}]
+              </span>
               <span className="text-xs text-slate-500 truncate hidden sm:inline">· {providerLabel}</span>
             </div>
             <button
@@ -381,24 +394,17 @@ export function AssistantSidebar({
           </div>
 
           {/* Footer */}
-          <div className="p-3.5 border-t border-slate-800 shrink-0 bg-slate-950/85 space-y-2">
-            <div className="flex items-center gap-2 text-[11px] text-slate-500 justify-center">
-              <Bot className="h-3 w-3 text-slate-600" />
-              <span>
-                Target: <span className="text-slate-400 font-mono">{state.ihvProvider}</span>
-              </span>
-            </div>
-            <p className="text-[11px] text-slate-600 text-center leading-snug px-1">
-              AI can be wrong. Verify Audit, Chat, and Apply changes against your model, EP, and Olive docs
-              before running jobs.
+          <div className="px-3.5 py-2 border-t border-slate-800 shrink-0 bg-slate-950/85 flex items-center justify-between gap-2">
+            <p className="text-[10px] text-slate-500 truncate leading-tight flex-1" title="AI can make mistakes. Verify Audit, Chat, and Apply changes before running jobs.">
+              Verify AI changes against your model & EP before running.
             </p>
             <button
               type="button"
               onClick={() => setIsReportOpen(true)}
-              className="w-full flex items-center justify-center gap-1.5 text-xs text-slate-500 hover:text-electric-blue transition-colors cursor-pointer py-1.5 rounded hover:bg-slate-800/50"
+              className="flex items-center gap-1 text-xs text-slate-400 hover:text-electric-blue transition-colors cursor-pointer py-1 px-2 rounded hover:bg-slate-800 shrink-0 font-medium"
             >
               <Bug className="h-3 w-3" />
-              Send feedback
+              <span>Feedback</span>
             </button>
           </div>
 

--- a/src/components/features/assistant/LocalAiSetupCard.tsx
+++ b/src/components/features/assistant/LocalAiSetupCard.tsx
@@ -1,4 +1,4 @@
-import { Download, RefreshCw } from "lucide-react";
+import { CheckCircle, Download, RefreshCw } from "lucide-react";
 import { openExternal } from "@/lib/openExternal";
 import { formatBytes } from "@/lib/utils";
 import { LocalModelManager } from "./LocalModelManager";
@@ -7,6 +7,7 @@ import {
   MODEL_ID_FUZZY_MIN_LEN,
   OLLAMA_STARTER_MODELS,
   findInstalledStarterId,
+  stemsLooselyMatch,
   type LocalEngine,
   type LocalStarterModel,
 } from "./aiProviderCatalog";
@@ -39,22 +40,20 @@ function EngineToggle({ preferredEngine, onSelect }: EngineToggleProps) {
       <button
         type="button"
         onClick={() => onSelect("lms")}
-        className={`flex-1 px-3 py-1.5 rounded-md text-xs font-semibold transition-all cursor-pointer ${
-          preferredEngine === "lms"
-            ? "bg-electric-blue/20 text-electric-blue border border-electric-blue/30"
-            : "text-slate-500 hover:text-slate-300 border border-transparent"
-        }`}
+        className={`flex-1 px-3 py-1.5 rounded-md text-xs font-semibold transition-all cursor-pointer ${preferredEngine === "lms"
+          ? "bg-electric-blue/20 text-electric-blue border border-electric-blue/30"
+          : "text-slate-500 hover:text-slate-300 border border-transparent"
+          }`}
       >
         LM Studio
       </button>
       <button
         type="button"
         onClick={() => onSelect("ollama")}
-        className={`flex-1 px-3 py-1.5 rounded-md text-xs font-semibold transition-all cursor-pointer ${
-          preferredEngine === "ollama"
-            ? "bg-emerald-500/20 text-emerald-400 border border-emerald-500/30"
-            : "text-slate-500 hover:text-slate-300 border border-transparent"
-        }`}
+        className={`flex-1 px-3 py-1.5 rounded-md text-xs font-semibold transition-all cursor-pointer ${preferredEngine === "ollama"
+          ? "bg-emerald-500/20 text-emerald-400 border border-emerald-500/30"
+          : "text-slate-500 hover:text-slate-300 border border-transparent"
+          }`}
       >
         Ollama
       </button>
@@ -126,6 +125,7 @@ interface StarterModelCardProps {
   /** True while any starter pull is in flight (disables sibling cards). */
   pullBusy?: boolean;
   installedId: string | null;
+  isActive?: boolean;
   onPull: () => void;
   onEnable: () => void;
 }
@@ -139,6 +139,7 @@ interface StarterModelCardProps {
  * @param isPulling - Whether this model is currently being downloaded and activated
  * @param pullBusy - Whether any starter pull is in progress
  * @param installedId - Installed engine model id when already present locally
+ * @param isActive - Whether this model is the currently active local model
  * @param onPull - Called when the download action is selected
  * @param onEnable - Called when enabling an already-installed starter
  */
@@ -149,11 +150,18 @@ function StarterModelCard({
   isPulling,
   pullBusy,
   installedId,
+  isActive = false,
   onPull,
   onEnable,
 }: StarterModelCardProps) {
   const installed = Boolean(installedId);
-  const disabled = isPulling || Boolean(pullBusy);
+  const disabled = isPulling || Boolean(pullBusy) || isActive;
+  const buttonStyle = isActive
+    ? "bg-emerald-500/20 border-emerald-500/50 text-emerald-300 font-bold cursor-default"
+    : installed
+      ? "bg-slate-900 border-slate-700 text-slate-300 hover:border-electric-blue hover:text-electric-blue cursor-pointer"
+      : accentBg;
+
   return (
     <div className="p-2.5 rounded-lg border border-slate-800 bg-slate-950/60 flex flex-col gap-1.5">
       <div className="flex items-center justify-between gap-2">
@@ -170,15 +178,19 @@ function StarterModelCard({
       ) : null}
       <button
         type="button"
-        onClick={installed ? onEnable : onPull}
+        onClick={installed ? (isActive ? undefined : onEnable) : onPull}
         disabled={disabled}
-        className={`mt-1 w-full h-7 border rounded text-xs font-bold flex items-center justify-center gap-1.5 transition-all cursor-pointer disabled:opacity-50 ${accentBg}`}
+        className={`mt-1 w-full h-7 border rounded text-xs font-bold flex items-center justify-center gap-1.5 transition-all disabled:opacity-75 ${buttonStyle}`}
       >
         {isPulling ? (
           <>
             <RefreshCw className="h-3 w-3 animate-spin" />
             <span>Pulling & Activating...</span>
           </>
+        ) : isActive ? (
+          <span className="flex items-center gap-1">
+            <CheckCircle className="h-3 w-3 text-emerald-400" /> Active
+          </span>
         ) : installed ? (
           <span>Enable</span>
         ) : (
@@ -293,9 +305,8 @@ export function LocalAiSetupCard({ local, activeModel, isOpen, onActivate }: Loc
           engine).
         </p>
         <span
-          className={`inline-block w-2 h-2 shrink-0 rounded-full ${
-            healthy === true ? "bg-emerald-400" : healthy === false ? "bg-rose-400" : "bg-slate-500"
-          }`}
+          className={`inline-block w-2 h-2 shrink-0 rounded-full ${healthy === true ? "bg-emerald-400" : healthy === false ? "bg-rose-400" : "bg-slate-500"
+            }`}
           title={
             healthy === true
               ? `${engineName} ready`
@@ -353,6 +364,12 @@ export function LocalAiSetupCard({ local, activeModel, isOpen, onActivate }: Loc
       <div className="space-y-2">
         {models.map((m) => {
           const installedId = findInstalledStarterId(m, local.installedModels);
+          const isStarterActive = Boolean(
+            installedId &&
+            activeModel &&
+            (installedId === activeModel ||
+              stemsLooselyMatch(activeModel.toLowerCase(), installedId.toLowerCase())),
+          );
           return (
             <StarterModelCard
               key={m.tag}
@@ -362,6 +379,7 @@ export function LocalAiSetupCard({ local, activeModel, isOpen, onActivate }: Loc
               isPulling={local.pullingModel === m.tag}
               pullBusy={Boolean(local.pullingModel)}
               installedId={installedId}
+              isActive={isStarterActive}
               onPull={() => void local.pullLocalModel(m.tag, local.preferredEngine)}
               onEnable={() => {
                 if (!installedId || local.pullingModel) return;

--- a/src/components/features/assistant/LocalAiSetupCard.tsx
+++ b/src/components/features/assistant/LocalAiSetupCard.tsx
@@ -107,7 +107,9 @@ function EngineMissingBanner({
         </button>
         <button
           type="button"
-          onClick={() => void openExternal(isLms ? "https://lmstudio.ai" : "https://ollama.com")}
+          onClick={() => void openExternal(isLms ? "https://lmstudio.ai" : "https://ollama.com").catch((err) => {
+            console.error("Failed to open external URL:", err);
+          })}
           className={`text-xs underline cursor-pointer bg-transparent border-none p-0 ${accentText}`}
         >
           Manual install
@@ -270,6 +272,10 @@ interface LocalAiSetupCardProps {
   local: LocalEngineSetup;
   /** Model currently serving audit/chat, shown by the model manager. */
   activeModel?: string;
+  /** Active provider ID (e.g., "openai-compat" for local engines). */
+  activeProvider?: string;
+  /** Active provider base URL (e.g., "http://127.0.0.1:1234/v1" for LM Studio). */
+  activeBaseUrl?: string;
   isOpen: boolean;
   onActivate?: (modelTag: string, source: LocalEngine) => void | Promise<void>;
 }
@@ -279,10 +285,12 @@ interface LocalAiSetupCardProps {
  *
  * @param local - Local AI engine state and actions
  * @param activeModel - The currently active local model
+ * @param activeProvider - The currently active provider ID
+ * @param activeBaseUrl - The currently active provider base URL
  * @param isOpen - Whether the local model manager is expanded
  * @param onActivate - Called when a model is activated
  */
-export function LocalAiSetupCard({ local, activeModel, isOpen, onActivate }: LocalAiSetupCardProps) {
+export function LocalAiSetupCard({ local, activeModel, activeProvider, activeBaseUrl, isOpen, onActivate }: LocalAiSetupCardProps) {
   const isLms = local.preferredEngine === "lms";
   const accentText = isLms ? "text-electric-blue" : "text-emerald-400";
   const accentBg = isLms
@@ -364,9 +372,13 @@ export function LocalAiSetupCard({ local, activeModel, isOpen, onActivate }: Loc
       <div className="space-y-2">
         {models.map((m) => {
           const installedId = findInstalledStarterId(m, local.installedModels);
+          // A starter is active only when the current provider is openai-compat with the matching loopback URL
+          const expectedBaseUrl = isLms ? "http://127.0.0.1:1234/v1" : "http://127.0.0.1:11434/v1";
+          const isLocalProviderActive = activeProvider === "openai-compat" && activeBaseUrl === expectedBaseUrl;
           const isStarterActive = Boolean(
             installedId &&
             activeModel &&
+            isLocalProviderActive &&
             (installedId === activeModel ||
               stemsLooselyMatch(activeModel.toLowerCase(), installedId.toLowerCase())),
           );

--- a/src/components/features/assistant/LocalModelManager.tsx
+++ b/src/components/features/assistant/LocalModelManager.tsx
@@ -18,6 +18,58 @@ function modelIdsMatch(activeModel: string | undefined, installedId: string): bo
   return activeModel.length >= MODEL_ID_FUZZY_MIN_LEN && installedId.endsWith(activeModel);
 }
 
+
+type EngineResult = { models: string[]; loaded: string[] } | null;
+
+/** Process a single engine's fetch result, returning models/loaded or surfacing errors. */
+async function processEngineResult(
+  res: PromiseSettledResult<Response | null>,
+  source: "lms" | "ollama",
+  engine: string,
+  isCancelled: (() => boolean) | undefined,
+  setError: (msg: string) => void,
+): Promise<EngineResult> {
+  if (res.status !== "fulfilled" || !res.value) return null;
+  if (res.value.ok) {
+    const d = await res.value.json();
+    if (source === "lms") {
+      return { models: d.installedModels || [], loaded: d.loadedModels || [] };
+    }
+    return { models: d.installedModels || [], loaded: d.runningModels || [] };
+  }
+  if (engine === source) {
+    const d = (await res.value.json().catch(() => ({}))) as { error?: string };
+    if (d.error && !isCancelled?.()) setError(d.error);
+  }
+  return null;
+}
+
+/** Merge and de-duplicate model lists from multiple engines. */
+function mergeModelLists(
+  lmsData: EngineResult,
+  ollamaData: EngineResult,
+): Array<{ id: string; loaded: boolean; source: "lms" | "ollama" }> {
+  const allModels: Array<{ id: string; loaded: boolean; source: "lms" | "ollama" }> = [];
+  const seen = new Set<string>();
+  if (lmsData) {
+    for (const id of lmsData.models) {
+      if (!seen.has(id)) {
+        seen.add(id);
+        allModels.push({ id, loaded: lmsData.loaded.includes(id), source: "lms" });
+      }
+    }
+  }
+  if (ollamaData) {
+    for (const id of ollamaData.models) {
+      if (!seen.has(id)) {
+        seen.add(id);
+        allModels.push({ id, loaded: ollamaData.loaded.includes(id), source: "ollama" });
+      }
+    }
+  }
+  return allModels;
+}
+
 /**
  * Displays installed local models with search, grouping, loading, and unloading controls.
  *
@@ -112,60 +164,15 @@ export function LocalModelManager({
 
       if (isCancelled?.()) return;
 
-      const lmsModels: string[] = [];
-      const ollamaModels: string[] = [];
-      const lmsLoaded: string[] = [];
-      const ollamaLoaded: string[] = [];
-
-      if (fetchLms && lmsRes.status === "fulfilled" && lmsRes.value && lmsRes.value.ok) {
-        const d = await lmsRes.value.json();
-        lmsModels.push(...(d.installedModels || []));
-        lmsLoaded.push(...(d.loadedModels || []));
-      } else if (
-        fetchLms &&
-        engine === "lms" &&
-        lmsRes.status === "fulfilled" &&
-        lmsRes.value &&
-        !lmsRes.value.ok
-      ) {
-        const d = (await lmsRes.value.json().catch(() => ({}))) as { error?: string };
-        if (d.error && !isCancelled?.()) setError(d.error);
-      }
-      if (fetchOllama && ollamaRes.status === "fulfilled" && ollamaRes.value && ollamaRes.value.ok) {
-        const d = await ollamaRes.value.json();
-        ollamaModels.push(...(d.installedModels || []));
-        ollamaLoaded.push(...(d.runningModels || []));
-      } else if (
-        fetchOllama &&
-        engine === "ollama" &&
-        ollamaRes.status === "fulfilled" &&
-        ollamaRes.value &&
-        !ollamaRes.value.ok
-      ) {
-        const d = (await ollamaRes.value.json().catch(() => ({}))) as { error?: string };
-        if (d.error && !isCancelled?.()) setError(d.error);
-      }
+      const lmsData = await processEngineResult(lmsRes, "lms", engine, isCancelled, setError);
+      const ollamaData = await processEngineResult(ollamaRes, "ollama", engine, isCancelled, setError);
 
       if (isCancelled?.()) return;
 
-      const allModels: Array<{ id: string; loaded: boolean; source: "lms" | "ollama" }> = [];
-      const seen = new Set<string>();
-      if (fetchLms) {
-        for (const id of lmsModels) {
-          if (!seen.has(id)) {
-            seen.add(id);
-            allModels.push({ id, loaded: lmsLoaded.includes(id), source: "lms" });
-          }
-        }
-      }
-      if (fetchOllama) {
-        for (const id of ollamaModels) {
-          if (!seen.has(id)) {
-            seen.add(id);
-            allModels.push({ id, loaded: ollamaLoaded.includes(id), source: "ollama" });
-          }
-        }
-      }
+      const allModels = mergeModelLists(
+        fetchLms ? lmsData : null,
+        fetchOllama ? ollamaData : null,
+      );
       if (!isCancelled?.()) setModels(allModels);
     } catch (err: unknown) {
       if (engine !== "all" && !isCancelled?.()) {

--- a/src/components/features/assistant/LocalModelManager.tsx
+++ b/src/components/features/assistant/LocalModelManager.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef, useMemo } from "react";
 import { ChevronDown, ChevronRight } from "lucide-react";
 
 import { MODEL_ID_FUZZY_MIN_LEN } from "@/lib/localEngineStarters";
+import { extractErrorMessage } from "@/lib/httpError";
 
 function modelIdsMatch(activeModel: string | undefined, installedId: string): boolean {
   if (!activeModel) return false;
@@ -204,8 +205,8 @@ export function LocalModelManager({
           body: JSON.stringify({ modelTag }),
         });
         if (!r.ok) {
-          const d = (await r.json().catch(() => ({}))) as { error?: string };
-          throw new Error(d.error || `HTTP ${r.status}`);
+          const d = await r.json().catch(() => ({}));
+          throw new Error(extractErrorMessage(d, `HTTP ${r.status}`));
         }
       }
       if (onActivate) await onActivate(modelTag, source);
@@ -228,8 +229,8 @@ export function LocalModelManager({
         body: JSON.stringify({ modelTag }),
       });
       if (!r.ok) {
-        const d = (await r.json().catch(() => ({}))) as { error?: string };
-        throw new Error(d.error || `HTTP ${r.status}`);
+        const d = await r.json().catch(() => ({}));
+        throw new Error(extractErrorMessage(d, `HTTP ${r.status}`));
       }
       await refresh();
     } catch (err) {
@@ -319,11 +320,10 @@ export function LocalModelManager({
                       return (
                         <div
                           key={`${m.source}:${m.id}`}
-                          className={`flex items-center justify-between gap-2 p-2 rounded-lg border text-xs ${
-                            active
-                              ? "border-emerald-500/40 bg-emerald-950/20"
-                              : "border-slate-800 bg-slate-950/60"
-                          }`}
+                          className={`flex items-center justify-between gap-2 p-2 rounded-lg border text-xs ${active
+                            ? "border-emerald-500/40 bg-emerald-950/20"
+                            : "border-slate-800 bg-slate-950/60"
+                            }`}
                         >
                           <div className="min-w-0 flex-1 space-y-0.5">
                             <div className="flex items-center gap-1.5 min-w-0">

--- a/src/components/features/assistant/SettingsPanel.tsx
+++ b/src/components/features/assistant/SettingsPanel.tsx
@@ -148,6 +148,8 @@ export function SettingsPanel({ providers, local, isOpen }: SettingsPanelProps) 
         <LocalAiSetupCard
           local={local}
           activeModel={providers.providerStatus.model}
+          activeProvider={providers.providerStatus.provider}
+          activeBaseUrl={providers.providerStatus.baseUrl ?? undefined}
           isOpen={isOpen}
           onActivate={async (modelTag, source) => {
             const ok = await providers.enableLocalAiProvider(source, modelTag);

--- a/src/components/features/assistant/SettingsPanel.tsx
+++ b/src/components/features/assistant/SettingsPanel.tsx
@@ -22,12 +22,15 @@ interface ActiveProviderCardProps {
  * Compact one-line active provider status with an optional Clear action.
  */
 function ActiveProviderCard({ providers }: ActiveProviderCardProps) {
-  const { providerStatus } = providers;
+  const { providerStatus, devinModels } = providers;
+  const normalizedId = normalizeUiProviderId(providerStatus.provider ?? "") ?? providerStatus.provider;
   const providerName =
     PROVIDER_OPTIONS.find(
-      (p) => p.id === (normalizeUiProviderId(providerStatus.provider ?? "") ?? providerStatus.provider),
+      (p) => p.id === normalizedId,
     )?.name ?? providerStatus.provider;
   const sourceLabel = activeProviderSourceLabel(providerStatus);
+  const devinMatch = normalizedId === "devin" ? devinModels.find((m) => m.id === providerStatus.model) : undefined;
+  const displayModel = devinMatch ? `${devinMatch.name}` : providerStatus.model;
 
   return (
     <div className="flex items-center justify-between gap-2 rounded-lg border border-slate-800 bg-slate-950/60 px-2.5 py-1.5">
@@ -37,7 +40,7 @@ function ActiveProviderCard({ providers }: ActiveProviderCardProps) {
         <p className="min-w-0 truncate text-sm text-slate-200">
           <span className="font-medium text-slate-100">{providerName}</span>
           <span className="text-slate-500">:</span>{" "}
-          <span className="font-mono text-slate-300">{providerStatus.model}</span>
+          <span className="font-mono text-slate-300" title={providerStatus.model}>{displayModel}</span>
           {sourceLabel ? <span className="text-slate-500"> · {sourceLabel}</span> : null}
         </p>
       )}
@@ -134,11 +137,12 @@ export function SettingsPanel({ providers, local, isOpen }: SettingsPanelProps) 
 
   return (
     <div className="space-y-4">
-      {/* Pull into the scroll panel's p-4 so nothing peeks above/behind while sticky */}
-      <div className="sticky top-0 z-10 -mx-4 -mt-4 space-y-3 bg-slate-950 px-4 pt-4 pb-3">
+      {/* Pull into the scroll panel's p-4 so only the active model card is persistent */}
+      <div className="sticky top-0 z-10 -mx-4 -mt-4 bg-slate-950 px-4 pt-4 pb-2 border-b border-slate-900/60 shadow-sm">
         <ActiveProviderCard providers={providers} />
-        <SettingsModeTabs mode={settingsMode} onChange={setSettingsMode} />
       </div>
+
+      <SettingsModeTabs mode={settingsMode} onChange={setSettingsMode} />
 
       {settingsMode === "local" ? (
         <LocalAiSetupCard

--- a/src/components/features/assistant/aiProviderCatalog.ts
+++ b/src/components/features/assistant/aiProviderCatalog.ts
@@ -1,3 +1,6 @@
+import { CLOUDFLARE_FALLBACK_MODELS } from "@/lib/cloudflare/client.ts";
+import { DEVIN_FALLBACK_MODELS } from "@/lib/devin/client.ts";
+
 export interface ProviderOption {
   readonly id: string;
   readonly name: string;
@@ -162,13 +165,7 @@ export const PROVIDER_OPTIONS: readonly ProviderOption[] = [
   {
     id: "cloudflare",
     name: "Cloudflare Workers AI",
-    models: [
-      "@cf/meta/llama-3.1-8b-instruct",
-      "@cf/meta/llama-3.3-70b-instruct-fp8-fast",
-      "@cf/deepseek-ai/deepseek-r1-distill-qwen-32b",
-      "@cf/mistral/mistral-7b-instruct-v0.2",
-      "@cf/qwen/qwen2.5-coder-32b-instruct",
-    ],
+    models: CLOUDFLARE_FALLBACK_MODELS.map((m) => m.id),
     keyEnvVar: "CLOUDFLARE_API_TOKEN + CLOUDFLARE_ACCOUNT_ID",
     docsUrl: "developers.cloudflare.com/workers-ai",
     category: "subscription",
@@ -202,7 +199,7 @@ export const PROVIDER_OPTIONS: readonly ProviderOption[] = [
   {
     id: "devin",
     name: "Devin",
-    models: ["swe-1-6", "swe-1-7", "claude-3-5-sonnet", "claude-3-7-sonnet", "gpt-4o", "kimi-k2"],
+    models: DEVIN_FALLBACK_MODELS.map((m) => m.id),
     keyEnvVar: "",
     docsUrl: "devin.ai",
     category: "subscription",

--- a/src/components/features/assistant/aiProviderCatalog.ts
+++ b/src/components/features/assistant/aiProviderCatalog.ts
@@ -143,7 +143,7 @@ export const PROVIDER_OPTIONS: readonly ProviderOption[] = [
   {
     id: "opencode",
     name: "OpenCode Zen",
-    models: ["default"],
+    models: ["kimi-k2.7-code", "claude-3-5-sonnet", "deepseek-r1", "gpt-4o", "meta-llama/llama-3.3-70b-instruct"],
     keyEnvVar: "OPENCODE_API_KEY",
     docsUrl: "opencode.ai",
     baseUrl: "https://opencode.ai/zen/v1",
@@ -152,7 +152,7 @@ export const PROVIDER_OPTIONS: readonly ProviderOption[] = [
   {
     id: "opencode-go",
     name: "OpenCode Go",
-    models: ["default"],
+    models: ["kimi-k2.7-code", "claude-3-5-sonnet", "deepseek-r1", "gpt-4o", "meta-llama/llama-3.3-70b-instruct"],
     keyEnvVar: "OPENCODE_API_KEY",
     docsUrl: "opencode.ai",
     baseUrl: "https://opencode.ai/zen/go/v1",
@@ -162,7 +162,13 @@ export const PROVIDER_OPTIONS: readonly ProviderOption[] = [
   {
     id: "cloudflare",
     name: "Cloudflare Workers AI",
-    models: ["@cf/meta/llama-3.1-8b-instruct"],
+    models: [
+      "@cf/meta/llama-3.1-8b-instruct",
+      "@cf/meta/llama-3.3-70b-instruct-fp8-fast",
+      "@cf/deepseek-ai/deepseek-r1-distill-qwen-32b",
+      "@cf/mistral/mistral-7b-instruct-v0.2",
+      "@cf/qwen/qwen2.5-coder-32b-instruct",
+    ],
     keyEnvVar: "CLOUDFLARE_API_TOKEN + CLOUDFLARE_ACCOUNT_ID",
     docsUrl: "developers.cloudflare.com/workers-ai",
     category: "subscription",
@@ -196,7 +202,7 @@ export const PROVIDER_OPTIONS: readonly ProviderOption[] = [
   {
     id: "devin",
     name: "Devin",
-    models: ["swe-1-6", "swe-1-7", "claude-sonnet-4", "claude-opus-4", "gpt-4o", "kimi-k2"],
+    models: ["swe-1-6", "swe-1-7", "claude-3-5-sonnet", "claude-3-7-sonnet", "gpt-4o", "kimi-k2"],
     keyEnvVar: "",
     docsUrl: "devin.ai",
     category: "subscription",

--- a/src/components/features/assistant/useAiProviderSettings.ts
+++ b/src/components/features/assistant/useAiProviderSettings.ts
@@ -444,7 +444,9 @@ export function useAiProviderSettings({
       };
       if (!r.ok || !data.ok) throw new Error(data.error || `HTTP ${r.status}`);
       if (data.authUrl) {
-        void openExternal(data.authUrl);
+        void openExternal(data.authUrl).catch((err) => {
+          console.error("Failed to open external URL:", err);
+        });
       }
       setCodexMessage(data.message || "Complete sign-in in the browser, then click Refresh status.");
       // Poll account a few times after login window opens
@@ -496,7 +498,9 @@ export function useAiProviderSettings({
       const r = await fetch("/api/devin/login");
       const data = (await r.json()) as { ok?: boolean; authUrl?: string; error?: string };
       if (!r.ok || !data.ok || !data.authUrl) throw new Error(data.error || `HTTP ${r.status}`);
-      void openExternal(data.authUrl);
+      void openExternal(data.authUrl).catch((err) => {
+        console.error("Failed to open external URL:", err);
+      });
       setDevinMessage("Sign in in the browser, then paste the token shown on the page below.");
     } catch (err: unknown) {
       setProviderSaveError(err instanceof Error ? err.message : String(err));

--- a/src/components/features/assistant/useAiProviderSettings.ts
+++ b/src/components/features/assistant/useAiProviderSettings.ts
@@ -712,6 +712,7 @@ export function useAiProviderSettings({
     refreshCodexAccount,
     handleCodexLogin,
     handleCodexLogout,
+    devinModels,
     devinStatus,
     devinBusy,
     devinMessage,

--- a/src/components/features/assistant/useLocalEngineSetup.ts
+++ b/src/components/features/assistant/useLocalEngineSetup.ts
@@ -293,7 +293,9 @@ export function useLocalEngineSetup({ isOpen, onModelActivated }: UseLocalEngine
     if (evt.type === "error") {
       const urlToOpen = state.openedUrl || evt.openedUrl;
       if (urlToOpen) {
-        void openExternal(urlToOpen);
+        void openExternal(urlToOpen).catch((err) => {
+          console.error("Failed to open external URL:", err);
+        });
       }
       throw new Error(evt.error || evt.message || "Setup failed");
     }
@@ -327,7 +329,11 @@ export function useLocalEngineSetup({ isOpen, onModelActivated }: UseLocalEngine
       openedUrl?: string;
     };
     if (!r.ok || !data.ok) {
-      if (data.openedUrl) void openExternal(data.openedUrl);
+      if (data.openedUrl) {
+        void openExternal(data.openedUrl).catch((err) => {
+          console.error("Failed to open external URL:", err);
+        });
+      }
       throw new Error(data.error || data.message || `HTTP ${r.status}`);
     }
     setLocalInstallInfo(data.message || "Engine ready.");

--- a/src/components/features/ihv/HardwareCompatibilityMatrix.tsx
+++ b/src/components/features/ihv/HardwareCompatibilityMatrix.tsx
@@ -40,11 +40,18 @@ function PassStatusBadge({
   isActive: boolean;
   disabled: boolean;
 }) {
+  const badgeColor =
+    disabled
+      ? color
+      : isActive
+      ? "bg-emerald-500/25 border-emerald-500/60 text-emerald-300 font-semibold shadow-sm"
+      : "bg-slate-900/80 border-slate-700/80 text-slate-300 hover:border-electric-blue hover:text-electric-blue";
+
   return (
     <span
       className={cn(
         "inline-flex h-7 min-w-[4.5rem] items-center justify-center rounded border px-2 text-[10.5px] font-mono font-medium transition-all",
-        color,
+        badgeColor,
         disabled && "opacity-60 cursor-not-allowed",
         !disabled && !isActive && "hover:brightness-110 active:scale-95 cursor-pointer",
       )}

--- a/src/lib/__tests__/aiProviderCatalog.test.ts
+++ b/src/lib/__tests__/aiProviderCatalog.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "vitest";
+import { PROVIDER_OPTIONS, normalizeUiProviderId } from "@/components/features/assistant/aiProviderCatalog";
+import { CLOUDFLARE_FALLBACK_MODELS } from "@/lib/cloudflare/client";
+import { DEVIN_FALLBACK_MODELS } from "@/lib/devin/client";
+
+describe("aiProviderCatalog / server model contract", () => {
+  it("keeps Cloudflare UI models identical to the server-owned fallback catalog", () => {
+    const cloudflare = PROVIDER_OPTIONS.find((p) => p.id === "cloudflare");
+    expect(cloudflare?.models).toEqual(CLOUDFLARE_FALLBACK_MODELS.map((m) => m.id));
+  });
+
+  it("keeps Devin UI models identical to the server-owned fallback catalog", () => {
+    const devin = PROVIDER_OPTIONS.find((p) => p.id === "devin");
+    expect(devin?.models).toEqual(DEVIN_FALLBACK_MODELS.map((m) => m.id));
+  });
+
+  it("keeps dynamically-supplied OpenCode model lists non-empty (no static server allowlist)", () => {
+    const opencode = PROVIDER_OPTIONS.find((p) => p.id === "opencode");
+    const opencodeGo = PROVIDER_OPTIONS.find((p) => p.id === "opencode-go");
+    expect(opencode?.models.length).toBeGreaterThan(0);
+    expect(opencodeGo?.models.length).toBeGreaterThan(0);
+  });
+
+  it("normalizes the legacy chatgpt-sub alias and rejects unknown ids", () => {
+    expect(normalizeUiProviderId("chatgpt-sub")).toBe("openai");
+    expect(normalizeUiProviderId("openai")).toBe("openai");
+    expect(normalizeUiProviderId("not-a-provider")).toBeNull();
+  });
+});

--- a/src/lib/__tests__/chatActions.test.ts
+++ b/src/lib/__tests__/chatActions.test.ts
@@ -5,6 +5,10 @@ import {
   parseChatStructuredReply,
   salvageChatActionPatchFromLooseJson,
   summarizeChatPatch,
+  extractGatedFields,
+  stripGatedFields,
+  confirmGatedPatchFields,
+  TRUST_REMOTE_CODE_CONFIRM_MESSAGE,
 } from "@/lib/chatActions";
 import { DEFAULT_PASSES } from "@/lib/defaultPasses";
 import type { UIState, IHVProvider } from "@/types";
@@ -45,6 +49,16 @@ describe("sanitizeChatActionPatch", () => {
     });
   });
 
+  it("preserves trustRemoteCode in patches", () => {
+    const patch = sanitizeChatActionPatch({
+      hfTrustRemoteCode: true,
+      trustRemoteCode: true,
+    });
+    expect(patch).toEqual({
+      trustRemoteCode: true,
+    });
+  });
+
   it("rejects invalid providers and empty patches", () => {
     expect(sanitizeChatActionPatch({ ihvProvider: "NotARealEP" })).toBeNull();
     expect(sanitizeChatActionPatch({})).toBeNull();
@@ -63,6 +77,64 @@ describe("chatPatchToUiState", () => {
     expect(next.passes?.quantization).toBe(true);
     expect(next.passes?.quantMethod).toBe("awq");
     expect(next.passes?.pruning).toBe(false);
+  });
+
+  it("blocks trustRemoteCode=true without explicit confirmGated", () => {
+    const state = baseState();
+    const next = chatPatchToUiState(state, { trustRemoteCode: true });
+    // trustRemoteCode=true is a security-sensitive toggle; it must not apply silently.
+    expect(next.passes?.trustRemoteCode).toBeUndefined();
+  });
+
+  it("applies trustRemoteCode=true when confirmGated is set", () => {
+    const state = baseState();
+    const next = chatPatchToUiState(state, { trustRemoteCode: true }, { confirmGated: true });
+    expect(next.passes?.trustRemoteCode).toBe(true);
+  });
+
+  it("allows trustRemoteCode=false without confirmation (disabling is safe)", () => {
+    const state = baseState();
+    state.passes.trustRemoteCode = true;
+    const next = chatPatchToUiState(state, { trustRemoteCode: false });
+    expect(next.passes?.trustRemoteCode).toBe(false);
+  });
+});
+
+describe("extractGatedFields", () => {
+  it("returns trustRemoteCode when patch enables it", () => {
+    expect(extractGatedFields({ trustRemoteCode: true })).toEqual({ trustRemoteCode: true });
+  });
+
+  it("returns null when trustRemoteCode is false or absent", () => {
+    expect(extractGatedFields({ trustRemoteCode: false })).toBeNull();
+    expect(extractGatedFields({ ihvProvider: "CUDAExecutionProvider" as IHVProvider })).toBeNull();
+    expect(extractGatedFields({})).toBeNull();
+  });
+});
+
+describe("stripGatedFields", () => {
+  it("removes trustRemoteCode=true from the patch", () => {
+    const stripped = stripGatedFields({ trustRemoteCode: true, ihvProvider: "CUDAExecutionProvider" as IHVProvider });
+    expect(stripped.trustRemoteCode).toBeUndefined();
+    expect(stripped.ihvProvider).toBe("CUDAExecutionProvider");
+  });
+
+  it("preserves trustRemoteCode=false (disabling is safe)", () => {
+    const stripped = stripGatedFields({ trustRemoteCode: false });
+    expect(stripped.trustRemoteCode).toBe(false);
+  });
+});
+
+describe("confirmGatedPatchFields", () => {
+  it("returns true immediately when patch has no gated fields", () => {
+    expect(confirmGatedPatchFields({ ihvProvider: "CUDAExecutionProvider" as IHVProvider })).toBe(true);
+    expect(confirmGatedPatchFields({ trustRemoteCode: false })).toBe(true);
+    expect(confirmGatedPatchFields({})).toBe(true);
+  });
+
+  it("returns false in headless environment without window", () => {
+    expect(confirmGatedPatchFields({ trustRemoteCode: true })).toBe(false);
+    expect(TRUST_REMOTE_CODE_CONFIRM_MESSAGE).toContain("Trust Remote Code");
   });
 });
 

--- a/src/lib/__tests__/chatActions.test.ts
+++ b/src/lib/__tests__/chatActions.test.ts
@@ -59,6 +59,34 @@ describe("sanitizeChatActionPatch", () => {
     });
   });
 
+  it("promotes nested passes.trustRemoteCode through the gated top-level field", () => {
+    const patch = sanitizeChatActionPatch({
+      passes: { quantization: true, trustRemoteCode: true },
+    });
+    expect(patch).not.toBeNull();
+    expect(patch).toEqual({
+      trustRemoteCode: true,
+      passes: { quantization: true },
+    });
+    // The nested value must be gated like a top-level one: blocked without confirmation,
+    // leaving the prior (false) value untouched rather than silently enabling it.
+    const state = baseState();
+    const next = chatPatchToUiState(state, patch!);
+    expect(next.passes?.trustRemoteCode).toBe(false);
+    const confirmed = chatPatchToUiState(state, patch!, { confirmGated: true });
+    expect(confirmed.passes?.trustRemoteCode).toBe(true);
+  });
+
+  it("does not promote nested passes.trustRemoteCode when a top-level value wins", () => {
+    const patch = sanitizeChatActionPatch({
+      trustRemoteCode: false,
+      passes: { trustRemoteCode: true },
+    });
+    // Disabling at the top level wins; the nested enable is dropped entirely.
+    expect(patch?.trustRemoteCode).toBe(false);
+    expect(patch?.passes).toBeUndefined();
+  });
+
   it("rejects invalid providers and empty patches", () => {
     expect(sanitizeChatActionPatch({ ihvProvider: "NotARealEP" })).toBeNull();
     expect(sanitizeChatActionPatch({})).toBeNull();
@@ -196,6 +224,15 @@ describe("parseChatStructuredReply", () => {
     const quantOnly = salvageChatActionPatchFromLooseJson({ step: "apply_quantization" });
     expect(quantOnly?.passes?.quantization).toBe(true);
     expect(quantOnly?.passes?.quantMethod).toBe("ptq");
+  });
+
+  it("parses trustRemoteCode loose strings only for explicit true/false", () => {
+    expect(salvageChatActionPatchFromLooseJson({ trust_remote_code: "true" })?.trustRemoteCode).toBe(true);
+    expect(salvageChatActionPatchFromLooseJson({ trust_remote_code: " TRUE " })?.trustRemoteCode).toBe(true);
+    expect(salvageChatActionPatchFromLooseJson({ trust_remote_code: "false" })?.trustRemoteCode).toBe(false);
+    // Unrecognized strings must not silently disable an existing toggle.
+    expect(salvageChatActionPatchFromLooseJson({ trust_remote_code: "yes please" })?.trustRemoteCode).toBeUndefined();
+    expect(salvageChatActionPatchFromLooseJson({ trust_remote_code: " " })?.trustRemoteCode).toBeUndefined();
   });
 
   it("does not salvage passes from free-form prose fields like note", () => {

--- a/src/lib/__tests__/findingContract.test.ts
+++ b/src/lib/__tests__/findingContract.test.ts
@@ -779,4 +779,25 @@ describe("Property 3: Non-Patch Actions Preserve Store", () => {
       { numRuns: 100 },
     );
   });
+
+  it("executeApplyPatchAction gates trustRemoteCode=true unless confirmGated is explicitly granted", () => {
+    const patchAction: ActionPayloadApplyPatch = {
+      kind: "applyPatch",
+      label: "Enable Trust Remote Code",
+      payload: {
+        hfModelId: "custom/arch-model",
+        trustRemoteCode: true,
+      },
+    };
+
+    // In headless test without confirmGated options, trustRemoteCode=true is blocked (stays false)
+    const resultUnconfirmed = executeAction(patchAction);
+    expect(resultUnconfirmed.success).toBe(true);
+    expect(usePipelineStore.getState().state.passes.trustRemoteCode).toBe(false);
+
+    // When confirmGated: true is provided, trustRemoteCode=true is applied
+    const resultConfirmed = executeAction(patchAction, { confirmGated: true });
+    expect(resultConfirmed.success).toBe(true);
+    expect(usePipelineStore.getState().state.passes.trustRemoteCode).toBe(true);
+  });
 });

--- a/src/lib/actionExecutor.ts
+++ b/src/lib/actionExecutor.ts
@@ -17,7 +17,13 @@ import type {
 } from "@/lib/types/findingTypes";
 import { usePipelineStore } from "@/lib/stores/pipelineStore";
 import { commitUiStateUpdate } from "@/lib/pipelineValidation";
-import { sanitizeChatActionPatch, chatPatchToUiState } from "@/lib/chatActions";
+import {
+  sanitizeChatActionPatch,
+  chatPatchToUiState,
+  stripGatedFields,
+  confirmGatedPatchFields,
+  type ChatPatchOptions,
+} from "@/lib/chatActions";
 import {
   isPipelineViewId,
   navigatePipeline,
@@ -111,12 +117,15 @@ export function executeDocumentationAction(
   };
 }
 
+export interface ExecuteApplyPatchOptions extends ChatPatchOptions {}
+
 /**
  * Execute an applyPatch action.
  * Applies the patch through commitUiStateUpdate. DOES modify PipelineStore.
  */
 export function executeApplyPatchAction(
   action: ActionPayloadApplyPatch,
+  options?: ExecuteApplyPatchOptions,
 ): ActionExecutionResult {
   const patch = sanitizeChatActionPatch(action.payload);
   if (!patch) {
@@ -126,8 +135,10 @@ export function executeApplyPatchAction(
       modifiedStore: false,
     };
   }
+  const confirmGated = options?.confirmGated ?? confirmGatedPatchFields(patch);
   const currentState = usePipelineStore.getState().state;
-  const partial = chatPatchToUiState(currentState, patch);
+  const appliedPatch = confirmGated ? patch : stripGatedFields(patch);
+  const partial = chatPatchToUiState(currentState, appliedPatch, { confirmGated });
   // Pass through commitUiStateUpdate to get the committed result, then
   // apply via replaceState so callers can detect coercion differences.
   const committed = commitUiStateUpdate(currentState, partial);
@@ -148,10 +159,13 @@ export function executeApplyPatchAction(
  * **Key invariant:** navigate, explain, and documentation actions return
  * `modifiedStore: false` and never call PipelineStore.setState.
  */
-export function executeAction(action: Action): ActionExecutionResult {
+export function executeAction(
+  action: Action,
+  options?: ExecuteApplyPatchOptions,
+): ActionExecutionResult {
   switch (action.kind) {
     case "applyPatch":
-      return executeApplyPatchAction(action);
+      return executeApplyPatchAction(action, options);
     case "navigate":
       return executeNavigateAction(action);
     case "explain":

--- a/src/lib/aiResponse.test.ts
+++ b/src/lib/aiResponse.test.ts
@@ -65,4 +65,55 @@ describe("parseJsonFromAiResponse", () => {
     ) as { score: number };
     expect(parsed.score).toBe(88);
   });
+
+  it("prefers explicit ```json block over earlier non-JSON code blocks", () => {
+    const text = `Here is a python snippet:
+\`\`\`python
+import olive
+print("not json")
+\`\`\`
+
+And here is the recommendation:
+\`\`\`json
+{
+  "reply": "Optimized",
+  "actions": []
+}
+\`\`\``;
+    const parsed = parseJsonFromAiResponse(text) as { reply: string };
+    expect(parsed.reply).toBe("Optimized");
+  });
+
+  it("finds parsable JSON among multiple untagged fenced blocks", () => {
+    const text = `Sample code:
+\`\`\`
+const a = 1;
+const b = 2;
+\`\`\`
+
+Configuration payload:
+\`\`\`
+{
+  "score": 95
+}
+\`\`\``;
+    const parsed = parseJsonFromAiResponse(text) as { score: number };
+    expect(parsed.score).toBe(95);
+  });
+
+  it("prefers balanced JSON in prose over non-JSON code block fallback", () => {
+    const text = `Sample snippet:
+\`\`\`bash
+echo 123
+\`\`\`
+
+And the structured analysis:
+{
+  "score": 99,
+  "level": "Optimized"
+}`;
+    const parsed = parseJsonFromAiResponse(text) as { score: number; level: string };
+    expect(parsed.score).toBe(99);
+    expect(parsed.level).toBe("Optimized");
+  });
 });

--- a/src/lib/aiResponse.ts
+++ b/src/lib/aiResponse.ts
@@ -5,28 +5,33 @@
  * @returns The parsed JSON value
  * @throws Error if the response is empty or does not contain valid JSON
  */
-export function parseJsonFromAiResponse(text: string): unknown {
-  const trimmed = text.trim();
-  if (!trimmed) {
-    throw new Error("AI response was empty.");
-  }
-
-  // Extract all fenced code block contents, classifying by tag
-  const explicitJsonBlocks: string[] = [];
-  const otherFencedBlocks: string[] = [];
+/** Extract fenced code blocks from text, classifying by language tag. */
+function extractFencedBlocks(
+  text: string,
+): { jsonBlocks: string[]; otherBlocks: string[] } {
+  const jsonBlocks: string[] = [];
+  const otherBlocks: string[] = [];
   const fenceRegex = /```([a-zA-Z0-9_-]+)?\s*([\s\S]*?)```/gi;
   let match: RegExpExecArray | null;
-  while ((match = fenceRegex.exec(trimmed)) !== null) {
+  while ((match = fenceRegex.exec(text)) !== null) {
     const lang = (match[1] ?? "").toLowerCase();
     const content = match[2]?.trim();
     if (!content) continue;
     if (lang === "json" || lang === "jsonc" || lang === "json5") {
-      explicitJsonBlocks.push(content);
+      jsonBlocks.push(content);
     } else {
-      otherFencedBlocks.push(content);
+      otherBlocks.push(content);
     }
   }
+  return { jsonBlocks, otherBlocks };
+}
 
+/** Build a prioritized, de-duplicated candidate list for JSON parsing. */
+function buildCandidateList(
+  trimmed: string,
+  jsonBlocks: string[],
+  otherBlocks: string[],
+): string[] {
   // Prioritize candidates:
   // 1. Explicit ```json blocks
   // 2. Balanced JSON chunks from overall text
@@ -34,12 +39,12 @@ export function parseJsonFromAiResponse(text: string): unknown {
   // 4. Raw trimmed response
   // 5. Other untagged / non-JSON fenced code blocks (fallback)
   const rawCandidates = [
-    ...explicitJsonBlocks,
+    ...jsonBlocks,
     ...collectBalancedJsonCandidates(trimmed),
-    ...explicitJsonBlocks.flatMap((b) => collectBalancedJsonCandidates(b)),
+    ...jsonBlocks.flatMap((b) => collectBalancedJsonCandidates(b)),
     trimmed,
-    ...otherFencedBlocks,
-    ...otherFencedBlocks.flatMap((b) => collectBalancedJsonCandidates(b)),
+    ...otherBlocks,
+    ...otherBlocks.flatMap((b) => collectBalancedJsonCandidates(b)),
   ];
 
   // De-duplicate candidates while preserving priority order
@@ -52,22 +57,47 @@ export function parseJsonFromAiResponse(text: string): unknown {
       candidates.push(s);
     }
   }
+  return candidates;
+}
+
+/** Attempt to parse a candidate string as JSON, with soft repair fallback. */
+function tryParseJson(
+  candidate: string,
+): { value: unknown } | { error: Error } {
+  try {
+    return { value: JSON.parse(candidate) };
+  } catch (err) {
+    const repaired = softRepairJson(candidate);
+    if (repaired && repaired !== candidate) {
+      try {
+        return { value: JSON.parse(repaired) };
+      } catch (err2) {
+        return { error: err2 instanceof Error ? err2 : new Error(String(err2)) };
+      }
+    }
+    return { error: err instanceof Error ? err : new Error(String(err)) };
+  }
+}
+
+export function parseJsonFromAiResponse(text: string): unknown {
+  const trimmed = text.trim();
+  if (!trimmed) {
+    throw new Error("AI response was empty.");
+  }
+
+  const { jsonBlocks: explicitJsonBlocks, otherBlocks: otherFencedBlocks } =
+    extractFencedBlocks(trimmed);
+  const candidates = buildCandidateList(
+    trimmed,
+    explicitJsonBlocks,
+    otherFencedBlocks,
+  );
 
   let lastErr: Error | undefined;
   for (const candidate of candidates) {
-    try {
-      return JSON.parse(candidate);
-    } catch (err) {
-      lastErr = err instanceof Error ? err : new Error(String(err));
-      const repaired = softRepairJson(candidate);
-      if (repaired && repaired !== candidate) {
-        try {
-          return JSON.parse(repaired);
-        } catch (err2) {
-          lastErr = err2 instanceof Error ? err2 : new Error(String(err2));
-        }
-      }
-    }
+    const result = tryParseJson(candidate);
+    if ("value" in result) return result.value;
+    lastErr = result.error;
   }
 
   const detail = lastErr?.message ? ` (${lastErr.message})` : "";

--- a/src/lib/aiResponse.ts
+++ b/src/lib/aiResponse.ts
@@ -11,21 +11,56 @@ export function parseJsonFromAiResponse(text: string): unknown {
     throw new Error("AI response was empty.");
   }
 
-  const fenced = trimmed.match(/^```(?:json)?\s*([\s\S]*?)```$/i);
-  const candidate = fenced ? fenced[1].trim() : trimmed;
-  const balancedCandidates = collectBalancedJsonCandidates(candidate);
-  const attempts = [candidate, ...balancedCandidates, softRepairJson(candidate)].filter((s): s is string =>
-    Boolean(s && s.trim()),
-  );
+  // Extract all fenced code block contents, classifying by tag
+  const explicitJsonBlocks: string[] = [];
+  const otherFencedBlocks: string[] = [];
+  const fenceRegex = /```([a-zA-Z0-9_-]+)?\s*([\s\S]*?)```/gi;
+  let match: RegExpExecArray | null;
+  while ((match = fenceRegex.exec(trimmed)) !== null) {
+    const lang = (match[1] ?? "").toLowerCase();
+    const content = match[2]?.trim();
+    if (!content) continue;
+    if (lang === "json" || lang === "jsonc" || lang === "json5") {
+      explicitJsonBlocks.push(content);
+    } else {
+      otherFencedBlocks.push(content);
+    }
+  }
+
+  // Prioritize candidates:
+  // 1. Explicit ```json blocks
+  // 2. Balanced JSON chunks from overall text
+  // 3. Balanced JSON chunks from explicit json blocks
+  // 4. Raw trimmed response
+  // 5. Other untagged / non-JSON fenced code blocks (fallback)
+  const rawCandidates = [
+    ...explicitJsonBlocks,
+    ...collectBalancedJsonCandidates(trimmed),
+    ...explicitJsonBlocks.flatMap((b) => collectBalancedJsonCandidates(b)),
+    trimmed,
+    ...otherFencedBlocks,
+    ...otherFencedBlocks.flatMap((b) => collectBalancedJsonCandidates(b)),
+  ];
+
+  // De-duplicate candidates while preserving priority order
+  const seen = new Set<string>();
+  const candidates: string[] = [];
+  for (const c of rawCandidates) {
+    const s = c.trim();
+    if (s && !seen.has(s)) {
+      seen.add(s);
+      candidates.push(s);
+    }
+  }
 
   let lastErr: Error | undefined;
-  for (const attempt of attempts) {
+  for (const candidate of candidates) {
     try {
-      return JSON.parse(attempt);
+      return JSON.parse(candidate);
     } catch (err) {
       lastErr = err instanceof Error ? err : new Error(String(err));
-      const repaired = softRepairJson(attempt);
-      if (repaired && repaired !== attempt) {
+      const repaired = softRepairJson(candidate);
+      if (repaired && repaired !== candidate) {
         try {
           return JSON.parse(repaired);
         } catch (err2) {

--- a/src/lib/chatActions.ts
+++ b/src/lib/chatActions.ts
@@ -29,9 +29,59 @@ export type ChatActionPatch = {
   modelSource?: ModelSource;
   hfModelId?: string;
   hfDataset?: string;
+  trustRemoteCode?: boolean;
+  hfTrustRemoteCode?: boolean;
   cacheDir?: string;
   passes?: Partial<UIState["passes"]>;
 };
+
+/**
+ * Fields that were stripped from an AI patch because they require explicit
+ * user confirmation before being applied (security-sensitive toggles).
+ */
+export type GatedPatchFields = {
+  trustRemoteCode?: true;
+};
+
+/**
+ * Extract security-sensitive fields from a patch that require user confirmation.
+ * Returns null when the patch contains no gated fields.
+ */
+export function extractGatedFields(patch: ChatActionPatch): GatedPatchFields | null {
+  if (patch.trustRemoteCode === true) {
+    return { trustRemoteCode: true };
+  }
+  return null;
+}
+
+/**
+ * Returns a copy of the patch with gated (security-sensitive) fields removed.
+ * Disabling trustRemoteCode (false) is always safe and passes through.
+ * Enabling trustRemoteCode (true) requires explicit confirmation via
+ * `chatPatchToUiState` with `{ confirmGated: true }`.
+ */
+export function stripGatedFields(patch: ChatActionPatch): ChatActionPatch {
+  if (patch.trustRemoteCode !== true) return patch;
+  const { trustRemoteCode: _, ...rest } = patch;
+  return rest;
+}
+
+export const TRUST_REMOTE_CODE_CONFIRM_MESSAGE =
+  "Enabling Trust Remote Code will execute Python code from the Hugging Face repository inside Olive on your machine. Only enable this for repositories you trust.\n\nDo you want to enable Trust Remote Code?";
+
+/**
+ * Checks for gated fields (like trustRemoteCode=true) and prompts the user for
+ * confirmation if running in an interactive browser environment.
+ * Returns true if no gated fields exist or if confirmed by user, false if declined.
+ */
+export function confirmGatedPatchFields(patch: ChatActionPatch): boolean {
+  const gated = extractGatedFields(patch);
+  if (!gated) return true;
+  if (typeof window === "undefined" || typeof window.confirm !== "function") {
+    return false;
+  }
+  return window.confirm(TRUST_REMOTE_CODE_CONFIRM_MESSAGE);
+}
 
 export type ChatAction = {
   id: string;
@@ -83,6 +133,11 @@ export function sanitizeChatActionPatch(raw: unknown): ChatActionPatch | null {
   if (typeof raw.hfDataset === "string") {
     patch.hfDataset = raw.hfDataset.trim().slice(0, 256);
   }
+  if (typeof raw.trustRemoteCode === "boolean") {
+    patch.trustRemoteCode = raw.trustRemoteCode;
+  } else if (typeof raw.hfTrustRemoteCode === "boolean") {
+    patch.trustRemoteCode = raw.hfTrustRemoteCode;
+  }
   if (typeof raw.cacheDir === "string" && raw.cacheDir.trim()) {
     patch.cacheDir = raw.cacheDir.trim().slice(0, 512);
   }
@@ -92,8 +147,17 @@ export function sanitizeChatActionPatch(raw: unknown): ChatActionPatch | null {
   return Object.keys(patch).length > 0 ? patch : null;
 }
 
+export type ChatPatchOptions = {
+  /**
+   * When true, security-sensitive fields (e.g. trustRemoteCode=true) are
+   * applied. When false or omitted, enabling trustRemoteCode is silently
+   * skipped — the caller must first show a confirmation dialog.
+   */
+  confirmGated?: boolean;
+};
+
 /** Merge a sanitized chat patch into a Partial<UIState> ready for setState. */
-export function chatPatchToUiState(state: UIState, patch: ChatActionPatch): Partial<UIState> {
+export function chatPatchToUiState(state: UIState, patch: ChatActionPatch, options?: ChatPatchOptions): Partial<UIState> {
   const next: Partial<UIState> = {};
   if (patch.ihvProvider) next.ihvProvider = patch.ihvProvider;
   if (patch.cudaVersion) next.cudaVersion = patch.cudaVersion;
@@ -102,19 +166,34 @@ export function chatPatchToUiState(state: UIState, patch: ChatActionPatch): Part
   if (patch.hfModelId !== undefined) next.hfModelId = patch.hfModelId;
   if (patch.hfDataset !== undefined) next.hfDataset = patch.hfDataset;
   if (patch.cacheDir !== undefined) next.cacheDir = patch.cacheDir;
-  if (patch.passes) {
+
+  // Determine whether trustRemoteCode should be applied:
+  // - Disabling (false) is always safe.
+  // - Enabling (true) requires explicit user confirmation via options.confirmGated.
+  const effectiveTrust: boolean | undefined =
+    patch.trustRemoteCode === false
+      ? false
+      : patch.trustRemoteCode === true && options?.confirmGated
+        ? true
+        : undefined;
+
+  if (patch.passes || effectiveTrust !== undefined) {
     const merged: UIState["passes"] = { ...state.passes, ...patch.passes };
+    // Apply trustRemoteCode into passes where it belongs in UIState.
+    if (effectiveTrust !== undefined) {
+      merged.trustRemoteCode = effectiveTrust;
+    }
     // Keep toggles consistent with method/precision changes.
-    if (patch.passes.quantMethod || patch.passes.quantPrecision) {
+    if (patch.passes?.quantMethod || patch.passes?.quantPrecision) {
       merged.quantization = true;
     }
-    if (patch.passes.quantMethod === "awq") {
+    if (patch.passes?.quantMethod === "awq") {
       merged.pruning = false;
     }
-    if (patch.passes.peftMethod) {
+    if (patch.passes?.peftMethod) {
       merged.peft = true;
     }
-    if (patch.passes.conversionFormat || patch.passes.conversionOpset) {
+    if (patch.passes?.conversionFormat || patch.passes?.conversionOpset) {
       merged.conversion = true;
     }
     next.passes = merged;
@@ -228,6 +307,7 @@ function negatedTargets(value: string): { quant: boolean; convert: boolean } {
 export function salvageChatActionPatchFromLooseJson(parsed: unknown): ChatActionPatch | null {
   const passes: Partial<UIState["passes"]> = {};
   let ihvProvider: IHVProvider | undefined;
+  let trustRemoteCode: boolean | undefined;
 
   const visit = (node: unknown, depth: number) => {
     if (depth > 8 || node == null) return;
@@ -322,6 +402,19 @@ export function salvageChatActionPatchFromLooseJson(parsed: unknown): ChatAction
         }
       }
 
+      if (
+        key === "trust_remote_code" ||
+        key === "trustremotecode" ||
+        key === "hftrustremotecode" ||
+        key === "hf_trust_remote_code"
+      ) {
+        if (typeof value === "boolean") {
+          trustRemoteCode = value;
+        } else if (typeof value === "string") {
+          trustRemoteCode = value.toLowerCase() === "true";
+        }
+      }
+
       if (key === "passes") visit(value, depth + 1);
       else if (isRecord(value) || Array.isArray(value)) visit(value, depth + 1);
     }
@@ -330,6 +423,7 @@ export function salvageChatActionPatchFromLooseJson(parsed: unknown): ChatAction
   visit(parsed, 0);
   const patch: ChatActionPatch = {};
   if (ihvProvider) patch.ihvProvider = ihvProvider;
+  if (trustRemoteCode !== undefined) patch.trustRemoteCode = trustRemoteCode;
   if (Object.keys(passes).length > 0) patch.passes = passes;
   return Object.keys(patch).length > 0 ? sanitizeChatActionPatch(patch) : null;
 }

--- a/src/lib/chatActions.ts
+++ b/src/lib/chatActions.ts
@@ -425,7 +425,9 @@ export function salvageChatActionPatchFromLooseJson(parsed: unknown): ChatAction
         if (typeof value === "boolean") {
           trustRemoteCode = value;
         } else if (typeof value === "string") {
-          trustRemoteCode = value.toLowerCase() === "true";
+          const normalized = value.trim().toLowerCase();
+          if (normalized === "true") trustRemoteCode = true;
+          else if (normalized === "false") trustRemoteCode = false;
         }
       }
 

--- a/src/lib/chatActions.ts
+++ b/src/lib/chatActions.ts
@@ -170,6 +170,46 @@ export type ChatPatchOptions = {
   confirmGated?: boolean;
 };
 
+/**
+ * Determine whether trustRemoteCode should be applied:
+ * - Disabling (false) is always safe.
+ * - Enabling (true) requires explicit user confirmation via options.confirmGated.
+ */
+function resolveEffectiveTrust(
+  patch: ChatActionPatch,
+  options?: ChatPatchOptions,
+): boolean | undefined {
+  if (patch.trustRemoteCode === false) return false;
+  if (patch.trustRemoteCode === true && options?.confirmGated) return true;
+  return undefined;
+}
+
+/** Merge passes from state and patch, applying consistency rules for toggles. */
+function mergePasses(
+  state: UIState,
+  patch: ChatActionPatch,
+  effectiveTrust: boolean | undefined,
+): UIState["passes"] | undefined {
+  if (!patch.passes && effectiveTrust === undefined) return undefined;
+  const merged: UIState["passes"] = { ...state.passes, ...patch.passes };
+  if (effectiveTrust !== undefined) {
+    merged.trustRemoteCode = effectiveTrust;
+  }
+  if (patch.passes?.quantMethod || patch.passes?.quantPrecision) {
+    merged.quantization = true;
+  }
+  if (patch.passes?.quantMethod === "awq") {
+    merged.pruning = false;
+  }
+  if (patch.passes?.peftMethod) {
+    merged.peft = true;
+  }
+  if (patch.passes?.conversionFormat || patch.passes?.conversionOpset) {
+    merged.conversion = true;
+  }
+  return merged;
+}
+
 /** Merge a sanitized chat patch into a Partial<UIState> ready for setState. */
 export function chatPatchToUiState(state: UIState, patch: ChatActionPatch, options?: ChatPatchOptions): Partial<UIState> {
   const next: Partial<UIState> = {};
@@ -181,37 +221,9 @@ export function chatPatchToUiState(state: UIState, patch: ChatActionPatch, optio
   if (patch.hfDataset !== undefined) next.hfDataset = patch.hfDataset;
   if (patch.cacheDir !== undefined) next.cacheDir = patch.cacheDir;
 
-  // Determine whether trustRemoteCode should be applied:
-  // - Disabling (false) is always safe.
-  // - Enabling (true) requires explicit user confirmation via options.confirmGated.
-  const effectiveTrust: boolean | undefined =
-    patch.trustRemoteCode === false
-      ? false
-      : patch.trustRemoteCode === true && options?.confirmGated
-        ? true
-        : undefined;
-
-  if (patch.passes || effectiveTrust !== undefined) {
-    const merged: UIState["passes"] = { ...state.passes, ...patch.passes };
-    // Apply trustRemoteCode into passes where it belongs in UIState.
-    if (effectiveTrust !== undefined) {
-      merged.trustRemoteCode = effectiveTrust;
-    }
-    // Keep toggles consistent with method/precision changes.
-    if (patch.passes?.quantMethod || patch.passes?.quantPrecision) {
-      merged.quantization = true;
-    }
-    if (patch.passes?.quantMethod === "awq") {
-      merged.pruning = false;
-    }
-    if (patch.passes?.peftMethod) {
-      merged.peft = true;
-    }
-    if (patch.passes?.conversionFormat || patch.passes?.conversionOpset) {
-      merged.conversion = true;
-    }
-    next.passes = merged;
-  }
+  const effectiveTrust = resolveEffectiveTrust(patch, options);
+  const mergedPasses = mergePasses(state, patch, effectiveTrust);
+  if (mergedPasses !== undefined) next.passes = mergedPasses;
   return next;
 }
 
@@ -314,14 +326,149 @@ function negatedTargets(value: string): { quant: boolean; convert: boolean } {
   return { quant, convert };
 }
 
+/** Mutable accumulator for loose-JSON salvage traversal. */
+interface SalvageContext {
+  passes: Partial<UIState["passes"]>;
+  ihvProvider: IHVProvider | undefined;
+  trustRemoteCode: boolean | undefined;
+}
+
+/** Detect and extract an IHV execution provider from a key-value pair. */
+function salvageProvider(ctx: SalvageContext, key: string, value: unknown): void {
+  if (
+    (key === "ihvprovider" || key === "execution_provider" || key === "executionprovider") &&
+    typeof value === "string" &&
+    IHV_PROVIDERS.has(value)
+  ) {
+    ctx.ihvProvider = value as IHVProvider;
+  }
+}
+
+/** Detect and extract a conversion opset from a key-value pair. */
+function salvageOpset(ctx: SalvageContext, key: string, value: unknown): void {
+  if (
+    (key.includes("opset") || key === "targetopset" || key === "target_opset") &&
+    typeof value === "number" &&
+    Number.isFinite(value)
+  ) {
+    ctx.passes.conversion = true;
+    ctx.passes.conversionOpset = Math.round(value);
+  }
+}
+
+/** Detect and extract a quant method from a key-value pair. */
+function salvageQuantMethod(ctx: SalvageContext, key: string, value: unknown): void {
+  if (key === "quantmethod" || key === "quant_method") {
+    if (typeof value === "string") {
+      const method = normalizeLooseQuantMethod(value);
+      if (method) {
+        ctx.passes.quantization = true;
+        ctx.passes.quantMethod = method;
+      }
+    }
+  }
+}
+
+/** Detect and extract quant precision from a key-value pair. */
+function salvagePrecision(ctx: SalvageContext, key: string, value: unknown): void {
+  if (key === "precision" || key === "quantprecision" || key === "quant_precision") {
+    if (typeof value === "string") {
+      const prec = normalizeLooseQuantPrecision(value);
+      if (prec) {
+        ctx.passes.quantization = true;
+        ctx.passes.quantPrecision = prec;
+        if (!ctx.passes.quantMethod) ctx.passes.quantMethod = "ptq";
+      }
+    }
+  }
+}
+
+/** Detect and extract quantization from action/step fields, handling negation. */
+function salvageQuantAction(ctx: SalvageContext, key: string, value: unknown): void {
+  const isActionField = key === "step" || key === "action" || key === "task";
+  // Negation must be scoped near the specific instruction it modifies —
+  // a single flag gating every detector on a multi-clause value (e.g.
+  // "convert to onnx without quantization") would wrongly suppress the
+  // unrelated, non-negated conversion instruction too.
+  const negated = typeof value === "string" ? negatedTargets(value) : { quant: false, convert: false };
+  const isQuantMentioned =
+    /quant/i.test(key) || (isActionField && typeof value === "string" && hasAffirmativeQuantToken(value));
+
+  if (
+    !isQuantMentioned ||
+    negated.quant ||
+    !(value === true || (typeof value === "string" && hasAffirmativeQuantToken(value)))
+  ) {
+    return;
+  }
+
+  ctx.passes.quantization = true;
+  if (typeof value === "string") {
+    const prec = normalizeLooseQuantPrecision(value) ?? extractLooseQuantPrecisionFromValue(value);
+    if (prec) ctx.passes.quantPrecision = prec;
+    const method = normalizeLooseQuantMethod(value) ?? extractLooseQuantMethodFromValue(value);
+    if (method) ctx.passes.quantMethod = method;
+  }
+  if (!ctx.passes.quantMethod && !ctx.passes.quantPrecision) {
+    // "apply_quantization" with no precision → enable PTQ toggle only
+    ctx.passes.quantMethod = ctx.passes.quantMethod ?? "ptq";
+  }
+}
+
+/** Detect and extract conversion from action/step fields, handling negation. */
+function salvageConvertAction(ctx: SalvageContext, key: string, value: unknown): void {
+  const isActionField = key === "step" || key === "action" || key === "task";
+  const negated = typeof value === "string" ? negatedTargets(value) : { quant: false, convert: false };
+
+  if (
+    negated.convert ||
+    !(/convert/.test(key) ||
+      key === "onnx" ||
+      /onnx/.test(key) ||
+      (isActionField && typeof value === "string" && (/convert/i.test(value) || /onnx/i.test(value)))) ||
+    !(value === true || typeof value === "string" || typeof value === "number" || isRecord(value))
+  ) {
+    return;
+  }
+
+  ctx.passes.conversion = true;
+  if (typeof value === "string" && /onnx|openvino|qnn|tensorrt/i.test(value)) {
+    const fmt = value.toLowerCase();
+    if (fmt === "onnx" || fmt === "openvino" || fmt === "qnn" || fmt === "tensorrt") {
+      ctx.passes.conversionFormat = fmt;
+    }
+  }
+}
+
+/** Detect and extract trustRemoteCode from a key-value pair. */
+function salvageTrustRemoteCode(ctx: SalvageContext, key: string, value: unknown): void {
+  if (
+    key !== "trust_remote_code" &&
+    key !== "trustremotecode" &&
+    key !== "hftrustremotecode" &&
+    key !== "hf_trust_remote_code"
+  ) {
+    return;
+  }
+  if (typeof value === "boolean") {
+    ctx.trustRemoteCode = value;
+  } else if (typeof value === "string") {
+    const normalized = value.trim().toLowerCase();
+    if (normalized === "true") ctx.trustRemoteCode = true;
+    else if (normalized === "false") ctx.trustRemoteCode = false;
+  }
+}
+
 /**
  * Small local models often invent custom step schemas instead of `actions[].patch`.
  * Walk loose JSON and map known fields onto an allowlisted ChatActionPatch.
  */
 export function salvageChatActionPatchFromLooseJson(parsed: unknown): ChatActionPatch | null {
-  const passes: Partial<UIState["passes"]> = {};
-  let ihvProvider: IHVProvider | undefined;
-  let trustRemoteCode: boolean | undefined;
+  const ctx: SalvageContext = {
+    passes: {},
+    ihvProvider: undefined,
+    trustRemoteCode: undefined,
+  };
 
   const visit = (node: unknown, depth: number) => {
     if (depth > 8 || node == null) return;
@@ -334,102 +481,13 @@ export function salvageChatActionPatchFromLooseJson(parsed: unknown): ChatAction
     for (const [rawKey, value] of Object.entries(node)) {
       const key = rawKey.toLowerCase().replace(/[\s-]+/g, "_");
 
-      if (
-        (key === "ihvprovider" || key === "execution_provider" || key === "executionprovider") &&
-        typeof value === "string" &&
-        IHV_PROVIDERS.has(value)
-      ) {
-        ihvProvider = value as IHVProvider;
-      }
-
-      if (
-        (key.includes("opset") || key === "targetopset" || key === "target_opset") &&
-        typeof value === "number" &&
-        Number.isFinite(value)
-      ) {
-        passes.conversion = true;
-        passes.conversionOpset = Math.round(value);
-      }
-
-      if (key === "quantmethod" || key === "quant_method") {
-        if (typeof value === "string") {
-          const method = normalizeLooseQuantMethod(value);
-          if (method) {
-            passes.quantization = true;
-            passes.quantMethod = method;
-          }
-        }
-      }
-
-      if (key === "precision" || key === "quantprecision" || key === "quant_precision") {
-        if (typeof value === "string") {
-          const prec = normalizeLooseQuantPrecision(value);
-          if (prec) {
-            passes.quantization = true;
-            passes.quantPrecision = prec;
-            if (!passes.quantMethod) passes.quantMethod = "ptq";
-          }
-        }
-      }
-
-      const isActionField = key === "step" || key === "action" || key === "task";
-      // Negation must be scoped near the specific instruction it modifies —
-      // a single flag gating every detector on a multi-clause value (e.g.
-      // "convert to onnx without quantization") would wrongly suppress the
-      // unrelated, non-negated conversion instruction too.
-      const negated = typeof value === "string" ? negatedTargets(value) : { quant: false, convert: false };
-      const isQuantMentioned =
-        /quant/i.test(key) || (isActionField && typeof value === "string" && hasAffirmativeQuantToken(value));
-
-      if (
-        isQuantMentioned &&
-        !negated.quant &&
-        (value === true || (typeof value === "string" && hasAffirmativeQuantToken(value)))
-      ) {
-        passes.quantization = true;
-        if (typeof value === "string") {
-          const prec = normalizeLooseQuantPrecision(value) ?? extractLooseQuantPrecisionFromValue(value);
-          if (prec) passes.quantPrecision = prec;
-          const method = normalizeLooseQuantMethod(value) ?? extractLooseQuantMethodFromValue(value);
-          if (method) passes.quantMethod = method;
-        }
-        if (!passes.quantMethod && !passes.quantPrecision) {
-          // "apply_quantization" with no precision → enable PTQ toggle only
-          passes.quantMethod = passes.quantMethod ?? "ptq";
-        }
-      }
-
-      if (
-        !negated.convert &&
-        (/convert/.test(key) ||
-          key === "onnx" ||
-          /onnx/.test(key) ||
-          (isActionField && typeof value === "string" && (/convert/i.test(value) || /onnx/i.test(value)))) &&
-        (value === true || typeof value === "string" || typeof value === "number" || isRecord(value))
-      ) {
-        passes.conversion = true;
-        if (typeof value === "string" && /onnx|openvino|qnn|tensorrt/i.test(value)) {
-          const fmt = value.toLowerCase();
-          if (fmt === "onnx" || fmt === "openvino" || fmt === "qnn" || fmt === "tensorrt") {
-            passes.conversionFormat = fmt;
-          }
-        }
-      }
-
-      if (
-        key === "trust_remote_code" ||
-        key === "trustremotecode" ||
-        key === "hftrustremotecode" ||
-        key === "hf_trust_remote_code"
-      ) {
-        if (typeof value === "boolean") {
-          trustRemoteCode = value;
-        } else if (typeof value === "string") {
-          const normalized = value.trim().toLowerCase();
-          if (normalized === "true") trustRemoteCode = true;
-          else if (normalized === "false") trustRemoteCode = false;
-        }
-      }
+      salvageProvider(ctx, key, value);
+      salvageOpset(ctx, key, value);
+      salvageQuantMethod(ctx, key, value);
+      salvagePrecision(ctx, key, value);
+      salvageQuantAction(ctx, key, value);
+      salvageConvertAction(ctx, key, value);
+      salvageTrustRemoteCode(ctx, key, value);
 
       if (key === "passes") visit(value, depth + 1);
       else if (isRecord(value) || Array.isArray(value)) visit(value, depth + 1);
@@ -438,9 +496,9 @@ export function salvageChatActionPatchFromLooseJson(parsed: unknown): ChatAction
 
   visit(parsed, 0);
   const patch: ChatActionPatch = {};
-  if (ihvProvider) patch.ihvProvider = ihvProvider;
-  if (trustRemoteCode !== undefined) patch.trustRemoteCode = trustRemoteCode;
-  if (Object.keys(passes).length > 0) patch.passes = passes;
+  if (ctx.ihvProvider) patch.ihvProvider = ctx.ihvProvider;
+  if (ctx.trustRemoteCode !== undefined) patch.trustRemoteCode = ctx.trustRemoteCode;
+  if (Object.keys(ctx.passes).length > 0) patch.passes = ctx.passes;
   return Object.keys(patch).length > 0 ? sanitizeChatActionPatch(patch) : null;
 }
 

--- a/src/lib/chatActions.ts
+++ b/src/lib/chatActions.ts
@@ -103,6 +103,8 @@ function sanitizePasses(raw: unknown): Partial<UIState["passes"]> | undefined {
   if (!isRecord(raw)) return undefined;
   const out: Partial<UIState["passes"]> = {};
   for (const [key, value] of Object.entries(raw)) {
+    // trustRemoteCode is security-gated and must not pass through nested passes merge
+    if (key === "trustRemoteCode") continue;
     const coerced = coercePassValue(key, value);
     if (coerced === null) continue;
     (out as Record<string, unknown>)[key] = coerced;
@@ -141,8 +143,20 @@ export function sanitizeChatActionPatch(raw: unknown): ChatActionPatch | null {
   if (typeof raw.cacheDir === "string" && raw.cacheDir.trim()) {
     patch.cacheDir = raw.cacheDir.trim().slice(0, 512);
   }
+
+  // Extract nested passes.trustRemoteCode before sanitizing passes
+  let nestedTrustRemoteCode: boolean | undefined;
+  if (isRecord(raw.passes) && typeof raw.passes.trustRemoteCode === "boolean") {
+    nestedTrustRemoteCode = raw.passes.trustRemoteCode;
+  }
+
   const passes = sanitizePasses(raw.passes);
   if (passes) patch.passes = passes;
+
+  // Process nested trustRemoteCode through the top-level gated field path
+  if (nestedTrustRemoteCode !== undefined && patch.trustRemoteCode === undefined) {
+    patch.trustRemoteCode = nestedTrustRemoteCode;
+  }
 
   return Object.keys(patch).length > 0 ? patch : null;
 }

--- a/src/lib/httpError.ts
+++ b/src/lib/httpError.ts
@@ -1,0 +1,26 @@
+/**
+ * Extracts a human-readable error message from an unknown JSON error payload.
+ *
+ * Handles common shapes returned by APIs:
+ *  - `{ error: "string" }`
+ *  - `{ error: { message: "string" } }`
+ *  - `{ message: "string" }`
+ *  - plain string body
+ *
+ * @param payload - The parsed JSON body (or string) from an error response.
+ * @param fallback - Fallback message when no known field is found.
+ * @returns The extracted error string.
+ */
+export function extractErrorMessage(payload: unknown, fallback: string): string {
+  if (typeof payload === "string") return payload;
+  if (typeof payload === "object" && payload !== null) {
+    const rec = payload as Record<string, unknown>;
+    if (typeof rec.error === "string") return rec.error;
+    if (typeof rec.error === "object" && rec.error !== null) {
+      const inner = rec.error as Record<string, unknown>;
+      if (typeof inner.message === "string") return inner.message;
+    }
+    if (typeof rec.message === "string") return rec.message;
+  }
+  return fallback;
+}

--- a/src/lib/httpError.ts
+++ b/src/lib/httpError.ts
@@ -12,15 +12,15 @@
  * @returns The extracted error string.
  */
 export function extractErrorMessage(payload: unknown, fallback: string): string {
-  if (typeof payload === "string") return payload;
+  if (typeof payload === "string" && payload.trim()) return payload;
   if (typeof payload === "object" && payload !== null) {
     const rec = payload as Record<string, unknown>;
-    if (typeof rec.error === "string") return rec.error;
+    if (typeof rec.error === "string" && rec.error.trim()) return rec.error;
     if (typeof rec.error === "object" && rec.error !== null) {
       const inner = rec.error as Record<string, unknown>;
-      if (typeof inner.message === "string") return inner.message;
+      if (typeof inner.message === "string" && inner.message.trim()) return inner.message;
     }
-    if (typeof rec.message === "string") return rec.message;
+    if (typeof rec.message === "string" && rec.message.trim()) return rec.message;
   }
   return fallback;
 }

--- a/src/lib/issueReport.test.ts
+++ b/src/lib/issueReport.test.ts
@@ -50,17 +50,40 @@ describe("redactSecrets", () => {
     expect(redactSecrets('api_key="sk-1234567890abcdef1234567890"')).toContain("[REDACTED]");
   });
 
-  it("redacts standalone JWTs and PEM private keys", () => {
+  it("redacts standalone JWTs and PEM private keys while preserving model names and semantic versions", () => {
     const jwt = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.signaturevalue123";
-    const compactJwt = "a.e30.-";
-    const emptySignatureJwt = "a.e30.";
     const pem = "-----BEGIN PRIVATE KEY-----\nsecret-material\n-----END PRIVATE KEY-----";
-    const redacted = redactSecrets(`jwt=${jwt}\ncompact=${compactJwt}\nempty=${emptySignatureJwt}\nkey=${pem}`);
+    const redacted = redactSecrets(`jwt=${jwt}\nkey=${pem}`);
     expect(redacted).not.toContain(jwt);
-    expect(redacted).not.toContain(compactJwt);
-    expect(redacted).not.toContain(emptySignatureJwt);
     expect(redacted).not.toContain("secret-material");
-    expect(redacted.match(/\[REDACTED\]/g)?.length).toBe(4);
+    expect(redacted.match(/\[REDACTED\]/g)?.length).toBe(2);
+
+    const modelName = "Qwen/Qwen2.5-0.5B-Instruct";
+    const semver = "v1.2.3";
+    expect(redactSecrets(`Model: ${modelName}, Version: ${semver}`)).toBe(`Model: ${modelName}, Version: ${semver}`);
+  });
+
+  it("redacts compact JWTs with short segments", () => {
+    const compact = "eyJhbGciOiJ9.e30.x";
+    const redacted = redactSecrets(`token=${compact}`);
+    expect(redacted).not.toContain(compact);
+    expect(redacted).toContain("[REDACTED]");
+  });
+
+  it("redacts three-segment dotted tokens that do not start with eyJ", () => {
+    const nonEyJ = "AbCdEfGh12345678.payload12345678.signature1234";
+    const redacted = redactSecrets(`session=${nonEyJ}`);
+    expect(redacted).not.toContain(nonEyJ);
+    expect(redacted).toContain("[REDACTED]");
+  });
+
+  it("does not redact model names, semver, or short dotted identifiers as JWTs", () => {
+    // Slash-qualified HF model ids with dots must survive.
+    expect(redactSecrets("Qwen/Qwen2.5-0.5B-Instruct")).toBe("Qwen/Qwen2.5-0.5B-Instruct");
+    // Short dotted tokens (segments < 8 chars, not eyJ) are not secrets.
+    expect(redactSecrets("node.js.org")).toBe("node.js.org");
+    expect(redactSecrets("package.json.bak")).toBe("package.json.bak");
+    expect(redactSecrets("1.0.0")).toBe("1.0.0");
   });
 
   it("redacts Windows user paths", () => {
@@ -115,7 +138,7 @@ describe("collectTelemetry", () => {
     const state = {
       hfModelId: "bert-base-uncased",
       ihvProvider: "CUDAExecutionProvider",
-    openvinoTargetDevice: "CPU",
+      openvinoTargetDevice: "CPU",
       modelSource: "huggingface" as const,
       passes: { conversion: true, quantization: false, pruning: false, onnxTransforms: false },
     } as BuildReportOptions["state"];

--- a/src/lib/issueReport.test.ts
+++ b/src/lib/issueReport.test.ts
@@ -70,6 +70,18 @@ describe("redactSecrets", () => {
     expect(redacted).toContain("[REDACTED]");
   });
 
+  it("redacts complete five-segment compact JWEs in one match", () => {
+    const jwe =
+      "eyJhbGciOiJkaXIiLCJlbmMiOiJBMTI4R0NNIn0.encryptedKey123456.ivSegment123456.ciphertext123456.authTag123456";
+    const redacted = redactSecrets(`token=${jwe}`);
+    expect(redacted).not.toContain(jwe);
+    // The full five segments must be consumed — no trailing segment may survive.
+    expect(redacted).not.toContain("encryptedKey123456");
+    expect(redacted).not.toContain("ciphertext123456");
+    expect(redacted).not.toContain("authTag123456");
+    expect(redacted.match(/\[REDACTED\]/g)?.length).toBe(1);
+  });
+
   it("redacts three-segment dotted tokens that do not start with eyJ", () => {
     const nonEyJ = "AbCdEfGh12345678.payload12345678.signature1234";
     const redacted = redactSecrets(`session=${nonEyJ}`);

--- a/src/lib/issueReport.ts
+++ b/src/lib/issueReport.ts
@@ -82,8 +82,11 @@ const SECRET_PATTERNS: RegExp[] = [
   /(?:AKIA|ASIA)[A-Z0-9]{16}/g,
   // Bearer tokens (Authorization header)
   /Bearer\s+[A-Za-z0-9\-._~+/]+=*/g,
-  // JSON Web Tokens — canonical form (JWS: 3 segments, JWE: 5 segments, base64url header starting with eyJ)
-  /(?<![A-Za-z0-9_-])eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+(?:\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+)?(?![A-Za-z0-9_-])/g,
+  // JSON Web Tokens — canonical form (JWS: 3 segments, JWE: 5 segments, base64url header starting with eyJ).
+  // The `{2,}` requires at least 3 segments and greedily consumes every
+  // contiguous dot-separated base64url segment so a complete 5-segment JWE is
+  // redacted in one match (the trailing lookahead must not stop at a `.`).
+  /(?<![A-Za-z0-9_-])eyJ[A-Za-z0-9_-]+(?:\.[A-Za-z0-9_-]+){2,}(?![A-Za-z0-9_-])/g,
   // Dotted base64url tokens that don't start with eyJ but are long enough to be secrets
   // (3+ segments, each ≥8 chars — safely excludes semver, model names, and short identifiers)
   /(?<![A-Za-z0-9_\-/])(?!eyJ)[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}(?:\.[A-Za-z0-9_-]{8,})*(?![A-Za-z0-9_\-/])/g,

--- a/src/lib/issueReport.ts
+++ b/src/lib/issueReport.ts
@@ -82,11 +82,11 @@ const SECRET_PATTERNS: RegExp[] = [
   /(?:AKIA|ASIA)[A-Z0-9]{16}/g,
   // Bearer tokens (Authorization header)
   /Bearer\s+[A-Za-z0-9\-._~+/]+=*/g,
-  // JSON Web Tokens — canonical form (base64url header starting with eyJ)
-  /(?<![A-Za-z0-9_-])eyJ[A-Za-z0-9_-]*\.[A-Za-z0-9_-]+(?:\.[A-Za-z0-9_-]*)?(?![A-Za-z0-9_-])/g,
+  // JSON Web Tokens — canonical form (JWS: 3 segments, JWE: 5 segments, base64url header starting with eyJ)
+  /(?<![A-Za-z0-9_-])eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+(?:\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+)?(?![A-Za-z0-9_-])/g,
   // Dotted base64url tokens that don't start with eyJ but are long enough to be secrets
-  // (3 segments, each ≥8 chars — safely excludes semver, model names, and short identifiers)
-  /(?<![A-Za-z0-9_\-/])(?!eyJ)[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}(?![A-Za-z0-9_\-/])/g,
+  // (3+ segments, each ≥8 chars — safely excludes semver, model names, and short identifiers)
+  /(?<![A-Za-z0-9_\-/])(?!eyJ)[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}(?:\.[A-Za-z0-9_-]{8,})*(?![A-Za-z0-9_\-/])/g,
   // PEM private-key blocks
   /-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z0-9 ]*PRIVATE KEY-----/gi,
   // Generic long hex strings that look like secrets (32+ hex chars)

--- a/src/lib/issueReport.ts
+++ b/src/lib/issueReport.ts
@@ -82,8 +82,11 @@ const SECRET_PATTERNS: RegExp[] = [
   /(?:AKIA|ASIA)[A-Z0-9]{16}/g,
   // Bearer tokens (Authorization header)
   /Bearer\s+[A-Za-z0-9\-._~+/]+=*/g,
-  // JSON Web Tokens (three base64url-encoded segments; payload/signature may be empty)
-  /(?<![A-Za-z0-9_-])[A-Za-z0-9_-]+\.[A-Za-z0-9_-]*\.[A-Za-z0-9_-]*(?![A-Za-z0-9_-])/g,
+  // JSON Web Tokens — canonical form (base64url header starting with eyJ)
+  /(?<![A-Za-z0-9_-])eyJ[A-Za-z0-9_-]*\.[A-Za-z0-9_-]+(?:\.[A-Za-z0-9_-]*)?(?![A-Za-z0-9_-])/g,
+  // Dotted base64url tokens that don't start with eyJ but are long enough to be secrets
+  // (3 segments, each ≥8 chars — safely excludes semver, model names, and short identifiers)
+  /(?<![A-Za-z0-9_\-/])(?!eyJ)[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}(?![A-Za-z0-9_\-/])/g,
   // PEM private-key blocks
   /-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z0-9 ]*PRIVATE KEY-----/gi,
   // Generic long hex strings that look like secrets (32+ hex chars)
@@ -267,7 +270,7 @@ export function buildIssueBody(report: IssueReport): string {
   lines.push(`**Category:** ${REPORT_CATEGORIES.find((c) => c.id === report.category)?.label ?? report.category}`);
   lines.push(`**Severity:** ${REPORT_SEVERITIES.find((s) => s.id === severity)?.label ?? severity}`);
   lines.push(`**Area:** ${REPORT_AREAS.find((a) => a.id === report.area)?.label ?? report.area}`);
-  
+
   // Frequency info for repeated errors
   if (report.frequencyInfo && report.frequencyInfo.count > 1) {
     lines.push(`**Occurrences:** ${report.frequencyInfo.count} times`);

--- a/src/lib/openExternal.ts
+++ b/src/lib/openExternal.ts
@@ -17,12 +17,11 @@ export async function openExternal(url: string): Promise<void> {
   try {
     parsed = new URL(url, window.location.href);
     if (!(["http:", "https:", "mailto:"] as const).includes(parsed.protocol as "http:" | "https:" | "mailto:")) {
-      console.warn("[openExternal] Refusing to open unsupported protocol:", parsed.protocol);
-      return;
+      throw new Error(`Unsupported protocol: ${parsed.protocol}`);
     }
-  } catch {
-    console.warn("[openExternal] Refusing to open invalid URL:", url);
-    return;
+  } catch (e) {
+    if (e instanceof Error && e.message.startsWith("Unsupported protocol")) throw e;
+    throw new Error("Invalid URL");
   }
 
   // Check if we're running in Tauri
@@ -33,11 +32,13 @@ export async function openExternal(url: string): Promise<void> {
     } catch (err) {
       console.error("[openExternal] Tauri shell.open failed:", err);
       // Fallback to window.open if Tauri fails
-      window.open(parsed.href, "_blank", "noopener,noreferrer");
+      const win = window.open(parsed.href, "_blank", "noopener,noreferrer");
+      if (!win) throw new Error("Browser blocked the popup");
     }
   } else {
     // Browser/web fallback
-    window.open(parsed.href, "_blank", "noopener,noreferrer");
+    const win = window.open(parsed.href, "_blank", "noopener,noreferrer");
+    if (!win) throw new Error("Browser blocked the popup");
   }
 }
 

--- a/src/lib/tour.test.ts
+++ b/src/lib/tour.test.ts
@@ -17,56 +17,10 @@ const mocks = vi.hoisted(() => {
 
 vi.mock("driver.js", () => ({ driver: mocks.driverFactory }));
 
-import tourDemoRecipe from "@/data/tour-demo-recipe.json";
-import { deriveUiStateFromOliveRecipe } from "@/lib/oliveRecipeHub";
 import { setPipelineOliveRunning } from "@/lib/pipelineNavigation";
-import { hasSelectedModel } from "@/lib/pipelineValidation";
-import { createDefaultPipelineState, usePipelineStore } from "@/lib/stores/pipelineStore";
+import { usePipelineStore } from "@/lib/stores/pipelineStore";
 import { usePreferencesStore } from "@/lib/stores/preferencesStore";
-import { ensureTourDemoModel, startGuidedTour, TOUR_STEPS } from "./tour";
-
-describe("tour demo recipe", () => {
-  it("derives a selected Hugging Face model on CPU with conversion enabled", () => {
-    const derived = deriveUiStateFromOliveRecipe(tourDemoRecipe, { replacePasses: true });
-    const state = {
-      ...createDefaultPipelineState(),
-      ...derived,
-      passes: { ...createDefaultPipelineState().passes, ...derived.passes },
-    };
-    expect(hasSelectedModel(state)).toBe(true);
-    expect(state.hfModelId).toBe("sshleifer/tiny-gpt2");
-    expect(state.modelSource).toBe("huggingface");
-    expect(state.ihvProvider).toBe("CPUExecutionProvider");
-    expect(state.passes.conversion).toBe(true);
-  });
-});
-
-describe("ensureTourDemoModel", () => {
-  beforeEach(() => {
-    usePipelineStore.getState().resetState();
-  });
-
-  it("applies the sample recipe when no model is selected", () => {
-    const result = ensureTourDemoModel();
-    expect(result.applied).toBe(true);
-    const state = usePipelineStore.getState().state;
-    expect(hasSelectedModel(state)).toBe(true);
-    expect(state.hfModelId).toBe("sshleifer/tiny-gpt2");
-  });
-
-  it("does not overwrite an already selected model", () => {
-    usePipelineStore.getState().setState({ hfModelId: "microsoft/phi-2" });
-    const result = ensureTourDemoModel();
-    expect(result.applied).toBe(false);
-    expect(usePipelineStore.getState().state.hfModelId).toBe("microsoft/phi-2");
-  });
-
-  it("is a no-op the second time after a successful apply", () => {
-    expect(ensureTourDemoModel().applied).toBe(true);
-    expect(ensureTourDemoModel().applied).toBe(false);
-    expect(usePipelineStore.getState().state.hfModelId).toBe("sshleifer/tiny-gpt2");
-  });
-});
+import { startGuidedTour, ensureTourDemoModel, TOUR_STEPS } from "./tour";
 
 describe("TOUR_STEPS", () => {
   it("starts with an unanchored Olive overview, then real controls", () => {
@@ -132,24 +86,13 @@ describe("startGuidedTour", () => {
     expect(mocks.drive).toHaveBeenCalledTimes(1);
   });
 
-  it("applies the sample recipe when Next is pressed on Model source with an empty workspace", () => {
-    mocks.getActiveStep.mockReturnValue({ data: { id: "model-source" } });
+  it("advances to the next step when onNextClick is triggered without mutating model state", () => {
     startGuidedTour(() => {});
     const config = mocks.driverFactory.mock.calls[0][0] as {
       onNextClick: () => void;
     };
     config.onNextClick();
-    expect(usePipelineStore.getState().state.hfModelId).toBe("sshleifer/tiny-gpt2");
-    expect(mocks.moveNext).toHaveBeenCalledTimes(1);
-  });
-
-  it("does not clobber an existing model when Next is pressed on Model source", () => {
-    usePipelineStore.getState().setState({ hfModelId: "microsoft/phi-2" });
-    mocks.getActiveStep.mockReturnValue({ data: { id: "model-source" } });
-    startGuidedTour(() => {});
-    const config = mocks.driverFactory.mock.calls[0][0] as { onNextClick: () => void };
-    config.onNextClick();
-    expect(usePipelineStore.getState().state.hfModelId).toBe("microsoft/phi-2");
+    expect(usePipelineStore.getState().state.hfModelId).toBe("");
     expect(mocks.moveNext).toHaveBeenCalledTimes(1);
   });
 
@@ -206,5 +149,31 @@ describe("guided tour preference", () => {
     expect(usePreferencesStore.getState()).not.toHaveProperty("welcomeDismissed");
     expect(usePreferencesStore.getState()).not.toHaveProperty("dismissWelcome");
     expect(usePreferencesStore.getState().tourSeen).toBe(false);
+  });
+});
+
+describe("ensureTourDemoModel", () => {
+  beforeEach(() => {
+    usePipelineStore.getState().resetState();
+  });
+
+  it("applies the tour demo recipe and resets to clean defaults when no model is selected", () => {
+    // Modify a non-recipe field before applying
+    usePipelineStore.getState().setState({ cacheDir: "/custom/cache" });
+    const result = ensureTourDemoModel();
+    expect(result.applied).toBe(true);
+    const state = usePipelineStore.getState().state;
+    expect(state.hfModelId).toBe("sshleifer/tiny-gpt2");
+    expect(state.passes.conversion).toBe(true);
+    expect(state.passes.conversionOpset).toBe(17);
+    // Ensure defaults are properly reset
+    expect(state.cacheDir).toBe("");
+  });
+
+  it("returns applied: false when a model is already selected", () => {
+    usePipelineStore.getState().setState({ hfModelId: "custom/my-model" });
+    const result = ensureTourDemoModel();
+    expect(result.applied).toBe(false);
+    expect(usePipelineStore.getState().state.hfModelId).toBe("custom/my-model");
   });
 });

--- a/src/lib/tour.ts
+++ b/src/lib/tour.ts
@@ -1,38 +1,16 @@
 import { driver, type DriveStep } from "driver.js";
 import "driver.js/dist/driver.css";
-import tourDemoRecipe from "@/data/tour-demo-recipe.json";
-import { deriveUiStateFromOliveRecipe } from "@/lib/oliveRecipeHub";
 import { isPipelineOliveRunning } from "@/lib/pipelineNavigation";
+import { usePipelineStore, createDefaultPipelineState } from "@/lib/stores/pipelineStore";
 import { hasSelectedModel } from "@/lib/pipelineValidation";
-import { createDefaultPipelineState, usePipelineStore } from "@/lib/stores/pipelineStore";
+import { deriveUiStateFromOliveRecipe } from "@/lib/oliveRecipeHub";
+import tourDemoRecipe from "@/data/tour-demo-recipe.json";
 
-let tourModelUnsub: (() => void) | undefined;
 let tourActive = false;
 
 /**
- * Loads the bundled sample recipe when the workspace has no model selected.
- *
- * @returns Whether a sample recipe was applied
- */
-export function ensureTourDemoModel(): { applied: boolean } {
-  const store = usePipelineStore.getState();
-  if (hasSelectedModel(store.state)) return { applied: false };
-  try {
-    const derived = deriveUiStateFromOliveRecipe(tourDemoRecipe, { replacePasses: true });
-    store.replaceState({
-      ...createDefaultPipelineState(),
-      ...derived,
-      passes: { ...createDefaultPipelineState().passes, ...derived.passes },
-    });
-    return { applied: hasSelectedModel(usePipelineStore.getState().state) };
-  } catch {
-    return { applied: false };
-  }
-}
-
-/**
  * Guided tour steps: Olive overview, then real pipeline controls.
- * Interaction steps use click-to-advance; Model source waits for a real Apply.
+ * Interaction steps use click-to-advance.
  */
 export const TOUR_STEPS: DriveStep[] = [
   {
@@ -129,17 +107,27 @@ export const TOUR_STEPS: DriveStep[] = [
   },
 ];
 
-function stepId(step: DriveStep | undefined): string | undefined {
-  const data = step?.data as { id?: string } | undefined;
-  return data?.id;
+/**
+ * Applies the bundled sample recipe when no model is currently selected.
+ * Used by the tour and the InputRecipeRail "Apply" button.
+ * Returns `{ applied: true }` only the first time it actually writes state.
+ */
+export function ensureTourDemoModel(): { applied: boolean } {
+  const store = usePipelineStore.getState();
+  if (hasSelectedModel(store.state)) return { applied: false };
+  const defaults = createDefaultPipelineState();
+  const derived = deriveUiStateFromOliveRecipe(tourDemoRecipe, { replacePasses: true });
+  store.replaceState({
+    ...defaults,
+    ...derived,
+    passes: {
+      ...defaults.passes,
+      ...(derived.passes ?? {}),
+    },
+  });
+  return { applied: true };
 }
 
-/**
- * Starts the guided tour and handles completion or dismissal.
- *
- * @param onSettled - Callback invoked once when the tour ends or is skipped
- * @returns The tour instance, or null when an Olive job is running or a tour is already active
- */
 export function startGuidedTour(onSettled: () => void) {
   if (isPipelineOliveRunning() || tourActive) return null;
 
@@ -155,29 +143,9 @@ export function startGuidedTour(onSettled: () => void) {
     disableActiveInteraction: false,
     steps: TOUR_STEPS,
     onNextClick: () => {
-      if (stepId(driverObj.getActiveStep()) === "model-source") {
-        ensureTourDemoModel();
-      }
       driverObj.moveNext();
     },
-    onHighlighted: (_element, step) => {
-      tourModelUnsub?.();
-      tourModelUnsub = undefined;
-      if (stepId(step) !== "model-source") return;
-      tourModelUnsub = usePipelineStore.subscribe((store) => {
-        if (!hasSelectedModel(store.state)) return;
-        tourModelUnsub?.();
-        tourModelUnsub = undefined;
-        driverObj.moveNext();
-      });
-    },
-    onDeselected: () => {
-      tourModelUnsub?.();
-      tourModelUnsub = undefined;
-    },
     onDestroyStarted: () => {
-      tourModelUnsub?.();
-      tourModelUnsub = undefined;
       tourActive = false;
       onSettled();
       driverObj.destroy();

--- a/src/lib/tour.ts
+++ b/src/lib/tour.ts
@@ -115,6 +115,24 @@ export const TOUR_STEPS: DriveStep[] = [
 export function ensureTourDemoModel(): { applied: boolean } {
   const store = usePipelineStore.getState();
   if (hasSelectedModel(store.state)) return { applied: false };
+  try {
+    const defaults = createDefaultPipelineState();
+    const derived = deriveUiStateFromOliveRecipe(tourDemoRecipe, { replacePasses: true });
+    store.replaceState({
+      ...defaults,
+      ...derived,
+      passes: {
+        ...defaults.passes,
+        ...(derived.passes ?? {}),
+      },
+    });
+    return { applied: true };
+  } catch {
+    return { applied: false };
+  }
+}
+  const store = usePipelineStore.getState();
+  if (hasSelectedModel(store.state)) return { applied: false };
   const defaults = createDefaultPipelineState();
   const derived = deriveUiStateFromOliveRecipe(tourDemoRecipe, { replacePasses: true });
   store.replaceState({

--- a/src/lib/tour.ts
+++ b/src/lib/tour.ts
@@ -131,20 +131,6 @@ export function ensureTourDemoModel(): { applied: boolean } {
     return { applied: false };
   }
 }
-  const store = usePipelineStore.getState();
-  if (hasSelectedModel(store.state)) return { applied: false };
-  const defaults = createDefaultPipelineState();
-  const derived = deriveUiStateFromOliveRecipe(tourDemoRecipe, { replacePasses: true });
-  store.replaceState({
-    ...defaults,
-    ...derived,
-    passes: {
-      ...defaults.passes,
-      ...(derived.passes ?? {}),
-    },
-  });
-  return { applied: true };
-}
 
 export function startGuidedTour(onSettled: () => void) {
   if (isPipelineOliveRunning() || tourActive) return null;

--- a/src/lib/vramEstimate.ts
+++ b/src/lib/vramEstimate.ts
@@ -296,11 +296,18 @@ export function getSelectedGpuVramGb(
         provider === "NvTensorRTRTXExecutionProvider" ||
         provider === "TensorrtExecutionProvider"
         ? (probe.nvidia?.gpus ?? [])
+        : provider === "DmlExecutionProvider" || provider === "WebGpuExecutionProvider"
+        ? [...(probe.nvidia?.gpus ?? []), ...(probe.rocm?.gpus ?? [])]
         : [];
 
   const vramMb = gpus.map((gpu) => gpu.vramMb).filter((value): value is number => value != null && value > 0);
 
-  if (!vramMb.length) return null;
+  if (!vramMb.length) {
+    if (provider === "DmlExecutionProvider" || provider === "WebGpuExecutionProvider") {
+      return getPrimaryGpuVramGb(probe);
+    }
+    return null;
+  }
   return Math.max(...vramMb) / 1024;
 }
 

--- a/src/server/routes/ai/lmStudioRoutes.ts
+++ b/src/server/routes/ai/lmStudioRoutes.ts
@@ -13,6 +13,7 @@ import {
   splitCliLines,
 } from "../../../lib/lmsPullProgress.ts";
 import { gateLocalPullDiskSpace } from "../../../lib/localEngineDisk.ts";
+import { extractErrorMessage } from "../../../lib/httpError.ts";
 import { heavyCommandRateLimit } from "../../middleware/rateLimit.ts";
 import { localEngineRuntime } from "../../services/ai/localEngineState.ts";
 import {
@@ -94,8 +95,8 @@ export function mountLmStudioRoutes(router: Router): void {
         body: JSON.stringify({ model: modelTag }),
       });
       if (!r.ok) {
-        const d = (await r.json().catch(() => ({}))) as { error?: string };
-        return res.status(500).json({ error: d.error || `HTTP ${r.status}` });
+        const d = await r.json().catch(() => ({}));
+        return res.status(500).json({ error: extractErrorMessage(d, `HTTP ${r.status}`) });
       }
       return res.json({ ok: true });
     } catch (err: unknown) {
@@ -116,8 +117,8 @@ export function mountLmStudioRoutes(router: Router): void {
         body: JSON.stringify({ model: modelTag }),
       });
       if (!r.ok) {
-        const d = (await r.json().catch(() => ({}))) as { error?: string };
-        return res.status(500).json({ error: d.error || `HTTP ${r.status}` });
+        const d = await r.json().catch(() => ({}));
+        return res.status(500).json({ error: extractErrorMessage(d, `HTTP ${r.status}`) });
       }
       return res.json({ ok: true });
     } catch (err: unknown) {

--- a/src/server/routes/ai/lmStudioRoutes.ts
+++ b/src/server/routes/ai/lmStudioRoutes.ts
@@ -95,7 +95,13 @@ export function mountLmStudioRoutes(router: Router): void {
         body: JSON.stringify({ model: modelTag }),
       });
       if (!r.ok) {
-        const d = await r.json().catch(() => ({}));
+        const text = await r.text();
+        let d: unknown;
+        try {
+          d = JSON.parse(text);
+        } catch {
+          d = text;
+        }
         return res.status(500).json({ error: extractErrorMessage(d, `HTTP ${r.status}`) });
       }
       return res.json({ ok: true });
@@ -117,7 +123,13 @@ export function mountLmStudioRoutes(router: Router): void {
         body: JSON.stringify({ model: modelTag }),
       });
       if (!r.ok) {
-        const d = await r.json().catch(() => ({}));
+        const text = await r.text();
+        let d: unknown;
+        try {
+          d = JSON.parse(text);
+        } catch {
+          d = text;
+        }
         return res.status(500).json({ error: extractErrorMessage(d, `HTTP ${r.status}`) });
       }
       return res.json({ ok: true });

--- a/src/server/routes/mcp.test.ts
+++ b/src/server/routes/mcp.test.ts
@@ -498,13 +498,19 @@ describe("GET /api/mcp/health", () => {
   });
 
   it("reports local health with venvExists when in local mode", async () => {
-    const res = await fetch(`${baseUrl}/api/mcp/health`);
-    expect(res.status).toBe(200);
-    const body = (await res.json()) as { ok?: boolean; available?: boolean; isRemote?: boolean; venvExists?: boolean };
-    expect(body.ok).toBe(true);
-    expect(body.available).toBe(true);
-    expect(body.isRemote).toBe(false);
-    expect(typeof body.venvExists).toBe("boolean");
+    const originalUrl = process.env.OLIVE_MCP_URL;
+    delete process.env.OLIVE_MCP_URL;
+    try {
+      const res = await fetch(`${baseUrl}/api/mcp/health`);
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { ok?: boolean; available?: boolean; isRemote?: boolean; venvExists?: boolean };
+      expect(body.ok).toBe(true);
+      expect(body.available).toBe(true);
+      expect(body.isRemote).toBe(false);
+      expect(typeof body.venvExists).toBe("boolean");
+    } finally {
+      if (originalUrl !== undefined) process.env.OLIVE_MCP_URL = originalUrl;
+    }
   });
 
   it("omits local venvExists check when OLIVE_MCP_URL is configured (remote mode)", async () => {

--- a/src/server/routes/mcp.test.ts
+++ b/src/server/routes/mcp.test.ts
@@ -487,3 +487,43 @@ describe("POST /api/mcp/settings", () => {
     }
   });
 });
+
+describe("GET /api/mcp/health", () => {
+  beforeEach(() => {
+    mcpToolMocks.callOliveMcpToolImpl = async () => ({ ok: true, capabilities: {} });
+  });
+
+  afterEach(() => {
+    mcpToolMocks.callOliveMcpToolImpl = null;
+  });
+
+  it("reports local health with venvExists when in local mode", async () => {
+    const res = await fetch(`${baseUrl}/api/mcp/health`);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { ok?: boolean; available?: boolean; isRemote?: boolean; venvExists?: boolean };
+    expect(body.ok).toBe(true);
+    expect(body.available).toBe(true);
+    expect(body.isRemote).toBe(false);
+    expect(typeof body.venvExists).toBe("boolean");
+  });
+
+  it("omits local venvExists check when OLIVE_MCP_URL is configured (remote mode)", async () => {
+    const originalUrl = process.env.OLIVE_MCP_URL;
+    process.env.OLIVE_MCP_URL = "http://localhost:8080/sse";
+    try {
+      const res = await fetch(`${baseUrl}/api/mcp/health`);
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { ok?: boolean; available?: boolean; isRemote?: boolean; venvExists?: boolean };
+      expect(body.ok).toBe(true);
+      expect(body.available).toBe(true);
+      expect(body.isRemote).toBe(true);
+      expect(body.venvExists).toBeUndefined();
+    } finally {
+      if (originalUrl !== undefined) {
+        process.env.OLIVE_MCP_URL = originalUrl;
+      } else {
+        delete process.env.OLIVE_MCP_URL;
+      }
+    }
+  });
+});

--- a/src/server/routes/mcp.ts
+++ b/src/server/routes/mcp.ts
@@ -13,7 +13,7 @@ import {
   isKbSyncInProgress,
   setKbSyncInProgress,
 } from "../services/mcp/state.ts";
-import { callOliveMcpTool, getMcpPython, MCP_UNAVAILABLE_ERROR, reconnectMcpClient } from "../services/mcp/client.ts";
+import { callOliveMcpTool, MCP_UNAVAILABLE_ERROR, reconnectMcpClient } from "../services/mcp/client.ts";
 import { isAllowedMcpToolName } from "../services/mcp/allowedTools.ts";
 import { evaluateStudioRecipeBridge } from "../services/mcp/studioRecipeBridge.ts";
 import {

--- a/src/server/routes/mcp.ts
+++ b/src/server/routes/mcp.ts
@@ -448,9 +448,11 @@ export function mountMcpRoutes(router: Router): void {
   // ─── MCP Health ────────────────────────────────────────────────────────
   router.get("/mcp/health", studioLocalOnly, kbStatusRateLimit, async (_req, res) => {
     const isRemote = Boolean(process.env.OLIVE_MCP_URL);
-    const python = isRemote ? null : getMcpPython();
-    const venvExists = isRemote ? undefined : fs.existsSync(python!);
-
+    const mcpVenvPython =
+      process.platform === "win32"
+        ? path.join(process.cwd(), "olive-mcp-server", ".venv", "Scripts", "python.exe")
+        : path.join(process.cwd(), "olive-mcp-server", ".venv", "bin", "python");
+    const venvExists = isRemote ? undefined : fs.existsSync(mcpVenvPython);
     try {
       const out = await callOliveMcpTool("get_mcp_capabilities", {});
       if (out.unavailable || out.error) {

--- a/src/server/routes/mcp.ts
+++ b/src/server/routes/mcp.ts
@@ -14,6 +14,7 @@ import {
   setKbSyncInProgress,
 } from "../services/mcp/state.ts";
 import { callOliveMcpTool, MCP_UNAVAILABLE_ERROR, reconnectMcpClient } from "../services/mcp/client.ts";
+import { getMcpPython } from "../services/mcp/paths.ts";
 import { isAllowedMcpToolName } from "../services/mcp/allowedTools.ts";
 import { evaluateStudioRecipeBridge } from "../services/mcp/studioRecipeBridge.ts";
 import {
@@ -448,11 +449,11 @@ export function mountMcpRoutes(router: Router): void {
   // ─── MCP Health ────────────────────────────────────────────────────────
   router.get("/mcp/health", studioLocalOnly, kbStatusRateLimit, async (_req, res) => {
     const isRemote = Boolean(process.env.OLIVE_MCP_URL);
-    const mcpVenvPython =
-      process.platform === "win32"
-        ? path.join(process.cwd(), "olive-mcp-server", ".venv", "Scripts", "python.exe")
-        : path.join(process.cwd(), "olive-mcp-server", ".venv", "bin", "python");
-    const venvExists = isRemote ? undefined : fs.existsSync(mcpVenvPython);
+    // getMcpPython() mirrors what the MCP client actually launches: it prefers
+    // olive-mcp-server/.venv and falls back to the repo-root .venv. Reporting
+    // existence of that exact interpreter keeps venvExists consistent with
+    // whether MCP can start locally.
+    const venvExists = isRemote ? undefined : fs.existsSync(getMcpPython());
     try {
       const out = await callOliveMcpTool("get_mcp_capabilities", {});
       if (out.unavailable || out.error) {

--- a/src/server/routes/mcp.ts
+++ b/src/server/routes/mcp.ts
@@ -13,7 +13,7 @@ import {
   isKbSyncInProgress,
   setKbSyncInProgress,
 } from "../services/mcp/state.ts";
-import { callOliveMcpTool, MCP_UNAVAILABLE_ERROR, reconnectMcpClient } from "../services/mcp/client.ts";
+import { callOliveMcpTool, getMcpPython, MCP_UNAVAILABLE_ERROR, reconnectMcpClient } from "../services/mcp/client.ts";
 import { isAllowedMcpToolName } from "../services/mcp/allowedTools.ts";
 import { evaluateStudioRecipeBridge } from "../services/mcp/studioRecipeBridge.ts";
 import {
@@ -250,8 +250,7 @@ function buildKbStatus(data: PassesJson, lastSync?: string | null): KbStatusCach
  *
  * @returns A successful status result, or an error response when the knowledge base cannot be read.
  */
-export function performKbSync():
-  { ok: true; status: KbStatusCache } | { ok: false; statusCode: number; body: Record<string, unknown> } {
+export function performKbSync(): { ok: true; status: KbStatusCache } | { ok: false; statusCode: number; body: Record<string, unknown> } {
   const kb = readPassesJson();
   if (!kb.ok) {
     return { ok: false, statusCode: 500, body: { ok: false, ...kbFailureResponse(kb) } };
@@ -420,22 +419,16 @@ export function mountMcpRoutes(router: Router): void {
         writeStudioConfig({ mcpSettings: next });
         try {
           await reconnectMcpClient();
-          return next;
-        } catch (err) {
-          // Revert config on disk if reconnect failed so failed settings are not persisted
+        } catch (reconnectErr) {
           writeStudioConfig({ mcpSettings: previousMcpSettings });
-          // Await restore so the next settings write cannot share this reconnect
-          // (and so we do not release the write queue while MCP is mid-rollback).
           try {
             await reconnectMcpClient();
-          } catch (rollbackErr) {
-            console.warn(
-              "[mcp] failed to restore previous MCP process after settings rollback:",
-              rollbackErr instanceof Error ? rollbackErr.message : rollbackErr,
-            );
+          } catch {
+            // best-effort rollback reconnect
           }
-          throw err;
+          throw reconnectErr;
         }
+        return next;
       });
       return res.json({ ok: true, mcpSettings });
     } catch {
@@ -450,5 +443,39 @@ export function mountMcpRoutes(router: Router): void {
       mcpSettings: mcpSettings ?? {},
       isRemote: Boolean(process.env.OLIVE_MCP_URL),
     });
+  });
+
+  // ─── MCP Health ────────────────────────────────────────────────────────
+  router.get("/mcp/health", studioLocalOnly, kbStatusRateLimit, async (_req, res) => {
+    const isRemote = Boolean(process.env.OLIVE_MCP_URL);
+    const python = isRemote ? null : getMcpPython();
+    const venvExists = isRemote ? undefined : fs.existsSync(python!);
+
+    try {
+      const out = await callOliveMcpTool("get_mcp_capabilities", {});
+      if (out.unavailable || out.error) {
+        return res.json({
+          ok: false,
+          available: false,
+          isRemote,
+          ...(venvExists !== undefined && { venvExists }),
+          error: "MCP server unavailable",
+        });
+      }
+      return res.json({
+        ok: true,
+        available: true,
+        isRemote,
+        ...(venvExists !== undefined && { venvExists }),
+      });
+    } catch {
+      return res.json({
+        ok: false,
+        available: false,
+        isRemote,
+        ...(venvExists !== undefined && { venvExists }),
+        error: "MCP health check failed",
+      });
+    }
   });
 }

--- a/src/server/services/ai/bedrock.test.ts
+++ b/src/server/services/ai/bedrock.test.ts
@@ -106,3 +106,65 @@ describe("bedrock buildConfig", () => {
     expect(cfg.apiKey).toBe("");
   });
 });
+
+describe("bedrock createBedrockClient validation", () => {
+  const saved = {
+    secret: process.env.AWS_SECRET_ACCESS_KEY,
+    token: process.env.AWS_SESSION_TOKEN,
+    region: process.env.AWS_REGION,
+  };
+
+  beforeEach(() => {
+    delete process.env.AWS_SECRET_ACCESS_KEY;
+    delete process.env.AWS_SESSION_TOKEN;
+    delete process.env.AWS_REGION;
+  });
+
+  afterEach(() => {
+    if (saved.secret === undefined) delete process.env.AWS_SECRET_ACCESS_KEY;
+    else process.env.AWS_SECRET_ACCESS_KEY = saved.secret;
+    if (saved.token === undefined) delete process.env.AWS_SESSION_TOKEN;
+    else process.env.AWS_SESSION_TOKEN = saved.token;
+    if (saved.region === undefined) delete process.env.AWS_REGION;
+    else process.env.AWS_REGION = saved.region;
+  });
+
+  it("throws a credentials-format error for a non-empty malformed apiKey", async () => {
+    const provider = getProvider("bedrock")!;
+    const cfg = {
+      provider: "bedrock" as const,
+      apiKey: "not-a-valid-key",
+      model: "anthropic.claude-3-5-haiku-20241022-v1:0",
+      baseUrl: "us-east-1",
+    };
+    await expect(provider.call(cfg, "system", [], false)).rejects.toThrow(
+      /Invalid AWS Bedrock credentials format/,
+    );
+  });
+
+  it("throws a credentials-format error for a non-empty malformed apiKey with surrounding whitespace", async () => {
+    const provider = getProvider("bedrock")!;
+    const cfg = {
+      provider: "bedrock" as const,
+      apiKey: "  garbage-key  ",
+      model: "anthropic.claude-3-5-haiku-20241022-v1:0",
+      baseUrl: "us-east-1",
+    };
+    await expect(provider.call(cfg, "system", [], false)).rejects.toThrow(
+      /Invalid AWS Bedrock credentials format/,
+    );
+  });
+
+  it("throws an incomplete-credentials error for a half-packed apiKey (access key without secret)", async () => {
+    const provider = getProvider("bedrock")!;
+    const cfg = {
+      provider: "bedrock" as const,
+      apiKey: "AKIAEXAMPLE:  ",
+      model: "anthropic.claude-3-5-haiku-20241022-v1:0",
+      baseUrl: "us-east-1",
+    };
+    await expect(provider.call(cfg, "system", [], false)).rejects.toThrow(
+      /incomplete/i,
+    );
+  });
+});

--- a/src/server/services/ai/bedrock.ts
+++ b/src/server/services/ai/bedrock.ts
@@ -120,12 +120,17 @@ function createBedrockClient(cfg: ProviderConfig): BedrockRuntimeClient {
 
   const region = resolveRegion(cfg);
 
-  if (cfg.apiKey?.trim()) {
-    if (!hasExplicitCredentials(cfg)) {
+  const normalizedApiKey = cfg.apiKey?.trim() ?? "";
+
+  if (normalizedApiKey) {
+    if (!hasExplicitCredentials({ ...cfg, apiKey: normalizedApiKey })) {
       throw new Error(
         "Invalid AWS Bedrock credentials format: enter as accessKeyId:secretAccessKey (accessKeyId must start with AKIA or ASIA). Or clear the API key to use your ~/.aws/credentials default profile.",
       );
     }
+
+    const { accessKeyId, secretAccessKey, sessionToken } =
+      parsePackedCredentials(normalizedApiKey);
     // Temporary / assumed-role credentials carry a third packed segment;
     // static keys omit it and no env token is mixed in.
     const { accessKeyId, secretAccessKey, sessionToken } = parsePackedCredentials(cfg.apiKey);

--- a/src/server/services/ai/bedrock.ts
+++ b/src/server/services/ai/bedrock.ts
@@ -120,7 +120,12 @@ function createBedrockClient(cfg: ProviderConfig): BedrockRuntimeClient {
 
   const region = resolveRegion(cfg);
 
-  if (hasExplicitCredentials(cfg)) {
+  if (cfg.apiKey?.trim()) {
+    if (!hasExplicitCredentials(cfg)) {
+      throw new Error(
+        "Invalid AWS Bedrock credentials format: enter as accessKeyId:secretAccessKey (accessKeyId must start with AKIA or ASIA). Or clear the API key to use your ~/.aws/credentials default profile.",
+      );
+    }
     // Temporary / assumed-role credentials carry a third packed segment;
     // static keys omit it and no env token is mixed in.
     const { accessKeyId, secretAccessKey, sessionToken } = parsePackedCredentials(cfg.apiKey);
@@ -236,7 +241,7 @@ registerProvider({
     const secretKey = process.env.AWS_SECRET_ACCESS_KEY!.trim();
     // Only temporary (ASIA) credentials carry a session token; never mix an
     // env token into a long-term (AKIA) key.
-    const sessionToken = /^ASIA/.test(accessKeyId) ? process.env.AWS_SESSION_TOKEN?.trim() : undefined;
+    const sessionToken = accessKeyId.startsWith("ASIA") ? process.env.AWS_SESSION_TOKEN?.trim() : undefined;
     const packedKey = sessionToken
       ? `${accessKeyId}:${secretKey}:${sessionToken}`
       : `${accessKeyId}:${secretKey}`;

--- a/src/server/services/ai/bedrock.ts
+++ b/src/server/services/ai/bedrock.ts
@@ -133,7 +133,6 @@ function createBedrockClient(cfg: ProviderConfig): BedrockRuntimeClient {
       parsePackedCredentials(normalizedApiKey);
     // Temporary / assumed-role credentials carry a third packed segment;
     // static keys omit it and no env token is mixed in.
-    const { accessKeyId, secretAccessKey, sessionToken } = parsePackedCredentials(cfg.apiKey);
     return new BedrockRuntimeClient({
       region,
       credentials: {

--- a/src/server/services/venv/familyEnsure.ts
+++ b/src/server/services/venv/familyEnsure.ts
@@ -162,7 +162,7 @@ async function buildFamilyTree(
       qnnNumpyPin = gate.numpyPin;
     }
 
-    clearBuildingRoot(family);
+    await clearBuildingRoot(family);
     await createVenvAt(getFamilyBuildingRoot(family), systemPython, onLine);
     const py = buildingPython(family);
     const spec = getFamilySpec(family);
@@ -237,7 +237,7 @@ async function buildFamilyIsolated(
 ): Promise<{ ok: boolean; error?: string }> {
   const built = await buildFamilyTree(family, systemPython, onLine);
   if (!built.ok) return built;
-  const promoted = promoteBuildingToLive(family);
+  const promoted = await promoteBuildingToLive(family);
   if (!promoted.ok) return { ok: false, error: promoted.error };
   onLine(`[setup] ${family} runtime ready at ${getFamilyRoot(family)}`);
   invalidateRuntimeStatusCache();
@@ -320,7 +320,7 @@ async function migrateGpuContaminatedVenv(
         const cudaBuild = await buildFamilyTree("cuda", systemPython, onLine);
         if (!cudaBuild.ok) {
           writeMigrationJournal("building", cudaBuild.error);
-          clearBuildingRoot("cuda");
+          await clearBuildingRoot("cuda");
           return cudaBuild;
         }
         writeMigrationJournal("cuda_built");
@@ -332,18 +332,18 @@ async function migrateGpuContaminatedVenv(
       const defBuild = await buildFamilyTree("default", systemPython, onLine);
       if (!defBuild.ok) {
         writeMigrationJournal("building", defBuild.error);
-        clearBuildingRoot("default");
-        if (cudaNeedsBuild) clearBuildingRoot("cuda");
+        await clearBuildingRoot("default");
+        if (cudaNeedsBuild) await clearBuildingRoot("cuda");
         return defBuild;
       }
       writeMigrationJournal("default_built");
 
       if (cudaNeedsBuild) {
-        const cudaPromote = promoteBuildingToLive("cuda");
+        const cudaPromote = await promoteBuildingToLive("cuda");
         if (!cudaPromote.ok) {
           writeMigrationJournal("cuda_promoted", cudaPromote.error);
-          clearBuildingRoot("default");
-          clearBuildingRoot("cuda");
+          await clearBuildingRoot("default");
+          await clearBuildingRoot("cuda");
           return { ok: false, error: cudaPromote.error };
         }
         cudaBackupPath = cudaPromote.backupPath;
@@ -351,7 +351,7 @@ async function migrateGpuContaminatedVenv(
         writeMigrationJournal("cuda_promoted");
       }
 
-      const defPromote = promoteBuildingToLive("default");
+      const defPromote = await promoteBuildingToLive("default");
       if (!defPromote.ok) {
         // Do not write "default_promoted" on failure — that phase means success.
         // If CUDA was already live and rollback fails, leave journal at
@@ -359,7 +359,7 @@ async function migrateGpuContaminatedVenv(
         // return to "building" so recovery knows neither promote finished.
         if (cudaPromoted) {
           onLine("[migrate] Default promote failed — rolling back CUDA promotion...");
-          const rolled = rollbackPromotedFamily("cuda", cudaBackupPath);
+          const rolled = await rollbackPromotedFamily("cuda", cudaBackupPath);
           if (!rolled.ok) {
             const err = `${defPromote.error}; CUDA rollback also failed: ${rolled.error}`;
             writeMigrationJournal("cuda_promoted", err);
@@ -367,7 +367,7 @@ async function migrateGpuContaminatedVenv(
           }
         }
         writeMigrationJournal("building", defPromote.error);
-        clearBuildingRoot("default");
+        await clearBuildingRoot("default");
         return { ok: false, error: defPromote.error };
       }
       writeMigrationJournal("default_promoted");
@@ -403,7 +403,7 @@ async function migrateGpuContaminatedVenv(
       const msg = err instanceof Error ? err.message : String(err);
       if (cudaPromoted) {
         onLine("[migrate] Migration failed — rolling back CUDA promotion...");
-        const rolled = rollbackPromotedFamily("cuda", cudaBackupPath);
+        const rolled = await rollbackPromotedFamily("cuda", cudaBackupPath);
         if (!rolled.ok) {
           writeMigrationJournal("cuda_promoted", `${msg}; CUDA rollback also failed: ${rolled.error}`);
           return {
@@ -412,8 +412,8 @@ async function migrateGpuContaminatedVenv(
           };
         }
       }
-      clearBuildingRoot("default");
-      clearBuildingRoot("cuda");
+      await clearBuildingRoot("default");
+      await clearBuildingRoot("cuda");
       writeMigrationJournal("building", msg);
       return { ok: false, error: msg };
     }

--- a/src/server/services/venv/familyEnsure.ts
+++ b/src/server/services/venv/familyEnsure.ts
@@ -341,7 +341,7 @@ async function migrateGpuContaminatedVenv(
       if (cudaNeedsBuild) {
         const cudaPromote = await promoteBuildingToLive("cuda");
         if (!cudaPromote.ok) {
-          writeMigrationJournal("cuda_promoted", cudaPromote.error);
+          writeMigrationJournal("building", cudaPromote.error);
           await clearBuildingRoot("default");
           await clearBuildingRoot("cuda");
           return { ok: false, error: cudaPromote.error };

--- a/src/server/services/venv/familyEnsureMigration.test.ts
+++ b/src/server/services/venv/familyEnsureMigration.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Regression test: when CUDA promotion fails during the GPU-contaminated venv
+ * migration, the migration journal must record the "building" phase (not
+ * "cuda_promoted") so recovery does not treat a failed promotion as live.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { EventEmitter } from "events";
+
+// Hoist mock functions so they are available inside vi.mock factories.
+const { promoteBuildingToLiveMock, familyPythonExistsMock, clearBuildingRootMock } =
+  vi.hoisted(() => ({
+    promoteBuildingToLiveMock: vi.fn(),
+    familyPythonExistsMock: vi.fn(),
+    clearBuildingRootMock: vi.fn(),
+  }));
+
+// Mock child_process.spawn to simulate successful Python/venv/pip commands.
+// Keep execFile and other exports intact for modules that depend on them.
+vi.mock("child_process", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("child_process")>();
+  return {
+    ...actual,
+    spawn: vi.fn(() => {
+      const proc = new EventEmitter() as EventEmitter & {
+        stdout: EventEmitter;
+        stderr: EventEmitter;
+      };
+      proc.stdout = new EventEmitter();
+      proc.stderr = new EventEmitter();
+      process.nextTick(() => proc.emit("close", 0));
+      return proc;
+    }),
+  };
+});
+
+// Mock ../shared/exec.ts so import checks succeed.
+vi.mock("../shared/exec.ts", () => ({
+  execFileAsync: vi.fn().mockResolvedValue({ stdout: "", stderr: "" }),
+}));
+
+// Mock ./promote.ts — promoteBuildingToLive fails for "cuda".
+vi.mock("./promote.ts", () => ({
+  promoteBuildingToLive: promoteBuildingToLiveMock,
+  familyPythonExists: familyPythonExistsMock,
+  clearBuildingRoot: clearBuildingRootMock,
+  writeVenvManifest: vi.fn(),
+  readVenvManifest: vi.fn().mockReturnValue(null),
+  rollbackPromotedFamily: vi.fn().mockResolvedValue({ ok: true }),
+}));
+
+// Mock ./systemPython.ts — return a fake Python path.
+vi.mock("./systemPython.ts", () => ({
+  findSystemPython: vi.fn().mockResolvedValue("/fake/python"),
+  getPythonVersion: vi.fn().mockResolvedValue("3.12.0"),
+}));
+
+// Mock ./migration.ts — keep real journal functions, override inspection + lock.
+vi.mock("./migration.ts", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./migration.ts")>();
+  return {
+    ...actual,
+    inspectDefaultVenvIntent: vi.fn().mockResolvedValue("cuda-contaminated"),
+    withMigrationLock: <T>(fn: () => Promise<T>): Promise<T> => fn(),
+  };
+});
+
+// Mock ./status.ts.
+vi.mock("./status.ts", () => ({
+  invalidateRuntimeStatusCache: vi.fn(),
+  listInstalledOrtDistributions: vi.fn().mockResolvedValue(["onnxruntime-gpu"]),
+}));
+
+import { ensureVenvFamily } from "./familyEnsure.ts";
+import { readMigrationJournal, clearMigrationJournal } from "./migration.ts";
+
+describe("migrateGpuContaminatedVenv — CUDA promotion failure", () => {
+  let tmp: string;
+  let prevCwd: string;
+
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), "olive-migrate-cuda-"));
+    prevCwd = process.cwd();
+    process.chdir(tmp);
+
+    // CUDA family does not exist → cudaNeedsBuild = true.
+    familyPythonExistsMock.mockReturnValue(false);
+    // CUDA promotion fails; default promotion would succeed but is never reached.
+    promoteBuildingToLiveMock.mockImplementation(async (family: string) => {
+      if (family === "cuda") {
+        return { ok: false, error: "Simulated CUDA promotion failure" };
+      }
+      return { ok: true, backupPath: undefined };
+    });
+    clearBuildingRootMock.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    process.chdir(prevCwd);
+    fs.rmSync(tmp, { recursive: true, force: true });
+    vi.clearAllMocks();
+  });
+
+  it("records the journal phase as 'building' (not 'cuda_promoted') when CUDA promotion fails", async () => {
+    const onLine = vi.fn();
+    const result = await ensureVenvFamily("default", onLine);
+
+    // Migration should fail.
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("Simulated CUDA promotion failure");
+
+    // Journal must be "building" — NOT "cuda_promoted".
+    const journal = readMigrationJournal();
+    expect(journal).not.toBeNull();
+    expect(journal!.phase).toBe("building");
+    expect(journal!.error).toContain("Simulated CUDA promotion failure");
+
+    clearMigrationJournal();
+  });
+});

--- a/src/server/services/venv/promote.test.ts
+++ b/src/server/services/venv/promote.test.ts
@@ -25,7 +25,7 @@ describe("promoteBuildingToLive", () => {
     fs.rmSync(tmp, { recursive: true, force: true });
   });
 
-  it("promotes building → live when live is missing", () => {
+  it("promotes building → live when live is missing", async () => {
     const building = getFamilyBuildingRoot("default");
     fs.mkdirSync(building, { recursive: true });
     fs.writeFileSync(path.join(building, "marker"), "new");
@@ -36,14 +36,14 @@ describe("promoteBuildingToLive", () => {
       createdAt: new Date().toISOString(),
     });
 
-    const result = promoteBuildingToLive("default");
+    const result = await promoteBuildingToLive("default");
     expect(result.ok).toBe(true);
     if (result.ok) expect(result.backupPath).toBeUndefined();
     expect(fs.existsSync(path.join(getFamilyRoot("default"), "marker"))).toBe(true);
     expect(fs.existsSync(building)).toBe(false);
   });
 
-  it("backs up live then promotes when live already exists", () => {
+  it("backs up live then promotes when live already exists", async () => {
     const live = getFamilyRoot("default");
     const building = getFamilyBuildingRoot("default");
     fs.mkdirSync(live, { recursive: true });
@@ -51,7 +51,7 @@ describe("promoteBuildingToLive", () => {
     fs.mkdirSync(building, { recursive: true });
     fs.writeFileSync(path.join(building, "new"), "2");
 
-    const result = promoteBuildingToLive("default");
+    const result = await promoteBuildingToLive("default");
     expect(result.ok).toBe(true);
     expect(fs.existsSync(path.join(live, "new"))).toBe(true);
     // Backup retained under .venv.backup-*
@@ -61,7 +61,7 @@ describe("promoteBuildingToLive", () => {
     if (result.ok) expect(result.backupPath).toBe(path.join(tmp, backups[0]!));
   });
 
-  it("rollbackPromotedFamily restores backup when present", () => {
+  it("rollbackPromotedFamily restores backup when present", async () => {
     const live = getFamilyRoot("cuda");
     const building = getFamilyBuildingRoot("cuda");
     fs.mkdirSync(live, { recursive: true });
@@ -69,34 +69,34 @@ describe("promoteBuildingToLive", () => {
     fs.mkdirSync(building, { recursive: true });
     fs.writeFileSync(path.join(building, "new-cuda"), "2");
 
-    const promoted = promoteBuildingToLive("cuda");
+    const promoted = await promoteBuildingToLive("cuda");
     expect(promoted.ok).toBe(true);
     expect(fs.existsSync(path.join(live, "new-cuda"))).toBe(true);
 
-    const rolled = rollbackPromotedFamily("cuda", promoted.ok ? promoted.backupPath : undefined);
+    const rolled = await rollbackPromotedFamily("cuda", promoted.ok ? promoted.backupPath : undefined);
     expect(rolled.ok).toBe(true);
     expect(fs.existsSync(path.join(live, "old-cuda"))).toBe(true);
     expect(fs.existsSync(path.join(live, "new-cuda"))).toBe(false);
   });
 
-  it("rollbackPromotedFamily removes newly created live when no backup", () => {
+  it("rollbackPromotedFamily removes newly created live when no backup", async () => {
     const live = getFamilyRoot("cuda");
     const building = getFamilyBuildingRoot("cuda");
     fs.mkdirSync(building, { recursive: true });
     fs.writeFileSync(path.join(building, "fresh"), "1");
-    const promoted = promoteBuildingToLive("cuda");
+    const promoted = await promoteBuildingToLive("cuda");
     expect(promoted.ok).toBe(true);
     expect(fs.existsSync(live)).toBe(true);
 
-    const rolled = rollbackPromotedFamily("cuda", undefined);
+    const rolled = await rollbackPromotedFamily("cuda", undefined);
     expect(rolled.ok).toBe(true);
     expect(fs.existsSync(live)).toBe(false);
   });
 
-  it("clearBuildingRoot removes building tree", () => {
+  it("clearBuildingRoot removes building tree", async () => {
     const building = getFamilyBuildingRoot("cuda");
     fs.mkdirSync(building, { recursive: true });
-    clearBuildingRoot("cuda");
+    await clearBuildingRoot("cuda");
     expect(fs.existsSync(building)).toBe(false);
   });
 });

--- a/src/server/services/venv/promote.ts
+++ b/src/server/services/venv/promote.ts
@@ -44,28 +44,15 @@ async function renameDir(from: string, to: string, maxAttempts = 10): Promise<vo
 
 async function rmDirSafe(dir: string, maxAttempts = 5): Promise<void> {
   if (!fs.existsSync(dir)) return;
-  let lastError: unknown;
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {
     try {
       await fs.promises.rm(dir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
       return;
     } catch (err) {
-      lastError = err;
       if (attempt === maxAttempts || !fs.existsSync(dir)) {
         console.warn(`[venv] rmDirSafe: failed to remove ${dir} after ${attempt} attempts`, err);
         throw err;
       }
-      await sleep(50 * attempt);
-    }
-  }
-}
-  if (!fs.existsSync(dir)) return;
-  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-    try {
-      await fs.promises.rm(dir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
-      return;
-    } catch {
-      if (attempt === maxAttempts || !fs.existsSync(dir)) return;
       await sleep(50 * attempt);
     }
   }

--- a/src/server/services/venv/promote.ts
+++ b/src/server/services/venv/promote.ts
@@ -4,6 +4,7 @@
  */
 import fs from "fs";
 import path from "path";
+import { setTimeout as sleep } from "timers/promises";
 import type { VenvFamily } from "../../../lib/venvFamily.ts";
 import {
   getFamilyBackupRoot,
@@ -19,13 +20,39 @@ export type PromoteResult =
   | { ok: true; backupPath?: string }
   | { ok: false; error: string; backupPath?: string };
 
-function renameDir(from: string, to: string): void {
-  fs.renameSync(from, to);
+async function renameDir(from: string, to: string, maxAttempts = 10): Promise<void> {
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      await fs.promises.rename(from, to);
+      return;
+    } catch (err: unknown) {
+      lastError = err;
+      const isTransient =
+        err != null &&
+        typeof err === "object" &&
+        "code" in err &&
+        (err.code === "EPERM" || err.code === "EBUSY" || err.code === "EACCES");
+      if (!isTransient || attempt === maxAttempts) {
+        throw err;
+      }
+      await sleep(50 * attempt);
+    }
+  }
+  throw lastError;
 }
 
-function rmDirSafe(dir: string): void {
+async function rmDirSafe(dir: string, maxAttempts = 5): Promise<void> {
   if (!fs.existsSync(dir)) return;
-  fs.rmSync(dir, { recursive: true, force: true });
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      await fs.promises.rm(dir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+      return;
+    } catch {
+      if (attempt === maxAttempts || !fs.existsSync(dir)) return;
+      await sleep(50 * attempt);
+    }
+  }
 }
 
 export function writeVenvManifest(root: string, manifest: VenvManifest): void {
@@ -48,7 +75,7 @@ export function readVenvManifest(root: string): VenvManifest | null {
  * live → backup, building → live; rollback on failure.
  * Returns `backupPath` when a previous live tree was moved aside.
  */
-export function promoteBuildingToLive(family: VenvFamily): PromoteResult {
+export async function promoteBuildingToLive(family: VenvFamily): Promise<PromoteResult> {
   const live = getFamilyRoot(family);
   const building = getFamilyBuildingRoot(family);
   if (!fs.existsSync(building)) {
@@ -60,18 +87,18 @@ export function promoteBuildingToLive(family: VenvFamily): PromoteResult {
 
   try {
     if (fs.existsSync(live)) {
-      if (fs.existsSync(backup)) rmDirSafe(backup);
-      renameDir(live, backup);
+      if (fs.existsSync(backup)) await rmDirSafe(backup);
+      await renameDir(live, backup);
       liveMoved = true;
     }
-    renameDir(building, live);
+    await renameDir(building, live);
     return { ok: true, backupPath: liveMoved ? backup : undefined };
   } catch (err: unknown) {
     const msg = err instanceof Error ? err.message : String(err);
     // Rollback best-effort
     try {
       if (liveMoved && fs.existsSync(backup) && !fs.existsSync(live)) {
-        renameDir(backup, live);
+        await renameDir(backup, live);
       }
     } catch {
       /* leave artifacts for recovery */
@@ -88,19 +115,19 @@ export function promoteBuildingToLive(family: VenvFamily): PromoteResult {
  * Undo a successful promotion: restore `backupPath` to live, or remove a
  * newly created live tree when there was no prior backup.
  */
-export function rollbackPromotedFamily(
+export async function rollbackPromotedFamily(
   family: VenvFamily,
   backupPath?: string,
-): PromoteResult {
+): Promise<PromoteResult> {
   const live = getFamilyRoot(family);
   try {
     if (backupPath && fs.existsSync(backupPath)) {
-      if (fs.existsSync(live)) rmDirSafe(live);
-      renameDir(backupPath, live);
+      if (fs.existsSync(live)) await rmDirSafe(live);
+      await renameDir(backupPath, live);
       return { ok: true, backupPath };
     }
     if (fs.existsSync(live)) {
-      rmDirSafe(live);
+      await rmDirSafe(live);
     }
     return { ok: true };
   } catch (err: unknown) {
@@ -110,19 +137,19 @@ export function rollbackPromotedFamily(
 }
 
 /** Remove a successful backup after validation (optional cleanup). */
-export function discardBackup(family: VenvFamily, backupPath?: string): void {
+export async function discardBackup(family: VenvFamily, backupPath?: string): Promise<void> {
   const target = backupPath ?? getFamilyBackupRoot(family);
   // Only remove paths that look like our backup naming.
   if (!target.includes(".backup-") && !target.includes(".legacy-")) return;
-  rmDirSafe(target);
+  await rmDirSafe(target);
 }
 
 export function ensureParentDir(dir: string): void {
   fs.mkdirSync(path.dirname(dir), { recursive: true });
 }
 
-export function clearBuildingRoot(family: VenvFamily): void {
-  rmDirSafe(getFamilyBuildingRoot(family));
+export async function clearBuildingRoot(family: VenvFamily): Promise<void> {
+  await rmDirSafe(getFamilyBuildingRoot(family));
 }
 
 export function familyPythonExists(family: VenvFamily): boolean {

--- a/src/server/services/venv/promote.ts
+++ b/src/server/services/venv/promote.ts
@@ -30,8 +30,8 @@ async function renameDir(from: string, to: string, maxAttempts = 10): Promise<vo
       lastError = err;
       const code = (err as NodeJS.ErrnoException | null | undefined)?.code;
       const isTransient = code === "EPERM" || code === "EBUSY" || code === "EACCES";
-      if (!isTransient) {
       if (!isTransient || attempt === maxAttempts) {
+        throw err;
       }
       await sleep(50 * attempt);
     }

--- a/src/server/services/venv/promote.ts
+++ b/src/server/services/venv/promote.ts
@@ -31,7 +31,7 @@ async function renameDir(from: string, to: string, maxAttempts = 10): Promise<vo
       const code = (err as NodeJS.ErrnoException | null | undefined)?.code;
       const isTransient = code === "EPERM" || code === "EBUSY" || code === "EACCES";
       if (!isTransient) {
-        throw err;
+      if (!isTransient || attempt === maxAttempts) {
       }
       await sleep(50 * attempt);
     }

--- a/src/server/services/venv/promote.ts
+++ b/src/server/services/venv/promote.ts
@@ -28,12 +28,8 @@ async function renameDir(from: string, to: string, maxAttempts = 10): Promise<vo
       return;
     } catch (err: unknown) {
       lastError = err;
-      const isTransient =
-        err != null &&
-        typeof err === "object" &&
-        "code" in err &&
-        (err.code === "EPERM" || err.code === "EBUSY" || err.code === "EACCES");
-      if (!isTransient || attempt === maxAttempts) {
+      const code = (err as NodeJS.ErrnoException | null | undefined)?.code;
+      const isTransient = code === "EPERM" || code === "EBUSY" || code === "EACCES";
         throw err;
       }
       await sleep(50 * attempt);

--- a/src/server/services/venv/promote.ts
+++ b/src/server/services/venv/promote.ts
@@ -44,6 +44,22 @@ async function renameDir(from: string, to: string, maxAttempts = 10): Promise<vo
 
 async function rmDirSafe(dir: string, maxAttempts = 5): Promise<void> {
   if (!fs.existsSync(dir)) return;
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      await fs.promises.rm(dir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+      return;
+    } catch (err) {
+      lastError = err;
+      if (attempt === maxAttempts || !fs.existsSync(dir)) {
+        console.warn(`[venv] rmDirSafe: failed to remove ${dir} after ${attempt} attempts`, err);
+        throw err;
+      }
+      await sleep(50 * attempt);
+    }
+  }
+}
+  if (!fs.existsSync(dir)) return;
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {
     try {
       await fs.promises.rm(dir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });

--- a/src/server/services/venv/promote.ts
+++ b/src/server/services/venv/promote.ts
@@ -30,6 +30,7 @@ async function renameDir(from: string, to: string, maxAttempts = 10): Promise<vo
       lastError = err;
       const code = (err as NodeJS.ErrnoException | null | undefined)?.code;
       const isTransient = code === "EPERM" || code === "EBUSY" || code === "EACCES";
+      if (!isTransient) {
         throw err;
       }
       await sleep(50 * attempt);


### PR DESCRIPTION
…ation

- Add scripts/dev.mjs to enforce 4GB V8 heap size for dev environment
- Update package.json dev script to use new launcher for cross-platform compatibility
- Add ServerConnectionBanner component to display server status in Dashboard
- Implement error handling in ReportIssueModal with openError state management
- Update ReportIssueModal to handle async operations and display browser open errors
- Enhance aiProviderCatalog with additional model configurations
- Add httpError.ts utility for standardized HTTP error handling
- Improve error handling in AI response processing and chat actions
- Update MCP routes with better error handling and logging
- Refactor assistant components for improved state management
- Add test coverage for new error handling paths
- Improve venv promotion logic with better error recovery

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tonythethompson/Olive-Studio/pull/382?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add cross-platform dev server launcher with 4GB heap limit and backend connection banner
> - Adds [scripts/dev.mjs](https://github.com/tonythethompson/Olive-Studio/pull/382/files#diff-0559901a4c3b5be9b8257debd3cd795b0424df2de22427404d0c1c82beb8311b), a Node wrapper that enforces `--max-old-space-size=4096` and forwards signals to the child process; `pnpm run dev` now invokes this instead of `tsx server.ts` directly.
> - Adds `ServerConnectionBanner` component that polls `/api/health` every few seconds and shows a persistent reconnect banner after two consecutive failures.
> - Adds gating logic for security-sensitive patch fields (`trustRemoteCode`): applying a chat patch via `ActionButton` or `AssistantSidebar` now requires user confirmation via `window.confirm`, and strips those fields if declined.
> - Converts venv promotion/rollback filesystem operations (`renameDir`, `rmDirSafe`, `promoteBuildingToLive`, etc.) to async with retry logic on `EPERM`/`EBUSY`/`EACCES` errors.
> - Adds a `GET /api/mcp/health` endpoint reporting MCP availability and, in local mode, whether the MCP venv exists.
> - Risk: `openExternal` now throws on invalid URLs, unsupported protocols, or blocked popups instead of silently returning — callers that did not handle errors will now surface them.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 488f060.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->