### PR TITLE
🤖 GLM 5.2 Fix for Issue #384

### DIFF
--- a/src/components/features/pipeline/PipelineStatusSummary.tsx
+++ b/src/components/features/pipeline/PipelineStatusSummary.tsx
@@ -3,7 +3,7 @@ import { cn } from "@/lib/utils";
 import { PROVIDER_CATALOG } from "@/lib/providerCatalog";
 import type { UIState } from "@/types";
 import type { PipelineValidationResult } from "@/lib/pipelineValidation";
-import { getEffectiveModelSource } from "@/lib/vramEstimate";
+import { getEffectiveModelSource } from "@/lib/modelSource";
 
 type StatusTone = "error" | "warning" | "success";
 
@@ -50,12 +50,9 @@ function truncateLabel(label: string, maxLength = 48): string {
   return `${label.slice(0, maxLength - 3)}...`;
 }
 
-function getModelLabel(state: UIState, modelSelected: boolean): string {
-  if (!modelSelected) return "No model selected";
-  // Resolve the model from whichever source actually has one configured,
-  // preferring the active tab but falling back to a model loaded from a
-  // different source (e.g. a recipe) while the user browses a new tab.
+function getModelLabel(state: UIState): string {
   const source = getEffectiveModelSource(state);
+  if (source === null) return "No model selected";
   if (source === "huggingface") return truncateLabel(state.hfModelId);
   if (source === "azure") return truncateLabel(state.azureModelPath);
   if (source === "local") {
@@ -85,7 +82,7 @@ function getPrimaryAction(
   validation: PipelineValidationResult,
   onSelectModel: () => void,
   onResolveIssues: () => void,
-  onReviewRun: () => void
+  onReviewRun: () => void,
 ): PrimaryAction {
   if (!modelSelected) {
     return { label: "Select a model", handler: onSelectModel };
@@ -108,7 +105,9 @@ export function PipelineStatusSummary({
   onResolveIssues,
   onReviewRun,
 }: PipelineStatusSummaryProps) {
-  const modelLabel = getModelLabel(state, modelSelected);
+  const effectiveModelSource = getEffectiveModelSource(state);
+  const effectiveModelSelected = effectiveModelSource !== null;
+  const modelLabel = getModelLabel(state);
   const providerLabel = getProviderName(state.ihvProvider);
   const statusTone = getStatusTone(validation);
   const StatusIcon = STATUS_ICON[statusTone];
@@ -117,7 +116,7 @@ export function PipelineStatusSummary({
     validation,
     onSelectModel,
     onResolveIssues,
-    onReviewRun
+    onReviewRun,
   );
 
   return (
@@ -126,26 +125,31 @@ export function PipelineStatusSummary({
         <div
           className={cn(
             "flex h-9 w-9 shrink-0 items-center justify-center rounded-lg border",
-            STATUS_BADGE_CLASS[statusTone]
+            STATUS_BADGE_CLASS[statusTone],
           )}
         >
           <StatusIcon className={cn("h-4 w-4", STATUS_ICON_COLOR[statusTone])} />
         </div>
         <div className="min-w-0">
           <p className="text-xs text-slate-500 truncate max-w-[18rem] sm:max-w-[28rem] lg:max-w-[40rem]">
-            {modelSelected ? "Model" : "Task summary"}:{" "}
-            <span className={cn("font-medium", modelSelected ? "text-slate-200" : "text-rose-400")}>
+            {effectiveModelSelected ? "Model" : "Task summary"}:{" "}
+            <span className={cn("font-medium", effectiveModelSelected ? "text-slate-200" : "text-rose-400")}>
               {modelLabel}
             </span>
           </p>
-          {modelSelected && (
+          {effectiveModelSelected && (
             <p className="text-[11px] text-slate-500 truncate max-w-[18rem] sm:max-w-[28rem] lg:max-w-[40rem]">
               Target: <span className="font-medium text-slate-300">{providerLabel}</span>
               {validation.statusLabel && (
                 <>
                   {" · "}
                   {statusTone === "success" ? (
-                    <span className={cn("ml-1 inline-flex items-center gap-1 font-medium", STATUS_LABEL_CLASS.success)}>
+                    <span
+                      className={cn(
+                        "ml-1 inline-flex items-center gap-1 font-medium",
+                        STATUS_LABEL_CLASS.success,
+                      )}
+                    >
                       {validation.statusLabel}
                     </span>
                   ) : (
@@ -154,9 +158,11 @@ export function PipelineStatusSummary({
                       onClick={statusTone === "error" ? onResolveIssues : actionHandler}
                       className={cn(
                         "ml-1 inline-flex items-center gap-1 font-medium hover:underline",
-                        STATUS_LABEL_CLASS[statusTone]
+                        STATUS_LABEL_CLASS[statusTone],
                       )}
-                      aria-label={statusTone === "error" ? "Jump to blocking issues" : "Review validation warnings"}
+                      aria-label={
+                        statusTone === "error" ? "Jump to blocking issues" : "Review validation warnings"
+                      }
                     >
                       {validation.statusLabel}
                     </button>

--- a/src/components/features/pipeline/PipelineStatusSummary.tsx
+++ b/src/components/features/pipeline/PipelineStatusSummary.tsx
@@ -3,6 +3,7 @@ import { cn } from "@/lib/utils";
 import { PROVIDER_CATALOG } from "@/lib/providerCatalog";
 import type { UIState } from "@/types";
 import type { PipelineValidationResult } from "@/lib/pipelineValidation";
+import { getEffectiveModelSource } from "@/lib/vramEstimate";
 
 type StatusTone = "error" | "warning" | "success";
 
@@ -51,11 +52,17 @@ function truncateLabel(label: string, maxLength = 48): string {
 
 function getModelLabel(state: UIState, modelSelected: boolean): string {
   if (!modelSelected) return "No model selected";
-  if (state.modelSource === "huggingface") return truncateLabel(state.hfModelId);
-  if (state.modelSource === "azure") return truncateLabel(state.azureModelPath);
-  if (state.localFiles.length === 1) return truncateLabel(state.localFiles[0].name);
-  if (state.localFiles.length > 1) {
-    return truncateLabel(`${state.localFiles[0].name} +${state.localFiles.length - 1} more`);
+  // Resolve the model from whichever source actually has one configured,
+  // preferring the active tab but falling back to a model loaded from a
+  // different source (e.g. a recipe) while the user browses a new tab.
+  const source = getEffectiveModelSource(state);
+  if (source === "huggingface") return truncateLabel(state.hfModelId);
+  if (source === "azure") return truncateLabel(state.azureModelPath);
+  if (source === "local") {
+    if (state.localFiles.length === 1) return truncateLabel(state.localFiles[0].name);
+    if (state.localFiles.length > 1) {
+      return truncateLabel(`${state.localFiles[0].name} +${state.localFiles.length - 1} more`);
+    }
   }
   return "No model selected";
 }

--- a/src/lib/__tests__/modelSource.test.ts
+++ b/src/lib/__tests__/modelSource.test.ts
@@ -1,28 +1,7 @@
 import { describe, it, expect } from "vitest";
-import type { UIState, IHVProvider } from "@/types";
-import { DEFAULT_PASSES } from "@/lib/defaultPasses";
+import type { UIState } from "@/types";
 import { getEffectiveModelSource } from "@/lib/modelSource";
-
-function baseState(overrides?: Partial<UIState>): UIState {
-  return {
-    modelSource: "huggingface",
-    localFiles: [],
-    azureModelPath: "",
-    hfModelId: "",
-    hfDataset: "",
-    ihvProvider: "CPUExecutionProvider" as IHVProvider,
-    openvinoTargetDevice: "CPU",
-    memoryOffload: "gpu_only",
-    cudaVersion: "auto",
-    cacheDir: "",
-    azureStr: "",
-    distributedCaching: false,
-    activeJobId: null,
-    ...overrides,
-    passes: { ...DEFAULT_PASSES, ...overrides?.passes },
-  } as UIState;
-}
-
+import { baseState } from "@/lib/__tests__/testState";
 describe("getEffectiveModelSource", () => {
   it("prefers the active tab when it has a model", () => {
     const state = baseState({

--- a/src/lib/__tests__/modelSource.test.ts
+++ b/src/lib/__tests__/modelSource.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from "vitest";
+import type { UIState, IHVProvider } from "@/types";
+import { DEFAULT_PASSES } from "@/lib/defaultPasses";
+import { getEffectiveModelSource } from "@/lib/modelSource";
+
+function baseState(overrides?: Partial<UIState>): UIState {
+  return {
+    modelSource: "huggingface",
+    localFiles: [],
+    azureModelPath: "",
+    hfModelId: "",
+    hfDataset: "",
+    ihvProvider: "CPUExecutionProvider" as IHVProvider,
+    openvinoTargetDevice: "CPU",
+    memoryOffload: "gpu_only",
+    cudaVersion: "auto",
+    cacheDir: "",
+    azureStr: "",
+    distributedCaching: false,
+    activeJobId: null,
+    ...overrides,
+    passes: { ...DEFAULT_PASSES, ...overrides?.passes },
+  } as UIState;
+}
+
+describe("getEffectiveModelSource", () => {
+  it("prefers the active tab when it has a model", () => {
+    const state = baseState({
+      modelSource: "local",
+      localFiles: [{ name: "model.bin", size: 1024 }],
+      hfModelId: "microsoft/phi-3",
+    });
+    expect(getEffectiveModelSource(state)).toBe("local");
+  });
+
+  it("falls back to a Hugging Face model when the active Local tab is empty", () => {
+    const state = baseState({
+      modelSource: "local",
+      localFiles: [],
+      hfModelId: "microsoft/Phi-3.5-mini-instruct",
+    });
+    expect(getEffectiveModelSource(state)).toBe("huggingface");
+  });
+
+  it("falls back to an Azure path when the active Local tab is empty", () => {
+    const state = baseState({
+      modelSource: "local",
+      localFiles: [],
+      azureModelPath: "azureml://models/m/versions/1",
+    });
+    expect(getEffectiveModelSource(state)).toBe("azure");
+  });
+
+  it("falls back to Azure when the active Hugging Face tab has no model", () => {
+    const state = baseState({
+      modelSource: "huggingface",
+      hfModelId: "   ",
+      azureModelPath: "azureml://models/m/versions/1",
+    });
+    expect(getEffectiveModelSource(state)).toBe("azure");
+  });
+
+  it("falls back to Local when the active Hugging Face tab has no model", () => {
+    const state = baseState({
+      modelSource: "huggingface",
+      hfModelId: "",
+      localFiles: [{ name: "model.safetensors", size: 1024 }],
+    });
+    expect(getEffectiveModelSource(state)).toBe("local");
+  });
+
+  it("prefers Local over Azure in fallback order when the active tab is empty", () => {
+    const state = baseState({
+      modelSource: "huggingface",
+      hfModelId: "",
+      localFiles: [{ name: "model.safetensors", size: 1024 }],
+      azureModelPath: "azureml://models/m/versions/1",
+    });
+    expect(getEffectiveModelSource(state)).toBe("local");
+  });
+
+  it("returns null when no source has any model", () => {
+    const state = baseState({ modelSource: "local", localFiles: [] });
+    expect(getEffectiveModelSource(state)).toBeNull();
+  });
+
+  it("is defensive against partial states (missing fields)", () => {
+    const partial = { ihvProvider: "cuda", passes: [] } as unknown as UIState;
+    expect(getEffectiveModelSource(partial)).toBeNull();
+  });
+});

--- a/src/lib/__tests__/pipelineValidation.test.ts
+++ b/src/lib/__tests__/pipelineValidation.test.ts
@@ -989,23 +989,12 @@ describe("0.13.0 validation rules", () => {
       expect(hasSelectedModel(state)).toBe(true);
     });
 
-    it("returns false for empty local files when no other source has a model", () => {
+    it("returns false for empty local files", () => {
       const state = baseState({
         modelSource: "local",
         localFiles: [],
-        hfModelId: "",
-        azureModelPath: "",
       });
       expect(hasSelectedModel(state)).toBe(false);
-    });
-
-    it("returns true for empty local files when a Hugging Face model is still loaded", () => {
-      const state = baseState({
-        modelSource: "local",
-        localFiles: [],
-        hfModelId: "microsoft/Phi-3.5-mini-instruct",
-      });
-      expect(hasSelectedModel(state)).toBe(true);
     });
 
     it("returns true for non-empty azure path", () => {
@@ -1016,31 +1005,18 @@ describe("0.13.0 validation rules", () => {
       expect(hasSelectedModel(state)).toBe(true);
     });
 
-    it("returns false for empty azure path when no other source has a model", () => {
+    it("returns false for empty azure path", () => {
       const state = baseState({
         modelSource: "azure",
         azureModelPath: "",
-        hfModelId: "",
-        localFiles: [],
       });
       expect(hasSelectedModel(state)).toBe(false);
     });
 
-    it("returns true for empty azure path when a Hugging Face model is still loaded", () => {
-      const state = baseState({
-        modelSource: "azure",
-        azureModelPath: "",
-        hfModelId: "microsoft/Phi-3.5-mini-instruct",
-      });
-      expect(hasSelectedModel(state)).toBe(true);
-    });
-
-    it("returns false for whitespace-only azure path when no other source has a model", () => {
+    it("returns false for whitespace-only azure path", () => {
       const state = baseState({
         modelSource: "azure",
         azureModelPath: "  \t  ",
-        hfModelId: "",
-        localFiles: [],
       });
       expect(hasSelectedModel(state)).toBe(false);
     });

--- a/src/lib/__tests__/pipelineValidation.test.ts
+++ b/src/lib/__tests__/pipelineValidation.test.ts
@@ -989,12 +989,23 @@ describe("0.13.0 validation rules", () => {
       expect(hasSelectedModel(state)).toBe(true);
     });
 
-    it("returns false for empty local files", () => {
+    it("returns false for empty local files when no other source has a model", () => {
       const state = baseState({
         modelSource: "local",
         localFiles: [],
+        hfModelId: "",
+        azureModelPath: "",
       });
       expect(hasSelectedModel(state)).toBe(false);
+    });
+
+    it("returns true for empty local files when a Hugging Face model is still loaded", () => {
+      const state = baseState({
+        modelSource: "local",
+        localFiles: [],
+        hfModelId: "microsoft/Phi-3.5-mini-instruct",
+      });
+      expect(hasSelectedModel(state)).toBe(true);
     });
 
     it("returns true for non-empty azure path", () => {
@@ -1005,18 +1016,31 @@ describe("0.13.0 validation rules", () => {
       expect(hasSelectedModel(state)).toBe(true);
     });
 
-    it("returns false for empty azure path", () => {
+    it("returns false for empty azure path when no other source has a model", () => {
       const state = baseState({
         modelSource: "azure",
         azureModelPath: "",
+        hfModelId: "",
+        localFiles: [],
       });
       expect(hasSelectedModel(state)).toBe(false);
     });
 
-    it("returns false for whitespace-only azure path", () => {
+    it("returns true for empty azure path when a Hugging Face model is still loaded", () => {
+      const state = baseState({
+        modelSource: "azure",
+        azureModelPath: "",
+        hfModelId: "microsoft/Phi-3.5-mini-instruct",
+      });
+      expect(hasSelectedModel(state)).toBe(true);
+    });
+
+    it("returns false for whitespace-only azure path when no other source has a model", () => {
       const state = baseState({
         modelSource: "azure",
         azureModelPath: "  \t  ",
+        hfModelId: "",
+        localFiles: [],
       });
       expect(hasSelectedModel(state)).toBe(false);
     });

--- a/src/lib/__tests__/testState.ts
+++ b/src/lib/__tests__/testState.ts
@@ -1,0 +1,22 @@
+import type { UIState, IHVProvider } from "@/types";
+import { DEFAULT_PASSES } from "@/lib/defaultPasses";
+
+export function baseState(overrides?: Partial<UIState>): UIState {
+  return {
+    modelSource: "huggingface",
+    localFiles: [],
+    azureModelPath: "",
+    hfModelId: "",
+    hfDataset: "",
+    ihvProvider: "CPUExecutionProvider" as IHVProvider,
+    openvinoTargetDevice: "CPU",
+    memoryOffload: "gpu_only",
+    cudaVersion: "auto",
+    cacheDir: "",
+    azureStr: "",
+    distributedCaching: false,
+    activeJobId: null,
+    ...overrides,
+    passes: { ...DEFAULT_PASSES, ...overrides?.passes },
+  } as UIState;
+}

--- a/src/lib/__tests__/vramEstimate.test.ts
+++ b/src/lib/__tests__/vramEstimate.test.ts
@@ -67,7 +67,28 @@ function baseState(overrides?: Partial<UIState>): UIState {
   } as UIState;
 }
 
-describe("getEffectiveModelSource", () => {
+  it("returns null when no source has any model", () => {
+    const state = baseState({ modelSource: "local", localFiles: [] });
+    expect(getEffectiveModelSource(state)).toBeNull();
+  });
+
+  it("falls back to Azure when the active Hugging Face tab has no model", () => {
+    const state = baseState({
+      modelSource: "huggingface",
+      hfModelId: "   ",
+      azureModelPath: "azureml://models/m/versions/1",
+    });
+    expect(getEffectiveModelSource(state)).toBe("azure");
+  });
+
+  it("falls back to Local when the active Hugging Face tab has no model", () => {
+    const state = baseState({
+      modelSource: "huggingface",
+      hfModelId: "",
+      localFiles: [{ name: "model.safetensors", size: 1024 }],
+    });
+    expect(getEffectiveModelSource(state)).toBe("local");
+  });
   it("prefers the active tab when it has a model", () => {
     const state = baseState({
       modelSource: "local",

--- a/src/lib/__tests__/vramEstimate.test.ts
+++ b/src/lib/__tests__/vramEstimate.test.ts
@@ -1,28 +1,7 @@
 import { describe, it, expect } from "vitest";
-import type { UIState, IHVProvider } from "@/types";
 import { DEFAULT_PASSES } from "@/lib/defaultPasses";
 import { getVramModelLabel, getVramModelShortName, estimateVramRequirement } from "@/lib/vramEstimate";
-
-function baseState(overrides?: Partial<UIState>): UIState {
-  return {
-    modelSource: "huggingface",
-    localFiles: [],
-    azureModelPath: "",
-    hfModelId: "",
-    hfDataset: "",
-    ihvProvider: "CPUExecutionProvider" as IHVProvider,
-    openvinoTargetDevice: "CPU",
-    memoryOffload: "gpu_only",
-    cudaVersion: "auto",
-    cacheDir: "",
-    azureStr: "",
-    distributedCaching: false,
-    activeJobId: null,
-    ...overrides,
-    passes: { ...DEFAULT_PASSES, ...overrides?.passes },
-  } as UIState;
-}
-
+import { baseState } from "@/lib/__tests__/testState";
 describe("VRAM panel regression: switch to Local after loading a HF recipe", () => {
   const hfModel = "microsoft/Phi-3.5-mini-instruct";
   // Pin the estimate to FP16 so the comparison against the ~7B FP16

--- a/src/lib/__tests__/vramEstimate.test.ts
+++ b/src/lib/__tests__/vramEstimate.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect } from "vitest";
+import type { UIState, IHVProvider } from "@/types";
+import {
+  getEffectiveModelSource,
+  getVramModelLabel,
+  getVramModelShortName,
+  estimateVramRequirement,
+} from "@/lib/vramEstimate";
+
+const DEFAULT_PASSES = {
+  quantization: false,
+  quantMethod: "awq",
+  quantPrecision: "int4",
+  conversion: false,
+  conversionFormat: "onnx",
+  conversionSourceFormat: "pytorch",
+  conversionOpset: 17,
+  conversionInputTargetTypes: "fp32",
+  pruning: false,
+  pruningType: "structured",
+  pruningMethod: "omc",
+  pruningCriteria: "snip_magnitude",
+  pruningSparsity: 0.3,
+  peft: false,
+  peftMethod: "lora",
+  diffusionLora: false,
+  splitting: false,
+  onnxTransforms: false,
+  gptqBlockSize: 128,
+  gptqGroupSize: 128,
+  gptqDescAct: false,
+  awqGroupSize: 128,
+  awqDampPercent: 0.45,
+  awqSym: true,
+  qatQuantPrecision: "int8",
+  qatCalibrateMethod: "entropy",
+  qatCalibrateSteps: 1000,
+  quantPreset: "weighted",
+  trustRemoteCode: false,
+} as unknown as UIState["passes"];
+
+function baseState(overrides?: Partial<UIState>): UIState {
+  return {
+    modelSource: "huggingface",
+    localFiles: [],
+    azureModelPath: "",
+    hfModelId: "",
+    hfDataset: "",
+    ihvProvider: "CPUExecutionProvider" as IHVProvider,
+    openvinoTargetDevice: "CPU",
+    memoryOffload: "gpu_only",
+    cudaVersion: "auto",
+    cacheDir: "",
+    azureStr: "",
+    distributedCaching: false,
+    activeJobId: null,
+    ...overrides,
+    passes: { ...DEFAULT_PASSES, ...overrides?.passes },
+  } as UIState;
+}
+
+describe("getEffectiveModelSource", () => {
+  it("prefers the active tab when it has a model", () => {
+    const state = baseState({
+      modelSource: "local",
+      localFiles: [{ name: "model.bin", size: 1024 }],
+      hfModelId: "microsoft/phi-3",
+    });
+    expect(getEffectiveModelSource(state)).toBe("local");
+  });
+
+  it("falls back to a Hugging Face model when the active Local tab is empty", () => {
+    const state = baseState({
+      modelSource: "local",
+      localFiles: [],
+      hfModelId: "microsoft/Phi-3.5-mini-instruct",
+    });
+    expect(getEffectiveModelSource(state)).toBe("huggingface");
+  });
+
+  it("falls back to an Azure path when the active Local tab is empty", () => {
+    const state = baseState({
+      modelSource: "local",
+      localFiles: [],
+      azureModelPath: "azureml://models/m/versions/1",
+    });
+    expect(getEffectiveModelSource(state)).toBe("azure");
+  });
+
+  it("returns null when no source has any model", () => {
+    const state = baseState({ modelSource: "local", localFiles: [] });
+    expect(getEffectiveModelSource(state)).toBeNull();
+  });
+
+  it("is defensive against partial states (missing fields)", () => {
+    const partial = { ihvProvider: "cuda", passes: [] } as unknown as UIState;
+    expect(getEffectiveModelSource(partial)).toBeNull();
+  });
+});
+
+describe("VRAM panel regression: switch to Local after loading a HF recipe", () => {
+  const hfModel = "microsoft/Phi-3.5-mini-instruct";
+  const loaded = baseState({ modelSource: "huggingface", hfModelId: hfModel });
+  // Switch the source tab to Local without uploading any files.
+  const switched = baseState({
+    modelSource: "local",
+    localFiles: [],
+    hfModelId: hfModel,
+  });
+
+  it("keeps showing the loaded model label", () => {
+    expect(getVramModelLabel(switched)).toBe(hfModel);
+    expect(getVramModelShortName(switched)).toBe("Phi-3.5-mini-instruct");
+  });
+
+  it("estimates the loaded model's VRAM, not a generic 7B placeholder", () => {
+    const before = estimateVramRequirement(loaded);
+    const after = estimateVramRequirement(switched);
+    expect(after.sourceWeightGb).toBeCloseTo(before.sourceWeightGb, 5);
+    expect(after.inferenceGb).toBeCloseTo(before.inferenceGb, 5);
+
+    // The 7B placeholder (used when truly nothing is selected) is larger than
+    // the real ~3.8B Phi-3.5 model at FP16 — the bug inflated to this value.
+    const none = estimateVramRequirement(baseState({ modelSource: "huggingface", hfModelId: "" }));
+    expect(after.sourceWeightGb).toBeLessThan(none.sourceWeightGb);
+  });
+
+  it("switches to local-file sizing once files are uploaded", () => {
+    const uploaded = baseState({
+      modelSource: "local",
+      localFiles: [{ name: "model.safetensors", size: 1 * 1024 ** 3 }],
+      hfModelId: hfModel,
+    });
+    expect(getEffectiveModelSource(uploaded)).toBe("local");
+    const est = estimateVramRequirement(uploaded);
+    expect(est.sourceWeightGb).toBeCloseTo(1, 5);
+  });
+});

--- a/src/lib/__tests__/vramEstimate.test.ts
+++ b/src/lib/__tests__/vramEstimate.test.ts
@@ -1,12 +1,7 @@
 import { describe, it, expect } from "vitest";
 import type { UIState, IHVProvider } from "@/types";
 import { DEFAULT_PASSES } from "@/lib/defaultPasses";
-import {
-  getEffectiveModelSource,
-  getVramModelLabel,
-  getVramModelShortName,
-  estimateVramRequirement,
-} from "@/lib/vramEstimate";
+import { getVramModelLabel, getVramModelShortName, estimateVramRequirement } from "@/lib/vramEstimate";
 
 function baseState(overrides?: Partial<UIState>): UIState {
   return {
@@ -27,63 +22,6 @@ function baseState(overrides?: Partial<UIState>): UIState {
     passes: { ...DEFAULT_PASSES, ...overrides?.passes },
   } as UIState;
 }
-
-describe("getEffectiveModelSource", () => {
-  it("prefers the active tab when it has a model", () => {
-    const state = baseState({
-      modelSource: "local",
-      localFiles: [{ name: "model.bin", size: 1024 }],
-      hfModelId: "microsoft/phi-3",
-    });
-    expect(getEffectiveModelSource(state)).toBe("local");
-  });
-
-  it("falls back to a Hugging Face model when the active Local tab is empty", () => {
-    const state = baseState({
-      modelSource: "local",
-      localFiles: [],
-      hfModelId: "microsoft/Phi-3.5-mini-instruct",
-    });
-    expect(getEffectiveModelSource(state)).toBe("huggingface");
-  });
-
-  it("falls back to an Azure path when the active Local tab is empty", () => {
-    const state = baseState({
-      modelSource: "local",
-      localFiles: [],
-      azureModelPath: "azureml://models/m/versions/1",
-    });
-    expect(getEffectiveModelSource(state)).toBe("azure");
-  });
-
-  it("falls back to Azure when the active Hugging Face tab has no model", () => {
-    const state = baseState({
-      modelSource: "huggingface",
-      hfModelId: "   ",
-      azureModelPath: "azureml://models/m/versions/1",
-    });
-    expect(getEffectiveModelSource(state)).toBe("azure");
-  });
-
-  it("falls back to Local when the active Hugging Face tab has no model", () => {
-    const state = baseState({
-      modelSource: "huggingface",
-      hfModelId: "",
-      localFiles: [{ name: "model.safetensors", size: 1024 }],
-    });
-    expect(getEffectiveModelSource(state)).toBe("local");
-  });
-
-  it("returns null when no source has any model", () => {
-    const state = baseState({ modelSource: "local", localFiles: [] });
-    expect(getEffectiveModelSource(state)).toBeNull();
-  });
-
-  it("is defensive against partial states (missing fields)", () => {
-    const partial = { ihvProvider: "cuda", passes: [] } as unknown as UIState;
-    expect(getEffectiveModelSource(partial)).toBeNull();
-  });
-});
 
 describe("VRAM panel regression: switch to Local after loading a HF recipe", () => {
   const hfModel = "microsoft/Phi-3.5-mini-instruct";
@@ -131,7 +69,6 @@ describe("VRAM panel regression: switch to Local after loading a HF recipe", () 
       localFiles: [{ name: "model.safetensors", size: 1 * 1024 ** 3 }],
       hfModelId: hfModel,
     });
-    expect(getEffectiveModelSource(uploaded)).toBe("local");
     const est = estimateVramRequirement(uploaded);
     expect(est.sourceWeightGb).toBeCloseTo(1, 5);
   });

--- a/src/lib/__tests__/vramEstimate.test.ts
+++ b/src/lib/__tests__/vramEstimate.test.ts
@@ -1,44 +1,5 @@
 import { describe, it, expect } from "vitest";
 import type { UIState, IHVProvider } from "@/types";
-import {
-  getEffectiveModelSource,
-  getVramModelLabel,
-  getVramModelShortName,
-  estimateVramRequirement,
-} from "@/lib/vramEstimate";
-
-const DEFAULT_PASSES = {
-  quantization: false,
-  quantMethod: "awq",
-  quantPrecision: "int4",
-  conversion: false,
-  conversionFormat: "onnx",
-  conversionSourceFormat: "pytorch",
-  conversionOpset: 17,
-  conversionInputTargetTypes: "fp32",
-  pruning: false,
-  pruningType: "structured",
-  pruningMethod: "omc",
-  pruningCriteria: "snip_magnitude",
-  pruningSparsity: 0.3,
-  peft: false,
-  peftMethod: "lora",
-  diffusionLora: false,
-  splitting: false,
-  onnxTransforms: false,
-  gptqBlockSize: 128,
-  gptqGroupSize: 128,
-  gptqDescAct: false,
-  awqGroupSize: 128,
-  awqDampPercent: 0.45,
-  awqSym: true,
-  qatQuantPrecision: "int8",
-  qatCalibrateMethod: "entropy",
-  qatCalibrateSteps: 1000,
-  quantPreset: "weighted",
-  trustRemoteCode: false,
-import { describe, it, expect } from "vitest";
-import type { UIState, IHVProvider } from "@/types";
 import { DEFAULT_PASSES } from "@/lib/defaultPasses";
 import {
   getEffectiveModelSource,
@@ -67,28 +28,7 @@ function baseState(overrides?: Partial<UIState>): UIState {
   } as UIState;
 }
 
-  it("returns null when no source has any model", () => {
-    const state = baseState({ modelSource: "local", localFiles: [] });
-    expect(getEffectiveModelSource(state)).toBeNull();
-  });
-
-  it("falls back to Azure when the active Hugging Face tab has no model", () => {
-    const state = baseState({
-      modelSource: "huggingface",
-      hfModelId: "   ",
-      azureModelPath: "azureml://models/m/versions/1",
-    });
-    expect(getEffectiveModelSource(state)).toBe("azure");
-  });
-
-  it("falls back to Local when the active Hugging Face tab has no model", () => {
-    const state = baseState({
-      modelSource: "huggingface",
-      hfModelId: "",
-      localFiles: [{ name: "model.safetensors", size: 1024 }],
-    });
-    expect(getEffectiveModelSource(state)).toBe("local");
-  });
+describe("getEffectiveModelSource", () => {
   it("prefers the active tab when it has a model", () => {
     const state = baseState({
       modelSource: "local",
@@ -116,6 +56,24 @@ function baseState(overrides?: Partial<UIState>): UIState {
     expect(getEffectiveModelSource(state)).toBe("azure");
   });
 
+  it("falls back to Azure when the active Hugging Face tab has no model", () => {
+    const state = baseState({
+      modelSource: "huggingface",
+      hfModelId: "   ",
+      azureModelPath: "azureml://models/m/versions/1",
+    });
+    expect(getEffectiveModelSource(state)).toBe("azure");
+  });
+
+  it("falls back to Local when the active Hugging Face tab has no model", () => {
+    const state = baseState({
+      modelSource: "huggingface",
+      hfModelId: "",
+      localFiles: [{ name: "model.safetensors", size: 1024 }],
+    });
+    expect(getEffectiveModelSource(state)).toBe("local");
+  });
+
   it("returns null when no source has any model", () => {
     const state = baseState({ modelSource: "local", localFiles: [] });
     expect(getEffectiveModelSource(state)).toBeNull();
@@ -129,12 +87,19 @@ function baseState(overrides?: Partial<UIState>): UIState {
 
 describe("VRAM panel regression: switch to Local after loading a HF recipe", () => {
   const hfModel = "microsoft/Phi-3.5-mini-instruct";
-  const loaded = baseState({ modelSource: "huggingface", hfModelId: hfModel });
+  // Pin the estimate to FP16 so the comparison against the ~7B FP16
+  // placeholder is apples-to-apples (the real DEFAULT_PASSES default is float32).
+  const loaded = baseState({
+    modelSource: "huggingface",
+    hfModelId: hfModel,
+    passes: { ...DEFAULT_PASSES, conversionInputTargetTypes: "float16" },
+  });
   // Switch the source tab to Local without uploading any files.
   const switched = baseState({
     modelSource: "local",
     localFiles: [],
     hfModelId: hfModel,
+    passes: { ...DEFAULT_PASSES, conversionInputTargetTypes: "float16" },
   });
 
   it("keeps showing the loaded model label", () => {
@@ -150,7 +115,13 @@ describe("VRAM panel regression: switch to Local after loading a HF recipe", () 
 
     // The 7B placeholder (used when truly nothing is selected) is larger than
     // the real ~3.8B Phi-3.5 model at FP16 — the bug inflated to this value.
-    const none = estimateVramRequirement(baseState({ modelSource: "huggingface", hfModelId: "" }));
+    const none = estimateVramRequirement(
+      baseState({
+        modelSource: "huggingface",
+        hfModelId: "",
+        passes: { ...DEFAULT_PASSES, conversionInputTargetTypes: "float16" },
+      }),
+    );
     expect(after.sourceWeightGb).toBeLessThan(none.sourceWeightGb);
   });
 

--- a/src/lib/__tests__/vramEstimate.test.ts
+++ b/src/lib/__tests__/vramEstimate.test.ts
@@ -37,7 +37,15 @@ const DEFAULT_PASSES = {
   qatCalibrateSteps: 1000,
   quantPreset: "weighted",
   trustRemoteCode: false,
-} as unknown as UIState["passes"];
+import { describe, it, expect } from "vitest";
+import type { UIState, IHVProvider } from "@/types";
+import { DEFAULT_PASSES } from "@/lib/defaultPasses";
+import {
+  getEffectiveModelSource,
+  getVramModelLabel,
+  getVramModelShortName,
+  estimateVramRequirement,
+} from "@/lib/vramEstimate";
 
 function baseState(overrides?: Partial<UIState>): UIState {
   return {

--- a/src/lib/modelSource.ts
+++ b/src/lib/modelSource.ts
@@ -1,0 +1,34 @@
+import type { ModelSource, UIState } from "@/types";
+
+export type EffectiveModelSource = ModelSource;
+
+/**
+ * Resolves which model source actually has a model configured, preferring
+ * the active `modelSource` tab but falling back to any other source that
+ * already has a model. This keeps the loaded model "active" while the user
+ * browses a different source tab without yet providing input: switching to
+ * "Local" right after loading a Hugging Face recipe should not discard the
+ * loaded model from the VRAM panel or the status summary.
+ *
+ * Returns `null` when no source has any model configured at all.
+ */
+export function getEffectiveModelSource(state: UIState): EffectiveModelSource | null {
+  // Defensive against partial / loosely-typed states (some callers pass a
+  // minimal snapshot): coerce missing fields to their empty equivalents so
+  // the checks never throw on `undefined`.
+  const hfModelId = state.hfModelId ?? "";
+  const azureModelPath = state.azureModelPath ?? "";
+  const localFiles = state.localFiles ?? [];
+
+  const active = state.modelSource;
+  if (active === "huggingface" && hfModelId.trim() !== "") return active;
+  if (active === "local" && localFiles.length > 0) return active;
+  if (active === "azure" && azureModelPath.trim() !== "") return active;
+
+  // Active tab has no model yet: fall back to any source that does, so the
+  // previously loaded model stays in effect until the user provides new input.
+  if (hfModelId.trim() !== "") return "huggingface";
+  if (localFiles.length > 0) return "local";
+  if (azureModelPath.trim() !== "") return "azure";
+  return null;
+}

--- a/src/lib/pipelineValidation.ts
+++ b/src/lib/pipelineValidation.ts
@@ -1,5 +1,6 @@
 import { IHVProvider, ModelSource, UIState, OliveRecipe } from "@/types";
 import { isMemoryOffloadAvailable } from "@/lib/memoryOffload";
+import { getEffectiveModelSource } from "@/lib/vramEstimate";
 import { getProviderAvailabilityBlock, type HardwareProbeResult, type GpuInfo } from "@/lib/hardwareProbe";
 import { buildOliveRecipe, isPyTorchNativeQuantMethod, hasOnnxGraphProducer } from "@/lib/oliveRecipeBuilder";
 import { isReplacementExportPipeline } from "@/lib/replacementExportPipeline";
@@ -820,11 +821,7 @@ function getAdvisoryIssues(state: UIState): PipelineIssue[] {
  */
 /** True once the user has actually picked a model in Model source (step 01). */
 export function hasSelectedModel(state: UIState): boolean {
-  return (
-    (state.modelSource === "huggingface" && state.hfModelId.trim() !== "") ||
-    (state.modelSource === "local" && state.localFiles.length > 0) ||
-    (state.modelSource === "azure" && state.azureModelPath.trim() !== "")
-  );
+  return getEffectiveModelSource(state) !== null;
 }
 
 function getRecipeRuntimeIssues(state: UIState, recipe: OliveRecipe): PipelineIssue[] {

--- a/src/lib/pipelineValidation.ts
+++ b/src/lib/pipelineValidation.ts
@@ -1,6 +1,5 @@
 import { IHVProvider, ModelSource, UIState, OliveRecipe } from "@/types";
 import { isMemoryOffloadAvailable } from "@/lib/memoryOffload";
-import { getEffectiveModelSource } from "@/lib/vramEstimate";
 import { getProviderAvailabilityBlock, type HardwareProbeResult, type GpuInfo } from "@/lib/hardwareProbe";
 import { buildOliveRecipe, isPyTorchNativeQuantMethod, hasOnnxGraphProducer } from "@/lib/oliveRecipeBuilder";
 import { isReplacementExportPipeline } from "@/lib/replacementExportPipeline";
@@ -821,7 +820,6 @@ function getAdvisoryIssues(state: UIState): PipelineIssue[] {
  */
 /** True once the user has actually picked a model in Model source (step 01). */
 export function hasSelectedModel(state: UIState): boolean {
-export function hasSelectedModel(state: UIState): boolean {
   // Keep the validation gate aligned with buildOliveRecipe: the active tab
   // must itself have a model. The effective-source fallback is used for
   // display/VRAM only (see getVramModelLabel / resolveSourceWeightGb), not
@@ -832,7 +830,6 @@ export function hasSelectedModel(state: UIState): boolean {
     (state.modelSource === "local" && state.localFiles.length > 0) ||
     (state.modelSource === "azure" && state.azureModelPath.trim() !== "")
   );
-}
 }
 
 function getRecipeRuntimeIssues(state: UIState, recipe: OliveRecipe): PipelineIssue[] {

--- a/src/lib/pipelineValidation.ts
+++ b/src/lib/pipelineValidation.ts
@@ -821,7 +821,18 @@ function getAdvisoryIssues(state: UIState): PipelineIssue[] {
  */
 /** True once the user has actually picked a model in Model source (step 01). */
 export function hasSelectedModel(state: UIState): boolean {
-  return getEffectiveModelSource(state) !== null;
+export function hasSelectedModel(state: UIState): boolean {
+  // Keep the validation gate aligned with buildOliveRecipe: the active tab
+  // must itself have a model. The effective-source fallback is used for
+  // display/VRAM only (see getVramModelLabel / resolveSourceWeightGb), not
+  // for run/export gating, so a stale cross-tab model never unblocks a
+  // recipe whose active tab has no model to build from.
+  return (
+    (state.modelSource === "huggingface" && state.hfModelId.trim() !== "") ||
+    (state.modelSource === "local" && state.localFiles.length > 0) ||
+    (state.modelSource === "azure" && state.azureModelPath.trim() !== "")
+  );
+}
 }
 
 function getRecipeRuntimeIssues(state: UIState, recipe: OliveRecipe): PipelineIssue[] {

--- a/src/lib/vramEstimate.ts
+++ b/src/lib/vramEstimate.ts
@@ -1,4 +1,4 @@
-import { IHVProvider, UIState } from "@/types";
+import { IHVProvider, ModelSource, UIState } from "@/types";
 import type { HardwareProbeResult } from "@/lib/hardwareProbe";
 
 export type VramConfidence = "high" | "medium" | "low";

--- a/src/lib/vramEstimate.ts
+++ b/src/lib/vramEstimate.ts
@@ -67,17 +67,45 @@ function inferParamBillions(identifier: string): { paramsB: number; confidence: 
   return { paramsB: 7, confidence: "low" };
 }
 
+export type EffectiveModelSource = "huggingface" | "local" | "azure";
+
+/**
+ * Resolves which model source actually has a model configured, preferring
+ * the active `modelSource` tab but falling back to any other source that
+ * already has a model. This keeps the loaded model "active" while the user
+ * browses a different source tab without yet providing input — e.g. switching
+ * to "Local" right after loading a Hugging Face recipe should not discard
+ * the loaded model from the VRAM panel or lock downstream pipeline sections.
+ *
+ * Returns `null` when no source has any model configured at all.
+ */
+export function getEffectiveModelSource(state: UIState): EffectiveModelSource | null {
+  // Defensive against partial / loosely-typed states (some callers pass a
+  // minimal snapshot): coerce missing fields to their empty equivalents so
+  // the checks never throw on `undefined`.
+  const hfModelId = state.hfModelId ?? "";
+  const azureModelPath = state.azureModelPath ?? "";
+  const localFiles = state.localFiles ?? [];
+
+  const active = state.modelSource;
+  if (active === "huggingface" && hfModelId.trim() !== "") return active;
+  if (active === "local" && localFiles.length > 0) return active;
+  if (active === "azure" && azureModelPath.trim() !== "") return active;
+
+  // Active tab has no model yet — fall back to any source that does, so the
+  // previously loaded model stays in effect until the user provides new input.
+  if (hfModelId.trim() !== "") return "huggingface";
+  if (localFiles.length > 0) return "local";
+  if (azureModelPath.trim() !== "") return "azure";
+  return null;
+}
+
 /** Short label for VRAM UI — full HF id or local filename. */
 export function getVramModelLabel(state: UIState): string {
-  if (state.modelSource === "huggingface" && state.hfModelId.trim()) {
-    return state.hfModelId.trim();
-  }
-  if (state.modelSource === "azure" && state.azureModelPath.trim()) {
-    return state.azureModelPath.trim();
-  }
-  if (state.modelSource === "local" && state.localFiles.length > 0) {
-    return state.localFiles[0].name;
-  }
+  const source = getEffectiveModelSource(state);
+  if (source === "huggingface") return (state.hfModelId ?? "").trim();
+  if (source === "azure") return (state.azureModelPath ?? "").trim();
+  if (source === "local") return state.localFiles[0].name;
   return "No model selected";
 }
 
@@ -96,7 +124,9 @@ function resolveSourceWeightGb(state: UIState): {
   confidence: VramConfidence;
   notes: string[];
 } {
-  if (state.modelSource === "local" && state.localFiles.length > 0) {
+  const source = getEffectiveModelSource(state);
+
+  if (source === "local") {
     const totalBytes = state.localFiles.reduce((sum, file) => sum + file.size, 0);
     return {
       weightGb: totalBytes / 1024 ** 3,
@@ -107,9 +137,9 @@ function resolveSourceWeightGb(state: UIState): {
   }
 
   const identifier =
-    state.modelSource === "huggingface"
+    source === "huggingface"
       ? state.hfModelId
-      : state.modelSource === "azure"
+      : source === "azure"
         ? state.azureModelPath
         : "";
 

--- a/src/lib/vramEstimate.ts
+++ b/src/lib/vramEstimate.ts
@@ -67,7 +67,7 @@ function inferParamBillions(identifier: string): { paramsB: number; confidence: 
   return { paramsB: 7, confidence: "low" };
 }
 
-export type EffectiveModelSource = "huggingface" | "local" | "azure";
+export type EffectiveModelSource = ModelSource;
 
 /**
  * Resolves which model source actually has a model configured, preferring

--- a/src/lib/vramEstimate.ts
+++ b/src/lib/vramEstimate.ts
@@ -1,5 +1,6 @@
-import { IHVProvider, ModelSource, UIState } from "@/types";
+import { IHVProvider, UIState } from "@/types";
 import type { HardwareProbeResult } from "@/lib/hardwareProbe";
+import { getEffectiveModelSource } from "@/lib/modelSource";
 
 export type VramConfidence = "high" | "medium" | "low";
 export type VramFit = "fits" | "tight" | "insufficient" | "unknown";
@@ -67,39 +68,6 @@ function inferParamBillions(identifier: string): { paramsB: number; confidence: 
   return { paramsB: 7, confidence: "low" };
 }
 
-export type EffectiveModelSource = ModelSource;
-
-/**
- * Resolves which model source actually has a model configured, preferring
- * the active `modelSource` tab but falling back to any other source that
- * already has a model. This keeps the loaded model "active" while the user
- * browses a different source tab without yet providing input — e.g. switching
- * to "Local" right after loading a Hugging Face recipe should not discard
- * the loaded model from the VRAM panel or lock downstream pipeline sections.
- *
- * Returns `null` when no source has any model configured at all.
- */
-export function getEffectiveModelSource(state: UIState): EffectiveModelSource | null {
-  // Defensive against partial / loosely-typed states (some callers pass a
-  // minimal snapshot): coerce missing fields to their empty equivalents so
-  // the checks never throw on `undefined`.
-  const hfModelId = state.hfModelId ?? "";
-  const azureModelPath = state.azureModelPath ?? "";
-  const localFiles = state.localFiles ?? [];
-
-  const active = state.modelSource;
-  if (active === "huggingface" && hfModelId.trim() !== "") return active;
-  if (active === "local" && localFiles.length > 0) return active;
-  if (active === "azure" && azureModelPath.trim() !== "") return active;
-
-  // Active tab has no model yet — fall back to any source that does, so the
-  // previously loaded model stays in effect until the user provides new input.
-  if (hfModelId.trim() !== "") return "huggingface";
-  if (localFiles.length > 0) return "local";
-  if (azureModelPath.trim() !== "") return "azure";
-  return null;
-}
-
 /** Short label for VRAM UI — full HF id or local filename. */
 export function getVramModelLabel(state: UIState): string {
   const source = getEffectiveModelSource(state);
@@ -137,11 +105,7 @@ function resolveSourceWeightGb(state: UIState): {
   }
 
   const identifier =
-    source === "huggingface"
-      ? state.hfModelId
-      : source === "azure"
-        ? state.azureModelPath
-        : "";
+    source === "huggingface" ? state.hfModelId : source === "azure" ? state.azureModelPath : "";
 
   if (!identifier.trim()) {
     const weightGb = paramsToGb(7, 2);
@@ -323,12 +287,12 @@ export function getSelectedGpuVramGb(
     provider === "ROCMExecutionProvider"
       ? (probe.rocm?.gpus ?? [])
       : provider === "CUDAExecutionProvider" ||
-        provider === "NvTensorRTRTXExecutionProvider" ||
-        provider === "TensorrtExecutionProvider"
+          provider === "NvTensorRTRTXExecutionProvider" ||
+          provider === "TensorrtExecutionProvider"
         ? (probe.nvidia?.gpus ?? [])
         : provider === "DmlExecutionProvider" || provider === "WebGpuExecutionProvider"
-        ? [...(probe.nvidia?.gpus ?? []), ...(probe.rocm?.gpus ?? [])]
-        : [];
+          ? [...(probe.nvidia?.gpus ?? []), ...(probe.rocm?.gpus ?? [])]
+          : [];
 
   const vramMb = gpus.map((gpu) => gpu.vramMb).filter((value): value is number => value != null && value > 0);
 


### PR DESCRIPTION
This PR was generated automatically by mini-swe-agent.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps the loaded model visible in the status summary and VRAM panel when switching Model source tabs, fixing regression #384. Old behavior: display and estimates cleared when the active tab had no model. New behavior: display/VRAM use an effective model from any configured source; run/export validation still requires a model on the active tab.

- Add `getEffectiveModelSource(state)` in `src/lib/modelSource.ts` with fallback order huggingface → local → azure; handles partial state and blank/whitespace paths.
- Update `PipelineStatusSummary` to resolve the label from the effective source; `getModelLabel` no longer depends on an active-tab-only flag.
- Update VRAM helpers (`getVramModelLabel`, `getVramModelShortName`, `estimateVramRequirement`) to use the effective source; keep `hasSelectedModel` strict to the active tab for run/export gating.
- Add tests for fallback resolution and the VRAM regression; share a `baseState` test fixture (`src/lib/__tests__/testState.ts`) to remove duplication.

<sup>Written for commit 0b7a2f2035d90ca97e59ea874c1eb8c70578d56d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tonythethompson/Olive-Studio/pull/385?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

