### PR TITLE
🤖 GLM 5.2 Fix for Issue #387

### DIFF
--- a/olive-mcp-server/olive_mcp_server/tools/agent_model_info.py
+++ b/olive-mcp-server/olive_mcp_server/tools/agent_model_info.py
@@ -91,6 +91,15 @@ def _params_from_whisper(model_id: str) -> tuple[float, str] | None:
 # Ordered family defaults: more-specific needles must appear before broader ones
 # (e.g. phi-3.5 before phi-3, llama-3.2 before llama-3, qwen2 before qwen).
 _FAMILY_DEFAULTS: tuple[tuple[tuple[str, ...], float, str], ...] = (
+    # GPT-2 variants — order matters: most specific first, generic gpt2 last.
+    # sshleifer/tiny-gpt2 is a ~5M-param model; without these rows the fallback
+    # reports 7B (~26 GB FP32) for models ranging from 5M to 1.5B params.
+    (("tiny-gpt2", "tiny_gpt2"), 0.005, "medium"),
+    (("distilgpt2",), 0.082, "low"),
+    (("gpt2-xl", "gpt2_xl"), 1.5, "low"),
+    (("gpt2-large", "gpt2_large"), 0.774, "low"),
+    (("gpt2-medium", "gpt2_medium"), 0.355, "low"),
+    (("gpt2",), 0.124, "low"),
     (("phi-3.5", "phi3.5"), 3.8, "low"),
     (("phi-3", "phi3"), 3.8, "low"),
     (("phi-2",), 2.7, "low"),
@@ -129,6 +138,9 @@ def _infer_param_billions(identifier: str) -> tuple[float, str]:
         (params_b, confidence) where confidence is "medium" or "low".
     """
     model_id = identifier.lower()
+    # Match the TS port: collapse gpt-2 / gpt_2 spellings so the family
+    # needles above also match hyphenated ids like gpt-2-medium.
+    model_id = model_id.replace("gpt-2", "gpt2").replace("gpt_2", "gpt2")
     for resolver in (
         _params_from_size_token,
         _params_from_whisper,

--- a/olive-mcp-server/tests/test_agent_model_info.py
+++ b/olive-mcp-server/tests/test_agent_model_info.py
@@ -318,6 +318,54 @@ class TestMixtralMoeHeuristic:
         _assert_json_roundtrip(result)
 
 
+# ---------------------------------------------------------------------------
+# Test: GPT-2 heuristic (synced with inferParamBillions in vramEstimate.ts)
+# ---------------------------------------------------------------------------
+
+
+class TestGpt2Heuristic:
+    """GPT-2 identifiers get realistic param counts, not the 7B fallback."""
+
+    @pytest.mark.parametrize(
+        "model_id, expected_params",
+        [
+            ("sshleifer/tiny-gpt2", 0.005),
+            ("sshleifer/tiny_gpt2", 0.005),
+            ("distilgpt2/distilgpt2", 0.082),
+            ("openai-community/gpt2", 0.124),
+            ("openai-community/gpt2-medium", 0.355),
+            ("openai-community/gpt2-large", 0.774),
+            ("openai-community/gpt2-xl", 1.5),
+            # Hyphenated spellings are normalized to the same gpt2 token.
+            ("openai-community/gpt-2", 0.124),
+            ("flax-community/gpt-2-medium", 0.355),
+            ("flax-community/gpt_2_large", 0.774),
+        ],
+    )
+    def test_gpt2_variants_not_7b(
+        self, monkeypatch: pytest.MonkeyPatch, model_id: str, expected_params: float
+    ):
+        """Heuristic fallback maps GPT-2 ids to real sizes, not the 7B default."""
+        _patch_hf(monkeypatch, None)
+        result = agent_model_info.get_model_info(model_id)
+        assert "error" not in result
+        assert result["source"] == "heuristic"
+        assert result["params_b"] == pytest.approx(expected_params)
+        assert result["estimated_vram_gb"] == pytest.approx(expected_params * 2.0)
+        assert result["recommended_quant"] == "int8"
+
+    def test_gpt2_confidence_and_unknown_fallback(self, monkeypatch: pytest.MonkeyPatch):
+        """tiny-gpt2 carries medium confidence; unknown ids keep the 7B fallback."""
+        _patch_hf(monkeypatch, None)
+        tiny = agent_model_info.get_model_info("sshleifer/tiny-gpt2")
+        assert tiny["confidence"] == "medium"
+        base = agent_model_info.get_model_info("openai-community/gpt2")
+        assert base["confidence"] == "low"
+        unknown = agent_model_info.get_model_info("some-org/some-unknown-model")
+        assert unknown["params_b"] == 7.0
+        assert unknown["confidence"] == "low"
+
+
 class TestArchitectureBasedModelType:
     """Opaque model IDs should classify from their HF architecture field."""
 

--- a/olive-mcp-server/tests/test_agent_model_info.py
+++ b/olive-mcp-server/tests/test_agent_model_info.py
@@ -342,9 +342,7 @@ class TestGpt2Heuristic:
             ("flax-community/gpt_2_large", 0.774),
         ],
     )
-    def test_gpt2_variants_not_7b(
-        self, monkeypatch: pytest.MonkeyPatch, model_id: str, expected_params: float
-    ):
+    def test_gpt2_variants_not_7b(self, monkeypatch: pytest.MonkeyPatch, model_id: str, expected_params: float):
         """Heuristic fallback maps GPT-2 ids to real sizes, not the 7B default."""
         _patch_hf(monkeypatch, None)
         result = agent_model_info.get_model_info(model_id)

--- a/src/components/features/input/InputEnvironmentPanel.tsx
+++ b/src/components/features/input/InputEnvironmentPanel.tsx
@@ -58,11 +58,12 @@ export function InputEnvironmentPanel({
     repoUrl, setRepoUrl, repoBranch, setRepoBranch, repoPath, setRepoPath,
     importJson, setImportJson, importError, setImportError,
     activeRecipeTab, setActiveRecipeTab, visitedRecipeTabs,
-    recipeSuccessMsg, applyingRecipePath, appliedRecipeLabel,
+    recipeSuccessMsg, setRecipeSuccessMsg, applyingRecipePath, appliedRecipeLabel,
     setRecipeRailExpanded,
     sourceConfigExpanded, setSourceConfigExpanded,
     recipeRailCollapsed,
     handleApplyCuratedRecipe, handleApplyCuratedRecipeAnyway,
+    handleClearRecipe,
     handleFetchRemote, handleImport,
   } = useRecipeHub({ setState, hardwareProbe });
 
@@ -137,6 +138,14 @@ export function InputEnvironmentPanel({
               >
                 Change recipe
               </Button>
+              <Button
+                type="button"
+                variant="outline"
+                className="h-8 shrink-0 self-start px-3 text-xs border-slate-700 text-slate-300 hover:text-rose-300 hover:border-rose-500/40 sm:self-center"
+                onClick={handleClearRecipe}
+              >
+                Clear recipe
+              </Button>
             </div>
           )}
 
@@ -189,6 +198,7 @@ export function InputEnvironmentPanel({
                 handleFetchRemote={handleFetchRemote}
                 handleApplyCuratedRecipe={handleApplyCuratedRecipe}
                 handleApplyCuratedRecipeAnyway={handleApplyCuratedRecipeAnyway}
+                notifyRecipeMessage={setRecipeSuccessMsg}
               />
             )}
 

--- a/src/components/features/input/InputRecipeRail.tsx
+++ b/src/components/features/input/InputRecipeRail.tsx
@@ -56,6 +56,8 @@ export interface InputRecipeRailProps {
   handleFetchRemote: (opts?: { url: string; branch: string; path: string }) => Promise<void>;
   handleApplyCuratedRecipe: (item: RecipeCatalogItem) => void;
   handleApplyCuratedRecipeAnyway: (item: RecipeCatalogItem) => void;
+  /** Surfaces a transient message in the recipes card (e.g. sample-apply result). */
+  notifyRecipeMessage: (msg: string) => void;
 }
 
 export function InputRecipeRail(props: InputRecipeRailProps) {
@@ -106,6 +108,7 @@ export function InputRecipeRail(props: InputRecipeRailProps) {
     handleFetchRemote,
     handleApplyCuratedRecipe,
     handleApplyCuratedRecipeAnyway,
+    notifyRecipeMessage,
   } = props;
 
   return (
@@ -135,7 +138,12 @@ export function InputRecipeRail(props: InputRecipeRailProps) {
             className="shrink-0 inline-flex items-center justify-center rounded-md bg-electric-blue px-3 py-1.5 text-xs font-semibold text-slate-950 hover:bg-electric-blue-dark cursor-pointer"
             onClick={() => {
               void import("@/lib/tour").then(({ ensureTourDemoModel }) => {
-                ensureTourDemoModel();
+                const result = ensureTourDemoModel();
+                notifyRecipeMessage(
+                  result.applied
+                    ? "Sample recipe applied: sshleifer/tiny-gpt2. Pick a preset to switch, or edit the model below."
+                    : "A model is already selected — pick a preset above to switch, or edit the model below.",
+                );
               });
             }}
           >

--- a/src/components/features/input/useRecipeHub.test.tsx
+++ b/src/components/features/input/useRecipeHub.test.tsx
@@ -1,0 +1,94 @@
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { useRecipeHub } from "./useRecipeHub";
+
+vi.mock("@/lib/oliveRecipeHub", () => ({
+  OLIVE_RECIPES_REPO: "microsoft/olive-recipes",
+  getRecipesBranch: () => "main",
+  fetchGitHubRecipeJson: vi.fn(() =>
+    Promise.resolve({ json: {}, target: { owner: "o", repo: "r", branch: "main", path: "p.json" } }),
+  ),
+  fetchOliveRecipesCatalogItem: vi.fn(() => Promise.resolve({})),
+  compareCatalogMetadataToRecipe: vi.fn(() => ({ catalogDevice: "CPU", recipeDevice: "CPU", matches: true })),
+  deriveUiStateFromOliveRecipe: vi.fn(() => ({ hfModelId: "org/model", modelSource: "huggingface" })),
+  getCatalogDeviceFromRecipe: vi.fn(() => "CPU"),
+}));
+
+vi.mock("@/lib/recipeHardwareCompatibility", () => ({
+  assessCatalogItemHardwareCompatibility: vi.fn(() => ({
+    tier: "compatible",
+    targetDevice: "CPU",
+    reason: "mocked",
+  })),
+  assessRecipeHardwareCompatibility: vi.fn(() => ({
+    tier: "compatible",
+    targetDevice: "CPU",
+    reason: "mocked",
+  })),
+}));
+
+vi.mock("@/lib/recipePipeline", () => ({
+  parseRecipeJson: vi.fn(() => ({ recipe: {}, schema: { valid: true, errors: [] } })),
+}));
+
+const SAMPLE_ITEM = {
+  name: "sshleifer-tiny-gpt2 · olive · sparsegpt",
+  architecture: "GPT-2",
+  device: "CPU",
+  repoPath: "sshleifer-tiny-gpt2/olive/sparsegpt.json",
+  description: "Sample tiny-gpt2 preset",
+};
+
+function renderHub() {
+  const setState = vi.fn();
+  const utils = renderHook(() => useRecipeHub({ setState, hardwareProbe: null }));
+  return { setState, utils };
+}
+
+describe("useRecipeHub clear-recipe escape (issue #387 stuck on tiny-gpt2)", () => {
+  it("re-opens the catalog rail after an applied recipe is cleared", async () => {
+    const { setState, utils } = renderHub();
+
+    // Simulate the reported stuck state: a curated recipe applies and collapses
+    // the rail behind the "Applied recipe" banner.
+    await act(async () => {
+      await utils.result.current.handleApplyCuratedRecipe(SAMPLE_ITEM);
+    });
+
+    expect(utils.result.current.appliedRecipeLabel).toBe(SAMPLE_ITEM.name);
+    expect(utils.result.current.recipeRailCollapsed).toBe(true);
+
+    await act(async () => {
+      utils.result.current.handleClearRecipe();
+    });
+
+    expect(utils.result.current.appliedRecipeLabel).toBeNull();
+    expect(utils.result.current.recipeRailCollapsed).toBe(false);
+    expect(utils.result.current.recipeSuccessMsg).toMatch(/Recipe cleared/i);
+    expect(setState).toHaveBeenCalledWith({
+      hfModelId: "",
+      hfDataset: "",
+      hfTask: "",
+      localFiles: [],
+      azureModelPath: "",
+    });
+  });
+
+  it("clears an applied recipe even when no curated recipe was applied", () => {
+    const { setState, utils } = renderHub();
+
+    act(() => {
+      utils.result.current.handleClearRecipe();
+    });
+
+    expect(utils.result.current.appliedRecipeLabel).toBeNull();
+    expect(utils.result.current.recipeRailCollapsed).toBe(false);
+    expect(setState).toHaveBeenCalledWith({
+      hfModelId: "",
+      hfDataset: "",
+      hfTask: "",
+      localFiles: [],
+      azureModelPath: "",
+    });
+  });
+});

--- a/src/components/features/input/useRecipeHub.ts
+++ b/src/components/features/input/useRecipeHub.ts
@@ -112,6 +112,26 @@ export function useRecipeHub({ setState, hardwareProbe }: UseRecipeHubOpts) {
   const handleApplyCuratedRecipeAnyway = (item: RecipeCatalogItem) =>
     applyCuratedRecipe(item, { allowIncompatible: true });
 
+  /**
+   * Clears the applied-recipe lock-in so the user can start over from the
+   * catalog or a custom model source. An applied recipe sets `appliedRecipeLabel`
+   * and collapses the rail with no way to dismiss it; clearing the model fields
+   * alone leaves the "Applied recipe" banner stuck on the old model (e.g. the
+   * tiny-gpt2 sample from issue #387). This resets both.
+   */
+  const handleClearRecipe = () => {
+    setState({ hfModelId: "", hfDataset: "", hfTask: "", localFiles: [], azureModelPath: "" });
+    setAppliedRecipeLabel(null);
+    setRecipeRailExpanded(true);
+    setSourceConfigExpanded(true);
+    setImportJson("");
+    setImportError(null);
+    setSyncStatus("idle");
+    setSyncError("");
+    setRecipeSuccessMsg("Recipe cleared — choose a preset above or configure a custom model.");
+    setTimeout(() => setRecipeSuccessMsg(null), 5000);
+  };
+
   const handleFetchRemote = async (overrides?: { url?: string; branch?: string; path?: string }) => {
     const url = (overrides?.url ?? repoUrl).trim();
     const branch = (overrides?.branch ?? repoBranch).trim() || "main";
@@ -174,11 +194,12 @@ export function useRecipeHub({ setState, hardwareProbe }: UseRecipeHubOpts) {
     repoUrl, setRepoUrl, repoBranch, setRepoBranch, repoPath, setRepoPath,
     importJson, setImportJson, importError, setImportError,
     activeRecipeTab, setActiveRecipeTab, visitedRecipeTabs,
-    recipeSuccessMsg, applyingRecipePath, appliedRecipeLabel,
+    recipeSuccessMsg, setRecipeSuccessMsg, applyingRecipePath, appliedRecipeLabel,
     recipeRailExpanded, setRecipeRailExpanded,
     sourceConfigExpanded, setSourceConfigExpanded,
     recipeRailCollapsed,
     handleApplyCuratedRecipe, handleApplyCuratedRecipeAnyway,
+    handleClearRecipe,
     handleFetchRemote, handleImport,
   };
 }

--- a/src/lib/__tests__/vramEstimate.tinygpt2.test.ts
+++ b/src/lib/__tests__/vramEstimate.tinygpt2.test.ts
@@ -3,74 +3,49 @@ import { DEFAULT_PASSES } from "@/lib/defaultPasses";
 import { estimateVramRequirement } from "@/lib/vramEstimate";
 import { baseState } from "@/lib/__tests__/testState";
 
+// Every GPT-2 branch inferParamBillions recognizes, plus the unknown-model
+// fallback. dtype drives the bytes-per-param multiplier (float32 -> 4, float16 -> 2).
+const cases = [
+  { id: "sshleifer/tiny-gpt2", paramsB: 0.005, confidence: "medium", dtype: "float32" },
+  { id: "sshleifer/tiny_gpt2", paramsB: 0.005, confidence: "medium", dtype: "float32" },
+  { id: "sshleifer-tiny-gpt2", paramsB: 0.005, confidence: "medium", dtype: "float32" },
+  { id: "distilgpt2/distilgpt2", paramsB: 0.082, confidence: "low", dtype: "float16" },
+  { id: "openai-community/gpt2", paramsB: 0.124, confidence: "low", dtype: "float16" },
+  { id: "openai-community/gpt2-medium", paramsB: 0.355, confidence: "low", dtype: "float16" },
+  { id: "openai-community/gpt2_large", paramsB: 0.774, confidence: "low", dtype: "float16" },
+  { id: "openai-community/gpt2-xl", paramsB: 1.5, confidence: "low", dtype: "float16" },
+  // Hyphenated spellings are normalized to the same gpt2 token.
+  { id: "openai-community/gpt-2", paramsB: 0.124, confidence: "low", dtype: "float16" },
+  { id: "flax-community/gpt-2-medium", paramsB: 0.355, confidence: "low", dtype: "float16" },
+  { id: "flax-community/gpt_2_large", paramsB: 0.774, confidence: "low", dtype: "float16" },
+  // Truly unknown ids still fall through to the 7B default.
+  { id: "some-org/some-unknown-model", paramsB: 7, confidence: "low", dtype: "float16" },
+];
+
 describe("tiny-gpt2 memory estimate fix", () => {
-  it("does not inflate tiny-gpt2 to 26 GB (the reported bug)", () => {
+  it("does not inflate tiny-gpt2 to ~26 GB (issue #387)", () => {
     const state = baseState({
       modelSource: "huggingface",
       hfModelId: "sshleifer/tiny-gpt2",
       passes: { ...DEFAULT_PASSES, conversionInputTargetTypes: "float32" },
     });
     const est = estimateVramRequirement(state);
-    // Before the fix this was ~26 GB (7B default * 4 bytes FP32).
-    // tiny-gpt2 is ~5M params, so the estimate should be well under 1 GB.
+    // tiny-gpt2 is ~5M params, so the FP32 estimate stays well under 1 GB.
     expect(est.sourceWeightGb).toBeLessThan(0.1);
     expect(est.inferenceGb).toBeLessThan(0.1);
     expect(est.peakRunGb).toBeLessThan(0.2);
   });
 
-  it("also works with underscore variant (tiny_gpt2)", () => {
+  it.each(cases)("$id infers ~$paramsB B params (not 7B)", ({ id, paramsB, confidence, dtype }) => {
+    const bytesPerParam = dtype === "float32" ? 4 : 2;
     const state = baseState({
       modelSource: "huggingface",
-      hfModelId: "sshleifer/tiny_gpt2",
-      passes: { ...DEFAULT_PASSES, conversionInputTargetTypes: "float32" },
+      hfModelId: id,
+      passes: { ...DEFAULT_PASSES, conversionInputTargetTypes: dtype },
     });
     const est = estimateVramRequirement(state);
-    expect(est.sourceWeightGb).toBeLessThan(0.1);
-  });
-
-  it("also works with catalog slug (sshleifer-tiny-gpt2)", () => {
-    const state = baseState({
-      modelSource: "huggingface",
-      hfModelId: "sshleifer-tiny-gpt2",
-      passes: { ...DEFAULT_PASSES, conversionInputTargetTypes: "float32" },
-    });
-    const est = estimateVramRequirement(state);
-    expect(est.sourceWeightGb).toBeLessThan(0.1);
-  });
-
-  it("gpt2 (base/small) estimates ~0.124B params, not 7B", () => {
-    const state = baseState({
-      modelSource: "huggingface",
-      hfModelId: "gpt2",
-      passes: { ...DEFAULT_PASSES, conversionInputTargetTypes: "float16" },
-    });
-    const est = estimateVramRequirement(state);
-    // 0.124B * 2 bytes FP16 ≈ 0.231 GiB
-    expect(est.sourceWeightGb).toBeGreaterThan(0.2);
-    expect(est.sourceWeightGb).toBeLessThan(0.3);
-  });
-
-  it("gpt2-large estimates ~0.774B params, not 7B", () => {
-    const state = baseState({
-      modelSource: "huggingface",
-      hfModelId: "gpt2-large",
-      passes: { ...DEFAULT_PASSES, conversionInputTargetTypes: "float16" },
-    });
-    const est = estimateVramRequirement(state);
-    // 0.774B * 2 bytes FP16 ≈ 1.44 GiB
-    expect(est.sourceWeightGb).toBeGreaterThan(1.0);
-    expect(est.sourceWeightGb).toBeLessThan(2.0);
-  });
-
-  it("still uses 7B default for truly unknown models", () => {
-    const state = baseState({
-      modelSource: "huggingface",
-      hfModelId: "some-org/some-unknown-model",
-      passes: { ...DEFAULT_PASSES, conversionInputTargetTypes: "float16" },
-    });
-    const est = estimateVramRequirement(state);
-    // 7B * 2 bytes FP16 ≈ 13.02 GiB
-    expect(est.sourceWeightGb).toBeGreaterThan(12);
-    expect(est.sourceWeightGb).toBeLessThan(14);
+    const expectedGb = (paramsB * 1e9 * bytesPerParam) / 1024 ** 3;
+    expect(est.sourceWeightGb).toBeCloseTo(expectedGb, 3);
+    expect(est.confidence).toBe(confidence);
   });
 });

--- a/src/lib/__tests__/vramEstimate.tinygpt2.test.ts
+++ b/src/lib/__tests__/vramEstimate.tinygpt2.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from "vitest";
+import { DEFAULT_PASSES } from "@/lib/defaultPasses";
+import { estimateVramRequirement } from "@/lib/vramEstimate";
+import { baseState } from "@/lib/__tests__/testState";
+
+describe("tiny-gpt2 memory estimate fix", () => {
+  it("does not inflate tiny-gpt2 to 26 GB (the reported bug)", () => {
+    const state = baseState({
+      modelSource: "huggingface",
+      hfModelId: "sshleifer/tiny-gpt2",
+      passes: { ...DEFAULT_PASSES, conversionInputTargetTypes: "float32" },
+    });
+    const est = estimateVramRequirement(state);
+    // Before the fix this was ~26 GB (7B default * 4 bytes FP32).
+    // tiny-gpt2 is ~5M params, so the estimate should be well under 1 GB.
+    expect(est.sourceWeightGb).toBeLessThan(0.1);
+    expect(est.inferenceGb).toBeLessThan(0.1);
+    expect(est.peakRunGb).toBeLessThan(0.2);
+  });
+
+  it("also works with underscore variant (tiny_gpt2)", () => {
+    const state = baseState({
+      modelSource: "huggingface",
+      hfModelId: "sshleifer/tiny_gpt2",
+      passes: { ...DEFAULT_PASSES, conversionInputTargetTypes: "float32" },
+    });
+    const est = estimateVramRequirement(state);
+    expect(est.sourceWeightGb).toBeLessThan(0.1);
+  });
+
+  it("also works with catalog slug (sshleifer-tiny-gpt2)", () => {
+    const state = baseState({
+      modelSource: "huggingface",
+      hfModelId: "sshleifer-tiny-gpt2",
+      passes: { ...DEFAULT_PASSES, conversionInputTargetTypes: "float32" },
+    });
+    const est = estimateVramRequirement(state);
+    expect(est.sourceWeightGb).toBeLessThan(0.1);
+  });
+
+  it("gpt2 (base/small) estimates ~0.124B params, not 7B", () => {
+    const state = baseState({
+      modelSource: "huggingface",
+      hfModelId: "gpt2",
+      passes: { ...DEFAULT_PASSES, conversionInputTargetTypes: "float16" },
+    });
+    const est = estimateVramRequirement(state);
+    // 0.124B * 2 bytes FP16 ≈ 0.231 GiB
+    expect(est.sourceWeightGb).toBeGreaterThan(0.2);
+    expect(est.sourceWeightGb).toBeLessThan(0.3);
+  });
+
+  it("gpt2-large estimates ~0.774B params, not 7B", () => {
+    const state = baseState({
+      modelSource: "huggingface",
+      hfModelId: "gpt2-large",
+      passes: { ...DEFAULT_PASSES, conversionInputTargetTypes: "float16" },
+    });
+    const est = estimateVramRequirement(state);
+    // 0.774B * 2 bytes FP16 ≈ 1.44 GiB
+    expect(est.sourceWeightGb).toBeGreaterThan(1.0);
+    expect(est.sourceWeightGb).toBeLessThan(2.0);
+  });
+
+  it("still uses 7B default for truly unknown models", () => {
+    const state = baseState({
+      modelSource: "huggingface",
+      hfModelId: "some-org/some-unknown-model",
+      passes: { ...DEFAULT_PASSES, conversionInputTargetTypes: "float16" },
+    });
+    const est = estimateVramRequirement(state);
+    // 7B * 2 bytes FP16 ≈ 13.02 GiB
+    expect(est.sourceWeightGb).toBeGreaterThan(12);
+    expect(est.sourceWeightGb).toBeLessThan(14);
+  });
+});

--- a/src/lib/vramEstimate.ts
+++ b/src/lib/vramEstimate.ts
@@ -50,6 +50,17 @@ function inferParamBillions(identifier: string): { paramsB: number; confidence: 
     return { paramsB: 1.5, confidence: "medium" };
   }
 
+  // GPT-2 variants — order matters: tiny before generic gpt2.
+  // sshleifer/tiny-gpt2 is a ~5M-param model used by the tour demo and catalog.
+  // Without this, unknown models fall through to the 7B default and show
+  // wildly inflated memory (e.g. 26 GB for a 5 MB model at FP32).
+  if (id.includes("tiny-gpt2") || id.includes("tiny_gpt2")) return { paramsB: 0.005, confidence: "medium" };
+  if (id.includes("distilgpt2")) return { paramsB: 0.082, confidence: "low" };
+  if (id.includes("gpt2-xl") || id.includes("gpt2_xl")) return { paramsB: 1.5, confidence: "low" };
+  if (id.includes("gpt2-large") || id.includes("gpt2_large")) return { paramsB: 0.774, confidence: "low" };
+  if (id.includes("gpt2-medium") || id.includes("gpt2_medium")) return { paramsB: 0.355, confidence: "low" };
+  if (id.includes("gpt2")) return { paramsB: 0.124, confidence: "low" };
+
   if (id.includes("phi-3.5") || id.includes("phi3.5")) return { paramsB: 3.8, confidence: "low" };
   if (id.includes("phi-3") || id.includes("phi3")) return { paramsB: 3.8, confidence: "low" };
   if (id.includes("phi-2")) return { paramsB: 2.7, confidence: "low" };

--- a/src/lib/vramEstimate.ts
+++ b/src/lib/vramEstimate.ts
@@ -23,6 +23,23 @@ const WHISPER_PARAMS_B: Record<string, number> = {
   "large-v3": 1.55,
 };
 
+// GPT-2 variants — order matters: most specific needles first, generic "gpt2" last.
+// sshleifer/tiny-gpt2 is a ~5M-param model used by the tour demo and catalog.
+// Without these, unknown models fall through to the 7B default and show wildly
+// inflated memory (e.g. 26 GB for a 5 MB model at FP32).
+const GPT2_VARIANTS: ReadonlyArray<{
+  needles: readonly string[];
+  paramsB: number;
+  confidence: VramConfidence;
+}> = [
+  { needles: ["tiny-gpt2", "tiny_gpt2"], paramsB: 0.005, confidence: "medium" },
+  { needles: ["distilgpt2"], paramsB: 0.082, confidence: "low" },
+  { needles: ["gpt2-xl", "gpt2_xl"], paramsB: 1.5, confidence: "low" },
+  { needles: ["gpt2-large", "gpt2_large"], paramsB: 0.774, confidence: "low" },
+  { needles: ["gpt2-medium", "gpt2_medium"], paramsB: 0.355, confidence: "low" },
+  { needles: ["gpt2"], paramsB: 0.124, confidence: "low" },
+];
+
 function inferParamBillions(identifier: string): { paramsB: number; confidence: VramConfidence } {
   const id = identifier.toLowerCase();
 
@@ -50,16 +67,14 @@ function inferParamBillions(identifier: string): { paramsB: number; confidence: 
     return { paramsB: 1.5, confidence: "medium" };
   }
 
-  // GPT-2 variants — order matters: tiny before generic gpt2.
-  // sshleifer/tiny-gpt2 is a ~5M-param model used by the tour demo and catalog.
-  // Without this, unknown models fall through to the 7B default and show
-  // wildly inflated memory (e.g. 26 GB for a 5 MB model at FP32).
-  if (id.includes("tiny-gpt2") || id.includes("tiny_gpt2")) return { paramsB: 0.005, confidence: "medium" };
-  if (id.includes("distilgpt2")) return { paramsB: 0.082, confidence: "low" };
-  if (id.includes("gpt2-xl") || id.includes("gpt2_xl")) return { paramsB: 1.5, confidence: "low" };
-  if (id.includes("gpt2-large") || id.includes("gpt2_large")) return { paramsB: 0.774, confidence: "low" };
-  if (id.includes("gpt2-medium") || id.includes("gpt2_medium")) return { paramsB: 0.355, confidence: "low" };
-  if (id.includes("gpt2")) return { paramsB: 0.124, confidence: "low" };
+  // GPT-2 variants — collapse gpt-2 / gpt_2 spellings so the needles above
+  // (which use "gpt2") also match hyphenated ids like gpt-2-medium.
+  const gpt2Id = id.replace(/gpt[-_]2/g, "gpt2");
+  for (const variant of GPT2_VARIANTS) {
+    if (variant.needles.some((needle) => gpt2Id.includes(needle))) {
+      return { paramsB: variant.paramsB, confidence: variant.confidence };
+    }
+  }
 
   if (id.includes("phi-3.5") || id.includes("phi3.5")) return { paramsB: 3.8, confidence: "low" };
   if (id.includes("phi-3") || id.includes("phi3")) return { paramsB: 3.8, confidence: "low" };


### PR DESCRIPTION
This PR was generated automatically by mini-swe-agent.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes inflated VRAM estimates for GPT‑2 variants and unsticks the tiny‑gpt2 sample flow (issue #387). Previously, unknown GPT‑2 IDs fell back to 7B (~26 GB FP32) and the “Applied recipe” banner could trap users; now known GPT‑2 variants return realistic sizes, and users can clear an applied recipe to reopen the catalog.

- Adds ordered GPT‑2 heuristics and `gpt-2`/`gpt_2` → `gpt2` normalization in `src/lib/vramEstimate.ts` and `olive_mcp_server/tools/agent_model_info.py`; tests cover `sshleifer/tiny-gpt2`, `sshleifer/tiny_gpt2`, `sshleifer-tiny-gpt2`, `distilgpt2`, `gpt2`, `gpt2-medium`, `gpt2-large`, `gpt2-xl`, hyphen/underscore spellings, and the 7B fallback for unknowns.
- Introduces a clear‑recipe escape in `useRecipeHub` (`handleClearRecipe`) that resets model fields, clears `appliedRecipeLabel`, re‑expands the rail, and shows a transient success message; wires a “Clear recipe” button in `InputEnvironmentPanel`; adds `notifyRecipeMessage` to `InputRecipeRail` and surfaces feedback when applying the sample recipe; tests cover the stuck‑state regression.
- No external API changes; only VRAM estimate outputs and input‑panel UX change. If you render `InputRecipeRail` outside `InputEnvironmentPanel`, pass `notifyRecipeMessage`.

<sup>Written for commit eb7b0eed1d8162dff7805fef97dd59ed7a0470e3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tonythethompson/Olive-Studio/pull/392?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

