### PR TITLE
🤖 GLM 5.2 Fix for Issue #389

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -131,9 +131,9 @@ function Dashboard() {
   // Header center cluster (KB sync / runtime) must never wrap
   // onto a second line. Measure the actual gap between the fixed left and
   // right header columns and collapse the cluster to icon-only once the
-  // full-label layout wouldn't fit — driven by real available space rather
-  // than a viewport breakpoint, since the sidebar and header columns already
-  // resize independently at their own breakpoints.
+  // full-label layout wouldn't fit. Below the wide-shell breakpoint the
+  // cluster is always compact so it collapses in lockstep with the sidebar
+  // and the Assistant button label (both driven by the CSS `wide` breakpoint).
   const headerLeftRef = useRef<HTMLDivElement>(null);
   const headerRightRef = useRef<HTMLDivElement>(null);
   const [headerCompact, setHeaderCompact] = useState(() => {
@@ -162,7 +162,12 @@ function Dashboard() {
 
     const measure = () => {
       const available = rightEl.getBoundingClientRect().left - leftEl.getBoundingClientRect().right;
-      setHeaderCompact(available < HEADER_CLUSTER_FULL_WIDTH);
+      // Stay compact below the wide-shell breakpoint so the header collapses
+      // to icons-only in lockstep with the sidebar and Assistant button label
+      // (which are driven by the CSS `wide` breakpoint).  Above the breakpoint
+      // the available-space heuristic still kicks in for very narrow content
+      // areas.
+      setHeaderCompact(available < HEADER_CLUSTER_FULL_WIDTH || window.innerWidth < WIDE_SHELL_MIN_WIDTH_PX);
     };
 
     measure();

--- a/src/components/features/KbSyncIndicator.test.tsx
+++ b/src/components/features/KbSyncIndicator.test.tsx
@@ -1,0 +1,71 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { KbSyncIndicator } from "./KbSyncIndicator";
+
+const freshKb = {
+  available: true,
+  version: "1.0.0",
+  lastUpdated: new Date().toISOString(),
+  lastSync: new Date().toISOString(),
+  passCount: 42,
+};
+
+function stubKbStatus(body: unknown) {
+  vi.spyOn(globalThis, "fetch").mockImplementation((url: unknown) => {
+    const urlStr = String(url);
+    if (urlStr.includes("/api/mcp/kb-status")) {
+      return Promise.resolve(new Response(JSON.stringify(body), { status: 200 }));
+    }
+    return Promise.resolve(new Response("{}", { status: 200 }));
+  });
+}
+
+function renderWithProvider(ui: React.ReactElement) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+  return render(
+    <QueryClientProvider client={client}>{ui}</QueryClientProvider>,
+  );
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("KbSyncIndicator compact mode", () => {
+  it("shows full labels when compact is false", async () => {
+    stubKbStatus(freshKb);
+    renderWithProvider(<KbSyncIndicator compact={false} />);
+    // The KB version text should be visible (not hidden)
+    const kbVersion = await screen.findByText(/KB v1\.0\.0/i);
+    expect(kbVersion).toBeTruthy();
+    expect(kbVersion.className).not.toContain("hidden");
+
+    // "sync" button text should be visible
+    const syncText = screen.getByText("sync");
+    expect(syncText).toBeTruthy();
+    expect(syncText.className).not.toContain("hidden");
+  });
+
+  it("hides text labels when compact is true (icon-only)", async () => {
+    stubKbStatus(freshKb);
+    renderWithProvider(<KbSyncIndicator compact={true} />);
+    // Wait for the KB version to appear (even if hidden)
+    await waitFor(() => {
+      const el = screen.queryByText(/KB v1\.0\.0/);
+      expect(el).not.toBeNull();
+    });
+
+    // The KB version text should be hidden
+    const kbVersion = screen.getByText(/KB v1\.0\.0/);
+    expect(kbVersion.className).toContain("hidden");
+
+    // "sync" button text should be hidden
+    const syncSpans = screen.getAllByText("sync");
+    for (const el of syncSpans) {
+      expect(el.className).toContain("hidden");
+    }
+  });
+});

--- a/src/components/features/RuntimeEnvControlsCompact.test.tsx
+++ b/src/components/features/RuntimeEnvControlsCompact.test.tsx
@@ -1,0 +1,61 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { RuntimeEnvControls } from "./RuntimeEnvControls";
+
+const installedStatus = {
+  venvExists: true,
+  venvPython: "/tmp/.venv/bin/python",
+  venvScripts: "/tmp/.venv/bin",
+  oliveInstalled: true,
+  oliveVersion: "0.7.0",
+  systemPython: "/usr/bin/python3",
+  configuredPython: "/tmp/.venv/bin/python",
+  venvOnUserPath: true,
+  platform: "linux",
+  hint: null,
+  pythonPrerequisite: null,
+};
+
+function stubRuntime(body: unknown) {
+  vi.spyOn(globalThis, "fetch").mockImplementation((url: unknown) => {
+    const urlStr = String(url);
+    if (urlStr.includes("/api/env/runtime")) {
+      return Promise.resolve(new Response(JSON.stringify(body), { status: 200 }));
+    }
+    return Promise.resolve(new Response("{}", { status: 200 }));
+  });
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("RuntimeEnvControls compact mode", () => {
+  it("shows full labels when compact is false", async () => {
+    stubRuntime(installedStatus);
+    render(<RuntimeEnvControls compact={false} />);
+
+    // Wait for the runtime label to appear (e.g. "Olive 0.7.0")
+    const label = await screen.findByText(/Olive 0\.7\.0/i);
+    expect(label).toBeTruthy();
+    expect(label.className).not.toContain("hidden");
+  });
+
+  it("hides text labels when compact is true (icon-only)", async () => {
+    stubRuntime(installedStatus);
+    render(<RuntimeEnvControls compact={true} />);
+
+    // Wait for status to load — the button should exist with an aria-label
+    await waitFor(() => {
+      const btn = screen.queryByRole("button", { expanded: false });
+      expect(btn).not.toBeNull();
+    });
+
+    // The runtime label text should be hidden when compact
+    const label = screen.queryByText(/Olive 0\.7\.0/i);
+    // Either it's not rendered (display:none parent) or has "hidden" class
+    if (label) {
+      expect(label.className).toContain("hidden");
+    }
+  });
+});


### PR DESCRIPTION
This PR was generated automatically by mini-swe-agent.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns the header center cluster collapse with the wide-shell CSS breakpoint to fix desync with the sidebar and Assistant button label (fixes #389). Previously it collapsed only by available space; now it is always icon-only below the breakpoint and still collapses by available-space heuristics above it.

- App.tsx: `Dashboard` sets `headerCompact` when available space is below `HEADER_CLUSTER_FULL_WIDTH` or `window.innerWidth < WIDE_SHELL_MIN_WIDTH_PX`.
- Tests: Add `KbSyncIndicator` and `RuntimeEnvControls` compact-mode tests that stub `/api/mcp/kb-status` and `/api/env/runtime`, asserting label visibility toggles with `compact` (visible when false, hidden when true).

<sup>Written for commit 4a63e1985bd8d84e89756188695e9f549dceab3f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tonythethompson/Olive-Studio/pull/393?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

