### PR TITLE
🤖 GLM 5.2 Fix for Issue #388

### DIFF
--- a/docs/ROADMAP-ai-sdk-adoption.md
+++ b/docs/ROADMAP-ai-sdk-adoption.md
@@ -20,7 +20,7 @@ import { generateText } from 'ai';
 
 // Inside the gemini plugin's call() handler:
 const result = await generateText({
-  model: google('gemini-2.5-flash', { apiKey: cfg.apiKey }),
+  model: google('gemini-3.7-flash', { apiKey: cfg.apiKey }),
   system,
   messages: messages.map(m => ({ role: m.role, content: m.content })),
 });

--- a/src/components/features/__tests__/testUtils.tsx
+++ b/src/components/features/__tests__/testUtils.tsx
@@ -94,6 +94,7 @@ export function useFetchRoutesMock(routes: Record<string, unknown> = {}) {
     spy = mockFetchRoutes(routes);
   });
   afterEach(() => {
+    localStorage.clear();
     spy.mockRestore();
     vi.clearAllMocks();
   });

--- a/src/components/features/assistant/AssistantSidebar.flows.test.tsx
+++ b/src/components/features/assistant/AssistantSidebar.flows.test.tsx
@@ -26,6 +26,7 @@ describe("AssistantSidebar flows", () => {
   });
 
   afterEach(() => {
+    localStorage.clear();
     vi.restoreAllMocks();
   });
   it("audits on open, chats, and renders provider settings", async () => {
@@ -33,7 +34,7 @@ describe("AssistantSidebar flows", () => {
       "ai/provider": {
         source: "runtime",
         provider: "gemini",
-        model: "gemini-2.5-flash",
+        model: "gemini-3.7-flash",
         baseUrl: null,
         envCredentials: {
           gemini: { present: true, envVar: "GEMINI_API_KEY", usable: true },
@@ -59,7 +60,7 @@ describe("AssistantSidebar flows", () => {
     renderWithProviders(<AssistantSidebar isOpen onClose={vi.fn()} />);
 
     // Header reflects the active provider and the assistant auto-runs analysis
-    await waitFor(() => expect(screen.getByText(/Google Gemini \/ gemini-2.5-flash/)).toBeTruthy());
+    await waitFor(() => expect(screen.getByText(/Google Gemini \/ gemini-3.7-flash/)).toBeTruthy());
     expect(screen.getByTestId("pipeline-review")).toBeTruthy();
 
     // Chat tab: preset query round-trips through /api/ai/chat

--- a/src/components/features/assistant/aiProviderCatalog.ts
+++ b/src/components/features/assistant/aiProviderCatalog.ts
@@ -29,7 +29,7 @@ export const PROVIDER_OPTIONS: readonly ProviderOption[] = [
   {
     id: "gemini",
     name: "Google Gemini",
-    models: ["gemini-2.5-flash", "gemini-2.5-pro", "gemini-2.0-flash"],
+    models: ["gemini-3.7-flash", "gemini-2.5-pro", "gemini-2.0-flash"],
     keyEnvVar: "GEMINI_API_KEY or GOOGLE_API_KEY",
     docsUrl: "aistudio.google.com",
     category: "direct",
@@ -84,7 +84,7 @@ export const PROVIDER_OPTIONS: readonly ProviderOption[] = [
     models: [
       "openai/gpt-4o",
       "anthropic/claude-sonnet-4-6",
-      "google/gemini-2.5-flash",
+      "google/gemini-3.7-flash",
       "meta-llama/llama-4-scout",
       "deepseek/deepseek-r1",
       "qwen/qwen3-235b-a22b",
@@ -190,7 +190,7 @@ export const PROVIDER_OPTIONS: readonly ProviderOption[] = [
   {
     id: "kilocode",
     name: "Kilo Gateway",
-    models: ["anthropic/claude-sonnet-4", "openai/gpt-4o", "google/gemini-2.5-flash", "deepseek/deepseek-r1"],
+    models: ["anthropic/claude-sonnet-4", "openai/gpt-4o", "google/gemini-3.7-flash", "deepseek/deepseek-r1"],
     keyEnvVar: "KILO_API_KEY or KILOCODE_API_KEY",
     docsUrl: "kilo.ai/docs/gateway",
     baseUrl: "https://api.kilo.ai/api/gateway",

--- a/src/components/features/assistant/useAiProviderSettings.test.ts
+++ b/src/components/features/assistant/useAiProviderSettings.test.ts
@@ -317,4 +317,72 @@ describe("useAiProviderSettings", () => {
     );
     expect(onProviderActivated).toHaveBeenCalledTimes(1);
   });
+
+  describe("persisted provider/model preference", () => {
+    const STORAGE_KEY = "olive-studio:ai-model-pref";
+    const seedPref = (provider: string, model: string) =>
+      localStorage.setItem(STORAGE_KEY, JSON.stringify({ provider, model }));
+
+    const renderSettings = () =>
+      renderHook(() =>
+        useAiProviderSettings({
+          isOpen: false,
+          activeTab: "settings",
+          onProviderActivated: vi.fn(),
+          onProviderCleared: vi.fn(),
+          onProviderMissing: vi.fn(),
+        }),
+      );
+
+    it("defaults to Gemini when no preference is stored", () => {
+      const { result } = renderSettings();
+      expect(result.current.settingsProvider).toBe("gemini");
+      expect(result.current.settingsModel).toBe("gemini-3.7-flash");
+    });
+
+    it("restores a previously persisted provider/model on initial render", () => {
+      seedPref("anthropic", "claude-sonnet-4-6");
+      const { result } = renderSettings();
+      expect(result.current.settingsProvider).toBe("anthropic");
+      expect(result.current.settingsModel).toBe("claude-sonnet-4-6");
+    });
+
+    it("falls back to the provider default when the persisted model was removed from the catalog", () => {
+      seedPref("gemini", "gemini-2.5-flash");
+      const { result } = renderSettings();
+      expect(result.current.settingsProvider).toBe("gemini");
+      expect(result.current.settingsModel).toBe("gemini-3.7-flash");
+    });
+
+    it("rejects a persisted model that does not belong to the persisted provider", () => {
+      seedPref("openai", "gemini-3.7-flash");
+      const { result } = renderSettings();
+      expect(result.current.settingsProvider).toBe("openai");
+      expect(result.current.settingsModel).toBe("gpt-4o");
+    });
+
+    it("accepts a freehand model for providers with an empty static catalog", () => {
+      seedPref("openai-compat", "my-fine-tuned-model");
+      const { result } = renderSettings();
+      expect(result.current.settingsProvider).toBe("openai-compat");
+      expect(result.current.settingsModel).toBe("my-fine-tuned-model");
+    });
+
+    it("persists the current selection back to localStorage when it changes", async () => {
+      const fetchSpy = vi
+        .spyOn(globalThis, "fetch")
+        .mockImplementation(() => Promise.resolve(jsonResponse({ models: [], source: "fallback" })));
+
+      const { result } = renderSettings();
+      await act(async () => {
+        result.current.selectProvider("openai");
+      });
+
+      expect(fetchSpy).toHaveBeenCalled();
+      expect(JSON.parse(localStorage.getItem(STORAGE_KEY) ?? "{}")).toEqual({
+        provider: "openai",
+        model: "gpt-4o",
+      });
+    });
+  });
 });

--- a/src/components/features/assistant/useAiProviderSettings.test.ts
+++ b/src/components/features/assistant/useAiProviderSettings.test.ts
@@ -12,6 +12,7 @@ function jsonResponse(body: unknown, init?: ResponseInit): Response {
 
 describe("useAiProviderSettings", () => {
   afterEach(() => {
+    localStorage.clear();
     vi.restoreAllMocks();
   });
 

--- a/src/components/features/assistant/useAiProviderSettings.ts
+++ b/src/components/features/assistant/useAiProviderSettings.ts
@@ -178,7 +178,7 @@ export function useAiProviderSettings({
   const [settingsModel, setSettingsModel] = useState(() => {
     if (!persistedPref) return "gemini-3.7-flash";
     const providerId = normalizeUiProviderId(persistedPref.provider) ?? "gemini";
-    const providerOption = PROVIDER_OPTIONS.find((p) => p.id === providerId) ?? PROVIDER_OPTIONS[0]!;
+    const providerOption = PROVIDER_OPTIONS.find((p) => p.id === providerId) ?? PROVIDER_OPTIONS.find((p) => p.id === "gemini")!;
     // Validate against the static catalog: a stale/removed model (e.g.
     // gemini-2.5-flash) must not be restored, so fall back to the provider's
     // first listed model. Providers with an empty static catalog

--- a/src/components/features/assistant/useAiProviderSettings.ts
+++ b/src/components/features/assistant/useAiProviderSettings.ts
@@ -11,6 +11,11 @@ interface PersistedModelPref {
   model: string;
 }
 
+/** True when a browser localStorage is available (guards SSR / non-browser envs). */
+function canUseLocalStorage(): boolean {
+  return typeof window !== "undefined" && typeof localStorage !== "undefined";
+}
+
 /**
  * Read the last-used AI provider/model from localStorage so the assistant
  * remembers the user's choice across sessions instead of always defaulting
@@ -18,6 +23,7 @@ interface PersistedModelPref {
  * unavailable.
  */
 function readPersistedModelPref(): PersistedModelPref | null {
+  if (!canUseLocalStorage()) return null;
   try {
     const raw = localStorage.getItem(AI_MODEL_PREF_STORAGE_KEY);
     if (!raw) return null;
@@ -36,6 +42,7 @@ function readPersistedModelPref(): PersistedModelPref | null {
  * mode, quota, etc.).
  */
 function writePersistedModelPref(provider: string, model: string): void {
+  if (!canUseLocalStorage()) return;
   try {
     localStorage.setItem(
       AI_MODEL_PREF_STORAGE_KEY,
@@ -158,18 +165,28 @@ export function useAiProviderSettings({
   // Restore the last-used provider/model from localStorage so the assistant
   // remembers the user's choice across sessions instead of always defaulting
   // to Gemini.  The server-side preference (readAiPreference) still takes
-  // priority once fetchProviderStatus completes.
+  // priority once fetchProviderStatus completes.  Read the preference once so
+  // both initial values derive from the same storage read.
+  const [persistedPref] = useState<PersistedModelPref | null>(() => readPersistedModelPref());
   const [settingsProvider, setSettingsProvider] = useState<ProviderId>(() => {
-    const pref = readPersistedModelPref();
-    if (pref) {
-      const uiId = normalizeUiProviderId(pref.provider);
+    if (persistedPref) {
+      const uiId = normalizeUiProviderId(persistedPref.provider);
       if (uiId) return uiId;
     }
     return "gemini";
   });
   const [settingsModel, setSettingsModel] = useState(() => {
-    const pref = readPersistedModelPref();
-    return pref?.model ?? "gemini-3.7-flash";
+    if (!persistedPref) return "gemini-3.7-flash";
+    const providerId = normalizeUiProviderId(persistedPref.provider) ?? "gemini";
+    const providerOption = PROVIDER_OPTIONS.find((p) => p.id === providerId) ?? PROVIDER_OPTIONS[0]!;
+    // Validate against the static catalog: a stale/removed model (e.g.
+    // gemini-2.5-flash) must not be restored, so fall back to the provider's
+    // first listed model. Providers with an empty static catalog
+    // (openai-compat freehand) accept any persisted model.
+    if (providerOption.models.length > 0 && !providerOption.models.includes(persistedPref.model)) {
+      return providerOption.models[0]!;
+    }
+    return persistedPref.model;
   });
   const [settingsApiKey, setSettingsApiKey] = useState("");
   const [settingsBaseUrl, setSettingsBaseUrl] = useState("");

--- a/src/components/features/assistant/useAiProviderSettings.ts
+++ b/src/components/features/assistant/useAiProviderSettings.ts
@@ -4,6 +4,48 @@ import { openExternal } from "@/lib/openExternal";
 import { PROVIDER_OPTIONS, normalizeUiProviderId, type ProviderId } from "./aiProviderCatalog";
 import type { ProviderStatus, SidebarTab } from "./types";
 
+const AI_MODEL_PREF_STORAGE_KEY = "olive-studio:ai-model-pref";
+
+interface PersistedModelPref {
+  provider: string;
+  model: string;
+}
+
+/**
+ * Read the last-used AI provider/model from localStorage so the assistant
+ * remembers the user's choice across sessions instead of always defaulting
+ * to Gemini.  Returns null when no preference has been stored or storage is
+ * unavailable.
+ */
+function readPersistedModelPref(): PersistedModelPref | null {
+  try {
+    const raw = localStorage.getItem(AI_MODEL_PREF_STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as Partial<PersistedModelPref>;
+    if (typeof parsed.provider !== "string" || typeof parsed.model !== "string") return null;
+    if (!parsed.provider || !parsed.model) return null;
+    return { provider: parsed.provider, model: parsed.model };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Persist the current provider/model selection to localStorage so it survives
+ * page reloads and app restarts.  Failures are silently ignored (private
+ * mode, quota, etc.).
+ */
+function writePersistedModelPref(provider: string, model: string): void {
+  try {
+    localStorage.setItem(
+      AI_MODEL_PREF_STORAGE_KEY,
+      JSON.stringify({ provider, model }),
+    );
+  } catch {
+    // Ignore storage failures (private mode, quota, etc.)
+  }
+}
+
 interface UseAiProviderSettingsOptions {
   isOpen: boolean;
   activeTab: SidebarTab;
@@ -113,8 +155,22 @@ export function useAiProviderSettings({
   onProviderMissing,
 }: UseAiProviderSettingsOptions) {
   const [providerStatus, setProviderStatus] = useState<ProviderStatus>({ source: "none" });
-  const [settingsProvider, setSettingsProvider] = useState<ProviderId>("gemini");
-  const [settingsModel, setSettingsModel] = useState("gemini-2.5-flash");
+  // Restore the last-used provider/model from localStorage so the assistant
+  // remembers the user's choice across sessions instead of always defaulting
+  // to Gemini.  The server-side preference (readAiPreference) still takes
+  // priority once fetchProviderStatus completes.
+  const [settingsProvider, setSettingsProvider] = useState<ProviderId>(() => {
+    const pref = readPersistedModelPref();
+    if (pref) {
+      const uiId = normalizeUiProviderId(pref.provider);
+      if (uiId) return uiId;
+    }
+    return "gemini";
+  });
+  const [settingsModel, setSettingsModel] = useState(() => {
+    const pref = readPersistedModelPref();
+    return pref?.model ?? "gemini-3.7-flash";
+  });
   const [settingsApiKey, setSettingsApiKey] = useState("");
   const [settingsBaseUrl, setSettingsBaseUrl] = useState("");
   const [settingsCloudflareAccountId, setSettingsCloudflareAccountId] = useState("");
@@ -325,6 +381,11 @@ export function useAiProviderSettings({
       return null;
     }
   };
+
+  // Persist the current provider/model selection so it survives app restarts.
+  useEffect(() => {
+    writePersistedModelPref(settingsProvider, settingsModel);
+  }, [settingsProvider, settingsModel]);
 
   useEffect(() => {
     if (!isOpen) return;

--- a/src/server/routes/ai/providerRoutes.test.ts
+++ b/src/server/routes/ai/providerRoutes.test.ts
@@ -101,7 +101,7 @@ describe("POST /api/ai/provider keyless activation", () => {
     const res = await fetch(`${baseUrl}/api/ai/provider`, {
       method: "POST",
       headers: { "content-type": "application/json" },
-      body: JSON.stringify({ provider: "gemini", model: "gemini-2.5-flash" }),
+      body: JSON.stringify({ provider: "gemini", model: "gemini-3.7-flash" }),
     });
     expect(res.status).toBe(400);
   });

--- a/src/server/services/ai/gemini.ts
+++ b/src/server/services/ai/gemini.ts
@@ -47,8 +47,8 @@ async function call(
 registerProvider({
   name: "gemini",
   label: "Google Gemini",
-  defaultModel: "gemini-2.5-flash",
+  defaultModel: "gemini-3.7-flash",
   envVarNames: ["GEMINI_API_KEY", "GOOGLE_API_KEY", "GOOGLE_GENAI_API_KEY"],
-  buildConfig: (apiKey) => ({ provider: "gemini", apiKey, model: "gemini-2.5-flash" }),
+  buildConfig: (apiKey) => ({ provider: "gemini", apiKey, model: "gemini-3.7-flash" }),
   call,
 });

--- a/src/server/services/ai/providers.validation.test.ts
+++ b/src/server/services/ai/providers.validation.test.ts
@@ -75,7 +75,7 @@ describe("AI provider empty-response validation", () => {
   it("Gemini throws on empty or whitespace text", async () => {
     mockedFetch.mockResolvedValue(jsonResponse({ candidates: [{ content: { parts: [{ text: "" }] } }] }));
     await expect(
-      callProvider({ provider: "gemini", apiKey: "k", model: "gemini-2.5-flash" }, "sys", [], false),
+      callProvider({ provider: "gemini", apiKey: "k", model: "gemini-3.7-flash" }, "sys", [], false),
     ).rejects.toThrow("Gemini returned an empty response.");
   });
 
@@ -84,7 +84,7 @@ describe("AI provider empty-response validation", () => {
       jsonResponse({ candidates: [{ content: { parts: [{ text: "hello" }] } }] }),
     );
     await callProvider(
-      { provider: "gemini", apiKey: "secret-key", model: "gemini-2.5-flash" },
+      { provider: "gemini", apiKey: "secret-key", model: "gemini-3.7-flash" },
       "sys",
       [],
       false,
@@ -92,7 +92,7 @@ describe("AI provider empty-response validation", () => {
 
     const [url, init] = mockedFetch.mock.calls[0] ?? [];
     expect(String(url)).toBe(
-      "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent",
+      "https://generativelanguage.googleapis.com/v1beta/models/gemini-3.7-flash:generateContent",
     );
     expect(String(url)).not.toContain("secret-key");
     expect(String(url)).not.toContain("key=");

--- a/src/server/services/ai/registry.test.ts
+++ b/src/server/services/ai/registry.test.ts
@@ -62,7 +62,7 @@ describe("Provider registration", () => {
     defaultModel: string;
     hasEnvVars: boolean; // falsy = runtime-override-only
   }> = [
-    { name: "gemini", label: "Google Gemini", defaultModel: "gemini-2.5-flash", hasEnvVars: true },
+    { name: "gemini", label: "Google Gemini", defaultModel: "gemini-3.7-flash", hasEnvVars: true },
     { name: "openai", label: "OpenAI", defaultModel: "gpt-4o-mini", hasEnvVars: true },
     {
       name: "chatgpt-sub",
@@ -422,7 +422,7 @@ describe("Edge cases", () => {
     vi.mocked(readEnvApiKey).mockReturnValue("sk-test");
     const result = detectEnvProvider();
     expect(result?.provider).toBe("gemini");
-    expect(result?.model).toBe("gemini-2.5-flash");
+    expect(result?.model).toBe("gemini-3.7-flash");
     expect(result?.apiKey).toBe("sk-test");
   });
 

--- a/src/server/services/ai/state.test.ts
+++ b/src/server/services/ai/state.test.ts
@@ -53,7 +53,7 @@ describe("restoreProviderFromPreference", () => {
   });
 
   it("still rejects key-required providers without env credentials", () => {
-    const pref: AiPreference = { provider: "gemini", model: "gemini-2.5-flash" };
+    const pref: AiPreference = { provider: "gemini", model: "gemini-3.7-flash" };
     expect(restoreProviderFromPreference(pref)).toBeNull();
   });
 });


### PR DESCRIPTION
This PR was generated automatically by mini-swe-agent.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sets Gemini’s default model to gemini-3.7-flash and persists the selected provider/model across reloads. Previously we defaulted to gemini-2.5-flash and forgot selections; now we restore the last valid choice (or the provider default) while server-side preference still overrides after provider status loads. Fixes #388.

- Review notes
  - Registry: defaultModel and buildConfig use gemini-3.7-flash; env detection tests expect 3.7.
  - Catalog: Gemini, aggregator, and `kilocode` entries reference gemini-3.7-flash.
  - Persistence: stores `olive-studio:ai-model-pref`; initializes once from storage, persists on change; SSR-safe; ignores storage failures.
  - Validation: restore only models valid for the stored provider; if missing, use the provider’s first model; reject cross-provider models; accept freehand for providers with an empty static catalog; normalize provider IDs.
  - Tests/docs: add persistence coverage; update AssistantSidebar, server tests, and ROADMAP snippet to 3.7; clear localStorage in test teardowns.

- Rollout
  - No config changes. Users see gemini-3.7-flash unless a stored preference exists; removed models fall back to the provider default.
  - Update tests pinned to gemini-2.5-flash or relying on lingering localStorage.

<sup>Written for commit 38b25ab13024e95a502055953bed300d0d0ff899. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tonythethompson/Olive-Studio/pull/394?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

