### PR TITLE
🤖 GLM 5.2 Fix for Issue #390

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -210,7 +210,7 @@ function Dashboard() {
   const scrollingToRef = useRef<ActiveView | null>(null);
 
   const handleOpenAiAudit = () => {
-    setIsAiSidebarOpen(true);
+    setAssistantSidebarOpen(true);
     setTriggerAiAudit(true);
   };
 
@@ -370,12 +370,12 @@ function Dashboard() {
     const onAskAiChat = (event: Event) => {
       const detail = (event as CustomEvent<AskAiChatDetail>).detail;
       if (!detail?.query) return;
-      setIsAiSidebarOpen(true);
+      setAssistantSidebarOpen(true);
       setPendingChatQuery(detail);
     };
     window.addEventListener(OLIVE_ASK_AI_CHAT, onAskAiChat);
     return () => window.removeEventListener(OLIVE_ASK_AI_CHAT, onAskAiChat);
-  }, []);
+  }, [setAssistantSidebarOpen]);
 
   useEffect(() => {
     const main = mainRef.current;
@@ -542,7 +542,7 @@ function Dashboard() {
                   <button
                     type="button"
                     data-tour="assistant"
-                    onClick={() => setIsAiSidebarOpen((open) => !open)}
+                    onClick={() => setAssistantSidebarOpen(!isAiSidebarOpen)}
                     aria-label={isAiSidebarOpen ? "Close Assistant" : "Open Assistant"}
                     aria-expanded={isAiSidebarOpen}
                     aria-controls="assistant-panel"
@@ -657,7 +657,7 @@ function Dashboard() {
               <Suspense fallback={<SidebarFallback />}>
                 <AssistantSidebar
                   isOpen={isAiSidebarOpen}
-                  onClose={() => setIsAiSidebarOpen(false)}
+                  onClose={() => setAssistantSidebarOpen(false)}
                   openToAudit={triggerAiAudit}
                   onAuditOpened={() => setTriggerAiAudit(false)}
                   pendingChatQuery={pendingChatQuery}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -143,7 +143,8 @@ function Dashboard() {
   const HEADER_CLUSTER_FULL_WIDTH = 520;
 
   const [isOliveRunning, setIsOliveRunning] = useState(false);
-  const [isAiSidebarOpen, setIsAiSidebarOpen] = useState(false);
+  const isAiSidebarOpen = usePreferencesStore((s) => s.assistantSidebarOpen);
+  const setAssistantSidebarOpen = usePreferencesStore((s) => s.setAssistantSidebarOpen);
   const [triggerAiAudit, setTriggerAiAudit] = useState(false);
   const [pendingChatQuery, setPendingChatQuery] = useState<AskAiChatDetail | null>(null);
   const [licenseOpen, setLicenseOpen] = useState(false);

--- a/src/components/features/AgentAccessControls.tsx
+++ b/src/components/features/AgentAccessControls.tsx
@@ -75,11 +75,14 @@ function formatAgentAccessError(status: number, serverError: string | undefined)
 interface AgentAccessControlsProps {
   compact?: boolean;
   variant?: "control" | "panel";
+  /** When true (sidebar open), re-fetches the policy to reflect latest server-side state. */
+  isOpen?: boolean;
 }
 
 export const AgentAccessControls = memo(function AgentAccessControls({
   compact = false,
   variant = "control",
+  isOpen = true,
 }: AgentAccessControlsProps) {
   const isPanel = variant === "panel";
 
@@ -146,8 +149,9 @@ export const AgentAccessControls = memo(function AgentAccessControls({
   }, [clearBusyTimer]);
 
   useEffect(() => {
+    if (!isOpen) return;
     void refresh();
-  }, [refresh]);
+  }, [refresh, isOpen]);
 
   const updateMenuPos = useCallback(() => {
     if (!rootRef.current) return;

--- a/src/components/features/assistant/AssistantSidebar.tsx
+++ b/src/components/features/assistant/AssistantSidebar.tsx
@@ -23,7 +23,7 @@ import { PROVIDER_OPTIONS, normalizeUiProviderId } from "./aiProviderCatalog";
 import { ChatPanel } from "./ChatPanel";
 import { SettingsPanel } from "./SettingsPanel";
 import type { SidebarTab } from "./types";
-import { usePreferencesStore, type AssistantSidebarTab } from "@/lib/stores/preferencesStore";
+import { usePreferencesStore } from "@/lib/stores/preferencesStore";
 import { useAiChat } from "./useAiChat";
 import { useAiProviderSettings } from "./useAiProviderSettings";
 import { useLocalEngineSetup } from "./useLocalEngineSetup";
@@ -78,7 +78,10 @@ export function AssistantSidebar({
   const setState = propSetState ?? storeState.setState;
   const persistedActiveTab = usePreferencesStore((s) => s.assistantActiveTab);
   const setPersistedActiveTab = usePreferencesStore((s) => s.setAssistantActiveTab);
-  const activeTab: SidebarTab = persistedActiveTab;
+  const activeTab: SidebarTab = useMemo(
+    () => (TABS.some((tab) => tab.id === persistedActiveTab) ? persistedActiveTab : "assistant"),
+    [persistedActiveTab],
+  );
   const setActiveTab = useCallback((tab: SidebarTab) => {
     setPersistedActiveTab(tab);
   }, [setPersistedActiveTab]);
@@ -205,7 +208,6 @@ export function AssistantSidebar({
 
   useEffect(() => {
     if (!openToAudit) return;
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- intentional: respond to prop change
     setActiveTab("assistant");
     requestReviewRefresh({ resetFirst: true });
     onAuditOpened?.();
@@ -213,7 +215,6 @@ export function AssistantSidebar({
 
   useEffect(() => {
     if (!pendingChatQuery) return;
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- intentional: respond to prop change
     setActiveTab("assistant");
     void chat.sendChat(pendingChatQuery.query);
     onChatQueryConsumed?.();

--- a/src/components/features/assistant/AssistantSidebar.tsx
+++ b/src/components/features/assistant/AssistantSidebar.tsx
@@ -23,6 +23,7 @@ import { PROVIDER_OPTIONS, normalizeUiProviderId } from "./aiProviderCatalog";
 import { ChatPanel } from "./ChatPanel";
 import { SettingsPanel } from "./SettingsPanel";
 import type { SidebarTab } from "./types";
+import { usePreferencesStore, type AssistantSidebarTab } from "@/lib/stores/preferencesStore";
 import { useAiChat } from "./useAiChat";
 import { useAiProviderSettings } from "./useAiProviderSettings";
 import { useLocalEngineSetup } from "./useLocalEngineSetup";
@@ -75,7 +76,12 @@ export function AssistantSidebar({
   const storeState = usePipelineState();
   const state = propState ?? storeState.state;
   const setState = propSetState ?? storeState.setState;
-  const [activeTab, setActiveTab] = useState<SidebarTab>("assistant");
+  const persistedActiveTab = usePreferencesStore((s) => s.assistantActiveTab);
+  const setPersistedActiveTab = usePreferencesStore((s) => s.setAssistantActiveTab);
+  const activeTab: SidebarTab = persistedActiveTab;
+  const setActiveTab = useCallback((tab: SidebarTab) => {
+    setPersistedActiveTab(tab);
+  }, [setPersistedActiveTab]);
   const [, startTabTransition] = useTransition();
   const { data: hardwareProbe = null } = useHardwareProbe({ enabled: isOpen });
 
@@ -377,7 +383,7 @@ export function AssistantSidebar({
                 activeTab === "agent" ? "block" : "hidden",
               )}
             >
-              <AgentAccessControls variant="panel" />
+              <AgentAccessControls variant="panel" isOpen={isOpen} />
             </div>
           </div>
 

--- a/src/lib/stores/preferencesStore.ts
+++ b/src/lib/stores/preferencesStore.ts
@@ -1,10 +1,10 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
+import type { SidebarTab } from "@/components/features/assistant/types";
 
 export type ThemePreference = "system" | "light" | "dark";
 export type ResolvedTheme = "light" | "dark";
 export type McpRetrievalMode = "auto" | "keyword" | "semantic";
-export type AssistantSidebarTab = "assistant" | "settings" | "agent";
 
 interface PreferencesState {
   themePreference: ThemePreference;
@@ -15,7 +15,7 @@ interface PreferencesState {
   /** Persisted Assistant sidebar open state so it survives page reloads / app restarts. */
   assistantSidebarOpen: boolean;
   /** Persisted active tab in the Assistant sidebar so users return to the panel they left. */
-  assistantActiveTab: AssistantSidebarTab;
+  assistantActiveTab: SidebarTab;
 }
 
 interface PreferencesActions {
@@ -24,7 +24,7 @@ interface PreferencesActions {
   setMcpRetrievalMode: (mode: McpRetrievalMode) => void;
   setMcpPreloadEmbeddings: (enabled: boolean) => void;
   setAssistantSidebarOpen: (open: boolean) => void;
-  setAssistantActiveTab: (tab: AssistantSidebarTab) => void;
+  setAssistantActiveTab: (tab: SidebarTab) => void;
 }
 
 type PreferencesStore = PreferencesState & PreferencesActions;

--- a/src/lib/stores/preferencesStore.ts
+++ b/src/lib/stores/preferencesStore.ts
@@ -4,6 +4,7 @@ import { persist } from "zustand/middleware";
 export type ThemePreference = "system" | "light" | "dark";
 export type ResolvedTheme = "light" | "dark";
 export type McpRetrievalMode = "auto" | "keyword" | "semantic";
+export type AssistantSidebarTab = "assistant" | "settings" | "agent";
 
 interface PreferencesState {
   themePreference: ThemePreference;
@@ -11,6 +12,10 @@ interface PreferencesState {
   tourSeen: boolean;
   mcpRetrievalMode: McpRetrievalMode;
   mcpPreloadEmbeddings: boolean;
+  /** Persisted Assistant sidebar open state so it survives page reloads / app restarts. */
+  assistantSidebarOpen: boolean;
+  /** Persisted active tab in the Assistant sidebar so users return to the panel they left. */
+  assistantActiveTab: AssistantSidebarTab;
 }
 
 interface PreferencesActions {
@@ -18,6 +23,8 @@ interface PreferencesActions {
   markTourSeen: () => void;
   setMcpRetrievalMode: (mode: McpRetrievalMode) => void;
   setMcpPreloadEmbeddings: (enabled: boolean) => void;
+  setAssistantSidebarOpen: (open: boolean) => void;
+  setAssistantActiveTab: (tab: AssistantSidebarTab) => void;
 }
 
 type PreferencesStore = PreferencesState & PreferencesActions;
@@ -31,10 +38,14 @@ export const usePreferencesStore = create<PreferencesStore>()(
       tourSeen: false,
       mcpRetrievalMode: "auto",
       mcpPreloadEmbeddings: false,
+      assistantSidebarOpen: false,
+      assistantActiveTab: "assistant",
       setThemePreference: (pref) => set({ themePreference: pref }),
       markTourSeen: () => set({ tourSeen: true }),
       setMcpRetrievalMode: (mode) => set({ mcpRetrievalMode: mode }),
       setMcpPreloadEmbeddings: (enabled) => set({ mcpPreloadEmbeddings: enabled }),
+      setAssistantSidebarOpen: (open) => set({ assistantSidebarOpen: open }),
+      setAssistantActiveTab: (tab) => set({ assistantActiveTab: tab }),
     }),
     { name: STORAGE_KEY },
   ),


### PR DESCRIPTION
This PR was generated automatically by mini-swe-agent.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persists Assistant sidebar open state and active tab across reloads, and refreshes agent policy only when the sidebar is visible. Previously the sidebar reset on reload and policy re-fetched when hidden; now state survives restarts and we avoid unnecessary network calls.

- Adds `assistantSidebarOpen` and `assistantActiveTab` to `usePreferencesStore` with setters; defaults are `false` and `"assistant"`.
- Updates `App` to read/write sidebar open state from the store; toolbar toggles and Ask AI events now open/close via the store.
- `AssistantSidebar` reads/writes the active tab via the store, validates it against supported tabs, and passes `isOpen` to `AgentAccessControls`.
- `AgentAccessControls` accepts `isOpen` (default `true`) and refreshes policy only when `isOpen` is `true`.
- Migration: If you render `AgentAccessControls` in a hidden panel, pass `isOpen` to match visibility and prevent background refreshes.

<sup>Written for commit 28753b32ef1cd50363e6b9ecbda333b51e1f9ed5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tonythethompson/Olive-Studio/pull/395?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

