### PR TITLE
🤖 GLM 5.2 Fix for Issue #399

### DIFF
--- a/src/server/services/playground/nativeInference.test.ts
+++ b/src/server/services/playground/nativeInference.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vitest";
+import path from "path";
+import { isSafeVenvPython } from "./nativeInference.ts";
+import { getVenvPython } from "../venv/paths.ts";
+import { getFamilyRoot } from "../venv/spec.ts";
+import type { VenvFamily } from "../../../lib/venvFamily.ts";
+
+const SCRIPT_BIN = process.platform === "win32" ? "Scripts" : "bin";
+
+describe("isSafeVenvPython", () => {
+  it("accepts the derived python path for every venv family", () => {
+    for (const family of ["default", "cuda", "openvino", "qnn"] as const) {
+      expect(isSafeVenvPython(getVenvPython(family), family)).toBe(true);
+    }
+  });
+
+  it("accepts a versioned interpreter basename inside the family root", () => {
+    const root = getFamilyRoot("default");
+    const versioned = process.platform === "win32" ? "python3.12.exe" : "python3.12";
+    expect(isSafeVenvPython(path.join(root, SCRIPT_BIN, versioned), "default")).toBe(true);
+  });
+
+  it("rejects an unknown venv family", () => {
+    expect(isSafeVenvPython(getVenvPython("default"), "bogus" as VenvFamily)).toBe(false);
+  });
+
+  it("rejects a path escaping the family root via .. traversal", () => {
+    const root = getFamilyRoot("default");
+    const escaped = path.join(root, "..", SCRIPT_BIN, "python");
+    expect(isSafeVenvPython(escaped, "default")).toBe(false);
+  });
+
+  it("rejects a sibling directory that only shares the root prefix", () => {
+    const root = getFamilyRoot("default");
+    const sibling = path.join(`${root}-evil`, SCRIPT_BIN, "python");
+    expect(isSafeVenvPython(sibling, "default")).toBe(false);
+  });
+
+  it("rejects a non-python basename", () => {
+    const root = getFamilyRoot("default");
+    expect(isSafeVenvPython(path.join(root, SCRIPT_BIN, "node"), "default")).toBe(false);
+  });
+
+  it("rejects an absolute path.relative result (Windows cross-drive)", () => {
+    if (process.platform !== "win32") return;
+    expect(isSafeVenvPython("D:\\evil\\python.exe", "default")).toBe(false);
+  });
+});

--- a/src/server/services/playground/nativeInference.ts
+++ b/src/server/services/playground/nativeInference.ts
@@ -6,6 +6,7 @@ import { spawn, spawnSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { getVenvPython } from "../venv/paths.ts";
+import { PYTHON_BASENAME_RE } from "../venv/pythonGuard.ts";
 import { type VenvFamily, VENV_FAMILIES } from "../../../lib/venvFamily.ts";
 import { getFamilyRoot } from "../venv/spec.ts";
 import {
@@ -81,18 +82,28 @@ export function isSafeVenvPython(pythonPath: string, family: VenvFamily): boolea
   const root = path.resolve(getFamilyRoot(family));
   const resolved = path.resolve(pythonPath);
   // Ensure the resolved python path is inside the expected venv root.
+  // This is a string-level containment check (path.resolve does not follow
+  // symlinks) and is defense-in-depth: the family is a closed enum and the
+  // python path is derived by getVenvPython, so it guards against path
+  // tampering, not a hostile actor with venv write access.
   const rel = path.relative(root, resolved);
+  // Windows can yield an absolute relative for cross-drive paths; reject both
+  // escape shapes (same reasoning as venv/pythonGuard.ts).
   if (rel.startsWith("..") || path.isAbsolute(rel)) return false;
-  // Only allow paths to the expected python binary name.
+  // Only allow paths to a Python interpreter binary.
   const basename = path.basename(resolved);
-  const expected = process.platform === "win32" ? "python.exe" : "python";
-  if (basename !== expected) return false;
+  if (!PYTHON_BASENAME_RE.test(basename)) return false;
   return true;
 }
 
 function findOrtDylibInVenv(venvFamily: VenvFamily = "default"): string | undefined {
   const python = getVenvPython(venvFamily);
-  if (!isSafeVenvPython(python, venvFamily)) return undefined;
+  if (!isSafeVenvPython(python, venvFamily)) {
+    console.warn(
+      `[native-playground] Rejected unsafe python path for venv family "${venvFamily}": ${python}`,
+    );
+    return undefined;
+  }
   if (!fs.existsSync(python)) return undefined;
 
   const script = `

--- a/src/server/services/playground/nativeInference.ts
+++ b/src/server/services/playground/nativeInference.ts
@@ -74,7 +74,7 @@ function sidecarEnv(dylibPath: string): NodeJS.ProcessEnv {
   return env;
 }
 
-function isSafeVenvPython(pythonPath: string, family: VenvFamily): boolean {
+export function isSafeVenvPython(pythonPath: string, family: VenvFamily): boolean {
   // Validate the family against an allowlist so untrusted input can never
   // influence the executable path passed to spawnSync.
   if (!VENV_FAMILIES.includes(family)) return false;

--- a/src/server/services/playground/nativeInference.ts
+++ b/src/server/services/playground/nativeInference.ts
@@ -6,7 +6,8 @@ import { spawn, spawnSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { getVenvPython } from "../venv/paths.ts";
-import type { VenvFamily } from "../../../lib/venvFamily.ts";
+import { type VenvFamily, VENV_FAMILIES } from "../../../lib/venvFamily.ts";
+import { getFamilyRoot } from "../venv/spec.ts";
 import {
   resolveOliveOutputForDownload,
   listOliveOutputs,
@@ -73,8 +74,25 @@ function sidecarEnv(dylibPath: string): NodeJS.ProcessEnv {
   return env;
 }
 
+function isSafeVenvPython(pythonPath: string, family: VenvFamily): boolean {
+  // Validate the family against an allowlist so untrusted input can never
+  // influence the executable path passed to spawnSync.
+  if (!VENV_FAMILIES.includes(family)) return false;
+  const root = path.resolve(getFamilyRoot(family));
+  const resolved = path.resolve(pythonPath);
+  // Ensure the resolved python path is inside the expected venv root.
+  const rel = path.relative(root, resolved);
+  if (rel.startsWith("..") || path.isAbsolute(rel)) return false;
+  // Only allow paths to the expected python binary name.
+  const basename = path.basename(resolved);
+  const expected = process.platform === "win32" ? "python.exe" : "python";
+  if (basename !== expected) return false;
+  return true;
+}
+
 function findOrtDylibInVenv(venvFamily: VenvFamily = "default"): string | undefined {
   const python = getVenvPython(venvFamily);
+  if (!isSafeVenvPython(python, venvFamily)) return undefined;
   if (!fs.existsSync(python)) return undefined;
 
   const script = `

--- a/src/server/services/venv/pythonGuard.ts
+++ b/src/server/services/venv/pythonGuard.ts
@@ -2,7 +2,7 @@ import path from "path";
 import fs from "fs";
 import os from "os";
 
-const PYTHON_BASENAME_RE = /^python(\d+(\.\d+)*)?(\.exe)?$/i;
+export const PYTHON_BASENAME_RE = /^python(\d+(\.\d+)*)?(\.exe)?$/i;
 
 /** Fixed PATH command names we will ever pass to execFile as the executable. */
 export const PATH_PYTHON_COMMANDS = ["python3", "python"] as const;


### PR DESCRIPTION
This PR was generated automatically by mini-swe-agent.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens native inference by validating the venv Python executable before spawning. Previously we trusted `getVenvPython(family)`; now we only spawn when the family is allowlisted, the path is under `getFamilyRoot(family)`, and the basename matches a Python interpreter, preventing accidental arbitrary execution.

- `findOrtDylibInVenv` may now return undefined when the guard fails (unknown `VenvFamily`, non-python basename, or path outside the family root); logs a warning instead of spawning.
- Exposes `isSafeVenvPython(pythonPath, family)` and adds unit tests covering allowlisted families, root containment, versioned basenames, path traversal, and Windows cross-drive cases; exports `PYTHON_BASENAME_RE` from `pythonGuard.ts` for reuse.

<sup>Written for commit 82f667653b494b357a255f57487acfbeb70caa3a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tonythethompson/Olive-Studio/pull/400?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

